### PR TITLE
chore(flake/spicetify-nix): `cf348178` -> `77a53c2f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -416,11 +416,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1727583380,
-        "narHash": "sha256-Wd73LwQvQufwlPWsCPTvc/hV7dYbQl6i9dS0e1hQTdA=",
+        "lastModified": 1727658421,
+        "narHash": "sha256-myoca5QJaI1P8tJfUxDvPIZDJnTjhT2IrJM5bWTyIHI=",
         "owner": "Gerg-L",
         "repo": "spicetify-nix",
-        "rev": "cf34817877db467a9c881ffa1de3d2822fdc137a",
+        "rev": "77a53c2fd59f829ace666aa371ec7004c1db5b5f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                  |
| ----------------------------------------------------------------------------------------------------- | ---------------------------------------- |
| [`77a53c2f`](https://github.com/Gerg-L/spicetify-nix/commit/77a53c2fd59f829ace666aa371ec7004c1db5b5f) | `` change to more traditional builder `` |
| [`5a6eb6d0`](https://github.com/Gerg-L/spicetify-nix/commit/5a6eb6d07dd6599c2721e705bfab300f0b33b2f7) | `` set sidebarConfig to false always ``  |