### PR TITLE
chore(flake/plasma-manager): `6f1db348` -> `a02fef2e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -464,11 +464,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1727020652,
-        "narHash": "sha256-zwTXt1bcf+wycX389ZyJFzUO2gzCb16ButXxiX2iA7Y=",
+        "lastModified": 1727210241,
+        "narHash": "sha256-lufS6uzSbSrggNCSgubymMQWnQMh7PvQ+lRZ8qH9Uoc=",
         "owner": "pjones",
         "repo": "plasma-manager",
-        "rev": "6f1db348fcb89fd6b0b9c32e279d29ee6b4d1272",
+        "rev": "a02fef2ece8084aff0b41700bb57d24d73574cd1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                        | Message                                                                 |
| ------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------- |
| [`a02fef2e`](https://github.com/nix-community/plasma-manager/commit/a02fef2ece8084aff0b41700bb57d24d73574cd1) | `` feat: add kara to additionalWidgetPackages (#365) ``                 |
| [`e3d60d6c`](https://github.com/nix-community/plasma-manager/commit/e3d60d6c8a0ff5f9b8b7db200589524c367af2f4) | `` fix(rc2nix): correct regex for boolean values (#371) ``              |
| [`d3b59aea`](https://github.com/nix-community/plasma-manager/commit/d3b59aea14a897e1031607aba5f86253b1d9dcbc) | `` Add known_data_files and a few more config files to rc2nix (#363) `` |