### PR TITLE
chore(flake/spicetify-nix): `1a8fa34b` -> `7dcfbba6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1084,11 +1084,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1729397826,
-        "narHash": "sha256-PKiCeeV0D8qBRVzlGlx3DE+/0WU8U8maMjB2rRJMBBA=",
+        "lastModified": 1729484282,
+        "narHash": "sha256-VnLaP3OH9rP/+5ZuEsETSyyKtBif5l3mNL3YOxPhBVo=",
         "owner": "Gerg-L",
         "repo": "spicetify-nix",
-        "rev": "1a8fa34b656d67c1d7d4c2b76cba03bf4d65dee4",
+        "rev": "7dcfbba64faedd15574e6df5d89b2bcf5bb20128",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                    |
| ----------------------------------------------------------------------------------------------------- | -------------------------- |
| [`7dcfbba6`](https://github.com/Gerg-L/spicetify-nix/commit/7dcfbba64faedd15574e6df5d89b2bcf5bb20128) | `` CI update 2024-10-21 `` |