### PR TITLE
chore(flake/plasma-manager): `ab213b4b` -> `60becd0e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -396,11 +396,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1725826908,
-        "narHash": "sha256-OFykXcFDqDEa9QxAlfoDHvaz4P+eLIx1HKA6lzQVP2c=",
+        "lastModified": 1725914634,
+        "narHash": "sha256-U74hu15xSb6JNySMOwyJrsh4uk1DVa182bdHLeHdYMc=",
         "owner": "pjones",
         "repo": "plasma-manager",
-        "rev": "ab213b4b6a9abf46516fbd6eecdd2c936fe98155",
+        "rev": "60becd0e994e25b372c8d0500fc944396f6c1085",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                        | Message                                                                                 |
| ------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------- |
| [`60becd0e`](https://github.com/nix-community/plasma-manager/commit/60becd0e994e25b372c8d0500fc944396f6c1085) | `` Some refactoring around startup-scripts (#355) ``                                    |
| [`1babfbeb`](https://github.com/nix-community/plasma-manager/commit/1babfbebdd7ea9f566dd0ab6e03f60a4808d6cba) | `` Add InhibitLidActionWhenExternalMonitorPresent option to powerdevil module (#361) `` |