### PR TITLE
chore(flake/nixpkgs-stable): `759537f0` -> `f6514145`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -324,11 +324,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1727264057,
-        "narHash": "sha256-KQPI8CTTnB9CrJ7LrmLC4VWbKZfljEPBXOFGZFRpxao=",
+        "lastModified": 1727397532,
+        "narHash": "sha256-pojbL/qteElw/nIXlN8kmHn/w6PQbEHr7Iz+WOXs0EM=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "759537f06e6999e141588ff1c9be7f3a5c060106",
+        "rev": "f65141456289e81ea0d5a05af8898333cab5c53d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                   |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------- |
| [`f1c0a9ca`](https://github.com/NixOS/nixpkgs/commit/f1c0a9cab48e2ec2da7c092f6fbf2ef0e089cf27) | `` nixVersions.nix_2_18: 2.18.7 -> 2.18.8 ``                              |
| [`48db5e72`](https://github.com/NixOS/nixpkgs/commit/48db5e72f2c9efd0025f7d16057814bd41866a7e) | `` nixos/printing: add option to disable browsed daemon ``                |
| [`df1cdd16`](https://github.com/NixOS/nixpkgs/commit/df1cdd1692ad3287d785b8c54b45e47dbb1a7901) | `` ungoogled-chromium: 129.0.6668.58-1 -> 129.0.6668.70-1 ``              |
| [`3d65908b`](https://github.com/NixOS/nixpkgs/commit/3d65908b7068db2371d24b797cc048becafeba1e) | `` chromium,chromedriver: 129.0.6668.58 -> 129.0.6668.70 ``               |
| [`46ef0796`](https://github.com/NixOS/nixpkgs/commit/46ef0796b61f19ee6b75dff793119ec1fe819230) | `` linuxPackages_6_11.perf: fix build ``                                  |
| [`0c5e6904`](https://github.com/NixOS/nixpkgs/commit/0c5e6904f3074a2baf79013f9f87710edcbe760d) | `` nixVersions.nix_2_24: 2.24.7 -> 2.24.8 ``                              |
| [`89a6369f`](https://github.com/NixOS/nixpkgs/commit/89a6369f7f2ad45559c58b3a22c36f7c41ad3cd6) | `` [Backport release-24.05] rustdesk-flutter: 1.3.0 -> 1.3.1 (#344379) `` |
| [`697fad2b`](https://github.com/NixOS/nixpkgs/commit/697fad2bae52c50ab11b3ab44ecc6e95325ec1c8) | `` cinnamon.cinnamon-screensaver: Ignore shift-f10 keybinding ``          |
| [`5a084d21`](https://github.com/NixOS/nixpkgs/commit/5a084d21e8bbd3c3eb1c484c449cdd257aaa3cea) | `` incus-lts: 6.0.1 -> 6.0.2 ``                                           |
| [`d0708e5e`](https://github.com/NixOS/nixpkgs/commit/d0708e5ebc782e67bfdf535e7b75765fde8ef803) | `` lxcfs: 6.0.1 -> 6.0.2 ``                                               |
| [`298d62ae`](https://github.com/NixOS/nixpkgs/commit/298d62ae7a27b95a98ad2dc7709cf341d35989aa) | `` lxc: 6.0.1 -> 6.0.2 ``                                                 |
| [`a5456f49`](https://github.com/NixOS/nixpkgs/commit/a5456f496b011a198752b0e3d4cda22ea80eb5b0) | `` lgogdownloader: move to `pkgs/by-name` ``                              |
| [`7d50e6b0`](https://github.com/NixOS/nixpkgs/commit/7d50e6b0c4e686aa8d743c24a97e25c37c1b23bd) | `` lgogdownloader: remove `meta = with lib;` ``                           |
| [`2ad7b707`](https://github.com/NixOS/nixpkgs/commit/2ad7b7075fd8e4fd2626b6c6059cd28b98dc7004) | `` lgogdownloader: format with nixfmt ``                                  |
| [`39b5f2cd`](https://github.com/NixOS/nixpkgs/commit/39b5f2cd31f303af429a80c146a319f05b982615) | `` lgogdownloader: 3.12 -> 3.14 ``                                        |
| [`9f592203`](https://github.com/NixOS/nixpkgs/commit/9f59220394088913764506831ae87878e4486593) | `` thunderbird-unwrapped: 128.1.1esr -> 128.2.3esr ``                     |
| [`436f3e01`](https://github.com/NixOS/nixpkgs/commit/436f3e0111caa2d04aa8d3aec23a024086ef0800) | `` linux_xanmod_latest: 6.10.9 -> 6.10.10 ``                              |
| [`a5b75d9b`](https://github.com/NixOS/nixpkgs/commit/a5b75d9b8e0f4052f73f3e2e85e16167489528bc) | `` linux_xanmod: 6.6.50 -> 6.6.51 ``                                      |
| [`04ba303d`](https://github.com/NixOS/nixpkgs/commit/04ba303d190f21ee15da832ef68d73fb8466bdb5) | `` nixos/prometheus-smartctl-exporter: fix NVMe scanning ``               |
| [`06bd95b2`](https://github.com/NixOS/nixpkgs/commit/06bd95b2a3870a9802229d355022f6c1678d2e7c) | `` papers: Make thumbnailer file point to absolute path ``                |
| [`e5dc2bc7`](https://github.com/NixOS/nixpkgs/commit/e5dc2bc7a48d5c8dbd74c35244e3081361902360) | `` linux_xanmod_latest: 6.10.7 -> 6.10.9 ``                               |
| [`278120e2`](https://github.com/NixOS/nixpkgs/commit/278120e2fa71d2856f46d147d7ffff4fad5a47e4) | `` linux_xanmod: 6.6.48 -> 6.6.50 ``                                      |