### PR TITLE
chore(flake/spicetify-nix): `6dd52674` -> `446351c3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1084,11 +1084,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1730089059,
-        "narHash": "sha256-0pUr7PrC6y352oGaMeN6quxUR8mUyCHJvNuGvSE+q54=",
+        "lastModified": 1730175473,
+        "narHash": "sha256-JASnF3cFrQ1k6KsitR2yylpeWdPNb2xJeIaMeipe3BA=",
         "owner": "Gerg-L",
         "repo": "spicetify-nix",
-        "rev": "6dd526742ecfbf5a589ed1327710cbe03ac592a1",
+        "rev": "446351c37e053a0098aa19d8c61448bbcfd8f0cc",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                    |
| ----------------------------------------------------------------------------------------------------- | -------------------------- |
| [`446351c3`](https://github.com/Gerg-L/spicetify-nix/commit/446351c37e053a0098aa19d8c61448bbcfd8f0cc) | `` CI update 2024-10-29 `` |