### PR TITLE
chore(flake/nixpkgs-stable): `4eb33fe6` -> `a9b86fc2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -830,11 +830,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1729181673,
-        "narHash": "sha256-LDiPhQ3l+fBjRATNtnuDZsBS7hqoBtPkKBkhpoBHv3I=",
+        "lastModified": 1729307008,
+        "narHash": "sha256-QUvb6epgKi9pCu9CttRQW4y5NqJ+snKr1FZpG/x3Wtc=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "4eb33fe664af7b41a4c446f87d20c9a0a6321fa3",
+        "rev": "a9b86fc2290b69375c5542b622088eb6eca2a7c3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                     |
| ---------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------- |
| [`717a6c38`](https://github.com/NixOS/nixpkgs/commit/717a6c385b83c00e3bc1b7b4f11da3db51130a6a) | `` tailscale: 1.76.0 -> 1.76.1 ``                                           |
| [`881e352b`](https://github.com/NixOS/nixpkgs/commit/881e352be107ab60f5a62fb322c3c90688f4d4ba) | `` firefox-bin: fix `webgpu` support ``                                     |
| [`a3f19f0f`](https://github.com/NixOS/nixpkgs/commit/a3f19f0f3cea537f02ee5a0630d6d54b8eca14e0) | `` nextcloud30: 30.0.0 -> 30.0.1 ``                                         |
| [`b17bad82`](https://github.com/NixOS/nixpkgs/commit/b17bad82dc4d0ae0e569b904e0d7705d8816c85f) | `` signal-desktop-beta: 7.29.0-beta.1 -> 7.30.0-beta.1 ``                   |
| [`6a92036f`](https://github.com/NixOS/nixpkgs/commit/6a92036f75bd241a6b2a9c6ac70577e4de36fdd7) | `` signal-desktop(linux): 7.28.0 -> 7.29.0 ``                               |
| [`0d142d97`](https://github.com/NixOS/nixpkgs/commit/0d142d97418ce2e91e949e030406f508b6468d6f) | `` present: fix crash caused by dependency ``                               |
| [`e2d2a59c`](https://github.com/NixOS/nixpkgs/commit/e2d2a59cea8ac1bbe4bba35d8e34e782b3f0a02c) | `` matrix-synapse: 1.116.0 -> 1.117.0 ``                                    |
| [`6429b7b3`](https://github.com/NixOS/nixpkgs/commit/6429b7b3228a9e593649679cb7073e8b74f48baa) | `` nixos/resilio: add package option ``                                     |
| [`73c98f9a`](https://github.com/NixOS/nixpkgs/commit/73c98f9a723f258ccf467fc12df6c81b76c54ba9) | `` slskd: disable flaky test ``                                             |
| [`a728cc9d`](https://github.com/NixOS/nixpkgs/commit/a728cc9d8637a31f4ae98d4860ed523ce6b82da4) | `` dbeaver-bin: add webkitgkt and glib-networking for webbrowser support `` |
| [`7d0bcfa1`](https://github.com/NixOS/nixpkgs/commit/7d0bcfa14c382f9e5b7c8b5c56d562c2d65bd2e2) | `` dbeaver-bin: 24.1.4 -> 24.1.5 ``                                         |
| [`be93dd4d`](https://github.com/NixOS/nixpkgs/commit/be93dd4d6d21d822f9905f21da4ee95e91f2dcc4) | `` dbeaver-bin: fix crash at startup ``                                     |
| [`a0aa3de3`](https://github.com/NixOS/nixpkgs/commit/a0aa3de362a90e82667867c56a05b15d8128c941) | `` dbeaver-bin: 24.1.3 -> 24.1.4 ``                                         |
| [`3cc92b4e`](https://github.com/NixOS/nixpkgs/commit/3cc92b4e36f2fe0823bfcfab00032b5a3ed918df) | `` dbeaver-bin: 24.1.2 -> 24.1.3 ``                                         |
| [`6e945b78`](https://github.com/NixOS/nixpkgs/commit/6e945b78b485450f9651ec643234be6742087522) | `` dbeaver-bin: 24.1.1 -> 24.1.2 ``                                         |
| [`64c1f0b3`](https://github.com/NixOS/nixpkgs/commit/64c1f0b35422c6f17ce76e7bf497d657a9c5aec1) | `` dbeaver-bin: 24.1.0 -> 24.1.1 ``                                         |
| [`1051eeed`](https://github.com/NixOS/nixpkgs/commit/1051eeed737558f7cc5b1fb2e671371e942fb58f) | `` dbeaver-bin: change order of attrs ``                                    |
| [`e13b0cc5`](https://github.com/NixOS/nixpkgs/commit/e13b0cc53a20eec0c5209efbe244e7f052ede50a) | `` dbeaver-bin: 24.0.5 -> 24.1.0 ``                                         |
| [`973ada21`](https://github.com/NixOS/nixpkgs/commit/973ada21fc2e78b5eb23081ac760b21d326f932b) | `` dbeaver-bin: add darwin support ``                                       |
| [`97156e72`](https://github.com/NixOS/nixpkgs/commit/97156e72a8bc51b08285b9a2c9bdff6d85783a03) | `` maintainers: format ``                                                   |
| [`36aeb9cc`](https://github.com/NixOS/nixpkgs/commit/36aeb9cc1dea8354353958a921315beec5de9155) | `` maintainers: add yzx9 ``                                                 |