### PR TITLE
chore(flake/nixpkgs-stable): `dbebdd67` -> `944b2aea`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -372,11 +372,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1726688310,
-        "narHash": "sha256-Xc9lEtentPCEtxc/F1e6jIZsd4MPDYv4Kugl9WtXlz0=",
+        "lastModified": 1726838390,
+        "narHash": "sha256-NmcVhGElxDbmEWzgXsyAjlRhUus/nEqPC5So7BOJLUM=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "dbebdd67a6006bb145d98c8debf9140ac7e651d0",
+        "rev": "944b2aea7f0a2d7c79f72468106bc5510cbf5101",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                             |
| ---------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------- |
| [`c34f195b`](https://github.com/NixOS/nixpkgs/commit/c34f195b67b3601c465d46b8ef5185adcec0b62d) | `` xone: fix kernel 6.11 compatibility ``                                           |
| [`a219f9fb`](https://github.com/NixOS/nixpkgs/commit/a219f9fb3f229f1d033e36d53e6e8fb0a93a06eb) | `` envoy: 1.30.5 -> 1.30.6 ``                                                       |
| [`85eeb641`](https://github.com/NixOS/nixpkgs/commit/85eeb641b1cb30a16ad77fb66c4f56c16c1183b4) | `` patroni: 3.3.2 -> 3.3.3 ``                                                       |
| [`3093d8ec`](https://github.com/NixOS/nixpkgs/commit/3093d8ec1a34381af75d7510a30f56de07a96282) | `` tor-browser: 13.5.3 -> 13.5.4 ``                                                 |
| [`0a944de7`](https://github.com/NixOS/nixpkgs/commit/0a944de72cb2f92d6ed8801e7877ae46b3166533) | `` unit: fix php82 module argument ``                                               |
| [`b768cf74`](https://github.com/NixOS/nixpkgs/commit/b768cf74944b22ae798c0c2552f2eee6c431a417) | `` gnome.sushi: use actual upstream url as homepage ``                              |
| [`33e19693`](https://github.com/NixOS/nixpkgs/commit/33e19693663cc26f3ec11623985f0616973ddb15) | `` discord-ptb: 0.0.103 -> 0.0.105 ``                                               |
| [`f92d957a`](https://github.com/NixOS/nixpkgs/commit/f92d957a4103d1b160d2b79a0058bfbbcc36c5e5) | `` linuxPackages_latest.nct6687d: 0-unstable-2024-02-23 -> 0-unstable-2024-09-02 `` |
| [`d4f15705`](https://github.com/NixOS/nixpkgs/commit/d4f1570582ebf7d4eb71beac09e217dd312656de) | `` linux_6_1: 6.1.110 -> 6.1.111 ``                                                 |
| [`c223f30f`](https://github.com/NixOS/nixpkgs/commit/c223f30f166c963b696e924c86622c0a4fbf76ee) | `` linux_6_6: 6.6.51 -> 6.6.52 ``                                                   |
| [`6d913024`](https://github.com/NixOS/nixpkgs/commit/6d9130241b8da16ac3e50f99579cdfc365fcc417) | `` linux_6_10: 6.10.10 -> 6.10.11 ``                                                |
| [`426f7bd1`](https://github.com/NixOS/nixpkgs/commit/426f7bd11c61dda9611920eac30e9c081c1a41fd) | `` lowdown: patch to fix macOS and UTF-8 bugs ``                                    |
| [`944b7a9d`](https://github.com/NixOS/nixpkgs/commit/944b7a9df3b5a7f577dd52e00a7dce3d844b2378) | `` chromium,chromedriver: 128.0.6613.137 -> 129.0.6668.58 ``                        |
| [`875e6ad2`](https://github.com/NixOS/nixpkgs/commit/875e6ad20a4f62d1b2c6c9e395f74f07b105e7a4) | `` nixos/systemd-boot: Fix regression in builder script ``                          |
| [`04e5385d`](https://github.com/NixOS/nixpkgs/commit/04e5385d9a5430b62c5a09f09b10490789e16f9d) | `` lxd-unwrapped-lts: 5.21.1 -> 5.21.2 ``                                           |