### PR TITLE
chore(flake/spicetify-nix): `85ca2b37` -> `d6e8bdf8`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -416,11 +416,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1728447442,
-        "narHash": "sha256-4KRBf3doA1OKSQcXc5eQu1NHFdno0SSZI/Xmj4zy1iU=",
+        "lastModified": 1728533825,
+        "narHash": "sha256-3+Sz3NWHQZWLsIr4B/Q2CSmZmpQyk/tE7rTB6urzjZI=",
         "owner": "Gerg-L",
         "repo": "spicetify-nix",
-        "rev": "85ca2b370f962f81973443adb31f2e3559eda1dd",
+        "rev": "d6e8bdf856dfba9f704fd58df4c865be8d819b30",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                    |
| ----------------------------------------------------------------------------------------------------- | -------------------------- |
| [`d6e8bdf8`](https://github.com/Gerg-L/spicetify-nix/commit/d6e8bdf856dfba9f704fd58df4c865be8d819b30) | `` CI update 2024-10-10 `` |