### PR TITLE
chore(flake/nixpkgs-stable): `32e940c7` -> `cd3e8833`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -830,11 +830,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1729691686,
-        "narHash": "sha256-BAuPWW+9fa1moZTU+jFh+1cUtmsuF8asgzFwejM4wac=",
+        "lastModified": 1729973466,
+        "narHash": "sha256-knnVBGfTCZlQgxY1SgH0vn2OyehH9ykfF8geZgS95bk=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "32e940c7c420600ef0d1ef396dc63b04ee9cad37",
+        "rev": "cd3e8833d70618c4eea8df06f95b364b016d4950",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                          |
| ---------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------- |
| [`9c45f831`](https://github.com/NixOS/nixpkgs/commit/9c45f8317492c5a2e74f0c2ce82c0e3ea454c8be) | `` ci/OWNERS: Remove removed path ``                                             |
| [`56e9a30c`](https://github.com/NixOS/nixpkgs/commit/56e9a30c12cbfa8e064f8dd4348942013584c220) | `` ci/OWNERS: Fix path of codeowners.yml ``                                      |
| [`b246490d`](https://github.com/NixOS/nixpkgs/commit/b246490d8cadf8c8a9eb5d3dfd99eb3b0e70956b) | `` workflows: Rename after security fixes ``                                     |
| [`ccc38ebb`](https://github.com/NixOS/nixpkgs/commit/ccc38ebba10a768c472c40cf34077bd13563d3cc) | `` workflows: Fix security issues ``                                             |
| [`56916255`](https://github.com/NixOS/nixpkgs/commit/5691625565d74d4f7d43e3dfeac36dc64f3dda6b) | `` workflows/codeowners: Fix security issue ``                                   |
| [`86b4df87`](https://github.com/NixOS/nixpkgs/commit/86b4df87378aefda81ee32e7e548d4e1206ba91b) | `` maintainers: update Atemu's emails ``                                         |
| [`cce85d9d`](https://github.com/NixOS/nixpkgs/commit/cce85d9d8c590984836c3ad3986f9e124e6c04bf) | `` arc-browser: 1.65.0-54911 -> 1.66.0-55166 ``                                  |
| [`37aa9c6a`](https://github.com/NixOS/nixpkgs/commit/37aa9c6a884e374486013464c1e16d5e62c52c28) | `` brave: 1.70.123 -> 1.71.118 ``                                                |
| [`0a19a469`](https://github.com/NixOS/nixpkgs/commit/0a19a4690eee7ffd0c57bb207b21a55df8278bef) | `` brave: move to by-name ``                                                     |
| [`de20c77e`](https://github.com/NixOS/nixpkgs/commit/de20c77eaad7703015ca79d3befd2f61a0ce90b1) | `` discourse.plugins: update ``                                                  |
| [`f01bb943`](https://github.com/NixOS/nixpkgs/commit/f01bb9431497631d07dcdd4d27fa19c1659f9a53) | `` discourse-mail-receiver: 4.0.7 -> 4.1.0 ``                                    |
| [`6bcdcaf3`](https://github.com/NixOS/nixpkgs/commit/6bcdcaf38ef0257b008a502739c1b02506988ca5) | `` discourse: 3.2.5 -> 3.3.2 ``                                                  |
| [`9e431b57`](https://github.com/NixOS/nixpkgs/commit/9e431b57282249d2fe6f86490f9766ebe8775d4c) | `` wireshark: 4.2.7 -> 4.2.8 ``                                                  |
| [`1dd950ba`](https://github.com/NixOS/nixpkgs/commit/1dd950babb22864de08d7f43404f601fed915a7a) | `` betterbird: mark as insecure ``                                               |
| [`8188ea1b`](https://github.com/NixOS/nixpkgs/commit/8188ea1b50a3a816993e0f79010cae69f9ac9f7b) | `` tor-browser: 13.5.7 -> 14.0 ``                                                |
| [`664f6173`](https://github.com/NixOS/nixpkgs/commit/664f617382d96f16cd08a2a4f89176a041660cc7) | `` [Backport release-24.05] discord: bump all versions (#350972) ``              |
| [`9d2777cf`](https://github.com/NixOS/nixpkgs/commit/9d2777cf4cf15f16f2e0da702ef45db7e18a5e46) | `` arc-browser: remove `set -euo pipefail` ``                                    |
| [`056905ca`](https://github.com/NixOS/nixpkgs/commit/056905ca46b69ad280b3e3eac2c567daa57aaee4) | `` arc-browser: quote paths ``                                                   |
| [`3210a923`](https://github.com/NixOS/nixpkgs/commit/3210a923e12df05af2c311194eb71ab4c95f49d2) | `` arc-browser: format with nixfmt-rfc-style ``                                  |
| [`6ca28821`](https://github.com/NixOS/nixpkgs/commit/6ca2882162e5423f186c80639b96be269f361c8d) | `` arc-browser: 1.63.1-54714 -> 1.65.0-54911 ``                                  |
| [`9504eb41`](https://github.com/NixOS/nixpkgs/commit/9504eb416d2203260f791f93fb6bdca812845b10) | `` preserves-tools: 4.994.0 -> 4.996.1 ``                                        |
| [`3d2815b7`](https://github.com/NixOS/nixpkgs/commit/3d2815b76970657da6c7bdc8d61b5585ae1ed585) | `` linux_xanmod_latest: 6.11.4 -> 6.11.5 ``                                      |
| [`6d3de63d`](https://github.com/NixOS/nixpkgs/commit/6d3de63da9d5ad64a5079b67e89b3f12b6f689b3) | `` linux_xanmod: 6.6.57 -> 6.6.58 ``                                             |
| [`533e7ad2`](https://github.com/NixOS/nixpkgs/commit/533e7ad28c5aa7aec276389a76df792b2578b057) | `` grafana: 10.4.10 -> 10.4.11 ``                                                |
| [`462c23c4`](https://github.com/NixOS/nixpkgs/commit/462c23c4dc9549222ce1444cc33dbe94626c9987) | `` libhv: 1.3.2 → 1.3.3 ``                                                       |
| [`728783a5`](https://github.com/NixOS/nixpkgs/commit/728783a500fac3e33829a969db05777ca9fffc84) | `` firefox-devedition-unwrapped: 132.0b5 -> 132.0b9 ``                           |
| [`9b3b8981`](https://github.com/NixOS/nixpkgs/commit/9b3b8981ef23217eb6a02d2f412661f9a5ac2a59) | `` firefox-beta-unwrapped: 132.0b5 -> 132.0b9 ``                                 |
| [`e33cb814`](https://github.com/NixOS/nixpkgs/commit/e33cb814084e20e529dac45f606f1d80a3395a76) | `` firefox-beta-bin-unwrapped: 132.0b6 -> 132.0b9 ``                             |
| [`faf07199`](https://github.com/NixOS/nixpkgs/commit/faf071999dca0d61183d8d8b8886193c9fae1309) | `` firefox-devedition-bin-unwrapped: 132.0b6 -> 132.0b9 ``                       |
| [`9939af6e`](https://github.com/NixOS/nixpkgs/commit/9939af6ed5e3cb2d16232e33da7382e099c234b7) | `` detect-it-easy: init at 3.09 ``                                               |
| [`0597b879`](https://github.com/NixOS/nixpkgs/commit/0597b8792865c0d02ef78ff557c3852baf176803) | `` maintainers: add ivyfanchiang ``                                              |
| [`636f8d41`](https://github.com/NixOS/nixpkgs/commit/636f8d415b15b14ece1b56d3715cbd19f564f0b7) | `` legcord: 1.0.1 -> 1.0.2 ``                                                    |
| [`dad4101c`](https://github.com/NixOS/nixpkgs/commit/dad4101c35d7dbe75ba46dcedc81c69a0b160113) | `` couchbase-shell: init at 1.0.0 ``                                             |
| [`315e3f3e`](https://github.com/NixOS/nixpkgs/commit/315e3f3e88fbc7bb553728dc8716d5b5c85a7abb) | `` maintainers: add petrkozorezov ``                                             |
| [`46f18807`](https://github.com/NixOS/nixpkgs/commit/46f1880793508c72d82d1dc19ba3f7cb6f34f34d) | `` soundsource: add maintainer donteatoreo ``                                    |
| [`155efea8`](https://github.com/NixOS/nixpkgs/commit/155efea89187a4f3a99cc74ce3032878fa34ed22) | `` soundsource: 5.6.3 -> 5.7.1 ``                                                |
| [`8f0c722e`](https://github.com/NixOS/nixpkgs/commit/8f0c722e64098d334ddcec3f5e1f0aebb4845ea3) | `` soundsource: format with `nixfmt-rfc-style` ``                                |
| [`80202bd4`](https://github.com/NixOS/nixpkgs/commit/80202bd4fab1f37f853d5eab3a843f6385e209b4) | `` ci/request-reviews: Avoid duplicates with different casings ``                |
| [`9af45a7f`](https://github.com/NixOS/nixpkgs/commit/9af45a7f850c1cd78bc0d850407e1b92684a38f7) | `` ci/request-reviews: fix headRef to point to the PR head ``                    |
| [`6e6a84a2`](https://github.com/NixOS/nixpkgs/commit/6e6a84a2a5bcc421159c800d411b28bef942283d) | `` ci/request-reviews: Fix for branches starting with "pr" ``                    |
| [`01f9bc54`](https://github.com/NixOS/nixpkgs/commit/01f9bc543fc188267d4315e716cce15571fa263f) | `` workflows/codeowners: Cache codeowner validator build ``                      |
| [`bd43ae43`](https://github.com/NixOS/nixpkgs/commit/bd43ae43124c132430ce938158c638018c64d8bd) | `` .gitattributes: Mark ci/OWNERS as CODEOWNERS ``                               |
| [`91153308`](https://github.com/NixOS/nixpkgs/commit/9115330873d866918080193b743f1e0498f2c59a) | `` ci/request-reviews: Make wrong base branch message hashes more transparent `` |
| [`3493325e`](https://github.com/NixOS/nixpkgs/commit/3493325e09961d55fcbaa9fbdd890e1e9c2ef0af) | `` CONTRIBUTING: Remove now-unneeded mass ping section ``                        |
| [`b2bfec90`](https://github.com/NixOS/nixpkgs/commit/b2bfec90cd6e529ca023d5eb1cb72d75cb0e66d8) | `` CODEOWNERS: Switch to alternate mechanism ``                                  |
| [`59990c7e`](https://github.com/NixOS/nixpkgs/commit/59990c7e7508fad01ba6656946be104299772b40) | `` ci/request-reviews: Request reviews for individual team members ``            |
| [`16b54e1a`](https://github.com/NixOS/nixpkgs/commit/16b54e1afbd0046ef681acfcf6a434489ea4c14c) | `` ci/request-reviews: Don't rerequest users that already reviewed ``            |
| [`bbd64b4b`](https://github.com/NixOS/nixpkgs/commit/bbd64b4b69c028a44bd23203c98392daad76ff95) | `` workflows/codeowners: Dry mode for now ``                                     |
| [`2e923fb2`](https://github.com/NixOS/nixpkgs/commit/2e923fb2f619e6e51f2f959853a6d61f3b23af08) | `` CODEOWNERS: Fix non-matching patterns ``                                      |
| [`2211c101`](https://github.com/NixOS/nixpkgs/commit/2211c1011f29566746ecec0f6c9916908d4fafec) | `` OWNERS: placeholder init ``                                                   |
| [`5de26baf`](https://github.com/NixOS/nixpkgs/commit/5de26baf9fe7059861ce48b2485a96092b583601) | `` workflows/codeowners: init ``                                                 |
| [`1a317c03`](https://github.com/NixOS/nixpkgs/commit/1a317c035cb4f11b8679a3565774132891faa600) | `` ci: Add codeowners validator ``                                               |
| [`2eb82ca0`](https://github.com/NixOS/nixpkgs/commit/2eb82ca07428e2a41cd64a83862d3a936ef62173) | `` ci: Add review request scripts ``                                             |
| [`4bedbf85`](https://github.com/NixOS/nixpkgs/commit/4bedbf85a97b307cdb53b42f89e256fa1e7f5b55) | `` ci: Add default.nix with exposed pkgs ``                                      |
| [`b112355d`](https://github.com/NixOS/nixpkgs/commit/b112355dd3e92393a2312456c4c3d80fdec3029e) | `` shell.nix: Enable e.g. --arg nixpkgs ./. ``                                   |