### PR TITLE
chore(flake/nixpkgs-stable): `a9b86fc2` -> `89172919`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -830,11 +830,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1729307008,
-        "narHash": "sha256-QUvb6epgKi9pCu9CttRQW4y5NqJ+snKr1FZpG/x3Wtc=",
+        "lastModified": 1729449015,
+        "narHash": "sha256-Gf04dXB0n4q0A9G5nTGH3zuMGr6jtJppqdeljxua1fo=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "a9b86fc2290b69375c5542b622088eb6eca2a7c3",
+        "rev": "89172919243df199fe237ba0f776c3e3e3d72367",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                      |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------ |
| [`89172919`](https://github.com/NixOS/nixpkgs/commit/89172919243df199fe237ba0f776c3e3e3d72367) | `` keepassxc: 2.7.8 -> 2.7.9 ``                              |
| [`b3bf8386`](https://github.com/NixOS/nixpkgs/commit/b3bf838631786994f4368286c5672eb837061aa6) | `` keepassxc: 2.7.7 -> 2.7.8 ``                              |
| [`3b850188`](https://github.com/NixOS/nixpkgs/commit/3b8501887ca9861ca925b56a20074094552b3281) | `` python3Packages.meshtastic: add missing dep, unbreak ``   |
| [`c83fd230`](https://github.com/NixOS/nixpkgs/commit/c83fd23006a3fcaedc6458081252c2763a6fe502) | `` nix-output-monitor: 2.1.3 -> 2.1.4 ``                     |
| [`c4f1f1e3`](https://github.com/NixOS/nixpkgs/commit/c4f1f1e3861b7dc48d8eb37c8cf464ca647939f8) | `` nix-output-monitor: 2.1.2 -> 2.1.3 ``                     |
| [`ce67285f`](https://github.com/NixOS/nixpkgs/commit/ce67285fbce7a34d8cad78557a629e764dc7b900) | `` lixVersions.lix_2_91: 2.91.0 -> 2.91.1 ``                 |
| [`b05f6e20`](https://github.com/NixOS/nixpkgs/commit/b05f6e2067567e50bfda1e45e768d550cfeec25b) | `` unifi8: 8.4.62 -> 8.5.6 ``                                |
| [`e135afca`](https://github.com/NixOS/nixpkgs/commit/e135afca607c9921525c06ec368855ab407fa912) | `` wiki-js: unpack into `source` ``                          |
| [`2e8d92a7`](https://github.com/NixOS/nixpkgs/commit/2e8d92a7214d26a3722b2ecdfdad0c7a56267b45) | `` wiki-js: 2.5.304 -> 2.5.305 ``                            |
| [`825a351c`](https://github.com/NixOS/nixpkgs/commit/825a351ccc1ab05bc6cd4275f3569d5ea421aa39) | `` chromium,chromedriver: 129.0.6668.100 -> 130.0.6723.58 `` |
| [`b139e78d`](https://github.com/NixOS/nixpkgs/commit/b139e78d68bf06ee4c866c16cac10a7d1bf5d9af) | `` cups-idprt-sp900: init at 1.4.0 ``                        |
| [`12d869ae`](https://github.com/NixOS/nixpkgs/commit/12d869ae2c6b3dc6cc0a9b0be199d5db89fe0882) | `` cups-idprt-mt890: init at 1.2.0 ``                        |
| [`13897053`](https://github.com/NixOS/nixpkgs/commit/1389705346bc356db32ebe51229eafc7bba6eb1b) | `` cups-idprt-mt888: init at 1.2.0 ``                        |
| [`4c7a0222`](https://github.com/NixOS/nixpkgs/commit/4c7a0222623ac8d61c4e40a3b01567c5c3408fbd) | `` cups-idprt-barcode: init at 1.2.1 ``                      |
| [`6c562770`](https://github.com/NixOS/nixpkgs/commit/6c5627709c130eaf96a53b6bd1f7ba0ace693ab9) | `` cups-idprt-tspl: init at 1.4.7 ``                         |
| [`2801a3c6`](https://github.com/NixOS/nixpkgs/commit/2801a3c6f435d2a71c1c9fba835fa4b2a082410a) | `` python312Packages.manifestoo-core: 1.6 -> 1.7 ``          |