### PR TITLE
chore(flake/plasma-manager): `c0026190` -> `3f1589c3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -396,11 +396,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1725210710,
-        "narHash": "sha256-HHWEeLhfDeprabbxjGc/jVWpUu0+gFaQ0jWgohe02XE=",
+        "lastModified": 1725327224,
+        "narHash": "sha256-+cMfiE+zigDuChOFlhUH3yN7Yll9hr1LRBHsO09pqjY=",
         "owner": "pjones",
         "repo": "plasma-manager",
-        "rev": "c00261909b44a960894552bbeafb762af2fa9bd8",
+        "rev": "3f1589c38428bd8121fd5deebd86ce4108b29d6e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                        | Message                             |
| ------------------------------------------------------------------------------------------------------------- | ----------------------------------- |
| [`3f1589c3`](https://github.com/nix-community/plasma-manager/commit/3f1589c38428bd8121fd5deebd86ce4108b29d6e) | `` Add module for KRunner (#346) `` |