### PR TITLE
chore(flake/nixpkgs-stable): `f6514145` -> `fbca5e74`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -324,11 +324,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1727397532,
-        "narHash": "sha256-pojbL/qteElw/nIXlN8kmHn/w6PQbEHr7Iz+WOXs0EM=",
+        "lastModified": 1727540905,
+        "narHash": "sha256-40J9tW7Y794J7Uw4GwcAKlMxlX2xISBl6IBigo83ih8=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "f65141456289e81ea0d5a05af8898333cab5c53d",
+        "rev": "fbca5e745367ae7632731639de5c21f29c8744ed",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                     |
| ---------------------------------------------------------------------------------------------- | ----------------------------------------------------------- |
| [`4962ad33`](https://github.com/NixOS/nixpkgs/commit/4962ad3390878ecb095262227f5d1b8d56fbc634) | `` brave: 1.70.117 -> 1.70.119 ``                           |
| [`cad72553`](https://github.com/NixOS/nixpkgs/commit/cad72553776976da6754e035490f032e6dbf7012) | `` spotify: 1.2.42.290.g242057a2 -> 1.2.45.454.gc16ec9f6 `` |
| [`bf83c15f`](https://github.com/NixOS/nixpkgs/commit/bf83c15f98183dd79f3e428f7027f9be929637c6) | `` grafana-agent: 0.43.0 -> 0.43.3 ``                       |
| [`ea20d767`](https://github.com/NixOS/nixpkgs/commit/ea20d767803885e15c9c9442ce122b10a390c594) | `` qq: 3.2.12-2024.9.2 -> 3.2.12-2024.9.27 ``               |
| [`e5a42b38`](https://github.com/NixOS/nixpkgs/commit/e5a42b38b87f09da1f3a669bc66674b457dec52e) | `` cups-filters: apply patch for CVE-2024-47076 ``          |
| [`7da1d417`](https://github.com/NixOS/nixpkgs/commit/7da1d417b36c66621d1ae43aa44ea5617b66fa0e) | `` nixos/influxdb2: wait until service is ready ``          |
| [`d39407cc`](https://github.com/NixOS/nixpkgs/commit/d39407cc783d6e63f070a1f18a2eaa1d0db0599d) | `` lgogdownloader: 3.14 -> 3.15 ``                          |
| [`e985bf72`](https://github.com/NixOS/nixpkgs/commit/e985bf725f5cac1d41ea70ce74a4d0f35afffdcf) | `` floorp-unwrapped: 11.17.8 -> 11.18.1 ``                  |
| [`8ba50eb1`](https://github.com/NixOS/nixpkgs/commit/8ba50eb123785dc8d206497e7247afc81023c2b9) | `` floorp-unwrapped: 11.17.7 -> 11.17.8 ``                  |
| [`70dfde41`](https://github.com/NixOS/nixpkgs/commit/70dfde41fe654593353e7d1f82af05a63fea890f) | `` emacs: do not allow webkitgtk on Emacs >= 30 ``          |
| [`91f34d54`](https://github.com/NixOS/nixpkgs/commit/91f34d54d41a5a2738afba98e667822fb2a0e1c0) | `` floorp: 11.17.5 -> 11.17.7 ``                            |
| [`c1a0c8ab`](https://github.com/NixOS/nixpkgs/commit/c1a0c8abf106aa4e475da9c6ed808becd968b6e2) | `` smtp4dev: init at 3.3.4 Fix style and refs ``            |
| [`c0fcb4f1`](https://github.com/NixOS/nixpkgs/commit/c0fcb4f14be9afc42959b1b83d70bf4409c192c8) | `` smtp4dev: init at 3.3.4 ``                               |
| [`3002cd23`](https://github.com/NixOS/nixpkgs/commit/3002cd2380d272a295efa174b3148cb5b7d632e2) | `` traefik: backport fix for CVE-2024-45410 ``              |
| [`ef0d329f`](https://github.com/NixOS/nixpkgs/commit/ef0d329f7ae94ed5329eae6f10dc42477c4c1b25) | `` traefik: 3.1.1 -> 3.1.2 ``                               |
| [`498d121b`](https://github.com/NixOS/nixpkgs/commit/498d121bf472e7e424f61ecc01ec9a3941680d24) | `` traefik: 3.1.0 -> 3.1.1 ``                               |
| [`ee515441`](https://github.com/NixOS/nixpkgs/commit/ee5154414f18ee7c23354dd6d59a3454928a215f) | `` traefik: 3.0.4 -> 3.1.0 ``                               |
| [`969227bb`](https://github.com/NixOS/nixpkgs/commit/969227bbe5f68b83e3aec50c8ce3b9ca4b25149d) | `` rcu: 2024.001p -> 2024.001q ``                           |
| [`57729df6`](https://github.com/NixOS/nixpkgs/commit/57729df607895ceafbb1a4e4c2d5cc6c40d7ed70) | `` rcu: Convert hash to SRI format ``                       |
| [`d6475d26`](https://github.com/NixOS/nixpkgs/commit/d6475d262d03af4181b5b493ff78dbfb5edc4d1a) | `` rcu: disable build on hydra ``                           |
| [`f2823764`](https://github.com/NixOS/nixpkgs/commit/f2823764cbccbe4c9c9c160955e5c1e364be92b2) | `` darling: fix build ``                                    |
| [`c1a0bc43`](https://github.com/NixOS/nixpkgs/commit/c1a0bc43be51452938f8b88275eae420524ab7f9) | `` cpu-x: add version test ``                               |
| [`e9514b2b`](https://github.com/NixOS/nixpkgs/commit/e9514b2b5c51ae6632b3b2822905b8bafe15942b) | `` cpu-x: modernise ``                                      |
| [`30aa3b07`](https://github.com/NixOS/nixpkgs/commit/30aa3b074c319bd6bd9062cc97fb9238d68596a4) | `` cpu-x: fix gtk support ``                                |
| [`468901ff`](https://github.com/NixOS/nixpkgs/commit/468901fff857e5665546ecc85e97ffd104756445) | `` cpu-x: avoid double-wrapping ``                          |
| [`00d6cfaa`](https://github.com/NixOS/nixpkgs/commit/00d6cfaa3bb7a6a5fdae5823778a63e431d96200) | `` cpu-x: nixfmt ``                                         |
| [`5bca104b`](https://github.com/NixOS/nixpkgs/commit/5bca104b7acf7e5e854de8057bd1efc9c6469d12) | `` matrix-gtk-theme: init at 0-unstable-2024-07-22 ``       |
| [`ad600666`](https://github.com/NixOS/nixpkgs/commit/ad6006660cecd799e4c408aa8c0e6ff6229f3ed8) | `` python311Packages.pycycling: init at 0.4.0 ``            |
| [`88f31dca`](https://github.com/NixOS/nixpkgs/commit/88f31dcaa442e6c034d47a293195f98321cdd757) | `` luaPackages.sqlite: make it work out of the box ``       |
| [`32480636`](https://github.com/NixOS/nixpkgs/commit/3248063613e46a05844841672546f30eca6ad807) | `` luaPackages.toml: remove debug leftover ``               |