### PR TITLE
chore(flake/nixpkgs-stable): `d51c2860` -> `c505ebf7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -324,11 +324,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1728500571,
-        "narHash": "sha256-dOymOQ3AfNI4Z337yEwHGohrVQb4yPODCW9MDUyAc4w=",
+        "lastModified": 1728627514,
+        "narHash": "sha256-r+SF9AnHrTg+bk6YszoKfV9lgyw+yaFUQe0dOjI0Z2o=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "d51c28603def282a24fa034bcb007e2bcb5b5dd0",
+        "rev": "c505ebf777526041d792a49d5f6dd4095ea391a7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                            |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------ |
| [`c505ebf7`](https://github.com/NixOS/nixpkgs/commit/c505ebf777526041d792a49d5f6dd4095ea391a7) | `` teamviewer: Update download url ``                              |
| [`75826e79`](https://github.com/NixOS/nixpkgs/commit/75826e79624027f9c11b20c1aa706df8d0453430) | `` linux_6_6: 6.6.55 -> 6.6.56 ``                                  |
| [`5a5fc214`](https://github.com/NixOS/nixpkgs/commit/5a5fc214da365c0da08b3b4b4b758fee4160078b) | `` linux_latest-libre: 19631 -> 19643 ``                           |
| [`f1994e65`](https://github.com/NixOS/nixpkgs/commit/f1994e65969887bc892354642d616cbebefd0a15) | `` linux_6_6: 6.6.54 -> 6.6.55 ``                                  |
| [`a4846226`](https://github.com/NixOS/nixpkgs/commit/a484622674cf8dbf9e3a104b0cacb6db2fe524f4) | `` linux_6_10: 6.10.13 -> 6.10.14 ``                               |
| [`e648a21e`](https://github.com/NixOS/nixpkgs/commit/e648a21e77a8f559cb309b1901da7c96a0707a2f) | `` linux_6_11: 6.11.2 -> 6.11.3 ``                                 |
| [`ce380bcd`](https://github.com/NixOS/nixpkgs/commit/ce380bcdf16538a0a0204ae1584ff34b87cd666d) | `` linux_testing: 6.12-rc1 -> 6.12-rc2 ``                          |
| [`9f688ac2`](https://github.com/NixOS/nixpkgs/commit/9f688ac24ba5a2308950aa7b64e84cc6ace3bcf3) | `` vscode: fix darwin build ``                                     |
| [`85e40512`](https://github.com/NixOS/nixpkgs/commit/85e405126f342ea24cab8600b482f9f86b503e4e) | `` ungoogled-chromium: 129.0.6668.89-1 -> 129.0.6668.100-1 ``      |
| [`b0272451`](https://github.com/NixOS/nixpkgs/commit/b0272451081a2bdc1725eea8daaf00b9f613e53e) | `` floorp: 11.19.0 -> 11.19.1 ``                                   |
| [`45bd53e3`](https://github.com/NixOS/nixpkgs/commit/45bd53e37b4984c7b99702f305db4f02c47270e1) | `` vscodium: 1.88.1 -> 1.94.1 ``                                   |
| [`9d4edd45`](https://github.com/NixOS/nixpkgs/commit/9d4edd45e4db7dcfc186ca36d7ed028c62c6b4f0) | `` google-chrome: 129.0.6668.89 -> 129.0.6668.100 ``               |
| [`0357df74`](https://github.com/NixOS/nixpkgs/commit/0357df74e47595939f2de575a71e4c02e4e9000b) | `` monero-cli: update submodule version; disable aarch64-darwin `` |
| [`e96cdbf9`](https://github.com/NixOS/nixpkgs/commit/e96cdbf9d53ccb45bf04498c914b5da29a7f0ba6) | `` floorp: add CVE-2024-9680 as a known vulnerability ``           |
| [`52e31f94`](https://github.com/NixOS/nixpkgs/commit/52e31f9424540b529a117705223dec6971123b9f) | `` librewolf-unwrapped: 130.0-3 -> 131.0.2-1 ``                    |
| [`dfe4051b`](https://github.com/NixOS/nixpkgs/commit/dfe4051b54a3c98492432934d124f24c4ab44bba) | `` mullvad-browser: 13.5.6 -> 13.5.7 ``                            |
| [`dd7727be`](https://github.com/NixOS/nixpkgs/commit/dd7727be6b5626101ae2efa8c4818334f93c7628) | `` chromium,chromedriver: 129.0.6668.91 -> 129.0.6668.100 ``       |
| [`871edd85`](https://github.com/NixOS/nixpkgs/commit/871edd85c3a5bbd36fe718958c0c9de3b8fd9e1f) | `` tor-browser: 13.5.6 -> 13.5.7 ``                                |
| [`d494edd5`](https://github.com/NixOS/nixpkgs/commit/d494edd5565456ad052a6fe448a05863bc0ad76b) | `` python313: 3.13.0.rc3 -> 3.13.0 ``                              |
| [`052f358a`](https://github.com/NixOS/nixpkgs/commit/052f358ab077fd285f7f3803126c43ca7e55afc4) | `` gitlab: 17.2.5 -> 17.2.8 ``                                     |