### PR TITLE
chore(flake/home-manager): `437ec620` -> `2f23fa30`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -56,6 +56,22 @@
         "type": "github"
       }
     },
+    "base16-foot": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1727574105,
+        "narHash": "sha256-ByMVgH0rZ1by2YIVJ47gE8/ZHWcG8yqsErQ4tKLbm7Q=",
+        "owner": "tinted-theming",
+        "repo": "base16-foot",
+        "rev": "e558fe47e187093313f19fa6a9eea61940ffbd6b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "tinted-theming",
+        "repo": "base16-foot",
+        "type": "github"
+      }
+    },
     "base16-helix": {
       "flake": false,
       "locked": {
@@ -72,18 +88,50 @@
         "type": "github"
       }
     },
-    "base16-vim": {
+    "base16-kitty": {
       "flake": false,
       "locked": {
-        "lastModified": 1716150083,
-        "narHash": "sha256-ZMhnNmw34ogE5rJZrjRv5MtG3WaqKd60ds2VXvT6hEc=",
+        "lastModified": 1721117198,
+        "narHash": "sha256-+vEXvEsar7w7wPVRmKx+rJKUTD5DBgLR7jfl0k7VhnE=",
+        "owner": "kdrag0n",
+        "repo": "base16-kitty",
+        "rev": "0898f2677f3a583cc6a89bde29b2b05ac2041e0b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "kdrag0n",
+        "repo": "base16-kitty",
+        "type": "github"
+      }
+    },
+    "base16-tmux": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1727571738,
+        "narHash": "sha256-AOITVZMhqELOzL5Jw54NIX7R8gFbTJqrHEDuPwgGYDQ=",
         "owner": "tinted-theming",
-        "repo": "base16-vim",
-        "rev": "6e955d704d046b0dc3e5c2d68a2a6eeffd2b5d3d",
+        "repo": "base16-tmux",
+        "rev": "44fbe9034653c83a8ae68941aaeeeeb7503cd1ae",
         "type": "github"
       },
       "original": {
         "owner": "tinted-theming",
+        "repo": "base16-tmux",
+        "type": "github"
+      }
+    },
+    "base16-vim": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1663659192,
+        "narHash": "sha256-uJvaYYDMXvoo0fhBZUhN8WBXeJ87SRgof6GEK2efFT0=",
+        "owner": "chriskempson",
+        "repo": "base16-vim",
+        "rev": "3be3cd82cd31acfcab9a41bad853d9c68d30478d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "chriskempson",
         "repo": "base16-vim",
         "type": "github"
       }
@@ -195,27 +243,6 @@
         "type": "github"
       }
     },
