### PR TITLE
chore(flake/nixpkgs-stable): `c0b1da36` -> `dc2e0028`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -830,11 +830,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1728909085,
-        "narHash": "sha256-WLxED18lodtQiayIPDE5zwAfkPJSjHJ35UhZ8h3cJUg=",
+        "lastModified": 1729044727,
+        "narHash": "sha256-GKJjtPY+SXfLF/yTN7M2cAnQB6RERFKnQhD8UvPSf3M=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "c0b1da36f7c34a7146501f684e9ebdf15d2bebf8",
+        "rev": "dc2e0028d274394f73653c7c90cc63edbb696be1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                        |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------ |
| [`c943cdbb`](https://github.com/NixOS/nixpkgs/commit/c943cdbb16eb0e4b3c8d891c9363f9aebce68dc7) | `` edl: mark as unfree ``                                                      |
| [`1c7d1365`](https://github.com/NixOS/nixpkgs/commit/1c7d1365c1db64fe9d9f5d7daaae0fc1a64eb88b) | `` element-desktop: 1.11.79 -> 1.11.81 ``                                      |
| [`afeaa6fa`](https://github.com/NixOS/nixpkgs/commit/afeaa6fa0834ac133ec800ba6ce97c38a9c4ef81) | `` signal-desktop-beta: 7.25.0-beta.2 -> 7.29.0-beta.1 ``                      |
| [`4e2d64ff`](https://github.com/NixOS/nixpkgs/commit/4e2d64ff1705d90f6f0b21eb8f070551c1c74968) | `` signal-desktop: 7.27.0 -> 7.28.0 ``                                         |
| [`be5695ff`](https://github.com/NixOS/nixpkgs/commit/be5695ff7a0c47933e98e0908152eb0d4e22dc88) | `` linux_xanmod: backport small refactor to allow clean backports ``           |
| [`5b03e0c1`](https://github.com/NixOS/nixpkgs/commit/5b03e0c166a65d6768da4fa1404c4b6eb5eb8199) | `` nix-direnv: Update resholve solutions from upstream ``                      |
| [`a2c9f81b`](https://github.com/NixOS/nixpkgs/commit/a2c9f81b3fbcfcf0852040ef952c08537118e3bf) | `` nix-direnv: 3.0.5 -> 3.0.6 ``                                               |
| [`c0327d88`](https://github.com/NixOS/nixpkgs/commit/c0327d885b0af945819f7daa461011bec68e7361) | `` mediawiki: 1.41.3 -> 1.41.4 ``                                              |
| [`2bcd284f`](https://github.com/NixOS/nixpkgs/commit/2bcd284fbf1ae5d7e1abed19689ffb592d75966b) | `` firefox-bin-unwrapped: 131.0.2 -> 131.0.3 ``                                |
| [`56f26728`](https://github.com/NixOS/nixpkgs/commit/56f26728e38512c804d4a35be16fd4603d72ce4c) | `` firefox-unwrapped: 131.0.2 -> 131.0.3 ``                                    |
| [`89297920`](https://github.com/NixOS/nixpkgs/commit/892979209d2f05e2a7fa5e0a2fe6b97785b18961) | `` linux_xanmod_latest: 6.11.2 -> 6.11.3 ``                                    |
| [`0af6c1b0`](https://github.com/NixOS/nixpkgs/commit/0af6c1b0d3d3fcd9bddd68cddba9bac72c8fb0f1) | `` linux_xanmod: 6.6.54 -> 6.6.56 ``                                           |
| [`ea923981`](https://github.com/NixOS/nixpkgs/commit/ea9239816bfcc7780488f25732a80b900ef6ddd9) | `` mattermost: 9.5.9 -> 9.5.10 ``                                              |
| [`f8685d8a`](https://github.com/NixOS/nixpkgs/commit/f8685d8a59d662f8f4392e7854ae7cec356e3a0f) | `` arc-browser: 1.61.2-54148 -> 1.63.1-54714 ``                                |
| [`948892d3`](https://github.com/NixOS/nixpkgs/commit/948892d3401d4d96b2ef3fcd8d4f82ba62bfd6a3) | `` gallery-dl: 1.27.5 -> 1.27.6 ``                                             |
| [`866164e1`](https://github.com/NixOS/nixpkgs/commit/866164e14e54ee125ea312db558235b0739b2400) | `` python3Packages.django-mdeditor: patch out polyfill.io usage, bump KaTeX `` |
| [`040a3726`](https://github.com/NixOS/nixpkgs/commit/040a37264a4370a57be9bcba3b144930f2963d88) | `` easyrsa: 3.2.0 -> 3.2.1 ``                                                  |
| [`9a40a769`](https://github.com/NixOS/nixpkgs/commit/9a40a7694a65ab4085d2a1ac8ed0e9eee9f35ad7) | `` oink: 1.3.0 -> 1.3.1 ``                                                     |
| [`0e4b0ab7`](https://github.com/NixOS/nixpkgs/commit/0e4b0ab7f43f347871bda5ca2cb48ba3cbedea30) | `` armcord: remove, add throw with migration details ``                        |
| [`46ff324c`](https://github.com/NixOS/nixpkgs/commit/46ff324c24ffe729bdeb56fffb8981169d9be7e6) | `` legcord: init at 1.0.1 ``                                                   |