### PR TITLE
chore(flake/nixpkgs): `bc947f54` -> `c31898ad`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -308,11 +308,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1728018373,
-        "narHash": "sha256-NOiTvBbRLIOe5F6RbHaAh6++BNjsb149fGZd1T4+KBg=",
+        "lastModified": 1728241625,
+        "narHash": "sha256-yumd4fBc/hi8a9QgA9IT8vlQuLZ2oqhkJXHPKxH/tRw=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "bc947f541ae55e999ffdb4013441347d83b00feb",
+        "rev": "c31898adf5a8ed202ce5bea9f347b1c6871f32d1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                     |
| ---------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------- |
| [`c31898ad`](https://github.com/NixOS/nixpkgs/commit/c31898adf5a8ed202ce5bea9f347b1c6871f32d1) | `` mininet: fix dependencies ``                                             |
| [`d20f08c6`](https://github.com/NixOS/nixpkgs/commit/d20f08c6c66a1980627ec363ee25444b8d8bc58b) | `` playwright: warn that the attribute will refer a different package ``    |
| [`379ca4e6`](https://github.com/NixOS/nixpkgs/commit/379ca4e67fd34ec157ab1b4bf79aa489d934cb09) | `` mautrix-meta: drop maintainership Rutherther ``                          |
| [`40bfbe32`](https://github.com/NixOS/nixpkgs/commit/40bfbe3226e4a125d321837d7eb2e927159b29ce) | `` nixos/scrutiny: wait until ready ``                                      |
| [`6abc2cbb`](https://github.com/NixOS/nixpkgs/commit/6abc2cbbc4f9d151b46f4d87cae0e6a2b1b20f49) | `` keyguard: 1.6.0 -> 1.6.1 (#346823) ``                                    |
| [`e62d2eba`](https://github.com/NixOS/nixpkgs/commit/e62d2eba7dbadce5dd2da2a78d9c989f9ef9e179) | `` wine-staging: 9.18 -> 9.19 (#346803) ``                                  |
| [`394f5d51`](https://github.com/NixOS/nixpkgs/commit/394f5d51e978d25d2c3dc60c439453267cca737a) | `` tinymist: 0.11.22 -> 0.11.28 (#346629) ``                                |
| [`567c3d53`](https://github.com/NixOS/nixpkgs/commit/567c3d53bd18b08b2e065b87ed4ed1597faee314) | `` seilfahrt: 1.0.2 -> 2.0.0 ``                                             |
| [`63cced39`](https://github.com/NixOS/nixpkgs/commit/63cced3917186fe11d4d773c2e533f1ea90de385) | `` dinit: init at 0.19.0 ``                                                 |
| [`e3249985`](https://github.com/NixOS/nixpkgs/commit/e3249985f6767e15c686ec6351f8accfae28be96) | `` checkstyle: 10.18.1 -> 10.18.2 (#346114) ``                              |
| [`a8335ef4`](https://github.com/NixOS/nixpkgs/commit/a8335ef4a1e096d7f96da4e3d473b3b65dad7854) | `` stdoutisatty: init at 1.0 (#345558) ``                                   |
| [`d64df4f6`](https://github.com/NixOS/nixpkgs/commit/d64df4f67e37fb851a70b39b042ba2c440439a77) | `` gokey: 0.1.2-unstable-2023-11-16 -> 0.1.3 ``                             |
| [`205e32c7`](https://github.com/NixOS/nixpkgs/commit/205e32c7eabb1d16132f654d3de578a663df4c39) | `` vyxal: init at 3.4.9 (#257860) ``                                        |
| [`859d6cdd`](https://github.com/NixOS/nixpkgs/commit/859d6cdd8e9fc2210ce180e45c1ba72e41c3bc8e) | `` rustpython: 0.3.1 -> 0.4.0 ``                                            |
| [`3e8fd883`](https://github.com/NixOS/nixpkgs/commit/3e8fd8839e2b3392f77e89aff71e3e7006db5a91) | `` home-assistant-custom-components.smartthinq-sensors: 0.39.2 -> 0.40.0 `` |
| [`faef33ad`](https://github.com/NixOS/nixpkgs/commit/faef33addaec3d2d790fffa99ec704bf3db7073a) | `` nim: 2.0.8 -> 2.2.0; nim: init updatescript; ``                          |
| [`12072184`](https://github.com/NixOS/nixpkgs/commit/120721843afaa7cd8c6c574a3d17c40489f122c0) | `` newsraft: 0.25 -> 0.27 ``                                                |
| [`023ce217`](https://github.com/NixOS/nixpkgs/commit/023ce2170777beda3fae4ffaf0ef99754ac653f7) | `` xpra: 6.1.2 -> 6.1.3 ``                                                  |
| [`60f6c6f5`](https://github.com/NixOS/nixpkgs/commit/60f6c6f5015d1b17805a6aa15cab43da771ce62a) | `` hysteria: add updater ``                                                 |
| [`225ee2f5`](https://github.com/NixOS/nixpkgs/commit/225ee2f5f172c1fbfeda8bcc48b72b3b31da1153) | `` wasmtime: 25.0.0 -> 25.0.1 ``                                            |
| [`e05db846`](https://github.com/NixOS/nixpkgs/commit/e05db846443cdd24359c064af9ae2f45198924d8) | `` ride: refactor and improve electron usage ``                             |
| [`17ea1f63`](https://github.com/NixOS/nixpkgs/commit/17ea1f63489265a427d42005d1a097bf5b1c0f9f) | `` python312Packages.grpcio-reflection: 1.65.4 -> 1.66.2 ``                 |
| [`20930895`](https://github.com/NixOS/nixpkgs/commit/209308953168f1831367d7c378f514328df85c9a) | `` pylyzer: 0.0.64 -> 0.0.65 (#346842) ``                                   |
| [`c22575be`](https://github.com/NixOS/nixpkgs/commit/c22575be40eeaa30627a9fe5d02dee9bc24fc144) | `` python312Packages.grpcio-health-checking: 1.65.4 -> 1.66.2 ``            |
| [`2ae6e53d`](https://github.com/NixOS/nixpkgs/commit/2ae6e53d37ea1789352fce3c2d79fa47e18cc164) | `` hysteria: 2.5.0 -> 2.5.2 ``                                              |
| [`ffd96b1c`](https://github.com/NixOS/nixpkgs/commit/ffd96b1cc0b91159aa9194a49b9bcbe920f8b67f) | `` hyprutils: 0.2.2 -> 0.2.3 ``                                             |
| [`58176558`](https://github.com/NixOS/nixpkgs/commit/58176558fb0357e975d473bb55bd06998d0fb010) | `` libretro.dosbox-pure: unstable-2024-09-16 -> unstable-2024-09-28 ``      |
| [`c6d62ae4`](https://github.com/NixOS/nixpkgs/commit/c6d62ae482e4d7d042f8c9b941c741d8c5769ff3) | `` python312Packages.grpcio-channelz: 1.65.4 -> 1.66.2 ``                   |
| [`82c9390f`](https://github.com/NixOS/nixpkgs/commit/82c9390fb7c2298a6ebe489e7c8fa4bfae4bb3fd) | `` process-compose: 1.27.0 -> 1.34.0 (#346512) ``                           |
| [`957647e1`](https://github.com/NixOS/nixpkgs/commit/957647e1caa1a5e9eedaf4d60c7cf6cd4dca54a2) | `` cinny-desktop: fix darwin build (#346640) ``                             |
| [`4d28461f`](https://github.com/NixOS/nixpkgs/commit/4d28461fec164659d1b69197d14a5fb19bbb46f2) | `` alpaca: 2.0.5 -> 2.0.6 (#346796) ``                                      |
| [`984999b3`](https://github.com/NixOS/nixpkgs/commit/984999b3a58130432461bc7510f5ead7272cef9a) | `` lazyjj: fix build (#346801) ``                                           |
| [`81b60bee`](https://github.com/NixOS/nixpkgs/commit/81b60beebfe94d209edec44721dfd08d06e6e861) | `` platformsh: 5.0.21 -> 5.0.22 (#346821) ``                                |
| [`17499a9c`](https://github.com/NixOS/nixpkgs/commit/17499a9cc94b590aa97da415fa9cd1c51c7dcba5) | `` upsun: 5.0.21 -> 5.0.22 (#346825) ``                                     |
| [`f5f81dee`](https://github.com/NixOS/nixpkgs/commit/f5f81deeaf85a626e4265793a96b9440a9bcf846) | `` unison-ucm: 0.5.26 -> 0.5.27 ``                                          |
| [`e77f7b6c`](https://github.com/NixOS/nixpkgs/commit/e77f7b6cebf6161a9852fafaf7e272f1d728d1a6) | `` python312Packages.oci: 2.135.0 -> 2.135.1 ``                             |
| [`d114c274`](https://github.com/NixOS/nixpkgs/commit/d114c274268338ffdc5aaa719ba329072a763c5c) | `` werf: 2.10.7 -> 2.10.9 ``                                                |
| [`cf614ee7`](https://github.com/NixOS/nixpkgs/commit/cf614ee78918b2a84f0693f3e0a3d28465353a18) | `` nixos/tests/dnsdist: fix dnscrypt test ``                                |
| [`28ef8921`](https://github.com/NixOS/nixpkgs/commit/28ef892139b2a7370c3ccfd74318a608de0721f7) | `` libretro.gambatte: unstable-2024-09-27 -> unstable-2024-10-04 ``         |
| [`7632ac7c`](https://github.com/NixOS/nixpkgs/commit/7632ac7cac7a5a8daf869e62861dcd0c9da57dc6) | `` plexRaw: 1.41.0.8992-8463ad060 -> 1.41.0.8994-f2c27da23 ``               |
| [`e3e56611`](https://github.com/NixOS/nixpkgs/commit/e3e566119d876bc5858152b08ea94bca0d7fd2fd) | `` libretro.flycast: unstable-2024-09-27 -> unstable-2024-10-05 ``          |
| [`324fdda1`](https://github.com/NixOS/nixpkgs/commit/324fdda1cafbdf10d29e537f2fb945659b74f36a) | `` libretro.atari800: unstable-2024-09-24 -> unstable-2024-10-01 ``         |
| [`9b6ea71b`](https://github.com/NixOS/nixpkgs/commit/9b6ea71b9b4bd26fa6693458c032d93970136a86) | `` libretro.bluemsx: unstable-2024-08-08 -> unstable-2024-10-01 ``          |
| [`8b44ec3f`](https://github.com/NixOS/nixpkgs/commit/8b44ec3facb2d148e6692c3a4fd16c85ec62b51c) | `` powerpipe: 0.4.3 -> 0.4.4 ``                                             |
| [`ed0d8366`](https://github.com/NixOS/nixpkgs/commit/ed0d8366c9f1cb44e8b5f5bab82078e5cf1f7562) | `` libretro.mame: unstable-2024-09-27 -> unstable-2024-10-04 ``             |
| [`7d3e4592`](https://github.com/NixOS/nixpkgs/commit/7d3e45928bd2ea8ee4787522c68efed59334073b) | `` fishPlugins.plugin-git: 0.2 -> 0.3 (#346751) ``                          |
| [`ff1081db`](https://github.com/NixOS/nixpkgs/commit/ff1081db9926414f218b93bf3ebaf637d8cd4c3b) | `` python312Packages.circus: allow local networking to fix darwin tests ``  |
| [`ab465eeb`](https://github.com/NixOS/nixpkgs/commit/ab465eeb20f246862a36e89d95ba9f4a2fb81016) | `` python312Packages.circus: add GaetanLepage as maintainer ``              |
| [`1c9844ef`](https://github.com/NixOS/nixpkgs/commit/1c9844ef89eeca2da48c805545ddbab09c9ce5e2) | `` discord: 0.0.67 -> 0.0.70 ``                                             |
| [`6f00ac2b`](https://github.com/NixOS/nixpkgs/commit/6f00ac2b5a8456440d5c956ddf0abd6ef5553ba5) | `` libretro.fbneo: unstable-2024-09-26 -> unstable-2024-10-03 ``            |
| [`a61e21f5`](https://github.com/NixOS/nixpkgs/commit/a61e21f5e964851a9b9b7005be749aaa916d991e) | `` exo: 0-unstable-2024-10-03 -> 0-unstable-2024-10-06 ``                   |
| [`5485dd7a`](https://github.com/NixOS/nixpkgs/commit/5485dd7a56abc048fdc2143a62db53b4222410af) | `` interactsh: 1.2.1 -> 1.2.2 ``                                            |
| [`336928d3`](https://github.com/NixOS/nixpkgs/commit/336928d3b0adb04957b7a65df26df615312c9a48) | `` libretro.hatari: unstable-2024-06-28 -> unstable-2024-10-01 ``           |
| [`3f645a5e`](https://github.com/NixOS/nixpkgs/commit/3f645a5e22579ceccd7eaffe2319080a9f153431) | `` libretro.beetle-supafaust: unstable-2023-06-19 -> unstable-2024-10-01 `` |
| [`8db65504`](https://github.com/NixOS/nixpkgs/commit/8db65504e6d09c3026008a68d334ca94ac995ae0) | `` rednotebook: switch to pypa builder ``                                   |
| [`fdb458ab`](https://github.com/NixOS/nixpkgs/commit/fdb458abc1e8d368567426ff1eea543b5b52fa23) | `` libretro.gpsp: unstable-2024-08-24 -> unstable-2024-10-01 ``             |
| [`c146dbb0`](https://github.com/NixOS/nixpkgs/commit/c146dbb08a16033fd2f6b519907ed2cee8727cca) | `` minio-client: 2024-09-16T17-43-14Z -> 2024-10-02T08-27-28Z ``            |
| [`77581438`](https://github.com/NixOS/nixpkgs/commit/7758143808a58667b4909a1a39293b3cf59a81d5) | `` pass-git-helper: modernize ``                                            |
| [`14a11a18`](https://github.com/NixOS/nixpkgs/commit/14a11a187f799f8c8c40ad934af5788094c79092) | `` libretro.ppsspp: unstable-2024-09-28 -> unstable-2024-10-03 ``           |
| [`0dd781ee`](https://github.com/NixOS/nixpkgs/commit/0dd781ee86b022dd1a2232e6801ad3b69b65e6b5) | `` libretro.mame2003-plus: unstable-2024-09-26 -> unstable-2024-10-05 ``    |
| [`138d3c10`](https://github.com/NixOS/nixpkgs/commit/138d3c1086df829cb1d73c8dde6b1a7aa9adad94) | `` libretro.beetle-saturn: unstable-2024-05-19 -> unstable-2024-10-01 ``    |
| [`9a6d752a`](https://github.com/NixOS/nixpkgs/commit/9a6d752a180f8cf2da5c84691f6faf6e057d20b1) | `` libretro.beetle-pce: unstable-2024-09-27 -> unstable-2024-10-01 ``       |
| [`052e0de7`](https://github.com/NixOS/nixpkgs/commit/052e0de70182f7a433dfd832dac8cfc15dbdc8cb) | `` libretro.stella: unstable-2024-09-26 -> unstable-2024-10-04 ``           |
| [`6af4ebd6`](https://github.com/NixOS/nixpkgs/commit/6af4ebd62a8368a79015f4d2b3c0a7618d052a5e) | `` fastfetch: 2.26.1 -> 2.27.1 (#346791) ``                                 |
| [`24170e37`](https://github.com/NixOS/nixpkgs/commit/24170e3700dec93b13383a95cf33eb8c554a4f86) | `` libretro.pcsx-rearmed: unstable-2024-09-03 -> unstable-2024-10-06 ``     |
| [`bc29708a`](https://github.com/NixOS/nixpkgs/commit/bc29708a962207059ceb65973d996c32d4417705) | `` libretro.thepowdertoy: unstable-2023-01-17 -> unstable-2024-10-01 ``     |
| [`136358c6`](https://github.com/NixOS/nixpkgs/commit/136358c6825fa588b457a5f8e909a794a0cc9169) | `` libretro.snes9x: unstable-2024-09-27 -> unstable-2024-10-03 ``           |
| [`5a5eb77a`](https://github.com/NixOS/nixpkgs/commit/5a5eb77a9b579e0700f1cf58ce7bd43269d74d04) | `` libretro.picodrive: unstable-2024-09-06 -> unstable-2024-10-01 ``        |
| [`d1157d70`](https://github.com/NixOS/nixpkgs/commit/d1157d70bc9dd258e2dddd49a82284f5abd3623d) | `` runme: 3.7.1 -> 3.8.3 ``                                                 |
| [`e771cab2`](https://github.com/NixOS/nixpkgs/commit/e771cab2f9494135843d1c7b76255006ac2642d9) | `` runme: nixfmt ``                                                         |
| [`1d0ffa1c`](https://github.com/NixOS/nixpkgs/commit/1d0ffa1c1015ee8f40304d863a3cd3011912bcf9) | `` mongosh: 2.3.0 -> 2.3.1 ``                                               |
| [`8440e7f3`](https://github.com/NixOS/nixpkgs/commit/8440e7f3437ca28c3ecccb23779b03c93edde5b9) | `` runme: move to pkgs/by-name ``                                           |
| [`3a046a7f`](https://github.com/NixOS/nixpkgs/commit/3a046a7fb8f217d5be6d96de82df2920332e0c1b) | `` shanggu-fonts: 1.020 -> 1.021 ``                                         |
| [`fff66699`](https://github.com/NixOS/nixpkgs/commit/fff666997c04429609e77d75f4d07a41374c371d) | `` ledfx: 2.0.100 -> 2.0.104 ``                                             |
| [`1aa7951d`](https://github.com/NixOS/nixpkgs/commit/1aa7951dfce7e57eb3116e9ea70bfa46ee7faac4) | `` wazero: 1.8.0 -> 1.8.1 ``                                                |
| [`f53222b4`](https://github.com/NixOS/nixpkgs/commit/f53222b40fff0ec649e8aa733ab5ded75b9c7b15) | `` shiori: 1.7.0 -> 1.7.1 ``                                                |