### PR TITLE
chore(flake/stylix): `cf8b6e2d` -> `993fcabd`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -501,11 +501,11 @@
         "tinted-tmux": "tinted-tmux"
       },
       "locked": {
-        "lastModified": 1727218376,
-        "narHash": "sha256-vRYd45uOqzXDaSt8M50hLcsBqIWbEMsflfHk/a1nYA8=",
+        "lastModified": 1727355527,
+        "narHash": "sha256-qFSPHeImI00fBzGTA94D66HMD+fJDkuz04WHp2Sg8eA=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "cf8b6e2d4e8aca8ef14b839a906ab5eb98b08561",
+        "rev": "993fcabd83d1e0ee5ea038b87041593cc73c1ebe",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                        | Message                                                                        |
| --------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------ |
| [`4b15fdcc`](https://github.com/danth/stylix/commit/4b15fdcc875dac45c37a7bc79d49a3e9a3062ac7) | `` stylix: remove deprecated 'stylix.palette.<BASE>' options at end-of-life `` |
| [`dba4bd2d`](https://github.com/danth/stylix/commit/dba4bd2d89450fac0295581f795ea9757921f695) | `` treewide: declare end-of-life for deprecated options ``                     |