### PR TITLE
chore(flake/plasma-manager): `9d851ceb` -> `30d186ab`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -934,11 +934,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1729188492,
-        "narHash": "sha256-GMZubGvIEZIpHhb3sw7GIK7hFtHGBijsXQbR8TBAF+U=",
+        "lastModified": 1729243807,
+        "narHash": "sha256-YxS3wU1cdhK/aYaj9ODukmg451uMCdCVlOhjtFh9YJc=",
         "owner": "pjones",
         "repo": "plasma-manager",
-        "rev": "9d851cebffd92ad3d2c69cc4df7a2c9368b78f73",
+        "rev": "30d186abf38f8dd248ed9046c45b422ed21bdbb0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                        | Message                                                                       |
| ------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------- |
| [`30d186ab`](https://github.com/nix-community/plasma-manager/commit/30d186abf38f8dd248ed9046c45b422ed21bdbb0) | `` feat(workspace): Add option to disable pasting with middle click (#387) `` |