### PR TITLE
chore(flake/home-manager): `c2cd2a52` -> `471e3eb0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -320,11 +320,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1724435763,
-        "narHash": "sha256-UNky3lJNGQtUEXT2OY8gMxejakSWPTfWKvpFkpFlAfM=",
+        "lastModified": 1725180166,
+        "narHash": "sha256-fzssXuGR/mCeGbzM1ExaTqDz7QDGta3WA4jJsZyRruo=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "c2cd2a52e02f1dfa1c88f95abeb89298d46023be",
+        "rev": "471e3eb0a114265bcd62d11d58ba8d3421ee68eb",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                             |
| ----------------------------------------------------------------------------------------------------------- | --------------------------------------------------- |
| [`471e3eb0`](https://github.com/nix-community/home-manager/commit/471e3eb0a114265bcd62d11d58ba8d3421ee68eb) | `` git: add option to provide difftastic package `` |