### PR TITLE
chore(flake/nixpkgs): `6e6b3dd3` -> `ecbc1ca8`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -374,11 +374,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1728067476,
-        "narHash": "sha256-/uJcVXuBt+VFCPQIX+4YnYrHaubJSx4HoNsJVNRgANM=",
+        "lastModified": 1728193676,
+        "narHash": "sha256-PbDWAIjKJdlVg+qQRhzdSor04bAPApDqIv2DofTyynk=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "6e6b3dd395c3b1eb9be9f2d096383a8d05add030",
+        "rev": "ecbc1ca8ffd6aea8372ad16be9ebbb39889e55b6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                           |
| ---------------------------------------------------------------------------------------------- | ----------------------------------------------------------------- |
| [`2275fa5b`](https://github.com/NixOS/nixpkgs/commit/2275fa5b7a109b84e88d8b5c8e0d2cecaa85091b) | `` ryujinx: archive.org tarball mirror for release-24.05 ``       |
| [`ffc03d2b`](https://github.com/NixOS/nixpkgs/commit/ffc03d2b46ac97cab228765920b3d13798a21f6e) | `` tailscaled: after NetworkManager-wait-online ``                |
| [`4a8ffdef`](https://github.com/NixOS/nixpkgs/commit/4a8ffdef31de573551be8ee1d9ea5e8422365cab) | `` skypeforlinux: 8.129.0.201 -> 8.129.0.202 ``                   |
| [`6782dbb5`](https://github.com/NixOS/nixpkgs/commit/6782dbb5621fe763011afadfbf5b771da82df3ac) | `` arc-browser: 1.61.0-53949 -> 1.61.2-54148 ``                   |
| [`204798c0`](https://github.com/NixOS/nixpkgs/commit/204798c0592af2fbc76908438197935a6ab4fea4) | `` azuki: init at 0-unstable-2021-07-02 ``                        |
| [`17ee0f74`](https://github.com/NixOS/nixpkgs/commit/17ee0f7496fad6bff9396557c73bef477535271b) | `` mullvad-browser: 13.5.3 -> 13.5.6 ``                           |
| [`a9438536`](https://github.com/NixOS/nixpkgs/commit/a94385367bac4c64762544e23a6513b47c2502d6) | `` tor-browser: 13.5.5 -> 13.5.6 ``                               |
| [`60d1231e`](https://github.com/NixOS/nixpkgs/commit/60d1231e752da3991f4c31b1b23c0661ca8126f4) | `` {tor,mullvad}-browser: get correct hash in update script ``    |
| [`a880c59a`](https://github.com/NixOS/nixpkgs/commit/a880c59a31c6a86c49d381111c191d2e9d5f9e38) | `` ungoogled-chromium: 129.0.6668.70-1 -> 129.0.6668.89-1 ``      |
| [`b973ca7f`](https://github.com/NixOS/nixpkgs/commit/b973ca7fcfb8617f9f356f32c86f3ebc87e21a57) | `` valkey: 7.2.6 -> 7.2.7 ``                                      |
| [`056fefad`](https://github.com/NixOS/nixpkgs/commit/056fefadae519b475fceff3a7bf38942cd9bca44) | `` valkey: 7.2.5 -> 7.2.6 ``                                      |
| [`d4eb7924`](https://github.com/NixOS/nixpkgs/commit/d4eb7924598b8bd830e85c93aeb6aa7c5294de9a) | `` brave: 1.70.119 -> 1.70.123 ``                                 |
| [`15a8ae93`](https://github.com/NixOS/nixpkgs/commit/15a8ae93e3ff29f671be62b8b7459289f5c3304e) | `` logiops: 0.3.4 -> 0.3.5 ``                                     |
| [`1f87464e`](https://github.com/NixOS/nixpkgs/commit/1f87464ede4326736435e2dc3566c70df9e5224b) | `` easytier: init at 1.2.3 ``                                     |
| [`8ca30671`](https://github.com/NixOS/nixpkgs/commit/8ca3067120fa120a4f6932d5a1e5118729c701df) | `` maintainers: add ltrump ``                                     |
| [`23dfd8fc`](https://github.com/NixOS/nixpkgs/commit/23dfd8fc0a363e663c79f2cc5849bceca416c542) | `` wavebox: 10.128.7-2 -> 10.129.27-2 ``                          |
| [`1488cb68`](https://github.com/NixOS/nixpkgs/commit/1488cb684d0ea88b5e25614d4475eca85ec37227) | `` thunderbird-bin-unwrapped: 128.2.0esr -> 128.2.3esr ``         |
| [`6d936451`](https://github.com/NixOS/nixpkgs/commit/6d936451ed3c9c7e2b2326f1c58b29028694084b) | `` protontricks: use steam-run-free ``                            |
| [`6b99175c`](https://github.com/NixOS/nixpkgs/commit/6b99175c4610d336592a4aff6ec19a2ab8b1d769) | `` protontricks: 1.11.1 -> 1.12.0 ``                              |
| [`e2766427`](https://github.com/NixOS/nixpkgs/commit/e27664274c94f4e3b4af035922a13035e8a5d47b) | `` python312Packages.vdf: add patch to support appinfo.vdf v29 `` |
| [`e5b69596`](https://github.com/NixOS/nixpkgs/commit/e5b695965c81f91cdb2d784d23f83686e1c40a0a) | `` mozillavpn: 2.23.1 → 2.24.0 ``                                 |
| [`3b41010a`](https://github.com/NixOS/nixpkgs/commit/3b41010afa7d48971b0eda2aa3b61679156c0162) | `` mozillavpn: migrate to by-name ``                              |
| [`a3f956e4`](https://github.com/NixOS/nixpkgs/commit/a3f956e48b9caf5a085675762d5fd27994d35eb8) | `` mozillavpn: switch to standard callPackage ``                  |