### PR TITLE
chore(flake/wfetch): `ed577b2a` -> `d534d8e0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1234,11 +1234,11 @@
         "systems": "systems_3"
       },
       "locked": {
-        "lastModified": 1728879375,
-        "narHash": "sha256-wvh1/Mo1T0sshh9838nK3hyPJgRhXRYhEeYFXcHGkEI=",
+        "lastModified": 1728993873,
+        "narHash": "sha256-mC9K7SfTocYTNHXh6IaVshdiyc8TJYo3AaeFf+Y26Dg=",
         "owner": "iynaix",
         "repo": "wfetch",
-        "rev": "ed577b2a2fa9b6a76259c7292ea17621fb36ecce",
+        "rev": "d534d8e0adfb9055a7cbd85f52caeb24b4aead6e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                              |
| ---------------------------------------------------------------------------------------------- | ---------------------------------------------------- |
| [`d534d8e0`](https://github.com/iynaix/wfetch/commit/d534d8e0adfb9055a7cbd85f52caeb24b4aead6e) | `` Show icons for kitty / ghostty ``                 |
| [`b533a4a5`](https://github.com/iynaix/wfetch/commit/b533a4a5f6dbe5c67ee93abcd1d245bdcb049e73) | `` Fix terminal detection by using setsid syscall `` |
| [`0e648cfa`](https://github.com/iynaix/wfetch/commit/0e648cfae6030f5f47942353640b808f56425541) | `` Add --scale for handling display scaling ``       |