### PR TITLE
chore(flake/plasma-manager): `8b06b3ea` -> `6f1db348`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -412,11 +412,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1727008344,
-        "narHash": "sha256-djaMevwLWodufSD4RGnQP5o7FXGKWRwNikyW0Hv6f7g=",
+        "lastModified": 1727020652,
+        "narHash": "sha256-zwTXt1bcf+wycX389ZyJFzUO2gzCb16ButXxiX2iA7Y=",
         "owner": "pjones",
         "repo": "plasma-manager",
-        "rev": "8b06b3ea025545a9f4463709058f56a001da1215",
+        "rev": "6f1db348fcb89fd6b0b9c32e279d29ee6b4d1272",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                        | Message                                                       |
| ------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------- |
| [`6f1db348`](https://github.com/nix-community/plasma-manager/commit/6f1db348fcb89fd6b0b9c32e279d29ee6b4d1272) | `` Add treefmt for formatting and format everything (#370) `` |