### PR TITLE
chore(flake/home-manager): `4803bf55` -> `dfe4d334`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -320,11 +320,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1726823634,
-        "narHash": "sha256-rU8Yy62KSLU8Q2J64F+50OJKORNdogxbXl2w4rFw13o=",
+        "lastModified": 1726863345,
+        "narHash": "sha256-fjbKe1/UJpLT6tQLAKJ/djJFdnmAh2kkdsgmylyFrQA=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "4803bf558bdf20cb067aceb8830b7ad70113f4e3",
+        "rev": "dfe4d334b172071e7189d971ddecd3a7f811b48d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                    |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------ |
| [`dfe4d334`](https://github.com/nix-community/home-manager/commit/dfe4d334b172071e7189d971ddecd3a7f811b48d) | `` wezterm: fix generated configuration `` |
| [`0b052dd8`](https://github.com/nix-community/home-manager/commit/0b052dd8119005c6ba819db48bcc657e48f401b7) | `` swayidle: minor cleanups ``             |