### PR TITLE
chore(flake/nixpkgs-stable): `944b2aea` -> `23cbb250`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -408,11 +408,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1726838390,
-        "narHash": "sha256-NmcVhGElxDbmEWzgXsyAjlRhUus/nEqPC5So7BOJLUM=",
+        "lastModified": 1726969270,
+        "narHash": "sha256-8fnFlXBgM/uSvBlLWjZ0Z0sOdRBesyNdH0+esxqizGc=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "944b2aea7f0a2d7c79f72468106bc5510cbf5101",
+        "rev": "23cbb250f3bf4f516a2d0bf03c51a30900848075",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                       |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------- |
| [`3dec2084`](https://github.com/NixOS/nixpkgs/commit/3dec208437c4d3072420a0c0ffd8f74d28a9ceb3) | `` discord-canary: 0.0.483 -> 0.0.492 ``                      |
| [`5d76b679`](https://github.com/NixOS/nixpkgs/commit/5d76b67907db253c98b46e51aff81cd6d3d5caa7) | `` ungoogled-chromium: 128.0.6613.137-1 -> 129.0.6668.58-1 `` |
| [`279e3a24`](https://github.com/NixOS/nixpkgs/commit/279e3a24e6ba903aa310c3238b45a7e84be5b4da) | `` arc-browser: 1.58.1-53264 -> 1.61.0-53949 ``               |
| [`79d9106e`](https://github.com/NixOS/nixpkgs/commit/79d9106ed6cd613c99d32e24e96b5e56b7edc573) | `` arc-browser: 1.55.0-52417 -> 1.58.1-53264 ``               |
| [`272a8a51`](https://github.com/NixOS/nixpkgs/commit/272a8a51ed86285ac664213e50277ceeda0b80d4) | `` grafana-agent: 0.42.0 -> 0.43.0 ``                         |
| [`0c123bab`](https://github.com/NixOS/nixpkgs/commit/0c123babc483a331d6d08ed1ccb3ed9d18fd3d67) | `` mautrix-meta: 0.3.2 -> 0.4.0 ``                            |
| [`3fbb64e5`](https://github.com/NixOS/nixpkgs/commit/3fbb64e5b6242f5048919cedee0dbc71a455896e) | `` dendrite: 0.13.7 -> 0.13.8 ``                              |
| [`c83e209a`](https://github.com/NixOS/nixpkgs/commit/c83e209a142863517bf9aa3d181c8922371c31b5) | `` python313: 3.13.0rc1 -> 3.13.0rc2 ``                       |
| [`36a44e33`](https://github.com/NixOS/nixpkgs/commit/36a44e333b9cc879ae2ba5a93bdfeeed32e1713c) | `` python310: 3.10.14 -> 3.10.15 ``                           |
| [`4ecb3ca1`](https://github.com/NixOS/nixpkgs/commit/4ecb3ca1e89b99f0780c2c5ff054e9572f5f9ba1) | `` python39: 3.9.19 -> 3.9.20 ``                              |
| [`d126c503`](https://github.com/NixOS/nixpkgs/commit/d126c5037327704a3b350f30a4d419959b21a838) | `` zitadel: add CVE-2024-41952 to knownVulnerabilities ``     |
| [`cfa7fe7a`](https://github.com/NixOS/nixpkgs/commit/cfa7fe7a380451f1124cf7d269e38e085ef40346) | `` zitadel: add patch for CVE-2024-41953 ``                   |