### PR TITLE
chore(flake/nixpkgs-stable): `ecbc1ca8` -> `1bfbbbe5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -324,11 +324,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1728193676,
-        "narHash": "sha256-PbDWAIjKJdlVg+qQRhzdSor04bAPApDqIv2DofTyynk=",
+        "lastModified": 1728328465,
+        "narHash": "sha256-a0a0M1TmXMK34y3M0cugsmpJ4FJPT/xsblhpiiX1CXo=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "ecbc1ca8ffd6aea8372ad16be9ebbb39889e55b6",
+        "rev": "1bfbbbe5bbf888d675397c66bfdb275d0b99361c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                                                                |
| ---------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------- |
| [`97ec8de3`](https://github.com/NixOS/nixpkgs/commit/97ec8de367940a95b6958343a51a584b6d344c4e) | `` deterministic-host-uname: fix use in nativeBuildInputs ``                                                                           |
| [`4a94f9da`](https://github.com/NixOS/nixpkgs/commit/4a94f9da496d522997713da0571b804e3db99078) | `` chromium: remove superfluous patch ``                                                                                               |
| [`1e07f1ab`](https://github.com/NixOS/nixpkgs/commit/1e07f1abb18018748a5c05a447ccd793c918bee5) | `` electron-chromedriver_32: 32.1.0 -> 32.1.1 ``                                                                                       |
| [`f488912f`](https://github.com/NixOS/nixpkgs/commit/f488912f54f2a39dbed9930681f5eb706db9d054) | `` electron-chromedriver_32: init at 32.1.0, electron-chromedriver_31: 31.4.0 -> 31.6.0, electron-chromedriver_30: 30.4.0 -> 30.5.1 `` |
| [`c221be9c`](https://github.com/NixOS/nixpkgs/commit/c221be9cca85cff374436c4781942c677ff91441) | `` electron-source.electron_32: init at 32.1.1 ``                                                                                      |
| [`82a224ca`](https://github.com/NixOS/nixpkgs/commit/82a224ca03ad8c33526fa0c1f91bb5fca277a5a2) | `` bitwarden-desktop: 2024.8.2 -> 2024.9.0 ``                                                                                          |
| [`59f3017a`](https://github.com/NixOS/nixpkgs/commit/59f3017ab4c873bd76d62b74c00b20ce75fcf052) | `` bitwarden-desktop: 2024.8.1 -> 2024.8.2 ``                                                                                          |
| [`7eecc01d`](https://github.com/NixOS/nixpkgs/commit/7eecc01d7f835c39feaa5132e8d71affbca32652) | `` electron_32-bin: init at 32.1.1 ``                                                                                                  |
| [`d6874f8b`](https://github.com/NixOS/nixpkgs/commit/d6874f8b44e923bfeb85e4c33fc98b2a57d97aff) | `` pdns-recursor: 5.0.6 -> 5.0.9 ``                                                                                                    |
| [`f6d4ec34`](https://github.com/NixOS/nixpkgs/commit/f6d4ec34d80b4067cee6046ebdf70e193a351714) | `` unison-ucm: 0.5.26 -> 0.5.27 ``                                                                                                     |
| [`e82dc77a`](https://github.com/NixOS/nixpkgs/commit/e82dc77a6a3d4605226d0119c197430f489b64ed) | `` doc/hooks/desktop-file-utils: document hook ``                                                                                      |
| [`0984dd85`](https://github.com/NixOS/nixpkgs/commit/0984dd85078e81c4d9c383b4554bee3af91e9641) | `` rewind-ai: 1.5284-15284.1-dcd0176-20240504 -> 1.5310-15310.1-5f6bcc5-20240930 ``                                                    |
| [`cb2976ab`](https://github.com/NixOS/nixpkgs/commit/cb2976aba6c483241c4a7a37acf303dbd84b0fb7) | `` tailscale: 1.74.0 -> 1.74.1 ``                                                                                                      |
| [`39525747`](https://github.com/NixOS/nixpkgs/commit/39525747c7a72526c1ff6201fe64b24e10c0d86f) | `` tailscale: 1.72.1 -> 1.74.0 ``                                                                                                      |
| [`01365ae2`](https://github.com/NixOS/nixpkgs/commit/01365ae2b93c786edcb0be9ca065556152445ec0) | `` go_1_23: 1.23.0 -> 1.23.1 ``                                                                                                        |
| [`06818320`](https://github.com/NixOS/nixpkgs/commit/06818320912a2d568e85b3c1900c9b803eea107b) | `` go_1_23: 1.23rc2 -> 1.23.0 ``                                                                                                       |
| [`6aced5fa`](https://github.com/NixOS/nixpkgs/commit/6aced5fabdcc4cd882d96cd004502f9e1b169ddf) | `` go_1_23: 1.23rc1 -> 1.23rc2 ``                                                                                                      |
| [`128bcc64`](https://github.com/NixOS/nixpkgs/commit/128bcc646d933e2fed5c46a743edcf4a2153c7e1) | `` go_1_23: init at 1.23rc1 ``                                                                                                         |
| [`e4231d55`](https://github.com/NixOS/nixpkgs/commit/e4231d5541108c5cfd7843ea88fd1087fe72dc71) | `` tailscale: 1.72.0 -> 1.72.1 ``                                                                                                      |
| [`0c6b68e5`](https://github.com/NixOS/nixpkgs/commit/0c6b68e52d2efdf95bc95e853a8dc926857a6090) | `` tailscale: 1.70.0 -> 1.72.0 ``                                                                                                      |
| [`f5c084de`](https://github.com/NixOS/nixpkgs/commit/f5c084de828f447915db7c450e7defbbd5018fb5) | `` tailscale: only generate shell completions if possible ``                                                                           |
| [`0f0533a6`](https://github.com/NixOS/nixpkgs/commit/0f0533a63b429772b28dc1d93ce94d71da80d2aa) | `` tailscale: add shell completions ``                                                                                                 |
| [`d8ae8dce`](https://github.com/NixOS/nixpkgs/commit/d8ae8dcefe267aec684410b086f88b0a33a346fd) | `` tailscale: 1.68.2 -> 1.70.0 ``                                                                                                      |
| [`eb872302`](https://github.com/NixOS/nixpkgs/commit/eb8723022e1b85fda1ff5900c5cb58db4f688f3d) | `` tailscale: 1.68.1 -> 1.68.2 ``                                                                                                      |
| [`f21868b6`](https://github.com/NixOS/nixpkgs/commit/f21868b6db512ab092410ff8f6f2c4c90db4281d) | `` tailscale: 1.68.0 -> 1.68.1 ``                                                                                                      |
| [`f57d9d54`](https://github.com/NixOS/nixpkgs/commit/f57d9d54058059b3f81a45b7af1ed1d5708b35b1) | `` tailscale: 1.66.4 -> 1.68.0 ``                                                                                                      |
| [`12bbc612`](https://github.com/NixOS/nixpkgs/commit/12bbc612e8e5332582c71d1282ae3ed49555eb1f) | `` vaultwarden: 1.32.0 -> 1.32.1 ``                                                                                                    |
| [`969d59cb`](https://github.com/NixOS/nixpkgs/commit/969d59cb119c335079487640f02969658dd9143f) | `` slskd: add version test ``                                                                                                          |
| [`ecf86d40`](https://github.com/NixOS/nixpkgs/commit/ecf86d40abb8a889320dcc38b556462ec694695a) | `` slskd: add getchoo as maintainer ``                                                                                                 |
| [`0b7c4c8d`](https://github.com/NixOS/nixpkgs/commit/0b7c4c8d0d557a0f6cb788960cfb85dcc75821df) | `` slskd: add meta.mainProgram ``                                                                                                      |
| [`6a8113b1`](https://github.com/NixOS/nixpkgs/commit/6a8113b1e5e034b9a318da6e394748ae271acfa5) | `` slskd: don't split derivations for build ``                                                                                         |
| [`299c2930`](https://github.com/NixOS/nixpkgs/commit/299c29304e008bec9bc6b9a61c01650de6f4155c) | `` slskd: 0.21.3 -> 0.21.4 ``                                                                                                          |
| [`e3296bd4`](https://github.com/NixOS/nixpkgs/commit/e3296bd4b14dc4b0009059c242cabd589db8979b) | `` gallery-dl: 1.27.4 -> 1.27.5 ``                                                                                                     |
| [`3e1774a4`](https://github.com/NixOS/nixpkgs/commit/3e1774a4c91d29701853131b2e7ee89e279e9f8d) | `` gitlab-timelogs: init at 0.3.0 ``                                                                                                   |