### PR TITLE
chore(flake/wfetch): `a9d5d652` -> `bdc30ca5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -190,11 +190,11 @@
         "pre-commit-hooks": "pre-commit-hooks_2"
       },
       "locked": {
-        "lastModified": 1728740426,
-        "narHash": "sha256-Y7bHzOlhA3jSG0zewmrAxFeeiRIK6aASlMyW6IjB0ws=",
+        "lastModified": 1729671818,
+        "narHash": "sha256-ywsxcSR/x+wLTvtYx1u8uLUhuZYGruOHlwGZzAwDtTs=",
         "owner": "cachix",
         "repo": "devenv",
-        "rev": "ef61728d91ad5eb91f86cdbcc16070602e7afa16",
+        "rev": "874a5265907f13437c5c3d92fd264c191d2148f2",
         "type": "github"
       },
       "original": {
@@ -1233,11 +1233,11 @@
         "systems": "systems_3"
       },
       "locked": {
-        "lastModified": 1729008524,
-        "narHash": "sha256-hcicD+zPMB5eotivlu9O1JJ2Lg8e9Tg+4J905ZyyIAY=",
+        "lastModified": 1729674717,
+        "narHash": "sha256-iDQbsV7+NWdUpwV5fJmb13guJFBgRrJytP6KF06F6Mc=",
         "owner": "iynaix",
         "repo": "wfetch",
-        "rev": "a9d5d6522e29f150d8123d59e0cad64369da93b5",
+        "rev": "bdc30ca5b89309019116b3946640bc8d40c73240",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                           |
| ---------------------------------------------------------------------------------------------- | ----------------------------------------------------------------- |
| [`bdc30ca5`](https://github.com/iynaix/wfetch/commit/bdc30ca5b89309019116b3946640bc8d40c73240) | `` Build image and fast_image_resize with optimizations in dev `` |