### PR TITLE
chore(flake/zen-browser): `8b86e4c8` -> `df7a5519`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -530,11 +530,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1730362892,
-        "narHash": "sha256-naoPiym9CjBeh8Llp2lubp+MbJQsadmCdHoAVaxIaUA=",
+        "lastModified": 1730432151,
+        "narHash": "sha256-2eQ6AIvqorTZuvLl6VQzFyuFMIMMp8qmzQkdGjozQwc=",
         "owner": "0xc000022070",
         "repo": "zen-browser-flake",
-        "rev": "8b86e4c8ebee78ff37cc8a827ac6eb7f3d4d87ac",
+        "rev": "df7a5519a9c24419a56dd6903abcc72679978be6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                          | Message                                 |
| --------------------------------------------------------------------------------------------------------------- | --------------------------------------- |
| [`df7a5519`](https://github.com/0xc000022070/zen-browser-flake/commit/df7a5519a9c24419a56dd6903abcc72679978be6) | `` Update Zen Browser to v1.0.1-a.17 `` |