### PR TITLE
chore(flake/home-manager): `04213d1c` -> `21c02186`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -356,11 +356,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1726985855,
-        "narHash": "sha256-NJPGK030Y3qETpWBhj9oobDQRbXdXOPxtu+YgGvZ84o=",
+        "lastModified": 1727111745,
+        "narHash": "sha256-EYLvFRoTPWtD+3uDg2wwQvlz88OrIr3zld+jFE5gDcY=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "04213d1ce4221f5d9b40bcee30706ce9a91d148d",
+        "rev": "21c021862fa696c8199934e2153214ab57150cb6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                               |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------- |
| [`21c02186`](https://github.com/nix-community/home-manager/commit/21c021862fa696c8199934e2153214ab57150cb6) | `` ci: disable the tests for macos `` |