### PR TITLE
chore(flake/spicetify-nix): `22d250d6` -> `defcdbfd`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -416,11 +416,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1730348281,
-        "narHash": "sha256-c5lP7JFqWlrEScvPXKxg7Z2+f5wdlznYZPjEa5jmEkw=",
+        "lastModified": 1730434620,
+        "narHash": "sha256-TRMTZ9nAU31tGTPQpf4ylUYDW+JfpYFbBQrZYf1/xj4=",
         "owner": "Gerg-L",
         "repo": "spicetify-nix",
-        "rev": "22d250d6a4dcc492a2d8836d3f2c901a09e7cb76",
+        "rev": "defcdbfdf0890df65685e25e8920d68035cb7720",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                    |
| ----------------------------------------------------------------------------------------------------- | -------------------------- |
| [`defcdbfd`](https://github.com/Gerg-L/spicetify-nix/commit/defcdbfdf0890df65685e25e8920d68035cb7720) | `` CI update 2024-11-01 `` |