### PR TITLE
chore(flake/plasma-manager): `a9960fef` -> `508a0774`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -934,11 +934,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1729011811,
-        "narHash": "sha256-lNzTx9nUEaezJJ77Zm1IkOzTdak9i1n+EP08Z4Ef7xY=",
+        "lastModified": 1729098898,
+        "narHash": "sha256-poRon0EwKWfOfttFk/8IiUPzCO/ahpNvtsSd9lizlHY=",
         "owner": "pjones",
         "repo": "plasma-manager",
-        "rev": "a9960fef15f27eb24ab172290c3febc2f1e66fd9",
+        "rev": "508a077405fa700de0248e7f84bc4fefbd308dd9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                        | Message                                                    |
| ------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------- |
| [`508a0774`](https://github.com/nix-community/plasma-manager/commit/508a077405fa700de0248e7f84bc4fefbd308dd9) | `` Various Additions to PowerDevil Configuration (#379) `` |