### PR TITLE
chore(flake/home-manager): `8a167164` -> `da8406a6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -320,11 +320,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1726036828,
-        "narHash": "sha256-ZQHbpyti0jcAKnwQY1lwmooecLmSG6wX1JakQ/eZNeM=",
+        "lastModified": 1726142087,
+        "narHash": "sha256-uT4TRd3PgreUD5sJaNioVfMemdyWFLoPHqN4AFszGmw=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "8a1671642826633586d12ac3158e463c7a50a112",
+        "rev": "da8406a6ff556b86dc368e96ca8bd81b2704a91a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                 |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------------- |
| [`da8406a6`](https://github.com/nix-community/home-manager/commit/da8406a6ff556b86dc368e96ca8bd81b2704a91a) | `` systemd: use getExe for sd-switch ``                 |
| [`e1c60940`](https://github.com/nix-community/home-manager/commit/e1c6094075d28d496a1b0db208afd31e0b213d67) | `` systemd: unify handling of switch environment ``     |
| [`51e46643`](https://github.com/nix-community/home-manager/commit/51e46643429b3dc96dadf3014757582eca6adf28) | `` treewide: use non-deprecated substitute arguments `` |