### PR TITLE
chore(flake/home-manager): `5ec753a1` -> `a4353cc4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -568,11 +568,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1729551526,
-        "narHash": "sha256-7LAGY32Xl14OVQp3y6M43/0AtHYYvV6pdyBcp3eoz0s=",
+        "lastModified": 1729716953,
+        "narHash": "sha256-FbRKGRRd0amsk/WS/UV9ukJ8jT1dZ2pJBISxkX+uq6A=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "5ec753a1fc4454df9285d8b3ec0809234defb975",
+        "rev": "a4353cc43d1b4dd6bdeacea90eb92a8b7b78a9d7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                            |
| ----------------------------------------------------------------------------------------------------------- | -------------------------------------------------- |
| [`a4353cc4`](https://github.com/nix-community/home-manager/commit/a4353cc43d1b4dd6bdeacea90eb92a8b7b78a9d7) | `` accounts/contacts: fix defaultText rendering `` |
| [`5765fe4f`](https://github.com/nix-community/home-manager/commit/5765fe4feb78092cf3cbe2aa5cd523513eea7769) | `` accounts/calendar: fix defaultText rendering `` |