### PR TITLE
chore(flake/home-manager): `58283095` -> `2b13611e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -272,11 +272,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1728644079,
-        "narHash": "sha256-TE8d5So6ur58hN+9V1o+A6tF30+3jrFvCpeZker3Pug=",
+        "lastModified": 1728685293,
+        "narHash": "sha256-1WowL96pksT/XCi+ZXHgqiQ9NiU5oxWuNIQYWqOoEYc=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "582830954264080aae93f751c3cdc58df600d2d1",
+        "rev": "2b13611eaed8326789f76f70d21d06fbb14e3e47",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                             |
| ----------------------------------------------------------------------------------------------------------- | --------------------------------------------------- |
| [`2b13611e`](https://github.com/nix-community/home-manager/commit/2b13611eaed8326789f76f70d21d06fbb14e3e47) | `` floorp: add module ``                            |
| [`65ae9c14`](https://github.com/nix-community/home-manager/commit/65ae9c147349829d3df0222151f53f79821c5134) | `` git: add module for `git maintenance` (#5772) `` |