### PR TITLE
chore(flake/nixpkgs-stable): `89172919` -> `32e940c7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -830,11 +830,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1729449015,
-        "narHash": "sha256-Gf04dXB0n4q0A9G5nTGH3zuMGr6jtJppqdeljxua1fo=",
+        "lastModified": 1729691686,
+        "narHash": "sha256-BAuPWW+9fa1moZTU+jFh+1cUtmsuF8asgzFwejM4wac=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "89172919243df199fe237ba0f776c3e3e3d72367",
+        "rev": "32e940c7c420600ef0d1ef396dc63b04ee9cad37",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                        |
| ---------------------------------------------------------------------------------------------- | -------------------------------------------------------------- |
| [`1724ad09`](https://github.com/NixOS/nixpkgs/commit/1724ad09ca321e83fbeaa8866f50206f874ece18) | `` openvi: 7.5.29 -> 7.6.30 ``                                 |
| [`5de08b5a`](https://github.com/NixOS/nixpkgs/commit/5de08b5ab1c68d49948577cfb696953383a4bb4a) | `` paper-clip: 5.5 -> 5.5.1 ``                                 |
| [`67e69239`](https://github.com/NixOS/nixpkgs/commit/67e69239226f37168d1adb8d29bd61150756a03e) | `` linux: cherry-pick netfilter fix ``                         |
| [`572e8c7b`](https://github.com/NixOS/nixpkgs/commit/572e8c7b6ea8a6f51a8018c947f90ba9b0e05ab8) | `` linux_5_10: 5.10.227 -> 5.10.228 ``                         |
| [`4fbffcb2`](https://github.com/NixOS/nixpkgs/commit/4fbffcb2c75e00077f36717a3ff2581ab645dc62) | `` linux_5_15: 5.15.168 -> 5.15.169 ``                         |
| [`77900c3b`](https://github.com/NixOS/nixpkgs/commit/77900c3ba3cd0faf3f42b4b549c072d5232cb460) | `` linux_6_1: 6.1.113 -> 6.1.114 ``                            |
| [`63f0f02b`](https://github.com/NixOS/nixpkgs/commit/63f0f02bc4a229354764969ebe8a91a3d6f08516) | `` linux_6_6: 6.6.57 -> 6.6.58 ``                              |
| [`f7a665a9`](https://github.com/NixOS/nixpkgs/commit/f7a665a960d56fc94a0004cc4b53d0c42b2d48d8) | `` linux_6_11: 6.11.4 -> 6.11.5 ``                             |
| [`aebdf812`](https://github.com/NixOS/nixpkgs/commit/aebdf8128c27d8ac464697990bec90a93bbdd5bf) | `` linux_testing: 6.12-rc3 -> 6.12-rc4 ``                      |
| [`a5decc1d`](https://github.com/NixOS/nixpkgs/commit/a5decc1ddbadb633a2f012eda9fd1f2b7266400a) | `` github-runner: nixfmt-rfc-style ``                          |
| [`6f4d16ab`](https://github.com/NixOS/nixpkgs/commit/6f4d16ab72f77d2ba339eeb722ac71c0fa3f17c2) | `` github-runner: 2.319.1 -> 2.320.0 ``                        |
| [`c4dbf07b`](https://github.com/NixOS/nixpkgs/commit/c4dbf07b75cea8b09307b8b5091f406ab6ec5fca) | `` yggdrasil: 0.5.7 -> 0.5.9 ``                                |
| [`7bdcb226`](https://github.com/NixOS/nixpkgs/commit/7bdcb226e2daa626b2c37ad7e972e10e6ad0dea8) | `` linux_xanmod_latest: 6.11.3 -> 6.11.4 ``                    |
| [`7db79890`](https://github.com/NixOS/nixpkgs/commit/7db79890033a992cc9e1d3c02cbcd31ba6aa452a) | `` linux_xanmod: 6.6.56 -> 6.6.57 ``                           |
| [`bdc4da6e`](https://github.com/NixOS/nixpkgs/commit/bdc4da6e9d6c0b751afc0cbf1e10d01e36a6dfae) | `` yt-dlp: 2024.10.7 -> 2024.10.22 ``                          |
| [`37c0534f`](https://github.com/NixOS/nixpkgs/commit/37c0534f08e6b1afe2d89556f773795ed704bc2f) | `` batman-adv: 2024.2 -> 2024.3 ``                             |
| [`362a5bde`](https://github.com/NixOS/nixpkgs/commit/362a5bdeada158f52e73c7cb836c1a2ca1cf5b12) | `` tailscale: move to by-name (#350402) ``                     |
| [`1d0c94b3`](https://github.com/NixOS/nixpkgs/commit/1d0c94b3f082a065e26d1e3f21fcd29a15d34e53) | `` thunderbird-bin-unwrapped: 128.3.1esr -> 128.3.2esr ``      |
| [`c1bcb35d`](https://github.com/NixOS/nixpkgs/commit/c1bcb35dacf70e259b2df30e6f6e239bc16fb7f8) | `` signal-desktop-beta: 7.30.0-beta.1 -> 7.30.0-beta.2 ``      |
| [`8b71a7f5`](https://github.com/NixOS/nixpkgs/commit/8b71a7f5bcb84528ec0a6d3cd9e0d5920406a777) | `` mbedtls: 3.6.1 -> 3.6.2 ``                                  |
| [`4a8bf96d`](https://github.com/NixOS/nixpkgs/commit/4a8bf96d1720d08b3313786e82ea4f507bb13355) | `` gitlab: 17.2.8 -> 17.2.9 ``                                 |
| [`e52fbe5a`](https://github.com/NixOS/nixpkgs/commit/e52fbe5ac5ab02b0e384abe800c2174203557ddb) | `` skypeforlinux: 8.129.0.202 -> 8.130.0.205 ``                |
| [`e270409c`](https://github.com/NixOS/nixpkgs/commit/e270409cf8f37be21b10251669a4540c1390b438) | `` ungoogled-chromium: 129.0.6668.100-1 -> 130.0.6723.58-1 ``  |
| [`bfcbc85a`](https://github.com/NixOS/nixpkgs/commit/bfcbc85a77c219b4c905dce97a28dd7b48136cd5) | `` percona-server_8_{0,4}: fix tests not being found ``        |
| [`2e65e24e`](https://github.com/NixOS/nixpkgs/commit/2e65e24eaee86b8eabdcbbade4a2d5d36c1e8285) | `` patroni: 3.3.3 -> 3.3.4 ``                                  |
| [`8548b4d7`](https://github.com/NixOS/nixpkgs/commit/8548b4d77680d8d8598cb3e1629917a24a89c18c) | `` stats: quote paths ``                                       |
| [`047ebe13`](https://github.com/NixOS/nixpkgs/commit/047ebe13873f09fac2e42d7c6a2c77c96834292b) | `` stats: format `meta.maintainers` ``                         |
| [`b44db269`](https://github.com/NixOS/nixpkgs/commit/b44db269539a82b1abb0b8a6cb868086f1193b16) | `` stats: 2.11.11 -> 2.11.14 ``                                |
| [`e63a72f9`](https://github.com/NixOS/nixpkgs/commit/e63a72f93e5cc68fc387bb7b463336bb7cebdbee) | `` stats: 2.11.7 -> 2.11.11 ``                                 |
| [`7f56f219`](https://github.com/NixOS/nixpkgs/commit/7f56f219871bc38f4516d1d15ffb5cc1a930fe91) | `` docker: 27.3.0 -> 27.3.1 ``                                 |
| [`b493b0e7`](https://github.com/NixOS/nixpkgs/commit/b493b0e7ccbd4718a0dce41ab1c47723e97d88ac) | `` docker_27: 27.2.0 -> 27.3.0 ``                              |
| [`574d2ff6`](https://github.com/NixOS/nixpkgs/commit/574d2ff60fa2df2390b82b979a9787d8b71457bd) | `` docker_27: 27.1.1 -> 27.2.0 ``                              |
| [`04e7fe78`](https://github.com/NixOS/nixpkgs/commit/04e7fe78c0c76c1032d6653b22ff9bcd5be8d55a) | `` lib.systems.examples: Fix deprecated attr ``                |
| [`d6ca1303`](https://github.com/NixOS/nixpkgs/commit/d6ca13034eca1dd010f304461bf363998c425b8b) | `` python3Packages.dbf: Workaround broken build on Darwin ``   |
| [`c78221a3`](https://github.com/NixOS/nixpkgs/commit/c78221a3eb850c564be1d44cdc9c05bc097ee87e) | `` python3Packages.dbf: Fix not running hooks in checkPhase `` |
| [`db55be6e`](https://github.com/NixOS/nixpkgs/commit/db55be6e21e0287d3b3f90073a4d29e1c172bf15) | `` python312Packages.biothings-client: init at 0.3.1 ``        |
| [`d025af54`](https://github.com/NixOS/nixpkgs/commit/d025af54733adfcddf8567b75e8169000b567161) | `` maintainers: add rayhem ``                                  |
| [`3196b4ae`](https://github.com/NixOS/nixpkgs/commit/3196b4ae7bcfa59751e0e60d8afba4adbdb5d34d) | `` katawa-shoujo: Fetch from archive.org ``                    |