### PR TITLE
chore(flake/spicetify-nix): `b4702ed0` -> `59aa5259`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -416,11 +416,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1728620224,
-        "narHash": "sha256-YfiNICuQO/+HheUQ9P9ijFOzQpiC7YmotA0W28fbRbE=",
+        "lastModified": 1728706579,
+        "narHash": "sha256-uMa7cC1F2m7DHGOT5yQ1ZoUFVWxsnZDBi9VXwOgnhqw=",
         "owner": "Gerg-L",
         "repo": "spicetify-nix",
-        "rev": "b4702ed0b3d634367e28c4d042bd1fd3fb29b692",
+        "rev": "59aa525938e501bdacad3753034e864a426b66f5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                    |
| ----------------------------------------------------------------------------------------------------- | -------------------------- |
| [`59aa5259`](https://github.com/Gerg-L/spicetify-nix/commit/59aa525938e501bdacad3753034e864a426b66f5) | `` CI update 2024-10-12 `` |