### PR TITLE
chore(flake/home-manager): `dfe4d334` -> `14929f70`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -320,11 +320,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1726863345,
-        "narHash": "sha256-fjbKe1/UJpLT6tQLAKJ/djJFdnmAh2kkdsgmylyFrQA=",
+        "lastModified": 1726902823,
+        "narHash": "sha256-Gkc7pwTVLKj4HSvRt8tXNvosl8RS9hrBAEhOjAE0Tt4=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "dfe4d334b172071e7189d971ddecd3a7f811b48d",
+        "rev": "14929f7089268481d86b83ed31ffd88713dcd415",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                |
| ----------------------------------------------------------------------------------------------------------- | -------------------------------------- |
| [`14929f70`](https://github.com/nix-community/home-manager/commit/14929f7089268481d86b83ed31ffd88713dcd415) | `` zoxide: clarify `options` option `` |
| [`51e1d69f`](https://github.com/nix-community/home-manager/commit/51e1d69f7a99446e5ef109ec5ed66b982e0434ca) | `` poweralertd: fix regression ``      |