### PR TITLE
chore(flake/stylix): `ef81ad9e` -> `35233f92`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -500,11 +500,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1725290973,
-        "narHash": "sha256-+jwXF9KI0HfvDgpsoJGvOdfOGGSKOrID1wQB79zjUbo=",
+        "lastModified": 1726170940,
+        "narHash": "sha256-sobkRkGBaMX9pD0bwU1iVPWi0WtQvZqlHyl1YtvNDio=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "ef81ad9e85e60420cc83d4642619c14b57139d33",
+        "rev": "35233f929629c8eb64e939e35260fc8347f94df9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                        | Message                                      |
| --------------------------------------------------------------------------------------------- | -------------------------------------------- |
| [`35233f92`](https://github.com/danth/stylix/commit/35233f929629c8eb64e939e35260fc8347f94df9) | `` emacs: explicitly set font size (#553) `` |