### PR TITLE
chore(flake/home-manager): `e78cbb20` -> `09a0c0c0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -568,11 +568,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1729174520,
-        "narHash": "sha256-QxCAdgQdeIOaCiE0Sr23s9lD0+T1b/wuz5pSiGwNrCQ=",
+        "lastModified": 1729260213,
+        "narHash": "sha256-jAvHoU/1y/yCuXzr2fNF+q6uKmr8Jj2xgAisK4QB9to=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "e78cbb20276f09c1802e62d2f77fc93ec32da268",
+        "rev": "09a0c0c02953318bf94425738c7061ffdc4cba75",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                   |
| ----------------------------------------------------------------------------------------------------------- | --------------------------------------------------------- |
| [`09a0c0c0`](https://github.com/nix-community/home-manager/commit/09a0c0c02953318bf94425738c7061ffdc4cba75) | `` cmus: add module ``                                    |
| [`346973b3`](https://github.com/nix-community/home-manager/commit/346973b338365240090eded0de62f7edce4ce3d1) | `` tests/firefox: add shared path test ``                 |
| [`2ffb68e2`](https://github.com/nix-community/home-manager/commit/2ffb68e20981d78bfcc73b2271f2dfa003df182c) | `` thunderbird: conditional search file ``                |
| [`d4a3186d`](https://github.com/nix-community/home-manager/commit/d4a3186de0eeb37d1e43ed65791b0af677e440a1) | `` firefox: conditional search file ``                    |
| [`cb93ab1c`](https://github.com/nix-community/home-manager/commit/cb93ab1c990c5719ec199e8c397e688de06cb46d) | `` direnv: remove nushell hack ``                         |
| [`1834304b`](https://github.com/nix-community/home-manager/commit/1834304bc3849bfec635cab408e6090d536a549f) | `` direnv: simplify, work around nushell/nushell#14112 `` |