### PR TITLE
chore(flake/plasma-manager): `9390dada` -> `247a8e67`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -934,11 +934,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1729372184,
-        "narHash": "sha256-Tb2/jJ74pt0nmfprkOW1g5zZphJTNbzLnyDENM+c5+I=",
+        "lastModified": 1729710171,
+        "narHash": "sha256-2sVt2hbL+G0FzEESm/EZBewPOmNtZ6MTnYhsvHJW6Rs=",
         "owner": "pjones",
         "repo": "plasma-manager",
-        "rev": "9390dadadc58ffda8e494b31ef66a4ae041f6dd1",
+        "rev": "247a8e677b51f053ca89dcf67059e24f85e47391",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                        | Message                                                   |
| ------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------- |
| [`247a8e67`](https://github.com/nix-community/plasma-manager/commit/247a8e677b51f053ca89dcf67059e24f85e47391) | `` feat(okular): add more accessibility options (#401) `` |