### PR TITLE
chore(flake/nixpkgs-stable): `c505ebf7` -> `a3f9ad65`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -324,11 +324,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1728627514,
-        "narHash": "sha256-r+SF9AnHrTg+bk6YszoKfV9lgyw+yaFUQe0dOjI0Z2o=",
+        "lastModified": 1728740863,
+        "narHash": "sha256-u+rxA79a0lyhG+u+oPBRtTDtzz8kvkc9a6SWSt9ekVc=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "c505ebf777526041d792a49d5f6dd4095ea391a7",
+        "rev": "a3f9ad65a0bf298ed5847629a57808b97e6e8077",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                               |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------- |
| [`268c0ddc`](https://github.com/NixOS/nixpkgs/commit/268c0ddc1f1e47476bfc90c7ac6f2266d701b885) | `` alt-tab-macos: 6.71.0 -> 6.73.0 ``                                                 |
| [`a1a2ad1e`](https://github.com/NixOS/nixpkgs/commit/a1a2ad1e5bae89c83c4d9dd35d265e2f97028237) | `` fop: apply patch for CVE-2024-28168 ``                                             |
| [`0c3b089b`](https://github.com/NixOS/nixpkgs/commit/0c3b089b4095e91a12fdde1a24b2d75b14e680b0) | `` tailscale: 1.74.1 -> 1.76.0 ``                                                     |
| [`943743da`](https://github.com/NixOS/nixpkgs/commit/943743dadd713562b3c22552b66d9d553cb26676) | `` alire: 2.0.1 -> 2.0.2 ``                                                           |
| [`9c5de48d`](https://github.com/NixOS/nixpkgs/commit/9c5de48df051c39310d69ee4ad77313fb620f946) | `` gerrit: 3.9.6 -> 3.9.7 ``                                                          |
| [`e50b6fe0`](https://github.com/NixOS/nixpkgs/commit/e50b6fe00929794d3acbb81ed3212547820894be) | `` thunderbird-bin: 128.2.3esr -> 128.3.1esr ``                                       |
| [`b170ccc5`](https://github.com/NixOS/nixpkgs/commit/b170ccc58364ab243d51b6da3beaf5fd3f4d8773) | `` firefox-devedition-bin-unwrapped: 131.0b9 -> 132.0b6 ``                            |
| [`494023b8`](https://github.com/NixOS/nixpkgs/commit/494023b8830e778b7748cac88da23fc8db3bcfd7) | `` firefox-beta-bin-unwrapped: 131.0b9 -> 132.0b6 ``                                  |
| [`0f390cb1`](https://github.com/NixOS/nixpkgs/commit/0f390cb162fd5e07401100d7195b4b5a3c382ffc) | `` palemoon-bin: 33.4.0 -> 33.4.0.1 ``                                                |
| [`7142c04c`](https://github.com/NixOS/nixpkgs/commit/7142c04cf88304a2b97d324a770bcac7a8ef6f8c) | `` palemoon-bin: 33.3.1 -> 33.4.0 ``                                                  |
| [`a8d35577`](https://github.com/NixOS/nixpkgs/commit/a8d35577ae35735ae899862888c77ce68dd315b8) | `` slack: 4.39.95 -> 4.40.128 ``                                                      |
| [`990d0521`](https://github.com/NixOS/nixpkgs/commit/990d052196ad5d2032927c91afc2c0f93be12c82) | `` keycloak.plugins.keycloak-metrics-spi: 5.0.0 -> 6.0.0 ``                           |
| [`cabf81a2`](https://github.com/NixOS/nixpkgs/commit/cabf81a26f202662a57844ab23880dfe07394065) | `` nixos/keycloak: raise memory size in tests to 2047M ``                             |
| [`3e133804`](https://github.com/NixOS/nixpkgs/commit/3e133804e4830927fd4109aa57a01a4e60047ad2) | `` nixos/keycloak: link $out/lib to KC_HOME_DIR to fix loading optimized app image `` |
| [`1c550f14`](https://github.com/NixOS/nixpkgs/commit/1c550f14bd043c217e9be263524ec0ca94730ec4) | `` keycloak: enable hostname:v1 feature by default ``                                 |
| [`85dcefb2`](https://github.com/NixOS/nixpkgs/commit/85dcefb258229626834138f2bfc51420a4226814) | `` keycloak: 25.0.5 -> 25.0.6 ``                                                      |
| [`af755132`](https://github.com/NixOS/nixpkgs/commit/af75513288cb4653c87a5c710ec434586bedf99c) | `` keycloak: 25.0.4 -> 25.0.5 ``                                                      |
| [`21a7e0b5`](https://github.com/NixOS/nixpkgs/commit/21a7e0b5de7a7ceec713f43cecf9db2ba2e506df) | `` keycloak: 25.0.2 -> 25.0.4 ``                                                      |
| [`6f40cf2e`](https://github.com/NixOS/nixpkgs/commit/6f40cf2e611038d47e2cb0a9600f7f98d91b9af2) | `` keycloak: 25.0.1 -> 25.0.2 ``                                                      |
| [`2f3952d5`](https://github.com/NixOS/nixpkgs/commit/2f3952d525088d798e5ac75d4f4b361ba6be673b) | `` keycloak: 24.0.5 -> 25.0.1 ``                                                      |
| [`9b0efed6`](https://github.com/NixOS/nixpkgs/commit/9b0efed679379cf43bd1eadc9b1d0f8897def0af) | `` grafanaPlugins.marcusolsson-dynamictext-panel: init at 5.4.0 ``                    |
| [`625ec997`](https://github.com/NixOS/nixpkgs/commit/625ec997048fed14acf6908dd2b721725c5c2236) | `` wasmtime: 20.0.2 -> 21.0.2 ``                                                      |
| [`c1db1f01`](https://github.com/NixOS/nixpkgs/commit/c1db1f016af44fb767fef01a014df244c1215446) | `` oath-toolkit: 2.6.11 -> 2.6.12 ``                                                  |
| [`aff26a96`](https://github.com/NixOS/nixpkgs/commit/aff26a96820871f70b1373f6fe68d1cf07f12178) | `` oath-toolkit: migrate to `pkgs/by-name` overlay ``                                 |