### PR TITLE
chore(flake/spicetify-nix): `9418361f` -> `6dd52674`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1084,11 +1084,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1730002599,
-        "narHash": "sha256-6uIfmh7oYU8+TukIC30nJ4sv6VLcIfIuR7BEx17gVDk=",
+        "lastModified": 1730089059,
+        "narHash": "sha256-0pUr7PrC6y352oGaMeN6quxUR8mUyCHJvNuGvSE+q54=",
         "owner": "Gerg-L",
         "repo": "spicetify-nix",
-        "rev": "9418361fae1e426a8f8957a7bfc6ddc72882ce2c",
+        "rev": "6dd526742ecfbf5a589ed1327710cbe03ac592a1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                    |
| ----------------------------------------------------------------------------------------------------- | -------------------------- |
| [`6dd52674`](https://github.com/Gerg-L/spicetify-nix/commit/6dd526742ecfbf5a589ed1327710cbe03ac592a1) | `` CI update 2024-10-28 `` |