### PR TITLE
chore(flake/zen-browser): `57996029` -> `8b86e4c8`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -340,11 +340,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1729880355,
-        "narHash": "sha256-RP+OQ6koQQLX5nw0NmcDrzvGL8HDLnyXt/jHhL1jwjM=",
+        "lastModified": 1730200266,
+        "narHash": "sha256-l253w0XMT8nWHGXuXqyiIC/bMvh1VRszGXgdpQlfhvU=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "18536bf04cd71abd345f9579158841376fdd0c5a",
+        "rev": "807e9154dcb16384b1b765ebe9cd2bba2ac287fd",
         "type": "github"
       },
       "original": {
@@ -530,11 +530,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1730337814,
-        "narHash": "sha256-Q0CdbWiiVWZqZQy4hRoPKA1TqUu6sifwnqDC82ePGQw=",
+        "lastModified": 1730362892,
+        "narHash": "sha256-naoPiym9CjBeh8Llp2lubp+MbJQsadmCdHoAVaxIaUA=",
         "owner": "0xc000022070",
         "repo": "zen-browser-flake",
-        "rev": "579960293b9617048adc6135448758d52a9d2123",
+        "rev": "8b86e4c8ebee78ff37cc8a827ac6eb7f3d4d87ac",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                          | Message                                 |
| --------------------------------------------------------------------------------------------------------------- | --------------------------------------- |
| [`8b86e4c8`](https://github.com/0xc000022070/zen-browser-flake/commit/8b86e4c8ebee78ff37cc8a827ac6eb7f3d4d87ac) | `` Update Zen Browser to v1.0.1-a.16 `` |