### PR TITLE
chore(flake/stylix): `993fcabd` -> `e3eb7fdf`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -501,11 +501,11 @@
         "tinted-tmux": "tinted-tmux"
       },
       "locked": {
-        "lastModified": 1727355527,
-        "narHash": "sha256-qFSPHeImI00fBzGTA94D66HMD+fJDkuz04WHp2Sg8eA=",
+        "lastModified": 1727362643,
+        "narHash": "sha256-Ceiq/aYjRlRBU677lBaemn8ZU2Jpr08Iso6UlBc9nFc=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "993fcabd83d1e0ee5ea038b87041593cc73c1ebe",
+        "rev": "e3eb7fdf8d129ff3676dfbc84ee1262322ca6fb4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                        | Message                                                     |
| --------------------------------------------------------------------------------------------- | ----------------------------------------------------------- |
| [`e3eb7fdf`](https://github.com/danth/stylix/commit/e3eb7fdf8d129ff3676dfbc84ee1262322ca6fb4) | `` vesktop: replace home.file with xdg.configFile (#575) `` |
| [`31902393`](https://github.com/danth/stylix/commit/3190239337e420afe0d1d4d4b927388e2d29be22) | `` regreet: init (#568) ``                                  |