### PR TITLE
chore(flake/nixpkgs-stable): `a3f9ad65` -> `c0b1da36`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -830,11 +830,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1728740863,
-        "narHash": "sha256-u+rxA79a0lyhG+u+oPBRtTDtzz8kvkc9a6SWSt9ekVc=",
+        "lastModified": 1728909085,
+        "narHash": "sha256-WLxED18lodtQiayIPDE5zwAfkPJSjHJ35UhZ8h3cJUg=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "a3f9ad65a0bf298ed5847629a57808b97e6e8077",
+        "rev": "c0b1da36f7c34a7146501f684e9ebdf15d2bebf8",
         "type": "github"
       },
       "original": {
@@ -1116,17 +1116,16 @@
         "tinted-tmux": "tinted-tmux"
       },
       "locked": {
-        "lastModified": 1728508267,
-        "narHash": "sha256-JH2+RXJNooFtZIN6ZhaGZWn2KChMrso4H7Fkp1Ujrdo=",
+        "lastModified": 1728900372,
+        "narHash": "sha256-hmG/u7qZEm7CTh1XPDi+pg4Oi0nNrv7sL8PgZDRe6wg=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "ed91a20c84a80a525780dcb5ea3387dddf6cd2de",
+        "rev": "33a2eff15181e557bb6dd9d2073b90f7d218975d",
         "type": "github"
       },
       "original": {
         "owner": "danth",
         "repo": "stylix",
-        "rev": "ed91a20c84a80a525780dcb5ea3387dddf6cd2de",
         "type": "github"
       }
     },


