### PR TITLE
chore(flake/plasma-manager): `7fb80fea` -> `8b06b3ea`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -412,11 +412,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1726955367,
-        "narHash": "sha256-+RNT92e6I4s4q/SLdzlMrPQrxalOmNwnEt6zcYo4j84=",
+        "lastModified": 1727008344,
+        "narHash": "sha256-djaMevwLWodufSD4RGnQP5o7FXGKWRwNikyW0Hv6f7g=",
         "owner": "pjones",
         "repo": "plasma-manager",
-        "rev": "7fb80fea2373c3cc9f05a84204ad0b3233464b17",
+        "rev": "8b06b3ea025545a9f4463709058f56a001da1215",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                        | Message                                                                      |
| ------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------- |
| [`8b06b3ea`](https://github.com/nix-community/plasma-manager/commit/8b06b3ea025545a9f4463709058f56a001da1215) | `` Add pausePlayersOnSuspend option to powerdevil module (#369) ``           |
| [`353abd96`](https://github.com/nix-community/plasma-manager/commit/353abd96844947eaca359661dd6000f72165fbc4) | `` Ensure power actions are correctly applied in powerdevil module (#368) `` |