### PR TITLE
chore(flake/home-manager): `2a4fd1cf` -> `78a7a070`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -568,11 +568,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1729027341,
-        "narHash": "sha256-IqWD7bA9iJVifvJlB4vs2KUXVhN+d9lECWdNB4jJ0tE=",
+        "lastModified": 1729165983,
+        "narHash": "sha256-gtcodl79t5ZbbX4TSx4RNyggasEvLdVnc/IM+RyxqJw=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "2a4fd1cfd8ed5648583dadef86966a8231024221",
+        "rev": "78a7a070bbcc3b37cc36080c2a3514207d427b3b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                              |
| ----------------------------------------------------------------------------------------------------------- | ---------------------------------------------------- |
| [`78a7a070`](https://github.com/nix-community/home-manager/commit/78a7a070bbcc3b37cc36080c2a3514207d427b3b) | `` flake.lock: Update ``                             |
| [`e43902a7`](https://github.com/nix-community/home-manager/commit/e43902a7d6df1ce25063d59fa35ab786fa9f7704) | `` broot: fix minor documentation bug ``             |
| [`800a191f`](https://github.com/nix-community/home-manager/commit/800a191f33ce7311e5070ff10d6fb5030b55fdde) | `` broot: allow multiple keyboard keys per verb ``   |
| [`1d9b4a3e`](https://github.com/nix-community/home-manager/commit/1d9b4a3e60398572f4a760bc93f89ebeebbdb3e2) | `` fish: make generation of completions optional ``  |
| [`5bb057a7`](https://github.com/nix-community/home-manager/commit/5bb057a7b527f8061f5b3dfaaf06650a23034f18) | `` Translate using Weblate (Lithuanian) ``           |
| [`f81be125`](https://github.com/nix-community/home-manager/commit/f81be125ff5a47b2f0a2289ccb6d4c752083659b) | `` Translate using Weblate (German) ``               |
| [`b5342765`](https://github.com/nix-community/home-manager/commit/b53427656655174c50c050b50c497d0e91405ab7) | `` Translate using Weblate (Romanian) ``             |
| [`628b15d2`](https://github.com/nix-community/home-manager/commit/628b15d275a536fd4d4b9ab4405dd1f0eb34fe18) | `` nushell: allow arbitrary environment variables `` |
| [`edf15f15`](https://github.com/nix-community/home-manager/commit/edf15f1549a2f4e65d704f7d6ab6be715d932976) | `` nushell: create generator helpers ``              |
| [`994a0baf`](https://github.com/nix-community/home-manager/commit/994a0baf7be821c6c1487ffb3ab2884a5581a293) | `` nushell: add joaquintrinanes as maintainer ``     |