### PR TITLE
chore(flake/home-manager): `503af483` -> `6c1a461a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -320,11 +320,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1726222338,
-        "narHash": "sha256-KuA8ciNR8qCF3dQaCaeh0JWyQUgEwkwDHr/f49Q5/e8=",
+        "lastModified": 1726308872,
+        "narHash": "sha256-d4vwO5N4RsLnCY7k5tY9xbdYDWQsY3RDMeUoIa4ms2A=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "503af483e1b328691ea3a434d331995595fb2e3d",
+        "rev": "6c1a461a444e6ccb3f3e42bb627b510c3a722a57",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                         |
| ----------------------------------------------------------------------------------------------------------- | ----------------------------------------------- |
| [`6c1a461a`](https://github.com/nix-community/home-manager/commit/6c1a461a444e6ccb3f3e42bb627b510c3a722a57) | `` mopidy: reduce test closure size ``          |
| [`c6e4ec39`](https://github.com/nix-community/home-manager/commit/c6e4ec39df78245f7ce678476ff068515763345b) | `` z-lua: add support for fish abbreviations `` |
| [`0d118885`](https://github.com/nix-community/home-manager/commit/0d118885b2840447b5b7f2b6097b4511ed3d02e9) | `` lsd: add support for fish abbreviations ``   |
| [`f69e61a2`](https://github.com/nix-community/home-manager/commit/f69e61a2d77b721f28868b6fdc55706ca1bad49c) | `` pls: add support for fish abbreviations ``   |
| [`7edf6cca`](https://github.com/nix-community/home-manager/commit/7edf6ccaec8001cb20368bf1bf6a677178cae07b) | `` Add translation using Weblate (Hindi) ``     |
| [`e94bee95`](https://github.com/nix-community/home-manager/commit/e94bee957400c8f871d9b9ea54308e15d664242c) | `` Translate using Weblate (Hindi) ``           |
| [`898eaef7`](https://github.com/nix-community/home-manager/commit/898eaef7ea906ddc8e86d57957f2a701878bfb05) | `` Translate using Weblate (Russian) ``         |
| [`f084d653`](https://github.com/nix-community/home-manager/commit/f084d653199345ad294abca921a0e25872bd75c0) | `` swaync: fix example configuration ``         |
| [`43845d04`](https://github.com/nix-community/home-manager/commit/43845d04f83d44d744206ea9884b8206e7640633) | `` git: add diff-highlight diff pager option `` |