### PR TITLE
chore(flake/spicetify-nix): `095be8b3` -> `3dd5c8c3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1084,11 +1084,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1729225092,
-        "narHash": "sha256-qIWFU7iVs5oTA12jOgHIMlXLY+V1dbdgjt37bbXfwOI=",
+        "lastModified": 1729311378,
+        "narHash": "sha256-EJieGv/hQr3EIo5hEvYHjvi8dMZc8fdT1nXrq6I0Ob0=",
         "owner": "Gerg-L",
         "repo": "spicetify-nix",
-        "rev": "095be8b3a9bb9ec14cbe67cc4710f5e224639da5",
+        "rev": "3dd5c8c33ee1b8d20d855e9fa425361719931b04",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                    |
| ----------------------------------------------------------------------------------------------------- | -------------------------- |
| [`3dd5c8c3`](https://github.com/Gerg-L/spicetify-nix/commit/3dd5c8c33ee1b8d20d855e9fa425361719931b04) | `` CI update 2024-10-19 `` |