### PR TITLE
chore(flake/stylix): `6c895c6b` -> `3a4101c4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -500,11 +500,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1724702977,
-        "narHash": "sha256-bP1/BHbEigLjTTmqyy1t8w5EVWHuLuABtOd/BBXVLtA=",
+        "lastModified": 1725126812,
+        "narHash": "sha256-E0CrYq8A/gdBjb9qC3PGKfH9lwSESyFX6sRZXJxq4JE=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "6c895c6b42ca205017abe72a7263baf36a197972",
+        "rev": "3a4101c4f4abee41859c0cb98f6250f04c80d0f6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                        | Message                                         |
| --------------------------------------------------------------------------------------------- | ----------------------------------------------- |
| [`3a4101c4`](https://github.com/danth/stylix/commit/3a4101c4f4abee41859c0cb98f6250f04c80d0f6) | `` fish: remove obsolete $base16_theme check `` |