### PR TITLE
chore(flake/nixpkgs-stable): `086b448a` -> `dbebdd67`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -372,11 +372,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1726447378,
-        "narHash": "sha256-2yV8nmYE1p9lfmLHhOCbYwQC/W8WYfGQABoGzJOb1JQ=",
+        "lastModified": 1726688310,
+        "narHash": "sha256-Xc9lEtentPCEtxc/F1e6jIZsd4MPDYv4Kugl9WtXlz0=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "086b448a5d54fd117f4dc2dee55c9f0ff461bdc1",
+        "rev": "dbebdd67a6006bb145d98c8debf9140ac7e651d0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                            |
| ---------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------- |
| [`6c5f1148`](https://github.com/NixOS/nixpkgs/commit/6c5f1148160ba32eeb8f4bd9d05355eee9428e76) | `` nix-serve.nix: Add ``                                                           |
| [`291c9512`](https://github.com/NixOS/nixpkgs/commit/291c95120d7bd3885624198c5f51e9f4a2740a17) | `` nixosTests.nix-serve: Use new entrypoint ``                                     |
| [`e7d80697`](https://github.com/NixOS/nixpkgs/commit/e7d8069780150e190532cbad33f7eb430a3ed697) | `` handbrake: fix build by applying an upstream patch again ``                     |
| [`26ba0cd7`](https://github.com/NixOS/nixpkgs/commit/26ba0cd7f7f5aae58b2429c9c3265f584c48a2d9) | `` signal-desktop(aarch64): 7.19.0 -> 7.23.0 ``                                    |
| [`88049656`](https://github.com/NixOS/nixpkgs/commit/88049656022edf50429aa87cf436e9d6910083ad) | `` signal-desktop-beta: 7.23.0-beta.1 -> 7.25.0-beta.2 ``                          |
| [`9673d175`](https://github.com/NixOS/nixpkgs/commit/9673d175ceb840e92df434035bfdc43b3eab4a74) | `` signal-desktop: 7.22.0 -> 7.24.1 ``                                             |
| [`89218ef5`](https://github.com/NixOS/nixpkgs/commit/89218ef54e90ba17ce95055ee5fde1cb8b173502) | `` rdiff-backup: add meta.mainProgram ``                                           |
| [`98be0352`](https://github.com/NixOS/nixpkgs/commit/98be0352703796bea915d9fbe5208f265a5c4a58) | `` element-desktop: 1.11.76 -> 1.11.77 ``                                          |
| [`fc7774c4`](https://github.com/NixOS/nixpkgs/commit/fc7774c4c6180ee152095bd7aa370e7bc03f2f9f) | `` davinci-resolve: add icon to desktop item ``                                    |
| [`4e09c145`](https://github.com/NixOS/nixpkgs/commit/4e09c14501dcf3ef322eb62525f8a1d7724e26f2) | `` wavebox: 10.128.5-2 -> 10.128.7-2 ``                                            |
| [`e3fa4880`](https://github.com/NixOS/nixpkgs/commit/e3fa4880bbab0e0538b7501c8e833ffe05daae35) | `` davinci-resolve: Fix incorrect mainProgram for studio ``                        |
| [`2138eef8`](https://github.com/NixOS/nixpkgs/commit/2138eef822d3a7aff96367b61a2b09d1652d0ba7) | `` davinci-resolve: Copy desktop item to FHS env ``                                |
| [`4e8741a3`](https://github.com/NixOS/nixpkgs/commit/4e8741a3c9f097a5fae17f3f772adbb657da05d0) | `` davinci-resolve: Fix incorrect fields in desktop item ``                        |
| [`051e9caa`](https://github.com/NixOS/nixpkgs/commit/051e9caadf9894ce3b894f308f3851eb9e479330) | `` workout-tracker: fix npmDepsHash ``                                             |
| [`a1052422`](https://github.com/NixOS/nixpkgs/commit/a1052422c5e42a7d8b47a8c2c949bc6ec37682ee) | `` workout-tracker: add assets ``                                                  |
| [`82b9e80f`](https://github.com/NixOS/nixpkgs/commit/82b9e80f684da83dd598af0287f15b6de895592a) | `` meshcentral: 1.1.29 -> 1.1.30 ``                                                |
| [`f8949501`](https://github.com/NixOS/nixpkgs/commit/f89495011d2482ccb4fb641dceba31fc276cc7e0) | `` Revert "zfs: dynamically determine latestCompatibleLinuxPackages" ``            |
| [`c7244354`](https://github.com/NixOS/nixpkgs/commit/c724435440145459d6cb72adf88444d6041b77a2) | `` fastly: 10.14.0 -> 10.14.1 ``                                                   |
| [`806e641b`](https://github.com/NixOS/nixpkgs/commit/806e641b60b2928870bce135a931e122c1d77326) | `` hdr10plus_tool: 1.6.0 -> 1.6.1 ``                                               |
| [`60390cff`](https://github.com/NixOS/nixpkgs/commit/60390cffa15a12d388ac68fd16ff8b24b5c21d9b) | `` python3Packages.pyqtdatavisualization: 5.15.5 -> 5.15.6 ``                      |
| [`40ff3d3c`](https://github.com/NixOS/nixpkgs/commit/40ff3d3c84d96c476f71bc46e10856bc214cd856) | `` python3Packages.pyqtchart: 5.15.6 -> 5.15.7 ``                                  |
| [`c7874e77`](https://github.com/NixOS/nixpkgs/commit/c7874e7716019e907aecf578e969535a9f83471c) | `` python3Packages.pyqt3d: 5.15.6 -> 5.15.7 ``                                     |
| [`55e6194a`](https://github.com/NixOS/nixpkgs/commit/55e6194a1a46ec91d7a2be342d1c8f52b6251fa7) | `` firefox-bin-unwrapped: 130.0 -> 130.0.1 ``                                      |
| [`b3f16dd3`](https://github.com/NixOS/nixpkgs/commit/b3f16dd3d492976e696f772528ac822438dd3b3c) | `` firefox-bin-unwrapped: 129.0.2 -> 130.0 ``                                      |
| [`272b8ea2`](https://github.com/NixOS/nixpkgs/commit/272b8ea28ad1bb2baf076a012a2f2283937ff634) | `` firefox-unwrapped: 130.0 -> 130.0.1 ``                                          |
| [`c05f6a46`](https://github.com/NixOS/nixpkgs/commit/c05f6a46c4312064616ad88876a23cc2eecff2e6) | `` hdr10plus_tool: init at 1.6.0 ``                                                |
| [`d38e757c`](https://github.com/NixOS/nixpkgs/commit/d38e757ca7acd12fcc4c8f75569dcb591ad12b11) | `` undocker: 1.2.2 -> 1.2.3 (#341364) ``                                           |
| [`c7a8d430`](https://github.com/NixOS/nixpkgs/commit/c7a8d43019710b991a7f3ab742d5f04acb3c6f3a) | `` framework-laptop-kmod: 0-unstable-2024-01-02 -> 0-unstable-2024-09-15 ``        |
| [`5d28a3e3`](https://github.com/NixOS/nixpkgs/commit/5d28a3e31a5b353e9338b51dc218c77524f42994) | `` uwsm: pass python-bin meson option ``                                           |
| [`21431222`](https://github.com/NixOS/nixpkgs/commit/2143122291a8e2fd7a718057144a893eacfb3c89) | `` uwsm: 0.18.2 -> 0.19.0 ``                                                       |
| [`6b256044`](https://github.com/NixOS/nixpkgs/commit/6b25604415b5ff831d405105a3c5f8c4384f0a1f) | `` flarum: fix installation and migration logic ``                                 |
| [`713b09b7`](https://github.com/NixOS/nixpkgs/commit/713b09b71cd9da800ee17ca07ec8fffef328254d) | `` python312Packages.uvloop: 0.19.0 -> 0.20.0 ``                                   |
| [`e3537f96`](https://github.com/NixOS/nixpkgs/commit/e3537f96981225fb0c3ffaf9831a56c7b50306ab) | `` oink: 1.1.1 -> 1.3.0 ``                                                         |
| [`843ab11a`](https://github.com/NixOS/nixpkgs/commit/843ab11aa0057bf4766fa5a1f06b87136f8ae77e) | `` python312Packages.jupyterlab: 4.2.4 -> 4.2.5 ``                                 |
| [`7853547f`](https://github.com/NixOS/nixpkgs/commit/7853547f7d0f78285abfe32eb9d8a7bcb2975170) | `` python312Packages.jupyterlab: 4.2.3 -> 4.2.4 ``                                 |
| [`96538794`](https://github.com/NixOS/nixpkgs/commit/9653879429ee8811372d9bc9ca244b7512cda4da) | `` python312Packages.jupyterlab: 4.2.2 -> 4.2.3 ``                                 |
| [`7f65c013`](https://github.com/NixOS/nixpkgs/commit/7f65c0136d258819ddb4a0d8982e7f8519bdee1d) | `` python3Packages.jupyterlab: 4.2.1 -> 4.2.2 ``                                   |
| [`39244a17`](https://github.com/NixOS/nixpkgs/commit/39244a17cf2a79e68e1b7981bd261e8ce539b583) | `` python311Packages.jupyterlab: 4.2.0 -> 4.2.1 ``                                 |
| [`42fb94a0`](https://github.com/NixOS/nixpkgs/commit/42fb94a04caea94c4ece0c22da8bbb11ef77500e) | `` python312Packages.executing: patch build with python-3.12.5 ``                  |
| [`e9404b6f`](https://github.com/NixOS/nixpkgs/commit/e9404b6fc42a86ffb2cd1c9fc52016e4bad247be) | `` gitlab-container-registry: 4.7.0 -> 4.9.0 ``                                    |
| [`10c38448`](https://github.com/NixOS/nixpkgs/commit/10c38448e28dff5d4c797db7acdff99f0ce17642) | `` gitlab: 17.2.4 -> 17.2.5 ``                                                     |
| [`b0b618eb`](https://github.com/NixOS/nixpkgs/commit/b0b618ebc9dc4fa6d9c22740258638b4d4dd327b) | `` python312Packages.mercurial: fix build by upstream patch ``                     |
| [`a8d87ba0`](https://github.com/NixOS/nixpkgs/commit/a8d87ba0491f6b57e7d23627e65d7c74e3bf2471) | `` armcord: 3.2.7 -> 3.3.1 ``                                                      |
| [`5dd3a70b`](https://github.com/NixOS/nixpkgs/commit/5dd3a70bbcda4d8277038cc2b20e2dc5012116f0) | `` Revert "tzdata: 2024a -> 2024b (#340296)" ``                                    |
| [`5284e6f4`](https://github.com/NixOS/nixpkgs/commit/5284e6f47e9684064705584f736823fb533a9260) | `` python312Packages.webob: add some key reverse dependencies to passthru.tests `` |
| [`757ad392`](https://github.com/NixOS/nixpkgs/commit/757ad392b4af2d37dd932821d3f55a3bd310fc76) | `` python312Packages.webob: 1.8.7 -> 1.8.8 ``                                      |
| [`fb7de0f5`](https://github.com/NixOS/nixpkgs/commit/fb7de0f563e2e9d0148571a5c4c5661ddee3ee43) | `` expat: 2.6.2 -> 2.6.3 ``                                                        |
| [`a83b19a8`](https://github.com/NixOS/nixpkgs/commit/a83b19a8991e35cf9d36c1d3afe1215a1f03436b) | `` tzdata: 2024a -> 2024b ``                                                       |
| [`cac1d428`](https://github.com/NixOS/nixpkgs/commit/cac1d4288030e3add0f6e374214bed64aab03ce0) | `` ruby: 3.3.4 -> 3.3.5 (#340137) ``                                               |
| [`f74e2ab1`](https://github.com/NixOS/nixpkgs/commit/f74e2ab10614e8f13011e77dc3b6ff2a7d6ad100) | `` tcpdump: 4.99.4 -> 4.99.5 ``                                                    |
| [`a9269f5f`](https://github.com/NixOS/nixpkgs/commit/a9269f5f7a16a15ec5c20b00b97f430fd1b1bc13) | `` python312Packages.django_4: 4.2.15 -> 4.2.16 ``                                 |
| [`1417a968`](https://github.com/NixOS/nixpkgs/commit/1417a968b2321f20367e8fae8f5f192ef72fa409) | `` cacert: 3.101.1 -> 3.104 ``                                                     |
| [`5e7ac373`](https://github.com/NixOS/nixpkgs/commit/5e7ac3737ac5abca6dc4b4506455b2cc5908931c) | `` cacert: 3.101 -> 3.101.1 ``                                                     |
| [`986d0194`](https://github.com/NixOS/nixpkgs/commit/986d01943ab0f5bc4571597143e8c4cedeb6cb6b) | `` vim: 9.1.0689 -> 9.1.0707 ``                                                    |
| [`87689c77`](https://github.com/NixOS/nixpkgs/commit/87689c772893b4d00f8fcfa91e1f9620cb20be61) | `` python311Packages.grpcio-tools: 1.62.2 -> 1.62.3 ``                             |
| [`2403d2b6`](https://github.com/NixOS/nixpkgs/commit/2403d2b662a2ee531ac7d5a5df4766a999d2b360) | `` python311Packages.grpcio-status: 1.62.2 -> 1.62.3 ``                            |
| [`9654c12c`](https://github.com/NixOS/nixpkgs/commit/9654c12c66d9a0c07278d713f7793fb8b2e4814d) | `` grpc: 1.62.1 -> 1.62.3 ``                                                       |
| [`36235416`](https://github.com/NixOS/nixpkgs/commit/362354165517b722e7ffadac18df3ae84923583d) | `` python312: 3.12.4 -> 3.12.5 ``                                                  |
| [`df3ad556`](https://github.com/NixOS/nixpkgs/commit/df3ad55663ecce0983be0da25d2c87657158f4f4) | `` cups: fix socket-only usage ``                                                  |
| [`dfe96032`](https://github.com/NixOS/nixpkgs/commit/dfe96032b8b02a9d3b3e07081178dbe331fbae2a) | `` cups: replace CVE-2024-35235 patch file with fetchpatch ``                      |
| [`47c7c372`](https://github.com/NixOS/nixpkgs/commit/47c7c372e76b9526284006e4b62a59012e296bc6) | `` gnupatch: fix segfault on cleanup ``                                            |
| [`7a0cc0df`](https://github.com/NixOS/nixpkgs/commit/7a0cc0df321bc4ea4012bae7102fe66c91b800b8) | `` vim: 9.1.0679 -> 9.1.0689 ``                                                    |
| [`8c5a6413`](https://github.com/NixOS/nixpkgs/commit/8c5a6413637a099d4f05e61d4a63dfd63af25b30) | `` linux: enable CONFIG_SND_HDA_CODEC_CS8409: restrict kernel >=6.6 ``             |
| [`04cc9358`](https://github.com/NixOS/nixpkgs/commit/04cc9358a7bd96c227934f16eea6a3668fbde049) | `` linux: enable CONFIG_SND_HDA_CODEC_CS8409 ``                                    |
| [`0ab819db`](https://github.com/NixOS/nixpkgs/commit/0ab819db177151e74180b37c8f25f2b2db8ea7be) | `` stdenv: create `env-vars` file before writing data to it ``                     |
| [`bbfff128`](https://github.com/NixOS/nixpkgs/commit/bbfff12880e50585796af54ca07689420a66a62b) | `` python3Packages.urllib3: 2.2.1 -> 2.2.2 ``                                      |
| [`f463b78d`](https://github.com/NixOS/nixpkgs/commit/f463b78dff3d3d929686df7b57f112d43dc84739) | `` vim: 9.1.0595 -> 9.1.0679 ``                                                    |
| [`6f1fa649`](https://github.com/NixOS/nixpkgs/commit/6f1fa649400778ae90e7eb8e393a160466427626) | `` vim: 9.1.0509 -> 9.1.0595 ``                                                    |
| [`a8a718a7`](https://github.com/NixOS/nixpkgs/commit/a8a718a756a65add1bbddbbefce2109e42cb9214) | `` vim: 9.1.0412 -> 9.1.0509 ``                                                    |
| [`b7fec185`](https://github.com/NixOS/nixpkgs/commit/b7fec1855f49841bb67428efadf9a7c69be13c62) | `` vim: 9.1.0377 -> 9.1.0412 ``                                                    |
| [`e0fbd153`](https://github.com/NixOS/nixpkgs/commit/e0fbd153a7ce9e85f1e21446bc61ee5acdb16b8f) | `` ffmpeg_7: 7.0.1 -> 7.0.2 ``                                                     |
| [`e5c3ef1e`](https://github.com/NixOS/nixpkgs/commit/e5c3ef1ea21dd31c7ae8ab070f9f5509bc057295) | `` ffmpeg_6: 6.1.1 -> 6.1.2 ``                                                     |
| [`df7ecf34`](https://github.com/NixOS/nixpkgs/commit/df7ecf34cc68bc9f1d03057381a56c193255049a) | `` stdenv: make sure the `env-vars` file created is not world readable ``          |
| [`145fb3ea`](https://github.com/NixOS/nixpkgs/commit/145fb3eae47ae8a88bf046ab53505b44ac6bda31) | `` libopenmpt: 0.7.8 -> 0.7.9 ``                                                   |