### PR TITLE
chore(flake/wfetch): `d534d8e0` -> `a9d5d652`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1116,17 +1116,16 @@
         "tinted-tmux": "tinted-tmux"
       },
       "locked": {
-        "lastModified": 1728508267,
-        "narHash": "sha256-JH2+RXJNooFtZIN6ZhaGZWn2KChMrso4H7Fkp1Ujrdo=",
+        "lastModified": 1728900372,
+        "narHash": "sha256-hmG/u7qZEm7CTh1XPDi+pg4Oi0nNrv7sL8PgZDRe6wg=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "ed91a20c84a80a525780dcb5ea3387dddf6cd2de",
+        "rev": "33a2eff15181e557bb6dd9d2073b90f7d218975d",
         "type": "github"
       },
       "original": {
         "owner": "danth",
         "repo": "stylix",
-        "rev": "ed91a20c84a80a525780dcb5ea3387dddf6cd2de",
         "type": "github"
       }
     },
@@ -1234,11 +1233,11 @@
         "systems": "systems_3"
       },
       "locked": {
-        "lastModified": 1728993873,
-        "narHash": "sha256-mC9K7SfTocYTNHXh6IaVshdiyc8TJYo3AaeFf+Y26Dg=",
+        "lastModified": 1729008524,
+        "narHash": "sha256-hcicD+zPMB5eotivlu9O1JJ2Lg8e9Tg+4J905ZyyIAY=",
         "owner": "iynaix",
         "repo": "wfetch",
-        "rev": "d534d8e0adfb9055a7cbd85f52caeb24b4aead6e",
+        "rev": "a9d5d6522e29f150d8123d59e0cad64369da93b5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                           |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------- |
| [`a9d5d652`](https://github.com/iynaix/wfetch/commit/a9d5d6522e29f150d8123d59e0cad64369da93b5) | `` Update README screenshots ``                   |
| [`9b380366`](https://github.com/iynaix/wfetch/commit/9b380366026bfbd8152d49b4a0191effc8b8ebb1) | `` Automatically get display scale on hyprland `` |