-    "flake-utils": {
-      "inputs": {
-        "systems": [
-          "stylix",
-          "systems"
-        ]
-      },
-      "locked": {
-        "lastModified": 1710146030,
-        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
     "flakeCompat": {
       "flake": false,
       "locked": {
@@ -272,15 +299,16 @@
         ]
       },
       "locked": {
-        "lastModified": 1727817100,
-        "narHash": "sha256-dlyV9/eiWkm/Y/t2+k4CFZ29tBvCANmJogEYaHeAOTw=",
+        "lastModified": 1726989464,
+        "narHash": "sha256-Vl+WVTJwutXkimwGprnEtXc/s/s8sMuXzqXaspIGlwM=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "437ec62009fa8ceb684eb447d455ffba25911cf9",
+        "rev": "2f23fa308a7c067e52dfcc30a0758f47043ec176",
         "type": "github"
       },
       "original": {
         "owner": "nix-community",
+        "ref": "release-24.05",
         "repo": "home-manager",
         "type": "github"
       }
@@ -308,6 +336,22 @@
     },
     "nixpkgs": {
       "locked": {
+        "lastModified": 1727907660,
+        "narHash": "sha256-QftbyPoieM5M50WKUMzQmWtBWib/ZJbHo7mhj5riQec=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "5966581aa04be7eff830b9e1457d56dc70a0b798",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-24.05",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-unstable": {
+      "locked": {
         "lastModified": 1727802920,
         "narHash": "sha256-HP89HZOT0ReIbI7IJZJQoJgxvB2Tn28V6XS3MNKnfLs=",
         "owner": "nixos",
@@ -318,22 +362,6 @@
       "original": {
         "owner": "nixos",
         "ref": "nixos-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs-stable": {
-      "locked": {
-        "lastModified": 1727672256,
-        "narHash": "sha256-9/79hjQc9+xyH+QxeMcRsA6hDyw6Z9Eo1/oxjvwirLk=",
-        "owner": "nixos",
-        "repo": "nixpkgs",
-        "rev": "1719f27dd95fd4206afb9cec9f415b539978827e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nixos",
-        "ref": "nixos-24.05",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -384,7 +412,7 @@
         "fine-cmdline": "fine-cmdline",
         "home-manager": "home-manager",
         "nixpkgs": "nixpkgs",
-        "nixpkgs-stable": "nixpkgs-stable",
+        "nixpkgs-unstable": "nixpkgs-unstable",
         "plasma-manager": "plasma-manager",
         "spicetify-nix": "spicetify-nix",
         "stylix": "stylix",
@@ -433,94 +461,30 @@
       "inputs": {
         "base16": "base16",
         "base16-fish": "base16-fish",
+        "base16-foot": "base16-foot",
         "base16-helix": "base16-helix",
+        "base16-kitty": "base16-kitty",
+        "base16-tmux": "base16-tmux",
         "base16-vim": "base16-vim",
         "flake-compat": "flake-compat_3",
-        "flake-utils": "flake-utils",
         "gnome-shell": "gnome-shell",
         "home-manager": "home-manager_2",
         "nixpkgs": [
           "nixpkgs"
-        ],
-        "systems": "systems",
-        "tinted-foot": "tinted-foot",
-        "tinted-kitty": "tinted-kitty",
-        "tinted-tmux": "tinted-tmux"
+        ]
       },
       "locked": {
-        "lastModified": 1727723275,
-        "narHash": "sha256-k4HrG8TJQ0RqDS1tlDz71kvWFBNQ7qZI9T5Z0qLR85Y=",
+        "lastModified": 1718122552,
+        "narHash": "sha256-A+dBkSwp8ssHKV/WyXb9uqIYrHBqHvtSedU24Lq9lqw=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "e7e97059776da7e34b739415a7bc8f80f606b803",
+        "rev": "e59d2c1725b237c362e4a62f5722f5b268d566c7",
         "type": "github"
       },
       "original": {
         "owner": "danth",
+        "ref": "release-24.05",
         "repo": "stylix",
-        "type": "github"
-      }
-    },
-    "systems": {
-      "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
-        "owner": "nix-systems",
-        "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-systems",
-        "repo": "default",
-        "type": "github"
-      }
-    },
-    "tinted-foot": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1696725948,
-        "narHash": "sha256-65bz2bUL/yzZ1c8/GQASnoiGwaF8DczlxJtzik1c0AU=",
-        "owner": "tinted-theming",
-        "repo": "tinted-foot",
-        "rev": "eedbcfa30de0a4baa03e99f5e3ceb5535c2755ce",
-        "type": "github"
-      },
-      "original": {
-        "owner": "tinted-theming",
-        "repo": "tinted-foot",
-        "type": "github"
-      }
-    },
-    "tinted-kitty": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1665001328,
-        "narHash": "sha256-aRaizTYPpuWEcvoYE9U+YRX+Wsc8+iG0guQJbvxEdJY=",
-        "owner": "tinted-theming",
-        "repo": "tinted-kitty",
-        "rev": "06bb401fa9a0ffb84365905ffbb959ae5bf40805",
-        "type": "github"
-      },
-      "original": {
-        "owner": "tinted-theming",
-        "repo": "tinted-kitty",
-        "type": "github"
-      }
-    },
-    "tinted-tmux": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1696725902,
-        "narHash": "sha256-wDPg5elZPcQpu7Df0lI5O8Jv4A3T6jUQIVg63KDU+3Q=",
-        "owner": "tinted-theming",
-        "repo": "tinted-tmux",
-        "rev": "c02050bebb60dbb20cb433cd4d8ce668ecc11ba7",
-        "type": "github"
-      },
-      "original": {
-        "owner": "tinted-theming",
-        "repo": "tinted-tmux",
         "type": "github"
       }
     },


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                           |
| ----------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------- |
| [`2f23fa30`](https://github.com/nix-community/home-manager/commit/2f23fa308a7c067e52dfcc30a0758f47043ec176) | `` borgmatic: fix service permissions ``                          |
| [`1bbc1a5a`](https://github.com/nix-community/home-manager/commit/1bbc1a5a1f4de7401c92db85b2119ed21bb4139d) | `` ci: bump DeterminateSystems/update-flake-lock from 23 to 24 `` |
| [`2ab00f89`](https://github.com/nix-community/home-manager/commit/2ab00f89dd3ecf8012f5090e6d7ca1a7ea30f594) | `` firefox: fix selection of lastUserContextId ``                 |
| [`208df2e5`](https://github.com/nix-community/home-manager/commit/208df2e558b73b6a1f0faec98493cb59a25f62ba) | `` ssh-agent: fix evaluation of maintainer field ``               |
| [`f8142df1`](https://github.com/nix-community/home-manager/commit/f8142df16b8e100532f4abbb099672e194f70aa1) | `` pulseeffects: fix test evaluation ``                           |
| [`3288b74c`](https://github.com/nix-community/home-manager/commit/3288b74c61b9cc09dd2d10854f5876b10d9f9383) | `` jujutsu: support darwin guidelines for config placement ``     |
| [`849f477e`](https://github.com/nix-community/home-manager/commit/849f477e8ab1234e8891a03dd68db064d7659145) | `` maintainers: remove polykernel ``                              |
| [`3bbe430d`](https://github.com/nix-community/home-manager/commit/3bbe430d8b87547bf7226f3345e0b82f933b191c) | `` treewide: fix eval after Nixpkgs maintainer changes ``         |
| [`b3e9c18b`](https://github.com/nix-community/home-manager/commit/b3e9c18b633b9979b016a2eb6003278bd001e12d) | `` treewide: fix eval after Nixpkgs maintainer changes ``         |
| [`175b2c6d`](https://github.com/nix-community/home-manager/commit/175b2c6d1dd18f9f3bae047de30ea0947831e7d2) | `` mpv: remove tadeokondrak as maintainer ``                      |
| [`7b251216`](https://github.com/nix-community/home-manager/commit/7b251216aceb0e951a0cd69418615be806c86431) | `` maintainers: remove ivar ``                                    |
| [`e1391fb2`](https://github.com/nix-community/home-manager/commit/e1391fb22e18a36f57e6999c7a9f966dc80ac073) | `` hyprland: onChange: remove subshell comment ``                 |
| [`c05d7204`](https://github.com/nix-community/home-manager/commit/c05d7204a9a27f8fb5d14e1781c108cc851ac14a) | `` hyprland: onChange: check XDG_RUNTIME_DIR as well ``           |
| [`391ca6e9`](https://github.com/nix-community/home-manager/commit/391ca6e950c2525b4f853cbe29922452c14eda82) | `` ci: bump DeterminateSystems/update-flake-lock from 22 to 23 `` |
| [`a1fddf09`](https://github.com/nix-community/home-manager/commit/a1fddf0967c33754271761d91a3d921772b30d0e) | `` ci: bump DeterminateSystems/update-flake-lock from 21 to 22 `` |
| [`c26f6faf`](https://github.com/nix-community/home-manager/commit/c26f6faf5a64d5a8fc8d5ddfb1a240f312f2fa3a) | `` docs: add redirect from the previous options.html ``           |
| [`8a687e4c`](https://github.com/nix-community/home-manager/commit/8a687e4cf563625fe84c27ed00d7e893c18c9731) | `` ci/labeler: fix upgrade to v5 format ``                        |
| [`1f45254e`](https://github.com/nix-community/home-manager/commit/1f45254ef9ac12f7c78bdee94af993f5be83dfe6) | `` ci/labeler: upgrade to v5 format ``                            |
| [`845a5c4c`](https://github.com/nix-community/home-manager/commit/845a5c4c073f74105022533907703441e0464bc3) | `` home-manager: mark 24.05 as release ``                         |
| [`a631666f`](https://github.com/nix-community/home-manager/commit/a631666f5ec18271e86a5cde998cba68c33d9ac6) | `` kanshi: fix configuration example ``                           |
| [`142d4365`](https://github.com/nix-community/home-manager/commit/142d4365b53e3c0f967c1757fed4a26f9e1747f5) | `` ci: bump actions/labeler from 4 to 5 ``                        |
| [`0cbfb58c`](https://github.com/nix-community/home-manager/commit/0cbfb58c6a7070cdd4e841276e7fee58232e1c6a) | `` ci: bump cachix/install-nix-action from 23 to 27 ``            |
| [`63816343`](https://github.com/nix-community/home-manager/commit/6381634330622ed234fecf26c7d549b16916cb2a) | `` ci: bump cachix/cachix-action from 13 to 15 ``                 |
| [`c719dbb7`](https://github.com/nix-community/home-manager/commit/c719dbb764a0939d2b2a20fa0a1a2e38d4ac2b42) | `` Translate using Weblate (Danish) ``                            |
| [`3f3884d7`](https://github.com/nix-community/home-manager/commit/3f3884d77ff12fd81d0754ce2faf3d7e2ecdc478) | `` Translate using Weblate (Japanese) ``                          |
| [`02de6f98`](https://github.com/nix-community/home-manager/commit/02de6f987b8cd4267e4fb32cc1e2e7ceb54a60aa) | `` Translate using Weblate (Japanese) ``                          |
| [`2b9c0014`](https://github.com/nix-community/home-manager/commit/2b9c00142894fd430ffb00696babf86f95724458) | `` Translate using Weblate (German) ``                            |
| [`ccc0e8d9`](https://github.com/nix-community/home-manager/commit/ccc0e8d95232040bf8ec87a9795764ad27c91909) | `` Translate using Weblate (Chinese (Simplified)) ``              |
| [`f3a45121`](https://github.com/nix-community/home-manager/commit/f3a451216628661ec537bbed1365e7d4eeea6e44) | `` ci: fix manual build in sourcehut build ``                     |
| [`569d9284`](https://github.com/nix-community/home-manager/commit/569d9284583909f416f00c44fab86f652c8b2c61) | `` home-manager: switch nixpkgs input to nixos-24.05 ``           |
| [`89fbc13a`](https://github.com/nix-community/home-manager/commit/89fbc13af5bc3254cadc54311b5589a03bf889f5) | `` home-manager: prepare release 24.05 ``                         |
| [`00a86e4f`](https://github.com/nix-community/home-manager/commit/00a86e4f7a6455ad58b7090a931f1c6097e4fcd7) | `` ci: make dependabot consider the release-24.05 ``              |
| [`c583e715`](https://github.com/nix-community/home-manager/commit/c583e715f7383a709549fb620998f60f1d60134f) | `` ci: make test workflow use nixos-24.05 ``                      |