### PR TITLE
chore(flake/nixpkgs-stable): `cd3e8833` -> `64b80bfb`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -830,11 +830,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1729973466,
-        "narHash": "sha256-knnVBGfTCZlQgxY1SgH0vn2OyehH9ykfF8geZgS95bk=",
+        "lastModified": 1730137625,
+        "narHash": "sha256-9z8oOgFZiaguj+bbi3k4QhAD6JabWrnv7fscC/mt0KE=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "cd3e8833d70618c4eea8df06f95b364b016d4950",
+        "rev": "64b80bfb316b57cdb8919a9110ef63393d74382a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                    |
| ---------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------- |
| [`b5804964`](https://github.com/NixOS/nixpkgs/commit/b5804964142a59431f1cec9040ea5b964a804941) | `` google-chrome: 130.0.6723.{58,59} -> 130.0.6723.{69,70} ``              |
| [`92ad2454`](https://github.com/NixOS/nixpkgs/commit/92ad24549654200d88416a7f3c85552ae62683b8) | `` sysstat: add iostat as mainProgram ``                                   |
| [`9fe0825a`](https://github.com/NixOS/nixpkgs/commit/9fe0825affa1a7b5ae82762ab0358e915c27cb4c) | `` sysstat: adopt ``                                                       |
| [`1aa3b5d7`](https://github.com/NixOS/nixpkgs/commit/1aa3b5d7517b2fc37edd0d8034d90af63d911e89) | `` maintainers: add hensoko ``                                             |
| [`e9e07262`](https://github.com/NixOS/nixpkgs/commit/e9e07262f4265a50cc137a077c9af617cc7e1bf0) | `` micropython: 1.23.0 -> 1.24.0 ``                                        |
| [`184cc0e6`](https://github.com/NixOS/nixpkgs/commit/184cc0e6bac6e6ce17ce318f538f6322f3458453) | `` micropython: 1.22.2 -> 1.23.0 ``                                        |
| [`bf4de27f`](https://github.com/NixOS/nixpkgs/commit/bf4de27fa4cafe3d75091449880f034ac5d8bd1d) | `` element-desktop: 1.11.81 -> 1.11.82 ``                                  |
| [`e8ab03fe`](https://github.com/NixOS/nixpkgs/commit/e8ab03fe9cd1e0957c3bc0cfcf8b5f703aa43dbd) | `` teams-for-linux: electron 30 -> electron 32 ``                          |
| [`e2bb6f82`](https://github.com/NixOS/nixpkgs/commit/e2bb6f8275ff86d5ed70afdd9184d7c977d79c0d) | `` teams-for-linux: 1.11.0 -> 1.11.2 ``                                    |
| [`0afbe274`](https://github.com/NixOS/nixpkgs/commit/0afbe2745821945823bf8a3ec9ad20c485b7c866) | `` teams-for-linux: 1.10.2 -> 1.11.0 ``                                    |
| [`a2a75b05`](https://github.com/NixOS/nixpkgs/commit/a2a75b055d4d828f7db2d86e806b54e7e570295e) | `` teams-for-linux: 1.9.6 -> 1.10.2 ``                                     |
| [`afdc6d0e`](https://github.com/NixOS/nixpkgs/commit/afdc6d0e20c21de278d5a5eadd90fb945b7a0610) | `` teams-for-linux: 1.9.5 -> 1.9.6 ``                                      |
| [`4fbfb6e8`](https://github.com/NixOS/nixpkgs/commit/4fbfb6e847ee00e4b719914e29737a322d709f97) | `` ungoogled-chromium: 130.0.6723.58-1 -> 130.0.6723.69-1 ``               |
| [`418ec140`](https://github.com/NixOS/nixpkgs/commit/418ec1405a4ffdb31b7ca74ccc4cbee1ec1010b5) | `` chromium,chromedriver: 130.0.6723.58 -> 130.0.6723.69 ``                |
| [`9d53405a`](https://github.com/NixOS/nixpkgs/commit/9d53405a77b06c25b3e56afa73eb8a06f2a13fcf) | `` pkgs/top-level/all-packages.nix ``                                      |
| [`926a76fa`](https://github.com/NixOS/nixpkgs/commit/926a76fac7db55a544b6674dd50c34416b940025) | `` minidjvu: mark as vulnerable ``                                         |
| [`4dc13f35`](https://github.com/NixOS/nixpkgs/commit/4dc13f35ef91af5df6220793dc18b187d90eb50f) | `` qq: 3.2.12-2024.9.27 -> 3.2.13-2024.10.23 ``                            |
| [`8a2ee5a3`](https://github.com/NixOS/nixpkgs/commit/8a2ee5a3c286eba8ddda0d3e26a6b286e538cab7) | `` qq: nixfmt ``                                                           |
| [`dd370d3d`](https://github.com/NixOS/nixpkgs/commit/dd370d3d0dbea97c42fc96b6d8d86e57174adccd) | `` tor: 0.4.8.12 -> 0.4.8.13 ``                                            |
| [`d9e04231`](https://github.com/NixOS/nixpkgs/commit/d9e04231de5c5dad3cc872a9ce5739d753688254) | `` tor: 0.4.8.11 -> 0.4.8.12 ``                                            |
| [`72ab48ed`](https://github.com/NixOS/nixpkgs/commit/72ab48edeb4989f947f1301c87b4beb1ecd9f85a) | `` skypeforlinux: 8.130.0.205 -> 8.131.0.202 ``                            |
| [`be9562c7`](https://github.com/NixOS/nixpkgs/commit/be9562c758758c839e546fc30e56e7b61de68174) | `` [24.05] python3Packages.js2py: remove usage in other packages ``        |
| [`264f4139`](https://github.com/NixOS/nixpkgs/commit/264f4139babf84004b18023b34f600da7fabf3ae) | `` grafana-loki: 3.1.1 -> 3.1.2 ``                                         |
| [`feacc947`](https://github.com/NixOS/nixpkgs/commit/feacc947d3b21dc6f5ab02dc97b020d72d239046) | `` vencord: add maintainer donteatoreo ``                                  |
| [`ea2703df`](https://github.com/NixOS/nixpkgs/commit/ea2703dfdc8d5178510c358c8277c367672d6316) | `` vencord: 1.10.4 -> 1.10.5 ``                                            |
| [`e3bf33fa`](https://github.com/NixOS/nixpkgs/commit/e3bf33fafd8205f7d654f48cc4d38ffaae2e8240) | `` vencord: 1.10.3 -> 1.10.4 ``                                            |
| [`fccd26fa`](https://github.com/NixOS/nixpkgs/commit/fccd26faaec03205dd72d2dd7f600531c55c804b) | `` vencord: 1.10.2 -> 1.10.3 ``                                            |
| [`d697b564`](https://github.com/NixOS/nixpkgs/commit/d697b564237d1eaf179770c77f5b88a4e96804fc) | `` linux_hardened: hacky build fix ``                                      |
| [`181d5bd0`](https://github.com/NixOS/nixpkgs/commit/181d5bd00edb3c98a18c697a8b7e68da41f7ef3e) | `` linux_6_10: remove, eol ``                                              |
| [`e566ec60`](https://github.com/NixOS/nixpkgs/commit/e566ec60a18893b53ab17f432877ee25d04031ad) | `` linux: switch netfilter fix to lore patch URL ``                        |
| [`a7c2804a`](https://github.com/NixOS/nixpkgs/commit/a7c2804aa96efff423181603911a27f504e72f93) | `` nixos/sway: workaround idle inhibit not working ``                      |
| [`360792ec`](https://github.com/NixOS/nixpkgs/commit/360792ecc15bbca8c4f1f547d30863d6c84e21f8) | `` furmark: add an icon ``                                                 |
| [`d9fd652e`](https://github.com/NixOS/nixpkgs/commit/d9fd652e81a8140eecd165f9a0dcce2a6c3d5178) | `` databrics-sql-cli: Relax dependencies ``                                |
| [`56ccad32`](https://github.com/NixOS/nixpkgs/commit/56ccad32fd30c553c86a3acb2edb4ef430975ed0) | `` pyhton3Packages.databricks-sql-connector: Fix broken, 3.1.0 -> 3.3.0 `` |