### PR TITLE
chore(flake/nixpkgs-stable): `fbca5e74` -> `1719f27d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -324,11 +324,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1727540905,
-        "narHash": "sha256-40J9tW7Y794J7Uw4GwcAKlMxlX2xISBl6IBigo83ih8=",
+        "lastModified": 1727672256,
+        "narHash": "sha256-9/79hjQc9+xyH+QxeMcRsA6hDyw6Z9Eo1/oxjvwirLk=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "fbca5e745367ae7632731639de5c21f29c8744ed",
+        "rev": "1719f27dd95fd4206afb9cec9f415b539978827e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                           |
| ---------------------------------------------------------------------------------------------- | ----------------------------------------------------------------- |
| [`fbab02e6`](https://github.com/NixOS/nixpkgs/commit/fbab02e64d957745fc618663aa5abc557540ac06) | `` outline: 0.79.0 -> 0.80.2 ``                                   |
| [`a091ccc1`](https://github.com/NixOS/nixpkgs/commit/a091ccc1be8f8ffa3bfd08506a11ac8aac30e2ae) | `` firefly-iii: 6.1.19 -> 6.1.20 ``                               |
| [`b52edc81`](https://github.com/NixOS/nixpkgs/commit/b52edc81b70ffc51e13b33b21e401620bb1459ea) | `` meshcentral: 1.1.30 -> 1.1.31 ``                               |
| [`8762b8ed`](https://github.com/NixOS/nixpkgs/commit/8762b8ed44d543c4d9e0d2d85fd4dff39bd5d6f1) | `` php83: 8.3.11 -> 8.3.12 ``                                     |
| [`ce5e0253`](https://github.com/NixOS/nixpkgs/commit/ce5e0253dc5351afd25d3fa7c2fe10902397dfe8) | `` php82: 8.2.23 -> 8.2.24 ``                                     |
| [`daf78364`](https://github.com/NixOS/nixpkgs/commit/daf78364266dba5ac8562130825a56cd87e9fa17) | `` php81: 8.1.29 -> 8.1.30 ``                                     |
| [`ced0da1e`](https://github.com/NixOS/nixpkgs/commit/ced0da1e7e7d50f1352bc6bdd25af8ae55eb3934) | `` nixos/invidious: add options for configuring inv-sig-helper `` |
| [`6485f89d`](https://github.com/NixOS/nixpkgs/commit/6485f89da4d5759d184666eecc08851f7c6b9dc6) | `` inv-sig-helper: init at 0-unstable-2024-08-17 ``               |
| [`0fb2db3e`](https://github.com/NixOS/nixpkgs/commit/0fb2db3e7a6294bf416665df2a21a1358238f341) | `` grafana: 10.4.8 -> 10.4.9, fix CVE-2024-8118 ``                |
| [`ae75e6ce`](https://github.com/NixOS/nixpkgs/commit/ae75e6ce663433bdd395e19e9a35fae9b5b2ef70) | `` mattermost-desktop: 5.8.1 -> 5.9.0 ``                          |
| [`30525fac`](https://github.com/NixOS/nixpkgs/commit/30525facdef7a8399ea934bf4dbb6f428d7267f1) | `` mattermost-desktop: 5.7.0 -> 5.8.1 ``                          |
| [`764e2fdd`](https://github.com/NixOS/nixpkgs/commit/764e2fddece4e091cd8c549b4dc8ac695d266a24) | `` tor-browser: 13.5.4 -> 13.5.5 ``                               |