### PR TITLE
chore(flake/home-manager): `c77c3bb2` -> `93435d27`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -568,11 +568,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1729848063,
-        "narHash": "sha256-1uGIPOSJq4IzoDvgfOF6A3sw5it1WX3ZdYl2+jCkjv8=",
+        "lastModified": 1729894599,
+        "narHash": "sha256-nL9nzNE5/re/P+zOv7NX6bRm5e+DeS1HIufQUJ01w20=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "c77c3bb23390a9ba91860e721edde54856fc5f7a",
+        "rev": "93435d27d250fa986bfec6b2ff263161ff8288cb",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                           |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------- |
| [`93435d27`](https://github.com/nix-community/home-manager/commit/93435d27d250fa986bfec6b2ff263161ff8288cb) | `` direnv: add support for mise integration ``    |
| [`0c0268a3`](https://github.com/nix-community/home-manager/commit/0c0268a3c80d30b989d0aadbd65f38d4fa27a9a0) | `` eza: add color option ``                       |
| [`c0e23159`](https://github.com/nix-community/home-manager/commit/c0e23159872e2e2135c7eb5cf96cd36cfe6ee1f4) | `` git-credential-oauth: add extraFlags option `` |
| [`6cc03e33`](https://github.com/nix-community/home-manager/commit/6cc03e337aa1d0222e5942f58839d965075a9781) | `` nix-gc: add `randomizedDelaySec` option ``     |