### PR TITLE
chore(flake/zen-browser): `cfc894ab` -> `7af3f77c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -533,11 +533,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1725096998,
-        "narHash": "sha256-ylP5YehroiFnf1AIT5yq1mcc8HUVlj9ItsWCtY6J6ck=",
+        "lastModified": 1725438139,
+        "narHash": "sha256-huKh54tzjtsNRVOw08candbPLHpf09jnQ0PSSct40K0=",
         "owner": "MarceColl",
         "repo": "zen-browser-flake",
-        "rev": "cfc894abb631e3ea61ff590b7520d79d35a26366",
+        "rev": "7af3f77cf6a3c60dc2410e163cc1c71e15c857b5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                                  |
| ------------------------------------------------------------------------------------------------------------ | ---------------------------------------- |
| [`7af3f77c`](https://github.com/MarceColl/zen-browser-flake/commit/7af3f77cf6a3c60dc2410e163cc1c71e15c857b5) | `` update version to 1.0.0-a.35 (#27) `` |