### PR TITLE
chore(flake/home-manager): `3ac39b2a` -> `03863036`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -272,11 +272,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1728306985,
-        "narHash": "sha256-l/KpcWTv2SjxCnqFs5GYhvjeVYd40WQV4/F2+w9btd4=",
+        "lastModified": 1728337164,
+        "narHash": "sha256-VdRTjJFyq4Q9U7Z/UoC2Q5jK8vSo6E86lHc2OanXtvc=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "3ac39b2a8b7cbfc0f96628d8a84867c885bc988b",
+        "rev": "038630363e7de57c36c417fd2f5d7c14773403e4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                            |
| ----------------------------------------------------------------------------------------------------------- | -------------------------------------------------- |
| [`03863036`](https://github.com/nix-community/home-manager/commit/038630363e7de57c36c417fd2f5d7c14773403e4) | `` xdg-mime type package options (#5920) ``        |
| [`271c83e2`](https://github.com/nix-community/home-manager/commit/271c83e21ea81f39a42ad128384e0e6804956a88) | `` firefox: organize tests by submodule (#5698) `` |