### PR TITLE
chore(flake/home-manager): `a9c9cc6e` -> `d2493de5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -320,11 +320,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1726440980,
-        "narHash": "sha256-ChhIrjtdu5d83W+YDRH+Ec5g1MmM0xk6hJnkz15Ot7M=",
+        "lastModified": 1726611255,
+        "narHash": "sha256-/bxaYvIK6/d3zqpW26QFS0rqfd0cO4qreSNWvYLTl/w=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "a9c9cc6e50f7cbd2d58ccb1cd46a1e06e9e445ff",
+        "rev": "d2493de5cd1da06b6a4c3e97f4e7d5dd791df457",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                         |
| ----------------------------------------------------------------------------------------------------------- | ----------------------------------------------- |
| [`d2493de5`](https://github.com/nix-community/home-manager/commit/d2493de5cd1da06b6a4c3e97f4e7d5dd791df457) | `` ci: remove 23.11 from dependabot ``          |
| [`4974dfb2`](https://github.com/nix-community/home-manager/commit/4974dfb26e1c84d22bfdf943d41a33c9e51209a8) | `` thunderbird: change settings type to json `` |
| [`4a4a8b14`](https://github.com/nix-community/home-manager/commit/4a4a8b145463ccfef579bb0e26275c97bf0b5bf2) | `` firefox: fix languagepacks policy ``         |