### PR TITLE
chore(flake/nixpkgs): `5966581a` -> `6e6b3dd3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -374,11 +374,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1727907660,
-        "narHash": "sha256-QftbyPoieM5M50WKUMzQmWtBWib/ZJbHo7mhj5riQec=",
+        "lastModified": 1728067476,
+        "narHash": "sha256-/uJcVXuBt+VFCPQIX+4YnYrHaubJSx4HoNsJVNRgANM=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "5966581aa04be7eff830b9e1457d56dc70a0b798",
+        "rev": "6e6b3dd395c3b1eb9be9f2d096383a8d05add030",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                      |
| ---------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------- |
| [`7f8eb7de`](https://github.com/NixOS/nixpkgs/commit/7f8eb7de10da840c7217b98aa0489273dc11304a) | `` linux/hardened/patches/6.6: v6.6.51-hardened1 -> v6.6.53-hardened1 ``     |
| [`c4587105`](https://github.com/NixOS/nixpkgs/commit/c4587105e81e5b9bc7dddfbf8ddea90bcc9fb246) | `` linux/hardened/patches/6.10: v6.10.10-hardened1 -> v6.10.12-hardened1 ``  |
| [`b06773c0`](https://github.com/NixOS/nixpkgs/commit/b06773c0ad38374da28ff8e5f6fe02dfeae61980) | `` linux/hardened/patches/6.1: v6.1.110-hardened1 -> v6.1.112-hardened1 ``   |
| [`e4f00671`](https://github.com/NixOS/nixpkgs/commit/e4f00671be8af9336e13a9259050adc1964cde4e) | `` linux-rt_5_15: 5.15.163-rt78 -> 5.15.167-rt79 ``                          |
| [`9ee53de6`](https://github.com/NixOS/nixpkgs/commit/9ee53de6c14ae533f296a51172ee7c33509d6428) | `` linux_6_6: 6.6.53 -> 6.6.54 ``                                            |
| [`38093b56`](https://github.com/NixOS/nixpkgs/commit/38093b56ba3b310ac6b2fbf80562f4d67f6ac7b1) | `` linux_6_10: 6.10.12 -> 6.10.13 ``                                         |
| [`a672b034`](https://github.com/NixOS/nixpkgs/commit/a672b0340b30840d0fc72c8325e26a3cb75a37a4) | `` linux_6_11: 6.11.1 -> 6.11.2 ``                                           |
| [`ce1558d2`](https://github.com/NixOS/nixpkgs/commit/ce1558d2b12b80f09a8f18638db71ac59a3da978) | `` linux_5_4_hardened: mark as broken ``                                     |
| [`34134792`](https://github.com/NixOS/nixpkgs/commit/3413479206d28ee7391dafbdf6503d7c3708e8cf) | `` linux/hardened/patches/6.9: remove ``                                     |
| [`684a7e41`](https://github.com/NixOS/nixpkgs/commit/684a7e41b7553fafb06de22ac84a0fe48419d873) | `` linux/hardened/patches/6.8: remove ``                                     |
| [`23f6e3b6`](https://github.com/NixOS/nixpkgs/commit/23f6e3b65a4364ffaa81f2856d689529e9cd2faf) | `` linux/hardened/patches/6.6: 6.6.32-hardened1 -> v6.6.51-hardened1 ``      |
| [`5295e717`](https://github.com/NixOS/nixpkgs/commit/5295e717878d12bfae8be9bc870309bc2daed0b5) | `` linux/hardened/patches/6.10: init at v6.10.10-hardened1 ``                |
| [`3cec82be`](https://github.com/NixOS/nixpkgs/commit/3cec82be718a49db93a09aef2ed0898a80b15ab7) | `` linux/hardened/patches/6.1: 6.1.92-hardened1 -> v6.1.110-hardened1 ``     |
| [`db682fae`](https://github.com/NixOS/nixpkgs/commit/db682faea7b069e2a3734c9ab4a604f9fdaf1a87) | `` linux/hardened/patches/5.4: 5.4.277-hardened1 -> v5.4.284-hardened1 ``    |
| [`ef410bef`](https://github.com/NixOS/nixpkgs/commit/ef410befa55999678395fe521f3325b165e1f4df) | `` linux/hardened/patches/5.15: 5.15.160-hardened1 -> v5.15.167-hardened1 `` |
| [`0112f1ed`](https://github.com/NixOS/nixpkgs/commit/0112f1ed950baa8445a9423dce33478a631fa599) | `` linux/hardened/patches/5.10: 5.10.218-hardened1 -> v5.10.226-hardened1 `` |
| [`ea76ee28`](https://github.com/NixOS/nixpkgs/commit/ea76ee283790635af2d9640d1c422668960cb653) | `` linux/hardened: fix update script ``                                      |
| [`bc5dc93f`](https://github.com/NixOS/nixpkgs/commit/bc5dc93f1cbeeb140691f1fe12139a91e4a4a2de) | `` chromium,chromedriver: 129.0.6668.70 -> 129.0.6668.89 ``                  |
| [`a136b63d`](https://github.com/NixOS/nixpkgs/commit/a136b63ddf5ae6183cdc2f10a04a6847a32ec45d) | `` google-chrome: add rpath for libGLESv2.so as well ``                      |
| [`9c6ca214`](https://github.com/NixOS/nixpkgs/commit/9c6ca214ba2b4d4d1b0f97ddc2beaf77fba267af) | `` google-chrome: replace bundled libvulkan.so.1 with vulkan-loader's ``     |
| [`acb0e986`](https://github.com/NixOS/nixpkgs/commit/acb0e986a4be17bd24f6f748d8348802225cda2d) | `` google-chrome: 129.0.6668.58 -> 129.0.6668.89 ``                          |
| [`b8142b62`](https://github.com/NixOS/nixpkgs/commit/b8142b62eda24c39a3eb31841d3da278d6ae2531) | `` logiops: 0.3.3 -> 0.3.4 ``                                                |
| [`a7fe2c46`](https://github.com/NixOS/nixpkgs/commit/a7fe2c46d9c4d744cc6f729cad820817090cfa27) | `` python313: 3.13.0rc2 -> 3.13.0rc3 ``                                      |
| [`f290b27d`](https://github.com/NixOS/nixpkgs/commit/f290b27df298947d8694e6161a79ae113df93bba) | `` jbigkit: add Archlinux patch to fix heap overflow issue ``                |
| [`d6c14ea8`](https://github.com/NixOS/nixpkgs/commit/d6c14ea8f6c729d79e4029eea14b01c19d520ded) | `` jbigkit: add patch to fix security issue CVE-2017-9937 ``                 |
| [`0010c39a`](https://github.com/NixOS/nixpkgs/commit/0010c39a77012492a1602258ad8e3fd5e9377bf6) | `` firefox-esr-115-unwrapped: 115.15.0esr -> 115.16.0esr ``                  |
| [`1f2e56b6`](https://github.com/NixOS/nixpkgs/commit/1f2e56b63b0d2ea6eced5978be3f011d73c41dd9) | `` firefox-esr-128-unwrapped: 128.2.0esr -> 128.3.0esr ``                    |
| [`4c10ab5c`](https://github.com/NixOS/nixpkgs/commit/4c10ab5c7ff1e9703143d905343a8c1acef5edb6) | `` firefox-bin-unwrapped: 130.0.1 -> 131.0 ``                                |
| [`bb673399`](https://github.com/NixOS/nixpkgs/commit/bb6733996808274b9db125aa16a9677db90eff69) | `` firefox-unwrapped: 130.0.1 -> 131.0 ``                                    |
| [`9e114eff`](https://github.com/NixOS/nixpkgs/commit/9e114eff67591023ac3a2f06f2771a53fdcc08f4) | `` yt-dlp: 2024.8.6 -> 2024.9.27 ``                                          |
| [`408f30b3`](https://github.com/NixOS/nixpkgs/commit/408f30b3636b1399eebc0fb54ad0f32d074d4761) | `` firefly-iii: 6.1.20 -> 6.1.21 ``                                          |
| [`203ecf7a`](https://github.com/NixOS/nixpkgs/commit/203ecf7a1df215eae0a3f164748289e3f95d2a23) | `` git-workspace: 1.5.0 -> 1.6.0 ``                                          |