### PR TITLE
chore(flake/nixpkgs): `2768c7d0` -> `18536bf0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -738,11 +738,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1729665710,
-        "narHash": "sha256-AlcmCXJZPIlO5dmFzV3V2XF6x/OpNWUV8Y/FMPGd8Z4=",
+        "lastModified": 1729880355,
+        "narHash": "sha256-RP+OQ6koQQLX5nw0NmcDrzvGL8HDLnyXt/jHhL1jwjM=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "2768c7d042a37de65bb1b5b3268fc987e534c49d",
+        "rev": "18536bf04cd71abd345f9579158841376fdd0c5a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                          |
| ---------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------- |
| [`e9905b3b`](https://github.com/NixOS/nixpkgs/commit/e9905b3b9c94bfe3e02167e058b1d03adcfde637) | `` cloud-hypervisor: 41.0 -> 42.0 ``                                             |
| [`1c5513a4`](https://github.com/NixOS/nixpkgs/commit/1c5513a4b9ab8e23f27b14d49f657214a5d2b3e1) | `` zotero: 7.0.7 -> 7.0.8 (#349542) ``                                           |
| [`df6fd680`](https://github.com/NixOS/nixpkgs/commit/df6fd680892fafdabe748fe1383abfe82047da0b) | `` gh: 2.59.0 -> 2.60.0 ``                                                       |
| [`6e32aa72`](https://github.com/NixOS/nixpkgs/commit/6e32aa72403bfd72a8a6894035eadca1c86235e9) | `` ananicy-rules-cachyos: 0-unstable-2024-09-18 -> 0-unstable-2024-10-25 ``      |
| [`71583a97`](https://github.com/NixOS/nixpkgs/commit/71583a97f815b8f62d6cd2357186a9b03ce256a0) | `` gamescope: 3.15.11 -> 3.15.13 ``                                              |
| [`aefe8bac`](https://github.com/NixOS/nixpkgs/commit/aefe8bacca5b964779bc9b178db85276aacbacb9) | `` uv: 0.4.25 -> 0.4.26 ``                                                       |
| [`2b5e0949`](https://github.com/NixOS/nixpkgs/commit/2b5e0949dec737a1e653b749a5fe9eb43a7ba62c) | `` tmux-sessionizer: 0.4.3 -> 0.4.4 ``                                           |
| [`1582530f`](https://github.com/NixOS/nixpkgs/commit/1582530fed096ed0ab1532045b92adb45f8ea6eb) | `` arc-browser: 1.65.0-54911 -> 1.66.0-55166 ``                                  |
| [`41dea553`](https://github.com/NixOS/nixpkgs/commit/41dea55321e5a999b17033296ac05fe8a8b5a257) | `` alephone-eternal: 1.2.0 -> 1.2.1 ``                                           |
| [`299522b7`](https://github.com/NixOS/nixpkgs/commit/299522b78a546b0238861cdad93f340f0b62b8fd) | `` virtualbox: 7.0.20 -> 7.0.22 (#350707) ``                                     |
| [`67913a7e`](https://github.com/NixOS/nixpkgs/commit/67913a7e7db77ded890f3040d3b3ecb88eff3f99) | `` pmtiles: 1.22.0 -> 1.22.1 ``                                                  |
| [`cda6874d`](https://github.com/NixOS/nixpkgs/commit/cda6874d142a9c2319a86f5723201e6f9120781e) | `` OWNERS: add myself to Rust ``                                                 |
| [`2b0b3704`](https://github.com/NixOS/nixpkgs/commit/2b0b37048c04c298485bbf47e1bda81839ba2f6a) | `` discourse.plugins: update ``                                                  |
| [`d642a421`](https://github.com/NixOS/nixpkgs/commit/d642a421cb218bbef22579e41f1245010292fcf0) | `` discourse-mail-receiver: 4.0.7 -> 4.1.0 ``                                    |
| [`6a5e0f7d`](https://github.com/NixOS/nixpkgs/commit/6a5e0f7dac618781e0c29e6eeaf0c82c87e62fd9) | `` discourse: 3.2.5 -> 3.3.2 ``                                                  |
| [`54e4669c`](https://github.com/NixOS/nixpkgs/commit/54e4669c75de7a7ccf442e4a6e4d358ca08ebd91) | `` docs: Clarify how to provide technical details/metadata ``                    |
| [`634b227b`](https://github.com/NixOS/nixpkgs/commit/634b227b15a384ced41f3e3baa2a95c721b35aa0) | `` geesefs: 0.41.3 -> 0.42.0 ``                                                  |
| [`a81bfa5b`](https://github.com/NixOS/nixpkgs/commit/a81bfa5b3d0e8e6ac87d6ed667d1758260413325) | `` gitu: 0.25.0 -> 0.26.0 ``                                                     |
| [`ae9f0e72`](https://github.com/NixOS/nixpkgs/commit/ae9f0e7233088b7bb3b4787004a52c5fc226f13c) | `` python312Packages.snowflake-connector-python: 3.12.2 -> 3.12.3 ``             |
| [`187dff00`](https://github.com/NixOS/nixpkgs/commit/187dff008976a94a7882c3368de71a75cfc8e95b) | `` tomboy-ng: init at 0.40 ``                                                    |
| [`25607567`](https://github.com/NixOS/nixpkgs/commit/25607567b9bb5c02b2ab9ae79bf7cfb6d07e9a78) | `` meilisearch: 1.10.2 -> 1.10.3 ``                                              |
| [`e9eca9b6`](https://github.com/NixOS/nixpkgs/commit/e9eca9b6e9828be9ccddf1007f6f30feb9a40e24) | `` system76-power: 1.2.1 -> 1.2.2 ``                                             |
| [`54c59082`](https://github.com/NixOS/nixpkgs/commit/54c59082722023a5f424ade70f8490d408e7ef3c) | `` python312Packages.tensorflow-bin: 2.17.0 -> 2.18.0 ``                         |
| [`31f260e2`](https://github.com/NixOS/nixpkgs/commit/31f260e2b7b4b0027b75165464122ef2aacb1a45) | `` python312Packages.xrootd: 5.6.6 -> 5.7.1 ``                                   |
| [`685c8307`](https://github.com/NixOS/nixpkgs/commit/685c8307326eccb5fc7ac61f1032871020791833) | `` xrootd: remove test-runner ``                                                 |
| [`4a13a18e`](https://github.com/NixOS/nixpkgs/commit/4a13a18e28f2decbe96cf10f6f9222e5a13a8977) | `` xrootd: modernize cmakeFlags ``                                               |
| [`3f9372d3`](https://github.com/NixOS/nixpkgs/commit/3f9372d31b8eee1aa470c1085dac6ad2f67e0dfc) | `` xrootd: fix the cmake flags influenced by enableTestRunner ``                 |
| [`93d37412`](https://github.com/NixOS/nixpkgs/commit/93d374121eaa640b5263459f0337952b46a0b91f) | `` xrootd: 5.6.6 -> 5.7.1 ``                                                     |
| [`7c3a580f`](https://github.com/NixOS/nixpkgs/commit/7c3a580f90eae20f804c9164c5d81000c0f59af7) | `` xrootd: format ``                                                             |
| [`4c91cc87`](https://github.com/NixOS/nixpkgs/commit/4c91cc87e40d753e3cf4b40e7ee73ac6f731dc2b) | `` xrootd: move to by-name ``                                                    |
| [`03e80482`](https://github.com/NixOS/nixpkgs/commit/03e80482ec47843a5c6fcb2797995db29b737282) | `` safety-cli: 3.2.8 -> 3.2.9 ``                                                 |
| [`0b85dd29`](https://github.com/NixOS/nixpkgs/commit/0b85dd29466c954c47a22ffd53f31f436f689814) | `` python312Packages.mkdocs-rss-plugin: 1.15.0 -> 1.16.0 ``                      |
| [`d1cc3bbf`](https://github.com/NixOS/nixpkgs/commit/d1cc3bbf26549b5e8687a8a322254eb1a5f1aa7f) | `` linuxPackages_latest.prl-tools: 20.1.0-55732 -> 20.1.1-55740 ``               |
| [`888a7eff`](https://github.com/NixOS/nixpkgs/commit/888a7effec00a3252b0bbaed0a4b8e56efac6499) | `` linuxPackages_latest.prl-tools: use libxml2 to parse html in update script `` |
| [`77054d54`](https://github.com/NixOS/nixpkgs/commit/77054d54e80b418cd905fc8ba81c7a3b3a50448e) | `` mutagen-compose: 0.17.6 -> 0.18.0 ``                                          |
| [`7e3a13be`](https://github.com/NixOS/nixpkgs/commit/7e3a13be5332c1eb8f61b41bd6468f55ff0736fc) | `` convco: 0.6.0 -> 0.6.1 ``                                                     |
| [`d1c9a500`](https://github.com/NixOS/nixpkgs/commit/d1c9a5003ac27e47d83848b0f8a517c42ad8ab57) | `` cytoscape: 3.10.2 -> 3.10.3 ``                                                |
| [`c688e010`](https://github.com/NixOS/nixpkgs/commit/c688e0101fb293b849e66c8724514db709d41134) | `` python312Packages.aioslimproto: 3.0.1 -> 3.1.0 ``                             |
| [`29802b59`](https://github.com/NixOS/nixpkgs/commit/29802b59e490c6638c995f91d06efe3f82182b0b) | `` ast-grep: 0.28.0 -> 0.28.1 ``                                                 |
| [`26e61825`](https://github.com/NixOS/nixpkgs/commit/26e61825a8479ec2a1d4ffc92b1731fdbdd49571) | `` bfs: 4.0.2 -> 4.0.3 ``                                                        |
| [`12a17c68`](https://github.com/NixOS/nixpkgs/commit/12a17c68e8c61c45e9cf5ef0ef059632a6f09b84) | `` eza: 0.20.4 -> 0.20.5 ``                                                      |
| [`91cbfce5`](https://github.com/NixOS/nixpkgs/commit/91cbfce5dffbfc7550ce00ecda180768a368db1d) | `` vector: stop overriding default features ``                                   |
| [`ff947ad0`](https://github.com/NixOS/nixpkgs/commit/ff947ad0d267bcf1b53b2592e1bd2edae2714129) | `` ghidra-extensions: fix package sorting ``                                     |
| [`26a24bfe`](https://github.com/NixOS/nixpkgs/commit/26a24bfe513ac1f28601fe61120f52df2d198253) | `` kubernetes-helm: 3.16.1 -> 3.16.2 ``                                          |
| [`1d53554f`](https://github.com/NixOS/nixpkgs/commit/1d53554f151e5eed345903c3551b1b022bd6d51f) | `` ghidra-extensions.ghidra-golanganalyzerextension: init at 1.2.4 ``            |
| [`2ed0ebf1`](https://github.com/NixOS/nixpkgs/commit/2ed0ebf1d3a8b663ac134090bbb75e965e81e6bd) | `` shadowsocks-rust: 1.21.0 -> 1.21.1 ``                                         |
| [`148d5795`](https://github.com/NixOS/nixpkgs/commit/148d579567fa52880cdc6fd3f6b0c8f98dcf8ff0) | `` bitwarden-desktop: add URL scheme ``                                          |
| [`c6418931`](https://github.com/NixOS/nixpkgs/commit/c64189315cf36dd02ce536fb45c2082a314f24a7) | `` python312Packages.quadprog: 0.1.12 -> 0.1.13 ``                               |
| [`f3a14b1a`](https://github.com/NixOS/nixpkgs/commit/f3a14b1af79e76ce65ce34dc10aef30f47322833) | `` rectangle: 0.83 -> 0.84 ``                                                    |
| [`77522b3c`](https://github.com/NixOS/nixpkgs/commit/77522b3c1079e19358d234b2db54597463a61561) | `` rustic: 0.9.3 -> 0.9.4 ``                                                     |
| [`6f3c4aab`](https://github.com/NixOS/nixpkgs/commit/6f3c4aabc11b98af319d498be51fddd59373affd) | `` ruff: move to buildPythonPackage ``                                           |
| [`264d77eb`](https://github.com/NixOS/nixpkgs/commit/264d77eb7927dc9505ad338a93409c7cbd8c14f6) | `` zed-editor: 0.158.1 -> 0.158.2 ``                                             |
| [`665e2042`](https://github.com/NixOS/nixpkgs/commit/665e20423ef2d2a194328e4a19c949dde855d989) | `` glanceclient: fix darwin build ``                                             |
| [`4d2ea7ff`](https://github.com/NixOS/nixpkgs/commit/4d2ea7ff45d81992cd4680522b3aca2c6c1211db) | `` pdfcpu: 0.9.0 -> 0.9.1 ``                                                     |
| [`f625128f`](https://github.com/NixOS/nixpkgs/commit/f625128f925ea82b14a7b709c955424a17c990f4) | `` hyfetch: use modern builders ``                                               |
| [`8962c791`](https://github.com/NixOS/nixpkgs/commit/8962c791f0fa2635e0b034b135e40d0c5a517ae8) | `` jetbrains.plugins: update ``                                                  |
| [`ca63cb8a`](https://github.com/NixOS/nixpkgs/commit/ca63cb8a24589518bdcb45f3689e50f4bc629271) | `` nixos/bazarr: normalize description ``                                        |
| [`023125a1`](https://github.com/NixOS/nixpkgs/commit/023125a1941da5b7a9eb74bdc41d00b7417ab86d) | `` jetbrains: 2024.1 -> 2024.2.7 ``                                              |
| [`c73fe023`](https://github.com/NixOS/nixpkgs/commit/c73fe023071e38834315bddc37dc4b384c87bbac) | `` monitoring-plugins: 2.3.5 -> 2.4.0 ``                                         |
| [`19d546a3`](https://github.com/NixOS/nixpkgs/commit/19d546a34fea0245a313678cbc562a2c70c34d02) | `` nagiosPlugins: add recurseIntoAttrs ``                                        |
| [`61c0322b`](https://github.com/NixOS/nixpkgs/commit/61c0322bb7c5abadbcb5c7263935db5a35f436cd) | `` aliases: fix nagiosPlugins aliases ``                                         |
| [`42fb6465`](https://github.com/NixOS/nixpkgs/commit/42fb6465a130d71b5a49aa59800c4a16cdeb86d9) | `` bash-language-server: pnpmWorkspace -> pnpmWorkspaces ``                      |
| [`1a1f5b8b`](https://github.com/NixOS/nixpkgs/commit/1a1f5b8b8f1c51b5f4ebcadc15130f8584420cde) | `` astro-language-server: pnpmWorkspace -> pnpmWorkspaces ``                     |
| [`698f4acc`](https://github.com/NixOS/nixpkgs/commit/698f4accb3a879e7dfcee54b09f445848ca1e0d5) | `` pnpm.fetchDeps: Better pnpmInstallFlags support ``                            |
| [`09cec0f5`](https://github.com/NixOS/nixpkgs/commit/09cec0f560e3eebab64a632ad59c49bf70f03d55) | `` pnpm.fetchDeps: pnpmWorkspace -> pnpmWorkspaces ``                            |
| [`82b056d1`](https://github.com/NixOS/nixpkgs/commit/82b056d16066c03409335e6da0165c62565b690a) | `` nagiosPlugins.check_ups_health: 2.8.3.3 -> 4.3.1.1 ``                         |
| [`60f2a31b`](https://github.com/NixOS/nixpkgs/commit/60f2a31be7c7a700a7dd41b5bce1ea10711d3b2f) | `` nagiosPlugins.check_nwc_health: 7.10.0.6 -> 11.7 ``                           |
| [`b8e1a4a7`](https://github.com/NixOS/nixpkgs/commit/b8e1a4a7735a870456ff7f2e84e7b6b250348c1e) | `` nagiosPlugins.check_mssql_health: 2.6.4.15 -> 2.7.7 ``                        |
| [`2f3919ec`](https://github.com/NixOS/nixpkgs/commit/2f3919ecc92132335ba3e5fc1ac485844c81f474) | `` maintainers: adding wizardlink ``                                             |
| [`b78661a7`](https://github.com/NixOS/nixpkgs/commit/b78661a7c167ecd30799f32367eaeba5ea88b6cd) | `` zenergy: init at 0-unstable-2024-10-10 ``                                     |
| [`026b947e`](https://github.com/NixOS/nixpkgs/commit/026b947ef2f4e4003f194173d3c231e30fe8cef3) | `` nagiosPlugins.check_uptime: fix version ``                                    |
| [`108e1f1e`](https://github.com/NixOS/nixpkgs/commit/108e1f1eff15815ed91e6eacb704a68d67db8da6) | `` rpiboot: add stv0g as maintainer ``                                           |
| [`e59dcc1e`](https://github.com/NixOS/nixpkgs/commit/e59dcc1eb9c6f6301d22cde075a73767929a91c1) | `` rpiboot: remove 'with lib' usage ``                                           |
| [`eceb0476`](https://github.com/NixOS/nixpkgs/commit/eceb047690b6bdfaf329921042851a3159e65605) | `` rpiboot: install more gadgets ``                                              |
| [`51c1e325`](https://github.com/NixOS/nixpkgs/commit/51c1e325094691818b82403cc9355a3bd3667e81) | `` rpiboot: 20221215-105525 -> 20240926-102326 ``                                |
| [`bcdc2a22`](https://github.com/NixOS/nixpkgs/commit/bcdc2a22c6f98cf016fdf9990844f088c5a95ae3) | `` python311Packages.tempest: 40.0.0 -> 41.0.0 ``                                |
| [`fb3df235`](https://github.com/NixOS/nixpkgs/commit/fb3df2356c18055c9515d68356c6be6626522dfa) | `` python311Packages.python-zunclient: 5.0.0 -> 5.1.0 ``                         |
| [`3d949fb2`](https://github.com/NixOS/nixpkgs/commit/3d949fb2c9cd03824152dea3a0245c2e6495d45e) | `` python311Packages.python-zaqarclient: 2.7.0 -> 2.8.0 ``                       |
| [`290c4406`](https://github.com/NixOS/nixpkgs/commit/290c4406b2279475ad6344e059d676c8a1101f25) | `` python311Packages.python-watcherclient: 4.4.0 -> 4.5.0 ``                     |
| [`cb45976b`](https://github.com/NixOS/nixpkgs/commit/cb45976be12cb83620c0bdf1d0db9fbae9f183ab) | `` python311Packages.pyeclib: 1.6.1 -> 1.6.2 ``                                  |
| [`5114de53`](https://github.com/NixOS/nixpkgs/commit/5114de533caafda47e86249ca525dc14dcf2c361) | `` python311Packages.python-troveclient: 8.5.0 -> 8.6.0 ``                       |
| [`fd4c19a2`](https://github.com/NixOS/nixpkgs/commit/fd4c19a2137d44b33f4b490dcf0b000ece0f5847) | `` python311Packages.python-openstackclient: 7.1.2 -> 7.2.0 ``                   |
| [`55131d78`](https://github.com/NixOS/nixpkgs/commit/55131d78ae2b5ac07e4721455f5eaed9f6349c65) | `` python311Packages.openstackdocstheme: 3.3.0 -> 3.4.0 ``                       |
| [`e01877fe`](https://github.com/NixOS/nixpkgs/commit/e01877fecb19fc7e9800039fb2328704c93c4fcc) | `` rpiboot: format with nixfmt (RFC166) ``                                       |
| [`9808443b`](https://github.com/NixOS/nixpkgs/commit/9808443bdd62a97cd7526972cb517e10b3696acd) | `` rpiboot: migrate to by-name ``                                                |
| [`49863997`](https://github.com/NixOS/nixpkgs/commit/49863997c826cb97f5d9ccc93bcc2c5a4e9cee2f) | `` luaPackages.toml-edit: 0.4.1 -> 0.5.0 ``                                      |
| [`d9fe61d0`](https://github.com/NixOS/nixpkgs/commit/d9fe61d0981d55d1a642461f51888c80eba5cfdc) | `` keycloak: 26.0.1 -> 26.0.2 ``                                                 |
| [`a4bea1e1`](https://github.com/NixOS/nixpkgs/commit/a4bea1e1c6fd9545f25389b1554964cc3cb2eb20) | `` ola: unstable-2020-07-17 -> 0.10.9 ``                                         |
| [`137e9abd`](https://github.com/NixOS/nixpkgs/commit/137e9abd990f91096f5dc16e9022970539f077b6) | `` isa-l: add package tests for igzip ``                                         |
| [`17f4b88d`](https://github.com/NixOS/nixpkgs/commit/17f4b88d0181e26715a18fea2918d1c5102c8f50) | `` tor-browser: 13.5.7 -> 14.0 ``                                                |
| [`6db8aafd`](https://github.com/NixOS/nixpkgs/commit/6db8aafdc32b2bb6d84cd5991d0e59e6f32dca37) | `` factorio: 2.0.9 -> 2.0.10 ``                                                  |
| [`374b122f`](https://github.com/NixOS/nixpkgs/commit/374b122f9909b06b86b427c1bd05d7fea639e3cd) | `` electrum: 4.5.6 -> 4.5.8 ``                                                   |
| [`765f9b75`](https://github.com/NixOS/nixpkgs/commit/765f9b75b9932ecd2982419cd2abf602537b092e) | `` inv-sig-helper: 0-unstable-2024-08-17 -> 0-unstable-2024-09-24 ``             |
| [`77f5f203`](https://github.com/NixOS/nixpkgs/commit/77f5f203cf0566e7ff5a273a7a16bb236bad51ee) | `` syncyomi: 1.1.1 -> 1.1.2 ``                                                   |
| [`9bbef50e`](https://github.com/NixOS/nixpkgs/commit/9bbef50e246b27ccb8eb1b38175a24f86d93b195) | `` nixos/switchable-system: add evaluation warning when using perl stc ``        |
| [`849d7bbb`](https://github.com/NixOS/nixpkgs/commit/849d7bbbba6bc7c740db86c8b1b1bc5698b34da9) | `` distrobuilder: update patch for distrobuilder's lxc.generator ``              |
| [`71fc5743`](https://github.com/NixOS/nixpkgs/commit/71fc5743a87cbbc0effb44764761205bed7bc5c7) | `` vencord: add maintainer donteatoreo ``                                        |
| [`be43e12f`](https://github.com/NixOS/nixpkgs/commit/be43e12f915f739b7bddca423e409ffe4f1306ed) | `` vencord: 1.10.4 -> 1.10.5 ``                                                  |
| [`7ba1c530`](https://github.com/NixOS/nixpkgs/commit/7ba1c530eef65f338a5bf296f60998d7d4ebe647) | `` prismlauncher-unwrapped: 9.0 -> 9.1 ``                                        |
| [`23ca692e`](https://github.com/NixOS/nixpkgs/commit/23ca692e3683f5c098c3879f5c3609e773cfe030) | `` coqPackages.relation-algebra: 1.7.9 -> 1.7.11 ``                              |
| [`9d28bd75`](https://github.com/NixOS/nixpkgs/commit/9d28bd753f6299166a09cfdbe6a3db4ce8cb9273) | `` cadical: enable version 2.0.0 and use it in cvc5 ``                           |
| [`dda4e6d0`](https://github.com/NixOS/nixpkgs/commit/dda4e6d0610762f124d491d322379d6b49cc76fa) | `` opnborg: 0.1.2 -> 0.1.18 ``                                                   |
| [`46abff06`](https://github.com/NixOS/nixpkgs/commit/46abff06a79af86b0edddd1503b78d99468b160e) | `` gpu-screen-recorder: Install the systemd unit again ``                        |
| [`e960bc8a`](https://github.com/NixOS/nixpkgs/commit/e960bc8aa22551f5f9b6e8b170a1dea2493ec07a) | `` aerospace: 0.14.2-Beta -> 0.15.2-Beta (#349798) ``                            |
| [`2830c1b5`](https://github.com/NixOS/nixpkgs/commit/2830c1b5a3006b89787b462d0a25bd54107a7d14) | `` python312Packages.codecov: drop ``                                            |
| [`c608c2a2`](https://github.com/NixOS/nixpkgs/commit/c608c2a26ca6a32cd1616b488db699c1cb238694) | `` discord-development: 0.0.30 -> 0.0.32 ``                                      |
| [`13d7fe4a`](https://github.com/NixOS/nixpkgs/commit/13d7fe4a4e7ca8744baee5441edcdde355b82199) | `` discord-canary: 0.0.503 -> 0.0.508 ``                                         |
| [`1aef2aa1`](https://github.com/NixOS/nixpkgs/commit/1aef2aa1adbc3f5f440118a860662747948a7b6e) | `` discord-ptb: 0.0.111 -> 0.0.112 ``                                            |
| [`6961be09`](https://github.com/NixOS/nixpkgs/commit/6961be09549059e47e5b7690511a61cd809c435d) | `` discord: 0.0.71 -> 0.0.72 ``                                                  |
| [`1774c382`](https://github.com/NixOS/nixpkgs/commit/1774c38287241cc385fae69bb7c05f14c37d2048) | `` cargo-crev: 0.25.9 -> 0.25.11 ``                                              |
| [`f48b8cf5`](https://github.com/NixOS/nixpkgs/commit/f48b8cf528782494b71aae1f4faed6fe08978ea9) | `` pkgsCross.x86_64-darwin.discord-development: 0.0.53 -> 0.0.55 ``              |
| [`8df675f2`](https://github.com/NixOS/nixpkgs/commit/8df675f2227a908d083b055936e54318b66a686a) | `` pkgsCross.x86_64-darwin.discord-canary: 0.0.612 -> 0.0.617 ``                 |
| [`702a31c2`](https://github.com/NixOS/nixpkgs/commit/702a31c225f96624655f201046361c39663f681d) | `` pkgsCross.x86_64-darwin.discord-ptb: 0.0.141 -> 0.0.142 ``                    |
| [`4069a0ec`](https://github.com/NixOS/nixpkgs/commit/4069a0ec948180d2294771fb2cfe0e7c3561a599) | `` pkgsCross.x86_64-darwin.discord: 0.0.322 -> 0.0.323 ``                        |
| [`b24921bc`](https://github.com/NixOS/nixpkgs/commit/b24921bc7c8161907016ea43bcfe8e8e38835949) | `` evcc: 0.131.0 -> 0.131.1 ``                                                   |
| [`81f92fbc`](https://github.com/NixOS/nixpkgs/commit/81f92fbc2943a6063e9229ffa9774ac1f878c33a) | `` nixos/switchable-system: nixfmt ``                                            |
| [`7c3e6dfc`](https://github.com/NixOS/nixpkgs/commit/7c3e6dfc959b9155124ea67bc4641b7554f65cb1) | `` rockcraft: 1.5.3 -> 1.6.0 ``                                                  |
| [`8991fdb1`](https://github.com/NixOS/nixpkgs/commit/8991fdb1369e55411e2d4a8a4c68171516f6feb9) | `` element-desktop: 1.11.81 -> 1.11.82 ``                                        |
| [`46b1c1eb`](https://github.com/NixOS/nixpkgs/commit/46b1c1ebefeb612a6d9ee5ec496c75a62788a7ad) | `` neocmakelsp: 0.8.4 -> 0.8.12 ``                                               |
| [`71282d3d`](https://github.com/NixOS/nixpkgs/commit/71282d3d22efb85c8971ac8ccc072b18700e3f27) | `` wayfreeze: 0-unstable-2024-05-23 -> 0-unstable-2024-09-20 ``                  |