### PR TITLE
chore(flake/plasma-manager): `a02fef2e` -> `29ad64f0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -416,11 +416,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1727210241,
-        "narHash": "sha256-lufS6uzSbSrggNCSgubymMQWnQMh7PvQ+lRZ8qH9Uoc=",
+        "lastModified": 1727463368,
+        "narHash": "sha256-5glMknkwQejUrKy28iy/kCFlSMwHcVyf/whmxqD0ggk=",
         "owner": "pjones",
         "repo": "plasma-manager",
-        "rev": "a02fef2ece8084aff0b41700bb57d24d73574cd1",
+        "rev": "29ad64f0ac4ae84710dfeb1d37572d95c94cbfd8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                        | Message                                                               |
| ------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------- |
| [`29ad64f0`](https://github.com/nix-community/plasma-manager/commit/29ad64f0ac4ae84710dfeb1d37572d95c94cbfd8) | `` feat(input): add displayName option for keyboard layouts (#374) `` |