### PR TITLE
chore(flake/spicetify-nix): `c208a9bd` -> `f972e25c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -468,11 +468,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1725682572,
-        "narHash": "sha256-K5feij1p3mheXVD6NO9l5LjAHPFRXucWT60/x+l2pf0=",
+        "lastModified": 1725768938,
+        "narHash": "sha256-Lmd6L/hF0hjid0ThYH8vYdyjkor95NvwzptlexdFmto=",
         "owner": "Gerg-L",
         "repo": "spicetify-nix",
-        "rev": "c208a9bd17d0e0b9dc91dd20b5fe0ff5df3b9ac8",
+        "rev": "f972e25c903479e175b1730292536de219e9b0c3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                    |
| ----------------------------------------------------------------------------------------------------- | -------------------------- |
| [`f972e25c`](https://github.com/Gerg-L/spicetify-nix/commit/f972e25c903479e175b1730292536de219e9b0c3) | `` CI update 2024-09-08 `` |