### PR TITLE
chore(flake/plasma-manager): `30d186ab` -> `9390dada`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -934,11 +934,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1729243807,
-        "narHash": "sha256-YxS3wU1cdhK/aYaj9ODukmg451uMCdCVlOhjtFh9YJc=",
+        "lastModified": 1729372184,
+        "narHash": "sha256-Tb2/jJ74pt0nmfprkOW1g5zZphJTNbzLnyDENM+c5+I=",
         "owner": "pjones",
         "repo": "plasma-manager",
-        "rev": "30d186abf38f8dd248ed9046c45b422ed21bdbb0",
+        "rev": "9390dadadc58ffda8e494b31ef66a4ae041f6dd1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                        | Message                                                                                                                             |
| ------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------- |
| [`9390dada`](https://github.com/nix-community/plasma-manager/commit/9390dadadc58ffda8e494b31ef66a4ae041f6dd1) | `` fix(kickoff): set `systemFavorites` when choosing what buttons to show (#396) ``                                                 |
| [`fda10d08`](https://github.com/nix-community/plasma-manager/commit/fda10d086b89defb8a604d4d15c4dab6797cc10b) | `` fix(kwin): update usage of `findFirstIndex` function from `lib` to `lib.lists` (#397) ``                                         |
| [`d226a67f`](https://github.com/nix-community/plasma-manager/commit/d226a67fdf835be15e5270c36406e922f4b6fa84) | `` refactor(treewide): remove unused/redundant arguments, format workspace module, remove whitespaces, remove `with lib;` (#390) `` |
| [`154ec91c`](https://github.com/nix-community/plasma-manager/commit/154ec91cc626269d078931877eb9c141bb0e837b) | `` feat(apps): make package installation optional (#389) ``                                                                         |
| [`a8953443`](https://github.com/nix-community/plasma-manager/commit/a8953443d8cc1a274f405735161af164a0cf9c61) | `` chore(examples): add desktop widget example (#393) ``                                                                            |