### PR DESCRIPTION
| Commit                                                                                         | Message                                                       |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------- |
| [`92b9278c`](https://github.com/NixOS/nixpkgs/commit/92b9278cfc01868d0794c0cfe35308813b82bd7a) | `` wire-desktop: add CVE-2024-6775 to knownVulnerabilities `` |
| [`a5dc08eb`](https://github.com/NixOS/nixpkgs/commit/a5dc08eb3f2aaebf29d9d83c8ce23969569a77e7) | `` open62541: 1.4.4 -> 1.4.6 ``                               |
| [`fb041e4b`](https://github.com/NixOS/nixpkgs/commit/fb041e4bb425897190200f24be57370a81f75c73) | `` firefox-esr-115-unwrapped: drop ``                         |
| [`479ae2a1`](https://github.com/NixOS/nixpkgs/commit/479ae2a1dd113325d896de3169d82b496131b111) | `` koboldcpp: add `meta.homepage` ``                          |
| [`c4bf31df`](https://github.com/NixOS/nixpkgs/commit/c4bf31dfb13ae04e614c215b7bdd7e6730670523) | `` koboldcpp: 1.75.2 -> 1.76 ``                               |
| [`a243030f`](https://github.com/NixOS/nixpkgs/commit/a243030fa2d0f8374031b40b0413f06b2b376e8a) | `` epson-escpr2: 1.2.13 -> 1.2.18 ``                          |
| [`9deaf6a6`](https://github.com/NixOS/nixpkgs/commit/9deaf6a6732b6c7232408f37abc1638c1614c8b9) | `` lutris: fix winetricks pango issue ``                      |
| [`458ec07e`](https://github.com/NixOS/nixpkgs/commit/458ec07eadd83346b0cd4e7d8ccf3abaed0f643c) | `` vpp: init at 24.06 ``                                      |
| [`0a363958`](https://github.com/NixOS/nixpkgs/commit/0a3639583b7a5a4b22dc19b2f643040eac155136) | `` maintainers: add romner-set ``                             |
| [`ddd8f651`](https://github.com/NixOS/nixpkgs/commit/ddd8f65194781327cd73c890b9531e53999c8ac8) | `` nextcloud30Packages: update ``                             |
| [`23f9a321`](https://github.com/NixOS/nixpkgs/commit/23f9a3219f1338733548353a4983e170c3db0c3e) | `` nextcloud29Packages: update ``                             |
| [`2f7e0e9f`](https://github.com/NixOS/nixpkgs/commit/2f7e0e9f877e78b6bb8b1e271a9c9d2807e42c1d) | `` nextcloud28Packages: update ``                             |
| [`ec8f3c88`](https://github.com/NixOS/nixpkgs/commit/ec8f3c8801d235c23d52fb8aee39e2f69917f265) | `` nextcloud29: 29.0.7 -> 29.0.8 ``                           |
| [`0f1d0231`](https://github.com/NixOS/nixpkgs/commit/0f1d0231cabc9f81af2ffbdda540dd3971fb8346) | `` nextcloud28: 28.0.10 -> 28.0.11 ``                         |
| [`fab86e9f`](https://github.com/NixOS/nixpkgs/commit/fab86e9f6f0e8d3744436a5394cf5feca9ba06cd) | `` discord: update all discord packages ``                    |
| [`97c73ae8`](https://github.com/NixOS/nixpkgs/commit/97c73ae89fc213cc4fd896f009aebab8ce29eec9) | `` discord: 0.0.67 -> 0.0.70 ``                               |
| [`cc38508a`](https://github.com/NixOS/nixpkgs/commit/cc38508af2c60ddcdabf7c893b4bfda22a215449) | `` raycast: 1.83.2 -> 1.84.2 ``                               |
| [`27e72db3`](https://github.com/NixOS/nixpkgs/commit/27e72db3b1f9f58ef3bc4031ef308270cacdf831) | `` raycast: 1.83.1 -> 1.83.2 ``                               |
| [`3d090901`](https://github.com/NixOS/nixpkgs/commit/3d090901d5b9fa4ebae0d59aaeaeed892d1ead6d) | `` raycast: 1.82.5 -> 1.83.1 ``                               |
| [`40f5073b`](https://github.com/NixOS/nixpkgs/commit/40f5073bf5d1bd167d80c4eef48cc23dbffdc33b) | `` raycast: 1.82.0 -> 1.82.5 ``                               |
| [`2c371c03`](https://github.com/NixOS/nixpkgs/commit/2c371c03bab48efeb635b7217e5b4f99322b24f9) | `` vscode-langservers-extracted: fix build ``                 |
| [`b6ced638`](https://github.com/NixOS/nixpkgs/commit/b6ced6385157d08d7d4950481d38987fae9c4ab8) | `` rdma-core: 52.0 -> 52.1 ``                                 |
| [`c3d2266a`](https://github.com/NixOS/nixpkgs/commit/c3d2266a5f2a5aa48beb3847632d0a3779bb749b) | `` panoply: 5.5.2 -> 5.5.3 ``                                 |
| [`9c863b10`](https://github.com/NixOS/nixpkgs/commit/9c863b1091cbdfe6c34a144493882a1628dbc859) | `` panoply: 5.5.1 -> 5.5.2 ``                                 |
| [`8307748e`](https://github.com/NixOS/nixpkgs/commit/8307748ef4bb5fd39dfe162305a282ac2c6221fd) | `` panoply: 5.5.0 -> 5.5.1 ``                                 |
| [`d3352c03`](https://github.com/NixOS/nixpkgs/commit/d3352c037d9947138e6e8279a6b2f58eb4743f10) | `` panoply: 5.4.3 -> 5.5.0 ``                                 |
| [`1fdcd1de`](https://github.com/NixOS/nixpkgs/commit/1fdcd1de61971de225294ac259260c632cbb63fd) | `` panoply: 5.4.1 -> 5.4.3 ``                                 |
| [`14a4915a`](https://github.com/NixOS/nixpkgs/commit/14a4915aa66a0143bbdfb656863ace343c9c2201) | `` vivaldi: 6.9.3447.48 -> 6.9.3447.51 ``                     |