### PR TITLE
chore(flake/home-manager): `122f7054` -> `fe563023`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -568,11 +568,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1729321331,
-        "narHash": "sha256-KVyQq+ez/oB30/WbdNgVD8g/bda34z8NiU187QKQb74=",
+        "lastModified": 1729414726,
+        "narHash": "sha256-Dtmm1OU8Ymiy9hVWn/a2B8DhRYo9Eoyx9veERdOBR4o=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "122f70545b29ccb922e655b08acfe05bfb44ec68",
+        "rev": "fe56302339bb28e3471632379d733547caec8103",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                        |
| ----------------------------------------------------------------------------------------------------------- | ---------------------------------------------- |
| [`fe563023`](https://github.com/nix-community/home-manager/commit/fe56302339bb28e3471632379d733547caec8103) | `` zoxide: fix fzf bash-completion conflict `` |
| [`892a6443`](https://github.com/nix-community/home-manager/commit/892a6443b7676207490c83d181367ba3abcb1f23) | `` nh: add module ``                           |