### PR TITLE
chore(flake/home-manager): `09a0c0c0` -> `122f7054`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -568,11 +568,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1729260213,
-        "narHash": "sha256-jAvHoU/1y/yCuXzr2fNF+q6uKmr8Jj2xgAisK4QB9to=",
+        "lastModified": 1729321331,
+        "narHash": "sha256-KVyQq+ez/oB30/WbdNgVD8g/bda34z8NiU187QKQb74=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "09a0c0c02953318bf94425738c7061ffdc4cba75",
+        "rev": "122f70545b29ccb922e655b08acfe05bfb44ec68",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                           |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------- |
| [`122f7054`](https://github.com/nix-community/home-manager/commit/122f70545b29ccb922e655b08acfe05bfb44ec68) | `` firefox: change container.json version to 5 `` |
| [`802b3cb2`](https://github.com/nix-community/home-manager/commit/802b3cb2d45ad66619ea8ad19b280baa460556d2) | `` espanso: use `launcher` command on Linux ``    |