### PR TITLE
chore(flake/home-manager): `03863036` -> `342a1d68`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -272,11 +272,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1728337164,
-        "narHash": "sha256-VdRTjJFyq4Q9U7Z/UoC2Q5jK8vSo6E86lHc2OanXtvc=",
+        "lastModified": 1728598744,
+        "narHash": "sha256-sSfvyO5xH3HObHHmh6lp/hcvo7tMjFKd/HXpxyrRnoE=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "038630363e7de57c36c417fd2f5d7c14773403e4",
+        "rev": "342a1d682386d3a1d74f9555cb327f2f311dda6e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                  |
| ----------------------------------------------------------------------------------------------------------- | -------------------------------------------------------- |
| [`342a1d68`](https://github.com/nix-community/home-manager/commit/342a1d682386d3a1d74f9555cb327f2f311dda6e) | `` flake.lock: Update ``                                 |
| [`03f8e0b3`](https://github.com/nix-community/home-manager/commit/03f8e0b3b3ca4f49d11bf0264dbff465d6ae9aae) | `` snixembed: add module ``                              |
| [`8bb5d53c`](https://github.com/nix-community/home-manager/commit/8bb5d53c5847d9a9b2ad1bda49f9aa9df0de282a) | `` docs: add XDG_*_HOME mentions to xdg.*Home options `` |
| [`d47d3325`](https://github.com/nix-community/home-manager/commit/d47d33254fbf4fdbdee9f1f14095f689662e479d) | `` home-manager-manual: expose options.json ``           |
| [`d3ee25c0`](https://github.com/nix-community/home-manager/commit/d3ee25c07848725e924a74a4813de2ad0f5d0878) | `` Translate using Weblate (Hindi) ``                    |