### PR TITLE
chore(flake/nixpkgs): `27e30d17` -> `5966581a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -56,6 +56,22 @@
         "type": "github"
       }
     },
+    "base16-foot": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1727574105,
+        "narHash": "sha256-ByMVgH0rZ1by2YIVJ47gE8/ZHWcG8yqsErQ4tKLbm7Q=",
+        "owner": "tinted-theming",
+        "repo": "base16-foot",
+        "rev": "e558fe47e187093313f19fa6a9eea61940ffbd6b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "tinted-theming",
+        "repo": "base16-foot",
+        "type": "github"
+      }
+    },
     "base16-helix": {
       "flake": false,
       "locked": {
@@ -72,18 +88,50 @@
         "type": "github"
       }
     },
-    "base16-vim": {
+    "base16-kitty": {
       "flake": false,
       "locked": {
-        "lastModified": 1716150083,
-        "narHash": "sha256-ZMhnNmw34ogE5rJZrjRv5MtG3WaqKd60ds2VXvT6hEc=",
+        "lastModified": 1721117198,
+        "narHash": "sha256-+vEXvEsar7w7wPVRmKx+rJKUTD5DBgLR7jfl0k7VhnE=",
+        "owner": "kdrag0n",
+        "repo": "base16-kitty",
+        "rev": "0898f2677f3a583cc6a89bde29b2b05ac2041e0b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "kdrag0n",
+        "repo": "base16-kitty",
+        "type": "github"
+      }
+    },
+    "base16-tmux": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1727571738,
+        "narHash": "sha256-AOITVZMhqELOzL5Jw54NIX7R8gFbTJqrHEDuPwgGYDQ=",
         "owner": "tinted-theming",
-        "repo": "base16-vim",
-        "rev": "6e955d704d046b0dc3e5c2d68a2a6eeffd2b5d3d",
+        "repo": "base16-tmux",
+        "rev": "44fbe9034653c83a8ae68941aaeeeeb7503cd1ae",
         "type": "github"
       },
       "original": {
         "owner": "tinted-theming",
+        "repo": "base16-tmux",
+        "type": "github"
+      }
+    },
+    "base16-vim": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1663659192,
+        "narHash": "sha256-uJvaYYDMXvoo0fhBZUhN8WBXeJ87SRgof6GEK2efFT0=",
+        "owner": "chriskempson",
+        "repo": "base16-vim",
+        "rev": "3be3cd82cd31acfcab9a41bad853d9c68d30478d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "chriskempson",
         "repo": "base16-vim",
         "type": "github"
       }
@@ -195,27 +243,6 @@
         "type": "github"
       }
     },
-    "flake-utils": {
-      "inputs": {
-        "systems": [
-          "stylix",
-          "systems"
-        ]
-      },
-      "locked": {
-        "lastModified": 1710146030,
-        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
     "flakeCompat": {
       "flake": false,
       "locked": {
@@ -272,15 +299,16 @@
         ]
       },
       "locked": {
-        "lastModified": 1727817100,
-        "narHash": "sha256-dlyV9/eiWkm/Y/t2+k4CFZ29tBvCANmJogEYaHeAOTw=",
+        "lastModified": 1726989464,
+        "narHash": "sha256-Vl+WVTJwutXkimwGprnEtXc/s/s8sMuXzqXaspIGlwM=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "437ec62009fa8ceb684eb447d455ffba25911cf9",
+        "rev": "2f23fa308a7c067e52dfcc30a0758f47043ec176",
         "type": "github"
       },
       "original": {
         "owner": "nix-community",
+        "ref": "release-24.05",
         "repo": "home-manager",
         "type": "github"
       }
@@ -308,6 +336,22 @@
     },
     "nixpkgs": {
       "locked": {
+        "lastModified": 1727907660,
+        "narHash": "sha256-QftbyPoieM5M50WKUMzQmWtBWib/ZJbHo7mhj5riQec=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "5966581aa04be7eff830b9e1457d56dc70a0b798",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-24.05",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-unstable": {
+      "locked": {
         "lastModified": 1727802920,
         "narHash": "sha256-HP89HZOT0ReIbI7IJZJQoJgxvB2Tn28V6XS3MNKnfLs=",
         "owner": "nixos",
@@ -318,22 +362,6 @@
       "original": {
         "owner": "nixos",
         "ref": "nixos-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs-stable": {
-      "locked": {
-        "lastModified": 1727672256,
-        "narHash": "sha256-9/79hjQc9+xyH+QxeMcRsA6hDyw6Z9Eo1/oxjvwirLk=",
-        "owner": "nixos",
-        "repo": "nixpkgs",
-        "rev": "1719f27dd95fd4206afb9cec9f415b539978827e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nixos",
-        "ref": "nixos-24.05",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -384,7 +412,7 @@
         "fine-cmdline": "fine-cmdline",
         "home-manager": "home-manager",
         "nixpkgs": "nixpkgs",
-        "nixpkgs-stable": "nixpkgs-stable",
+        "nixpkgs-unstable": "nixpkgs-unstable",
         "plasma-manager": "plasma-manager",
         "spicetify-nix": "spicetify-nix",
         "stylix": "stylix",
@@ -433,94 +461,30 @@
       "inputs": {
         "base16": "base16",
         "base16-fish": "base16-fish",
+        "base16-foot": "base16-foot",
         "base16-helix": "base16-helix",
+        "base16-kitty": "base16-kitty",
+        "base16-tmux": "base16-tmux",
         "base16-vim": "base16-vim",
         "flake-compat": "flake-compat_3",
-        "flake-utils": "flake-utils",
         "gnome-shell": "gnome-shell",
         "home-manager": "home-manager_2",
         "nixpkgs": [
           "nixpkgs"
-        ],
-        "systems": "systems",
-        "tinted-foot": "tinted-foot",
-        "tinted-kitty": "tinted-kitty",
-        "tinted-tmux": "tinted-tmux"
+        ]
       },
       "locked": {
-        "lastModified": 1727723275,
-        "narHash": "sha256-k4HrG8TJQ0RqDS1tlDz71kvWFBNQ7qZI9T5Z0qLR85Y=",
+        "lastModified": 1718122552,
+        "narHash": "sha256-A+dBkSwp8ssHKV/WyXb9uqIYrHBqHvtSedU24Lq9lqw=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "e7e97059776da7e34b739415a7bc8f80f606b803",
+        "rev": "e59d2c1725b237c362e4a62f5722f5b268d566c7",
         "type": "github"
       },
       "original": {
         "owner": "danth",
+        "ref": "release-24.05",
         "repo": "stylix",
-        "type": "github"
-      }
-    },
-    "systems": {
-      "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
-        "owner": "nix-systems",
-        "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-systems",
-        "repo": "default",
-        "type": "github"
-      }
-    },
-    "tinted-foot": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1696725948,
-        "narHash": "sha256-65bz2bUL/yzZ1c8/GQASnoiGwaF8DczlxJtzik1c0AU=",
-        "owner": "tinted-theming",
-        "repo": "tinted-foot",
-        "rev": "eedbcfa30de0a4baa03e99f5e3ceb5535c2755ce",
-        "type": "github"
-      },
-      "original": {
-        "owner": "tinted-theming",
-        "repo": "tinted-foot",
-        "type": "github"
-      }
-    },
-    "tinted-kitty": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1665001328,
-        "narHash": "sha256-aRaizTYPpuWEcvoYE9U+YRX+Wsc8+iG0guQJbvxEdJY=",
-        "owner": "tinted-theming",
-        "repo": "tinted-kitty",
-        "rev": "06bb401fa9a0ffb84365905ffbb959ae5bf40805",
-        "type": "github"
-      },
-      "original": {
-        "owner": "tinted-theming",
-        "repo": "tinted-kitty",
-        "type": "github"
-      }
-    },
-    "tinted-tmux": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1696725902,
-        "narHash": "sha256-wDPg5elZPcQpu7Df0lI5O8Jv4A3T6jUQIVg63KDU+3Q=",
-        "owner": "tinted-theming",
-        "repo": "tinted-tmux",
-        "rev": "c02050bebb60dbb20cb433cd4d8ce668ecc11ba7",
-        "type": "github"
-      },
-      "original": {
-        "owner": "tinted-theming",
-        "repo": "tinted-tmux",
         "type": "github"
       }
     },


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                              |
| ---------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------- |
| [`73e971d4`](https://github.com/NixOS/nixpkgs/commit/73e971d42d3102b9e66a721bd68fa705880d5cfa) | `` matrix-synapse-unwrapped: 1.115.0 -> 1.116.0 ``                                                   |
| [`69be6d72`](https://github.com/NixOS/nixpkgs/commit/69be6d72ab4609eed4fd25a2729f9f395105e360) | `` meshcentral: 1.1.31 -> 1.1.32 ``                                                                  |
| [`39868f08`](https://github.com/NixOS/nixpkgs/commit/39868f081927e96eb572957f2962c991ba6563e9) | `` element-desktop: 1.11.77 -> 1.11.79 ``                                                            |
| [`61d217c3`](https://github.com/NixOS/nixpkgs/commit/61d217c34b5f912889dfa1d338a5e6a678246870) | `` teamspeak_client: update pluginsdk ``                                                             |
| [`0588150a`](https://github.com/NixOS/nixpkgs/commit/0588150a0a858b2028f325d938ab8f48bd21dfbe) | `` teamspeak_client: format with nixfmt ``                                                           |
| [`1b675565`](https://github.com/NixOS/nixpkgs/commit/1b6755659a271d5f261228d853a7405b984af9d0) | `` teamspeak_{client,server}: move distribution note ``                                              |
| [`87a6ef7e`](https://github.com/NixOS/nixpkgs/commit/87a6ef7e98f3b264b8da274de30dba1e991a3c30) | `` wireshark: 4.2.6 -> 4.2.7 ``                                                                      |
| [`20b569ac`](https://github.com/NixOS/nixpkgs/commit/20b569ac2ef5fd14692c585cedb7ddb2ea71929f) | `` libdigidocpp: update TSA_URL ``                                                                   |
| [`2954d8dd`](https://github.com/NixOS/nixpkgs/commit/2954d8dd2e7dbdc40b1c03b923e375ce29c86798) | `` nextcloud*Packages: another update to make more apps available on nc30 ``                         |
| [`17f95840`](https://github.com/NixOS/nixpkgs/commit/17f958406c03ce5eeed8e3cff4372f7743dbcbb9) | `` nextcloud30: init at 30.0.0 ``                                                                    |
| [`5809c973`](https://github.com/NixOS/nixpkgs/commit/5809c9739b8b89e08e8c826b78f8c2d95ead42e2) | `` nextcloud29Packages: update ``                                                                    |
| [`b0ff374e`](https://github.com/NixOS/nixpkgs/commit/b0ff374e7c7831f8f96ffcd514a82c5c43eed52b) | `` nextcloud28Packages: update ``                                                                    |
| [`613e41d2`](https://github.com/NixOS/nixpkgs/commit/613e41d2eed840ce2f119f198e2e7b5b4a468909) | `` signal-desktop: 7.25.0 -> 7.26.0 ``                                                               |
| [`343d2615`](https://github.com/NixOS/nixpkgs/commit/343d26152c416a180fd65f1c37e1e245865e2924) | `` microsoft-edge: 129.0.2792.52 -> 129.0.2792.65 ``                                                 |
| [`4aef69c7`](https://github.com/NixOS/nixpkgs/commit/4aef69c73e059b61083172d925567e46fed00ca3) | `` linux/common-config: update for 6.12 ``                                                           |
| [`e8a8a3d0`](https://github.com/NixOS/nixpkgs/commit/e8a8a3d0d952237494d64d44e5dbe1056bff6882) | `` linux-rt_6_6: 6.6.49-rt41 -> 6.6.52-rt43 ``                                                       |
| [`7701c2d4`](https://github.com/NixOS/nixpkgs/commit/7701c2d4c9b4b62c2f8e2d4d4c884af0021fc2b3) | `` linux-rt_6_1: 6.1.108-rt40 -> 6.1.111-rt42 ``                                                     |
| [`46c63c1c`](https://github.com/NixOS/nixpkgs/commit/46c63c1c7c5c01a07cd35caf19c3e9bdcf81d64b) | `` linux-rt_5_10: 5.10.224-rt116 -> 5.10.225-rt117 ``                                                |
| [`8749852c`](https://github.com/NixOS/nixpkgs/commit/8749852c4d102ea7854dc3684585f18989d380d1) | `` linux_6_1: 6.1.111 -> 6.1.112 ``                                                                  |
| [`f7c914b0`](https://github.com/NixOS/nixpkgs/commit/f7c914b0932cb1fe50f9349babe81940965440df) | `` linux_6_6: 6.6.52 -> 6.6.53 ``                                                                    |
| [`14aaecf2`](https://github.com/NixOS/nixpkgs/commit/14aaecf23700e742f475cb2047c8d4d0f249e7ef) | `` linux_6_10: 6.10.11 -> 6.10.12 ``                                                                 |
| [`56208614`](https://github.com/NixOS/nixpkgs/commit/562086149e97ce485276b5a7b7975251fee362d2) | `` linux_6_11: 6.11 -> 6.11.1 ``                                                                     |
| [`29f829e5`](https://github.com/NixOS/nixpkgs/commit/29f829e5ca32c740ff9b8e3b93bfb6f8f10345b8) | `` linux_testing: 6.11-rc7 -> 6.12-rc1 ``                                                            |
| [`8344c101`](https://github.com/NixOS/nixpkgs/commit/8344c101f3f06e85503ae88d8bd687e960bf8c58) | `` strace: set enableParallelBuilding = true ``                                                      |
| [`52443360`](https://github.com/NixOS/nixpkgs/commit/5244336058d861ad3cc4b103e6468c9a7af6dc85) | `` nss_latest: 3.104 -> 3.105 ``                                                                     |
| [`fb5dba65`](https://github.com/NixOS/nixpkgs/commit/fb5dba65045edde328685f1986fd28a22a1e5d81) | `` vivaldi: 6.9.3447.46 -> 6.9.3447.48 ``                                                            |
| [`19a38a0d`](https://github.com/NixOS/nixpkgs/commit/19a38a0d75f127b5f33c4246601ac6921a0972ad) | `` mastodon: 4.2.12 -> 4.2.13 ``                                                                     |
| [`69d489f3`](https://github.com/NixOS/nixpkgs/commit/69d489f347be2088b8010398adb97eb8205bf8f8) | `` chess-clock: 0.6.0 -> 0.6.1 (#344378) ``                                                          |
| [`fbab02e6`](https://github.com/NixOS/nixpkgs/commit/fbab02e64d957745fc618663aa5abc557540ac06) | `` outline: 0.79.0 -> 0.80.2 ``                                                                      |
| [`488841fe`](https://github.com/NixOS/nixpkgs/commit/488841fed56776f1f3c14a45baf2f8f98e33c743) | `` nvd: switch source repository to Sourcehut ``                                                     |
| [`2e74e35b`](https://github.com/NixOS/nixpkgs/commit/2e74e35bbc89eaad3289ffcd457c609b65df1238) | `` usage: init at 0.3.1 ``                                                                           |
| [`a091ccc1`](https://github.com/NixOS/nixpkgs/commit/a091ccc1be8f8ffa3bfd08506a11ac8aac30e2ae) | `` firefly-iii: 6.1.19 -> 6.1.20 ``                                                                  |
| [`b52edc81`](https://github.com/NixOS/nixpkgs/commit/b52edc81b70ffc51e13b33b21e401620bb1459ea) | `` meshcentral: 1.1.30 -> 1.1.31 ``                                                                  |
| [`8762b8ed`](https://github.com/NixOS/nixpkgs/commit/8762b8ed44d543c4d9e0d2d85fd4dff39bd5d6f1) | `` php83: 8.3.11 -> 8.3.12 ``                                                                        |
| [`ce5e0253`](https://github.com/NixOS/nixpkgs/commit/ce5e0253dc5351afd25d3fa7c2fe10902397dfe8) | `` php82: 8.2.23 -> 8.2.24 ``                                                                        |
| [`daf78364`](https://github.com/NixOS/nixpkgs/commit/daf78364266dba5ac8562130825a56cd87e9fa17) | `` php81: 8.1.29 -> 8.1.30 ``                                                                        |
| [`ced0da1e`](https://github.com/NixOS/nixpkgs/commit/ced0da1e7e7d50f1352bc6bdd25af8ae55eb3934) | `` nixos/invidious: add options for configuring inv-sig-helper ``                                    |
| [`6485f89d`](https://github.com/NixOS/nixpkgs/commit/6485f89da4d5759d184666eecc08851f7c6b9dc6) | `` inv-sig-helper: init at 0-unstable-2024-08-17 ``                                                  |
| [`0fb2db3e`](https://github.com/NixOS/nixpkgs/commit/0fb2db3e7a6294bf416665df2a21a1358238f341) | `` grafana: 10.4.8 -> 10.4.9, fix CVE-2024-8118 ``                                                   |
| [`4962ad33`](https://github.com/NixOS/nixpkgs/commit/4962ad3390878ecb095262227f5d1b8d56fbc634) | `` brave: 1.70.117 -> 1.70.119 ``                                                                    |
| [`ae75e6ce`](https://github.com/NixOS/nixpkgs/commit/ae75e6ce663433bdd395e19e9a35fae9b5b2ef70) | `` mattermost-desktop: 5.8.1 -> 5.9.0 ``                                                             |
| [`30525fac`](https://github.com/NixOS/nixpkgs/commit/30525facdef7a8399ea934bf4dbb6f428d7267f1) | `` mattermost-desktop: 5.7.0 -> 5.8.1 ``                                                             |
| [`cad72553`](https://github.com/NixOS/nixpkgs/commit/cad72553776976da6754e035490f032e6dbf7012) | `` spotify: 1.2.42.290.g242057a2 -> 1.2.45.454.gc16ec9f6 ``                                          |
| [`bf83c15f`](https://github.com/NixOS/nixpkgs/commit/bf83c15f98183dd79f3e428f7027f9be929637c6) | `` grafana-agent: 0.43.0 -> 0.43.3 ``                                                                |
| [`764e2fdd`](https://github.com/NixOS/nixpkgs/commit/764e2fddece4e091cd8c549b4dc8ac695d266a24) | `` tor-browser: 13.5.4 -> 13.5.5 ``                                                                  |
| [`ea20d767`](https://github.com/NixOS/nixpkgs/commit/ea20d767803885e15c9c9442ce122b10a390c594) | `` qq: 3.2.12-2024.9.2 -> 3.2.12-2024.9.27 ``                                                        |
| [`80237d8f`](https://github.com/NixOS/nixpkgs/commit/80237d8fc0c4a6614aaec68543802cad5bbd3e09) | `` skypeforlinux: 8.127.0.200 -> 8.129.0.201 ``                                                      |
| [`e5a42b38`](https://github.com/NixOS/nixpkgs/commit/e5a42b38b87f09da1f3a669bc66674b457dec52e) | `` cups-filters: apply patch for CVE-2024-47076 ``                                                   |
| [`7da1d417`](https://github.com/NixOS/nixpkgs/commit/7da1d417b36c66621d1ae43aa44ea5617b66fa0e) | `` nixos/influxdb2: wait until service is ready ``                                                   |
| [`d39407cc`](https://github.com/NixOS/nixpkgs/commit/d39407cc783d6e63f070a1f18a2eaa1d0db0599d) | `` lgogdownloader: 3.14 -> 3.15 ``                                                                   |
| [`e985bf72`](https://github.com/NixOS/nixpkgs/commit/e985bf725f5cac1d41ea70ce74a4d0f35afffdcf) | `` floorp-unwrapped: 11.17.8 -> 11.18.1 ``                                                           |
| [`8ba50eb1`](https://github.com/NixOS/nixpkgs/commit/8ba50eb123785dc8d206497e7247afc81023c2b9) | `` floorp-unwrapped: 11.17.7 -> 11.17.8 ``                                                           |
| [`70dfde41`](https://github.com/NixOS/nixpkgs/commit/70dfde41fe654593353e7d1f82af05a63fea890f) | `` emacs: do not allow webkitgtk on Emacs >= 30 ``                                                   |
| [`91f34d54`](https://github.com/NixOS/nixpkgs/commit/91f34d54d41a5a2738afba98e667822fb2a0e1c0) | `` floorp: 11.17.5 -> 11.17.7 ``                                                                     |
| [`f1c0a9ca`](https://github.com/NixOS/nixpkgs/commit/f1c0a9cab48e2ec2da7c092f6fbf2ef0e089cf27) | `` nixVersions.nix_2_18: 2.18.7 -> 2.18.8 ``                                                         |
| [`48db5e72`](https://github.com/NixOS/nixpkgs/commit/48db5e72f2c9efd0025f7d16057814bd41866a7e) | `` nixos/printing: add option to disable browsed daemon ``                                           |
| [`df1cdd16`](https://github.com/NixOS/nixpkgs/commit/df1cdd1692ad3287d785b8c54b45e47dbb1a7901) | `` ungoogled-chromium: 129.0.6668.58-1 -> 129.0.6668.70-1 ``                                         |
| [`3d65908b`](https://github.com/NixOS/nixpkgs/commit/3d65908b7068db2371d24b797cc048becafeba1e) | `` chromium,chromedriver: 129.0.6668.58 -> 129.0.6668.70 ``                                          |
| [`c1a0c8ab`](https://github.com/NixOS/nixpkgs/commit/c1a0c8abf106aa4e475da9c6ed808becd968b6e2) | `` smtp4dev: init at 3.3.4 Fix style and refs ``                                                     |
| [`c0fcb4f1`](https://github.com/NixOS/nixpkgs/commit/c0fcb4f14be9afc42959b1b83d70bf4409c192c8) | `` smtp4dev: init at 3.3.4 ``                                                                        |
| [`46ef0796`](https://github.com/NixOS/nixpkgs/commit/46ef0796b61f19ee6b75dff793119ec1fe819230) | `` linuxPackages_6_11.perf: fix build ``                                                             |
| [`0c5e6904`](https://github.com/NixOS/nixpkgs/commit/0c5e6904f3074a2baf79013f9f87710edcbe760d) | `` nixVersions.nix_2_24: 2.24.7 -> 2.24.8 ``                                                         |
| [`89a6369f`](https://github.com/NixOS/nixpkgs/commit/89a6369f7f2ad45559c58b3a22c36f7c41ad3cd6) | `` [Backport release-24.05] rustdesk-flutter: 1.3.0 -> 1.3.1 (#344379) ``                            |
| [`697fad2b`](https://github.com/NixOS/nixpkgs/commit/697fad2bae52c50ab11b3ab44ecc6e95325ec1c8) | `` cinnamon.cinnamon-screensaver: Ignore shift-f10 keybinding ``                                     |
| [`759537f0`](https://github.com/NixOS/nixpkgs/commit/759537f06e6999e141588ff1c9be7f3a5c060106) | `` coqPackages.hierarchy-builder: do not pass VFILES if version >= 1.1.0 (#341171) ``                |
| [`aac6c070`](https://github.com/NixOS/nixpkgs/commit/aac6c070f5f0dc87829c88179d7583532787b18d) | `` devenv: 1.1 -> 1.2 ``                                                                             |
| [`5a084d21`](https://github.com/NixOS/nixpkgs/commit/5a084d21e8bbd3c3eb1c484c449cdd257aaa3cea) | `` incus-lts: 6.0.1 -> 6.0.2 ``                                                                      |
| [`d0708e5e`](https://github.com/NixOS/nixpkgs/commit/d0708e5ebc782e67bfdf535e7b75765fde8ef803) | `` lxcfs: 6.0.1 -> 6.0.2 ``                                                                          |
| [`298d62ae`](https://github.com/NixOS/nixpkgs/commit/298d62ae7a27b95a98ad2dc7709cf341d35989aa) | `` lxc: 6.0.1 -> 6.0.2 ``                                                                            |
| [`a5456f49`](https://github.com/NixOS/nixpkgs/commit/a5456f496b011a198752b0e3d4cda22ea80eb5b0) | `` lgogdownloader: move to `pkgs/by-name` ``                                                         |
| [`7d50e6b0`](https://github.com/NixOS/nixpkgs/commit/7d50e6b0c4e686aa8d743c24a97e25c37c1b23bd) | `` lgogdownloader: remove `meta = with lib;` ``                                                      |
| [`2ad7b707`](https://github.com/NixOS/nixpkgs/commit/2ad7b7075fd8e4fd2626b6c6059cd28b98dc7004) | `` lgogdownloader: format with nixfmt ``                                                             |
| [`39b5f2cd`](https://github.com/NixOS/nixpkgs/commit/39b5f2cd31f303af429a80c146a319f05b982615) | `` lgogdownloader: 3.12 -> 3.14 ``                                                                   |
| [`3002cd23`](https://github.com/NixOS/nixpkgs/commit/3002cd2380d272a295efa174b3148cb5b7d632e2) | `` traefik: backport fix for CVE-2024-45410 ``                                                       |
| [`ef0d329f`](https://github.com/NixOS/nixpkgs/commit/ef0d329f7ae94ed5329eae6f10dc42477c4c1b25) | `` traefik: 3.1.1 -> 3.1.2 ``                                                                        |
| [`498d121b`](https://github.com/NixOS/nixpkgs/commit/498d121bf472e7e424f61ecc01ec9a3941680d24) | `` traefik: 3.1.0 -> 3.1.1 ``                                                                        |
| [`ee515441`](https://github.com/NixOS/nixpkgs/commit/ee5154414f18ee7c23354dd6d59a3454928a215f) | `` traefik: 3.0.4 -> 3.1.0 ``                                                                        |
| [`4fa7aade`](https://github.com/NixOS/nixpkgs/commit/4fa7aadebd47967516c0489364f32900a536478a) | `` fetchurl: enable TLS verification when credentials are used ``                                    |
| [`3d3fe6e6`](https://github.com/NixOS/nixpkgs/commit/3d3fe6e656e92b74da7cf74f80f8845a7032f622) | `` [Backport release-24.05] rustdesk-flutter: add missing libayatana-appindicator patch (#343894) `` |
| [`a280bb18`](https://github.com/NixOS/nixpkgs/commit/a280bb1899be8353bf5a92054471b51a6c05d13b) | `` koboldcpp: 1.74 -> 1.75.2 ``                                                                      |
| [`9f592203`](https://github.com/NixOS/nixpkgs/commit/9f59220394088913764506831ae87878e4486593) | `` thunderbird-unwrapped: 128.1.1esr -> 128.2.3esr ``                                                |
| [`b6b948c3`](https://github.com/NixOS/nixpkgs/commit/b6b948c36f09eb46fac710895aaa35a05c3f6590) | `` garage: move from sha256 to hash ``                                                               |
| [`08d69ce0`](https://github.com/NixOS/nixpkgs/commit/08d69ce0b771c0cfa1ea86c235fa8aad5232442b) | `` snipe-it: 7.0.11 -> 7.0.12 ``                                                                     |
| [`4a9e7971`](https://github.com/NixOS/nixpkgs/commit/4a9e7971aa381c1085149814f870473b664f8f4b) | `` snipe-it: 7.0.7 -> 7.0.11 ``                                                                      |
| [`80e9e2b1`](https://github.com/NixOS/nixpkgs/commit/80e9e2b14677ed4b08120deb25ca3499fc7382e5) | `` snipe-it: 7.0.6 -> 7.0.7 ``                                                                       |
| [`48d685b1`](https://github.com/NixOS/nixpkgs/commit/48d685b1115b7909f5caad0df87aa6cd0a24a07b) | `` snipe-it: 7.0.4 -> 7.0.6 ``                                                                       |
| [`4ce3feb2`](https://github.com/NixOS/nixpkgs/commit/4ce3feb29940f37c07f3dd88de0885399b428153) | `` snipe-it: 6.4.2 -> 7.0.4 ``                                                                       |
| [`bffd4c48`](https://github.com/NixOS/nixpkgs/commit/bffd4c48cae2ba50081808ffe96fb3aa8f6950b0) | `` colloid-gtk-theme: 2024-05-13 -> 2024-06-18 ``                                                    |
| [`a5cb8915`](https://github.com/NixOS/nixpkgs/commit/a5cb891595cce446e0ed71d9b6318f5f014ed0a3) | `` google-chrome: 128.0.6613.138 -> 129.0.6668.59 (Darwin) ``                                        |
| [`7982b54a`](https://github.com/NixOS/nixpkgs/commit/7982b54a507538a206e528f412a310b05b7164bc) | `` google-chrome: fix update script ``                                                               |
| [`643f7c5a`](https://github.com/NixOS/nixpkgs/commit/643f7c5aa24a3d4c4cddb9811feeda2a1d81a912) | `` signal-desktop: 7.24.1 -> 7.25.0 ``                                                               |
| [`b796bf9d`](https://github.com/NixOS/nixpkgs/commit/b796bf9d3f936573e43c91bd4353e9440436f421) | `` garage: 1.0.0 -> 1.0.1 ``                                                                         |
| [`56acf92e`](https://github.com/NixOS/nixpkgs/commit/56acf92e3d7fa46ea8fdf42827bf2fcbc247fecb) | `` wiki-js: 2.5.303 -> 2.5.304, fix CVE-2024-45298 ``                                                |
| [`6977bea3`](https://github.com/NixOS/nixpkgs/commit/6977bea3fa9f38aec52171e3beca86eaf7c1d40e) | `` matrix-synapse-unwrapped: 1.114.0 -> 1.115.0 ``                                                   |
| [`b34eac72`](https://github.com/NixOS/nixpkgs/commit/b34eac728a84c3086926eeec91a997cfb367bf4a) | `` [release-24.05]: update nix-fallback-paths ``                                                     |
| [`0ad5214f`](https://github.com/NixOS/nixpkgs/commit/0ad5214f14483dd815901b8e7ef9ca6b0d5e4375) | `` firefox-beta-unwrapped: 131.0b2 -> 131.0b9 ``                                                     |
| [`2207ebbb`](https://github.com/NixOS/nixpkgs/commit/2207ebbb4139074700e51b08054cf17c2bfbfd06) | `` firefox-devedition-unwrapped: 131.0b2 -> 131.0b9 ``                                               |
| [`f6726fa2`](https://github.com/NixOS/nixpkgs/commit/f6726fa233e37f1a6cfddddc2ddaca96158097eb) | `` firefox-beta-bin-unwrapped: 131.0b2 -> 131.0b9 ``                                                 |
| [`68b67dec`](https://github.com/NixOS/nixpkgs/commit/68b67decab56e6a3e8e04c13df3d6f3ab46f8e79) | `` firefox-devedition-bin-unwrapped: 131.0b2 -> 131.0b9 ``                                           |
| [`1217584b`](https://github.com/NixOS/nixpkgs/commit/1217584b501c89c840e0d9a139b9fd25a978469c) | `` vencord: 1.10.1 -> 1.10.2 ``                                                                      |
| [`0e9509ed`](https://github.com/NixOS/nixpkgs/commit/0e9509eda0a4fdf9ec9ed16a40b1d93c30e6651c) | `` google-chrome: 128.0.6613.137 -> 129.0.6668.58 ``                                                 |
| [`3dec2084`](https://github.com/NixOS/nixpkgs/commit/3dec208437c4d3072420a0c0ffd8f74d28a9ceb3) | `` discord-canary: 0.0.483 -> 0.0.492 ``                                                             |
| [`5d76b679`](https://github.com/NixOS/nixpkgs/commit/5d76b67907db253c98b46e51aff81cd6d3d5caa7) | `` ungoogled-chromium: 128.0.6613.137-1 -> 129.0.6668.58-1 ``                                        |
| [`279e3a24`](https://github.com/NixOS/nixpkgs/commit/279e3a24e6ba903aa310c3238b45a7e84be5b4da) | `` arc-browser: 1.58.1-53264 -> 1.61.0-53949 ``                                                      |
| [`4efa2759`](https://github.com/NixOS/nixpkgs/commit/4efa2759e539733681d96051a5997a9c159a4725) | `` brave: 1.69.168 -> 1.70.117 ``                                                                    |
| [`2b45d813`](https://github.com/NixOS/nixpkgs/commit/2b45d813e872169c2cb48d73266e760c4af9065d) | `` microsoft-edge: 128.0.2739.67 -> 129.0.2792.52 ``                                                 |
| [`dcedcd8d`](https://github.com/NixOS/nixpkgs/commit/dcedcd8d584d8db38ac7c1054acf747eecb6ac5c) | `` vivaldi: 6.9.3447.41 -> 6.9.3447.46 ``                                                            |
| [`79d9106e`](https://github.com/NixOS/nixpkgs/commit/79d9106ed6cd613c99d32e24e96b5e56b7edc573) | `` arc-browser: 1.55.0-52417 -> 1.58.1-53264 ``                                                      |
| [`272a8a51`](https://github.com/NixOS/nixpkgs/commit/272a8a51ed86285ac664213e50277ceeda0b80d4) | `` grafana-agent: 0.42.0 -> 0.43.0 ``                                                                |
| [`969227bb`](https://github.com/NixOS/nixpkgs/commit/969227bbe5f68b83e3aec50c8ce3b9ca4b25149d) | `` rcu: 2024.001p -> 2024.001q ``                                                                    |
| [`57729df6`](https://github.com/NixOS/nixpkgs/commit/57729df607895ceafbb1a4e4c2d5cc6c40d7ed70) | `` rcu: Convert hash to SRI format ``                                                                |
| [`0c123bab`](https://github.com/NixOS/nixpkgs/commit/0c123babc483a331d6d08ed1ccb3ed9d18fd3d67) | `` mautrix-meta: 0.3.2 -> 0.4.0 ``                                                                   |
| [`d6475d26`](https://github.com/NixOS/nixpkgs/commit/d6475d262d03af4181b5b493ff78dbfb5edc4d1a) | `` rcu: disable build on hydra ``                                                                    |
| [`d6366768`](https://github.com/NixOS/nixpkgs/commit/d63667683134ae2eb32bca7ecfbeb2bcfdc91923) | `` nixVersions.git: 2.25.0pre20240910 -> 2.25.0pre20240920 ``                                        |
| [`c592dd06`](https://github.com/NixOS/nixpkgs/commit/c592dd0687cbe42bd3a914062a6b5b2f7c6490dd) | `` nixVersions.nix_2_18: 2.18.5 -> 2.18.7 ``                                                         |
| [`e8d65bf4`](https://github.com/NixOS/nixpkgs/commit/e8d65bf48d05c1e339336727b89d87f0288f7739) | `` nixVersions.nix_2_24: 2.24.6 -> 2.24.7 ``                                                         |
| [`c34f195b`](https://github.com/NixOS/nixpkgs/commit/c34f195b67b3601c465d46b8ef5185adcec0b62d) | `` xone: fix kernel 6.11 compatibility ``                                                            |
| [`a219f9fb`](https://github.com/NixOS/nixpkgs/commit/a219f9fb3f229f1d033e36d53e6e8fb0a93a06eb) | `` envoy: 1.30.5 -> 1.30.6 ``                                                                        |
| [`85eeb641`](https://github.com/NixOS/nixpkgs/commit/85eeb641b1cb30a16ad77fb66c4f56c16c1183b4) | `` patroni: 3.3.2 -> 3.3.3 ``                                                                        |
| [`3093d8ec`](https://github.com/NixOS/nixpkgs/commit/3093d8ec1a34381af75d7510a30f56de07a96282) | `` tor-browser: 13.5.3 -> 13.5.4 ``                                                                  |
| [`b1d27e13`](https://github.com/NixOS/nixpkgs/commit/b1d27e13229408717e5c1d1511a7f0194d923bdf) | `` amazon-init: include the general system's software and wrappers in PATH ``                        |
| [`e6fb8a42`](https://github.com/NixOS/nixpkgs/commit/e6fb8a4224ecf6e44c96bc8e6a3b010cb7de2536) | `` amazon-ssm-agent: add the system's software to the path ``                                        |
| [`3fbb64e5`](https://github.com/NixOS/nixpkgs/commit/3fbb64e5b6242f5048919cedee0dbc71a455896e) | `` dendrite: 0.13.7 -> 0.13.8 ``                                                                     |
| [`436f3e01`](https://github.com/NixOS/nixpkgs/commit/436f3e0111caa2d04aa8d3aec23a024086ef0800) | `` linux_xanmod_latest: 6.10.9 -> 6.10.10 ``                                                         |
| [`a5b75d9b`](https://github.com/NixOS/nixpkgs/commit/a5b75d9b8e0f4052f73f3e2e85e16167489528bc) | `` linux_xanmod: 6.6.50 -> 6.6.51 ``                                                                 |
| [`04ba303d`](https://github.com/NixOS/nixpkgs/commit/04ba303d190f21ee15da832ef68d73fb8466bdb5) | `` nixos/prometheus-smartctl-exporter: fix NVMe scanning ``                                          |
| [`0a944de7`](https://github.com/NixOS/nixpkgs/commit/0a944de72cb2f92d6ed8801e7877ae46b3166533) | `` unit: fix php82 module argument ``                                                                |
| [`b768cf74`](https://github.com/NixOS/nixpkgs/commit/b768cf74944b22ae798c0c2552f2eee6c431a417) | `` gnome.sushi: use actual upstream url as homepage ``                                               |
| [`33e19693`](https://github.com/NixOS/nixpkgs/commit/33e19693663cc26f3ec11623985f0616973ddb15) | `` discord-ptb: 0.0.103 -> 0.0.105 ``                                                                |
| [`f92d957a`](https://github.com/NixOS/nixpkgs/commit/f92d957a4103d1b160d2b79a0058bfbbcc36c5e5) | `` linuxPackages_latest.nct6687d: 0-unstable-2024-02-23 -> 0-unstable-2024-09-02 ``                  |
| [`d4f15705`](https://github.com/NixOS/nixpkgs/commit/d4f1570582ebf7d4eb71beac09e217dd312656de) | `` linux_6_1: 6.1.110 -> 6.1.111 ``                                                                  |
| [`c223f30f`](https://github.com/NixOS/nixpkgs/commit/c223f30f166c963b696e924c86622c0a4fbf76ee) | `` linux_6_6: 6.6.51 -> 6.6.52 ``                                                                    |
| [`6d913024`](https://github.com/NixOS/nixpkgs/commit/6d9130241b8da16ac3e50f99579cdfc365fcc417) | `` linux_6_10: 6.10.10 -> 6.10.11 ``                                                                 |
| [`426f7bd1`](https://github.com/NixOS/nixpkgs/commit/426f7bd11c61dda9611920eac30e9c081c1a41fd) | `` lowdown: patch to fix macOS and UTF-8 bugs ``                                                     |
| [`944b7a9d`](https://github.com/NixOS/nixpkgs/commit/944b7a9df3b5a7f577dd52e00a7dce3d844b2378) | `` chromium,chromedriver: 128.0.6613.137 -> 129.0.6668.58 ``                                         |
| [`6c5f1148`](https://github.com/NixOS/nixpkgs/commit/6c5f1148160ba32eeb8f4bd9d05355eee9428e76) | `` nix-serve.nix: Add ``                                                                             |
| [`291c9512`](https://github.com/NixOS/nixpkgs/commit/291c95120d7bd3885624198c5f51e9f4a2740a17) | `` nixosTests.nix-serve: Use new entrypoint ``                                                       |
| [`a6dd1e70`](https://github.com/NixOS/nixpkgs/commit/a6dd1e7035e7f17b26c73e259cfc849cfb404877) | `` fedifetcher: 7.1.4 -> 7.1.5 ``                                                                    |
| [`9037d569`](https://github.com/NixOS/nixpkgs/commit/9037d56901bfaa5e39e82182d5666b3ca299363a) | `` fedifetcher: 7.1.1 -> 7.1.4 ``                                                                    |
| [`9ab16fb2`](https://github.com/NixOS/nixpkgs/commit/9ab16fb240132174d94b314b2071618e0e464838) | `` fedifetcher: 7.0.5 -> 7.1.1 ``                                                                    |
| [`f5e607c0`](https://github.com/NixOS/nixpkgs/commit/f5e607c0b45df2d5c67c8bebd94b76dda09dd4bf) | `` fedifetcher: adopt into c3d2 team ``                                                              |
| [`9abb177d`](https://github.com/NixOS/nixpkgs/commit/9abb177dc8414fe2d950d5d5659ae0d08a055e89) | `` fedifetcher: 7.0.4 -> 7.0.5 ``                                                                    |
| [`e7d80697`](https://github.com/NixOS/nixpkgs/commit/e7d8069780150e190532cbad33f7eb430a3ed697) | `` handbrake: fix build by applying an upstream patch again ``                                       |
| [`26ba0cd7`](https://github.com/NixOS/nixpkgs/commit/26ba0cd7f7f5aae58b2429c9c3265f584c48a2d9) | `` signal-desktop(aarch64): 7.19.0 -> 7.23.0 ``                                                      |
| [`88049656`](https://github.com/NixOS/nixpkgs/commit/88049656022edf50429aa87cf436e9d6910083ad) | `` signal-desktop-beta: 7.23.0-beta.1 -> 7.25.0-beta.2 ``                                            |