### PR TITLE
chore(flake/home-manager): `471e3eb0` -> `aaebdea7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -320,11 +320,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1725180166,
-        "narHash": "sha256-fzssXuGR/mCeGbzM1ExaTqDz7QDGta3WA4jJsZyRruo=",
+        "lastModified": 1725694918,
+        "narHash": "sha256-+HsjshXpqNiJHLaJaK0JnIicJ/a1NquKcfn4YZ3ILgg=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "471e3eb0a114265bcd62d11d58ba8d3421ee68eb",
+        "rev": "aaebdea769a5c10f1c6e50ebdf5924c1a13f0cda",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                           |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------- |
| [`aaebdea7`](https://github.com/nix-community/home-manager/commit/aaebdea769a5c10f1c6e50ebdf5924c1a13f0cda) | `` taskwarrior: support taskwarrior3 migration `` |
| [`127ccc3e`](https://github.com/nix-community/home-manager/commit/127ccc3eb7e36fa75e8c3fbd8a343154f66cc1c6) | `` i3/sway: support str type for font size ``     |
| [`7d569851`](https://github.com/nix-community/home-manager/commit/7d569851e95e8b360a3d7a2f52c5fc6a597a7657) | `` flake.lock: Update ``                          |
| [`5b95e061`](https://github.com/nix-community/home-manager/commit/5b95e0611b498fac7c8425d1b1bc4cacfd64e7f0) | `` Translate using Weblate (Hungarian) ``         |
| [`b00bdf59`](https://github.com/nix-community/home-manager/commit/b00bdf59c0aa5515a0a8e1773fa19128e7efa181) | `` xdg: add option 'xdg.stateFile' ``             |
| [`03b49187`](https://github.com/nix-community/home-manager/commit/03b49187a2e41f042896a26761ca86ce90cb7f2c) | `` sway: indent sway configuration options ``     |
| [`5130249a`](https://github.com/nix-community/home-manager/commit/5130249ab20229480aa732942c9c555a38fb910a) | `` taskwarrior-sync: add package option ``        |