### PR TITLE
chore(flake/spicetify-nix): `65e118fa` -> `9f373314`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -468,11 +468,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1726546530,
-        "narHash": "sha256-cgfOnRrsSgxXOUNqTyiLFlnFSC7ukveTEqAzsanCHdk=",
+        "lastModified": 1726633022,
+        "narHash": "sha256-Ef/kTMoV3aPfecL2X27sxYshsLJJDIBFKYjPsqaTUBw=",
         "owner": "Gerg-L",
         "repo": "spicetify-nix",
-        "rev": "65e118fae842aa8d7c0d3c11e3b484effc0dde16",
+        "rev": "9f373314f087e11183afe6928d48a816d44929d4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                    |
| ----------------------------------------------------------------------------------------------------- | -------------------------- |
| [`9f373314`](https://github.com/Gerg-L/spicetify-nix/commit/9f373314f087e11183afe6928d48a816d44929d4) | `` CI update 2024-09-18 `` |