### PR TITLE
chore(flake/nixpkgs-stable): `dc2e0028` -> `4eb33fe6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -830,11 +830,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1729044727,
-        "narHash": "sha256-GKJjtPY+SXfLF/yTN7M2cAnQB6RERFKnQhD8UvPSf3M=",
+        "lastModified": 1729181673,
+        "narHash": "sha256-LDiPhQ3l+fBjRATNtnuDZsBS7hqoBtPkKBkhpoBHv3I=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "dc2e0028d274394f73653c7c90cc63edbb696be1",
+        "rev": "4eb33fe664af7b41a4c446f87d20c9a0a6321fa3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                           |
| ---------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------- |
| [`5428b533`](https://github.com/NixOS/nixpkgs/commit/5428b533108e95aed923dae6a577bfd4a56a0902) | `` linux: enable FF support for hid-nvidia-shield ``                              |
| [`e1eef410`](https://github.com/NixOS/nixpkgs/commit/e1eef410db34eae6a8ccccf5ae564ade129e10b2) | `` linux-firmware: 20240909 -> 20241017 ``                                        |
| [`5789394a`](https://github.com/NixOS/nixpkgs/commit/5789394a31ecf5d9c7309daab08beaaaf374685b) | `` linux_5_10: 5.10.226 -> 5.10.227 ``                                            |
| [`f74f9200`](https://github.com/NixOS/nixpkgs/commit/f74f92002ac9c77c5cbe82218bb3ef3dca5e3ef9) | `` linux_5_15: 5.15.167 -> 5.15.168 ``                                            |
| [`0dffe837`](https://github.com/NixOS/nixpkgs/commit/0dffe83747699260fe128a8ccd3d58ed279acd59) | `` linux_6_1: 6.1.112 -> 6.1.113 ``                                               |
| [`f142a768`](https://github.com/NixOS/nixpkgs/commit/f142a76870a94e9917305f29b2311e0bf2a72a59) | `` linux_6_6: 6.6.56 -> 6.6.57 ``                                                 |
| [`20fd796a`](https://github.com/NixOS/nixpkgs/commit/20fd796a79e07269ff6641647236e24e2d84a971) | `` linux_6_11: 6.11.3 -> 6.11.4 ``                                                |
| [`0d2aca1f`](https://github.com/NixOS/nixpkgs/commit/0d2aca1f93f1a03709e4293b30ea8384b1327dc0) | `` linux_testing: 6.12-rc2 -> 6.12-rc3 ``                                         |
| [`8b57afd0`](https://github.com/NixOS/nixpkgs/commit/8b57afd0f34695615650c27f83370c7559705338) | `` discourse: mark as known vulnerable ``                                         |
| [`86ca1d86`](https://github.com/NixOS/nixpkgs/commit/86ca1d8631eb0802fb6984bb5514cf0ea0cd6966) | `` python3Packages.lark: disable tests ``                                         |
| [`9a125361`](https://github.com/NixOS/nixpkgs/commit/9a125361b3063e8202a6067b1ba17dea77ef41c1) | `` python312Packages.js2py: mark insecure ``                                      |
| [`332dfb4b`](https://github.com/NixOS/nixpkgs/commit/332dfb4bfcd139bd25a15434d1b68d8b981c02af) | `` mattermost: 9.5.10 -> 9.5.11 ``                                                |
| [`f89556b8`](https://github.com/NixOS/nixpkgs/commit/f89556b83e0090831144233639e7b024942d477a) | `` vintagestory: Fix cursor on wayland ``                                         |
| [`15d00b60`](https://github.com/NixOS/nixpkgs/commit/15d00b60d4f3435c94a4a1c00203d2b7661cdef8) | `` google-chrome: 129.0.6668.101 -> 130.0.6723.59 ``                              |
| [`5474a0d6`](https://github.com/NixOS/nixpkgs/commit/5474a0d65de00b3685d2367d857389d831377ef6) | `` google-chrome: 129.0.6668.100 -> 130.0.6723.58 ``                              |
| [`a8edf0e6`](https://github.com/NixOS/nixpkgs/commit/a8edf0e6366ef21d40ea52da7d8ecb01eecd069d) | `` google-chrome: add `shellcheck` ``                                             |
| [`e7a00b0c`](https://github.com/NixOS/nixpkgs/commit/e7a00b0cde89632d08d8409946ab584dcef33ccd) | `` google-chrome: fix URL encoding for version filter ``                          |
| [`2c891ff6`](https://github.com/NixOS/nixpkgs/commit/2c891ff6a2c2d85644163fb653938ca694585ffb) | `` warp-terminal: 0.2024.10.08.08.02.stable_01 -> 0.2024.10.08.08.02.stable_02 `` |
| [`72acc8b5`](https://github.com/NixOS/nixpkgs/commit/72acc8b556d78f6034629e2d22a0f7d7112fb864) | `` warp-terminal: 0.2024.09.24.08.02.stable_01 -> 0.2024.10.08.08.02.stable_01 `` |
| [`0317d53d`](https://github.com/NixOS/nixpkgs/commit/0317d53de1b5a13409fbe096caf78def621aeb60) | `` warp-terminal: 0.2024.09.17.08.02.stable_01 -> 0.2024.09.24.08.02.stable_01 `` |
| [`6dc2c7dd`](https://github.com/NixOS/nixpkgs/commit/6dc2c7dd0a797a6b724e29312e279517ac2a3b6d) | `` warp-terminal: 0.2024.09.10.08.02.stable_01 -> 0.2024.09.17.08.02.stable_01 `` |
| [`ad758436`](https://github.com/NixOS/nixpkgs/commit/ad7584362c2eb485da1d9bad6c7f3338d1b1bba9) | `` warp-terminal: 0.2024.09.03.08.02.stable_03 -> 0.2024.09.10.08.02.stable_01 `` |
| [`9e4a41ef`](https://github.com/NixOS/nixpkgs/commit/9e4a41ef219854697332910f420b063c8dedd0a7) | `` warp-terminal: 0.2024.08.20.08.02.stable_00 -> 0.2024.09.03.08.02.stable_03 `` |
| [`b67fae83`](https://github.com/NixOS/nixpkgs/commit/b67fae83fe5f6010940e7d52ff7e5102f41662f4) | `` warp-terminal: Add Aarch64 support ``                                          |
| [`5bdee0fc`](https://github.com/NixOS/nixpkgs/commit/5bdee0fcffb0fe6da4d0792ea76f00fe6f15f042) | `` warp-terminal: 0.2024.08.13.08.02.stable_04 -> 0.2024.08.20.08.02.stable_00 `` |
| [`b1cf00c5`](https://github.com/NixOS/nixpkgs/commit/b1cf00c537547e861ab6b8ad6c417da70cd5418c) | `` warp-terminal: 0.2024.08.06.08.01.stable_00 -> 0.2024.08.13.08.02.stable_04 `` |
| [`81331e4d`](https://github.com/NixOS/nixpkgs/commit/81331e4d511d878ae5592be57105e618cdf9d1ae) | `` warp-terminal: 0.2024.07.30.08.02.stable_01 -> 0.2024.08.06.08.01.stable_00 `` |
| [`d010865d`](https://github.com/NixOS/nixpkgs/commit/d010865d9b7c8ce9831f063f7c0a8a85e14f77e7) | `` warp-terminal: 0.2024.07.16.08.02.stable_03 -> 0.2024.07.30.08.02.stable_01 `` |
| [`0f920a33`](https://github.com/NixOS/nixpkgs/commit/0f920a3375cfaa8692485f3213c1408ac1862017) | `` lutris: fix libjansson and cursor issues ``                                    |
| [`faa0c495`](https://github.com/NixOS/nixpkgs/commit/faa0c49593922bb7f61068f74db5123388a8b3b5) | `` percona: don't bump LTS name ``                                                |
| [`746bbd84`](https://github.com/NixOS/nixpkgs/commit/746bbd84c72aa4d47f3e8e2620f04b2158f7ea97) | `` tests/mysql: properly specify percona packages ``                              |
| [`26061364`](https://github.com/NixOS/nixpkgs/commit/260613643d5fec6da52b5871bc4e56c1851d5e6c) | `` .git-blame-ignore-revs: add percona reformatting ``                            |
| [`369350af`](https://github.com/NixOS/nixpkgs/commit/369350afcba8e6a231dd25b6a010c4e9dec713b9) | `` percona: apply nixfmt ``                                                       |
| [`57c9def7`](https://github.com/NixOS/nixpkgs/commit/57c9def7653de4172603b26a9b4a0aea86379c79) | `` percona-xtrabackup_8_4: init at 8.4.0-1 ``                                     |
| [`f258b586`](https://github.com/NixOS/nixpkgs/commit/f258b58634c2f96dd309a9cacf1c8d1dff6c76f1) | `` percona-xtrabackup_8_0: 8.0.36-30 -> 8.0.35-31 ``                              |
| [`53caac33`](https://github.com/NixOS/nixpkgs/commit/53caac336455e9cf2e860dd461d808624a015ddf) | `` percona-server_8_0: 8.0.36-28 -> 8.0.37-29 ``                                  |
| [`d768a2d0`](https://github.com/NixOS/nixpkgs/commit/d768a2d0f301e64e06943cffe6c1038cb1bfab3d) | `` percona-server_8_4: init at 8.4.0-1 ``                                         |
| [`84451df1`](https://github.com/NixOS/nixpkgs/commit/84451df13b9105fdc5698219166568c16a55ce58) | `` percona-server, percona-xtrabackup: rework naming ``                           |
| [`9c0ae0a3`](https://github.com/NixOS/nixpkgs/commit/9c0ae0a39a125f05d14e5f4788665562ed0be8ab) | `` percona: fix references to utilities in scripts ``                             |
| [`1d81a822`](https://github.com/NixOS/nixpkgs/commit/1d81a82220cc4dce552fd9689e379b8b67d2d3b0) | `` mathematica: 14.0.0 -> 14.1.0 ``                                               |
| [`aa65abdd`](https://github.com/NixOS/nixpkgs/commit/aa65abdd3f3ae7372bc4087d3f7bd82a1575c291) | `` mathematica: add chewblacka to maintainers ``                                  |
| [`9bb7ed4e`](https://github.com/NixOS/nixpkgs/commit/9bb7ed4e5613bbaf6d87b498a1462870533938b2) | `` thunderbird-128: 128.2.3esr -> 128.3.1esr ``                                   |
| [`b75308c2`](https://github.com/NixOS/nixpkgs/commit/b75308c2392abab092e0e8c371d29c4a0b8d8db0) | `` thunderbird-115: 115.15.0 -> 115.16.0esr ``                                    |
| [`2bc67ad3`](https://github.com/NixOS/nixpkgs/commit/2bc67ad3e81e54bdcc39d77dd5bbd37958f6d713) | `` discord: remove `with lib;` from `meta` ``                                     |
| [`694f99a4`](https://github.com/NixOS/nixpkgs/commit/694f99a43f898619fe35969646e63559fa8e987c) | `` discord: add maintainer donteatoreo ``                                         |
| [`335e3151`](https://github.com/NixOS/nixpkgs/commit/335e3151b319db7c5b87026f0630a7188f47e96f) | `` discord: sort `meta.maintainers` alphabetically ``                             |
| [`75836f86`](https://github.com/NixOS/nixpkgs/commit/75836f860d9992bebfc23bf98afbba6642c11b49) | `` discord: sort `meta` alphabetically ``                                         |
| [`87f97666`](https://github.com/NixOS/nixpkgs/commit/87f976664fa67d98f467ce6d284d5b2d4a581f17) | `` discord-canary: 0.0.502 -> 0.0.503 ``                                          |
| [`74fb0aa2`](https://github.com/NixOS/nixpkgs/commit/74fb0aa297e06b44cd988b8aadd2c8fcb3120bc9) | `` discord-ptb: 0.0.110 -> 0.0.111 ``                                             |
| [`b50b56c6`](https://github.com/NixOS/nixpkgs/commit/b50b56c6fffdbcc21b6866806cc863dc5dad8503) | `` pkgsCross.x86_64-darwin.discord-ptb: 0.0.140 -> 0.0.141 ``                     |
| [`3d19c1a0`](https://github.com/NixOS/nixpkgs/commit/3d19c1a04023248c4e63991d708af289df1dd495) | `` pkgsCross.x86_64-darwin.discord-canary: 0.0.611 -> 0.0.612 ``                  |
| [`b12847e7`](https://github.com/NixOS/nixpkgs/commit/b12847e710006d1220b1029fe24867d0a5ae5fd6) | `` discord: format {darwin,default,linux}.nix files with nixfmt-rfc-style ``      |
| [`2b3d3821`](https://github.com/NixOS/nixpkgs/commit/2b3d38213152195298a0b585bb1d9d923a1daced) | `` discord: fix parsing versions in updateScripts ``                              |