### PR TITLE
chore(flake/plasma-manager): `bc14b17b` -> `c6d4b6f3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -364,11 +364,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1727917089,
-        "narHash": "sha256-XWNBGf8Z03sqA5/m99X6XTFbHGNuVx1gMaMQJbdDIrY=",
+        "lastModified": 1728750492,
+        "narHash": "sha256-9IHlIsH4gLqQjS2lFbEnsl/ItdqzBBLWLsyXS0k0jf8=",
         "owner": "pjones",
         "repo": "plasma-manager",
-        "rev": "bc14b17bff1557de8f103172508f896a87bb9cdb",
+        "rev": "c6d4b6f3e0138c08f37d66fcfbcbe37dab08f108",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                        | Message                                                       |
| ------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------- |
| [`c6d4b6f3`](https://github.com/nix-community/plasma-manager/commit/c6d4b6f3e0138c08f37d66fcfbcbe37dab08f108) | `` ci: add backport workflow (#383) ``                        |
| [`0b5b6751`](https://github.com/nix-community/plasma-manager/commit/0b5b67518ef569f8f7de81533b2279bc63339c3c) | `` feat(kwin): add strength options for blur effect (#382) `` |