### PR TITLE
chore(flake/spicetify-nix): `27aefaa7` -> `863ec9bd`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -517,11 +517,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1727065001,
-        "narHash": "sha256-YG76K8qSYZ2el9HMGght15Bvo1xaxPYKTK9TWdJrWn0=",
+        "lastModified": 1727237824,
+        "narHash": "sha256-T/34AmPn0Sxrnjzr+vpQVK81bt3vAS7ajUTSsOsuP1k=",
         "owner": "Gerg-L",
         "repo": "spicetify-nix",
-        "rev": "27aefaa7fc56ea40202ad172b6e2f77f7377b2e7",
+        "rev": "863ec9bd1dcd383c4a22551ccb29234a73f094c8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                    |
| ----------------------------------------------------------------------------------------------------- | -------------------------- |
| [`863ec9bd`](https://github.com/Gerg-L/spicetify-nix/commit/863ec9bd1dcd383c4a22551ccb29234a73f094c8) | `` CI update 2024-09-25 `` |
| [`3a6d37e1`](https://github.com/Gerg-L/spicetify-nix/commit/3a6d37e1a968df0d61a0a34268376afb78fd5bfb) | `` CI update 2024-09-24 `` |