### PR TITLE
chore(flake/spicetify-nix): `4bcc76b9` -> `194e9bb7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -416,11 +416,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1728274624,
-        "narHash": "sha256-auf6OnXvV8LiH/KvGIDmxUdhPeivGSxOHxrPvMHd+T4=",
+        "lastModified": 1728379846,
+        "narHash": "sha256-fsjXOHFv+FdvsYOfYPifgMQd/HH7wTrtKpKr9VIlKo8=",
         "owner": "Gerg-L",
         "repo": "spicetify-nix",
-        "rev": "4bcc76b94f01cfddc899191e99d96059b8702608",
+        "rev": "194e9bb7a43639cbebf26527438ca56defc4c076",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                         |
| ----------------------------------------------------------------------------------------------------- | ----------------------------------------------- |
| [`194e9bb7`](https://github.com/Gerg-L/spicetify-nix/commit/194e9bb7a43639cbebf26527438ca56defc4c076) | `` Bump actions/checkout from 4.2.0 to 4.2.1 `` |
| [`292e6e18`](https://github.com/Gerg-L/spicetify-nix/commit/292e6e185fe1e710d8f8e23ce3ec9f93e5bb6306) | `` CI update 2024-10-08 ``                      |