### PR TITLE
chore(flake/nixpkgs-stable): `64b80bfb` -> `080166c1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -324,11 +324,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1730137625,
-        "narHash": "sha256-9z8oOgFZiaguj+bbi3k4QhAD6JabWrnv7fscC/mt0KE=",
+        "lastModified": 1730327045,
+        "narHash": "sha256-xKel5kd1AbExymxoIfQ7pgcX6hjw9jCgbiBjiUfSVJ8=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "64b80bfb316b57cdb8919a9110ef63393d74382a",
+        "rev": "080166c15633801df010977d9d7474b4a6c549d7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                      |
| ---------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------- |
| [`937730bb`](https://github.com/NixOS/nixpkgs/commit/937730bb4a7d5d6293d7d49097097ac28160d98a) | `` panoply: 5.5.3 -> 5.5.4 ``                                                                |
| [`86c6c628`](https://github.com/NixOS/nixpkgs/commit/86c6c628423504b6c4714c5619dedf416a4f0027) | `` tor-browser: 14.0 -> 14.0.1 ``                                                            |
| [`64900ea6`](https://github.com/NixOS/nixpkgs/commit/64900ea6545328e2dd3bf91f1c8d9fad3260eba5) | `` thunderbirdPackages.thunderbird-115: mark eol ``                                          |
| [`08cecce1`](https://github.com/NixOS/nixpkgs/commit/08cecce10cb548c9af4eb07a5d88846fa66c7b6b) | `` thunderbird-bin-unwrapped: 128.4.0esr -> 128.4.0esr ``                                    |
| [`d32eb03d`](https://github.com/NixOS/nixpkgs/commit/d32eb03de4622a5af080237ebe7d5b2b06916ffe) | `` scx.full: init ``                                                                         |
| [`9ad91340`](https://github.com/NixOS/nixpkgs/commit/9ad913403bd1db2d51fcbb56471e2cc056260041) | `` scx.rusty: init ``                                                                        |
| [`b013ad16`](https://github.com/NixOS/nixpkgs/commit/b013ad162db2e0f9353c11d6c64c37ee50fc107c) | `` scx: few nitpicks ``                                                                      |
| [`70655bee`](https://github.com/NixOS/nixpkgs/commit/70655bee1dd5f638f0e2a813adbe2a67fbfe56a7) | `` scx: init at 1.05 ``                                                                      |
| [`96867dea`](https://github.com/NixOS/nixpkgs/commit/96867dea2fcaefcbd8a2fa82fdd131bac37f0d1f) | `` nix: fix  macOS sandbox escape via builtin builders ``                                    |
| [`f9fbea3c`](https://github.com/NixOS/nixpkgs/commit/f9fbea3cd1c6a8af0f885769631c59ff184e2f66) | `` xwayland: 24.1.3 -> 24.1.4 ``                                                             |
| [`28fe3d04`](https://github.com/NixOS/nixpkgs/commit/28fe3d044ab2b16705a1404723a08e2dc66e9060) | `` xwayland: 24.1.2 -> 24.1.3 ``                                                             |
| [`aa9d36e7`](https://github.com/NixOS/nixpkgs/commit/aa9d36e7780b50fac2257819273769a16157058a) | `` xwayland: 24.1.1 -> 24.1.2 ``                                                             |
| [`426794ae`](https://github.com/NixOS/nixpkgs/commit/426794aec32de90dfe09c124f35bb35533b492bf) | `` xwayland: 24.1.0 -> 24.1.1 ``                                                             |
| [`5ef5faae`](https://github.com/NixOS/nixpkgs/commit/5ef5faae53f87a792d4511fa3277cb52af00b601) | `` xwayland: fix impure dependency on /bin/sh ``                                             |
| [`b3c5b94b`](https://github.com/NixOS/nixpkgs/commit/b3c5b94b4cb7ce68a7bfdbf4d595f9e153e76902) | `` xwayland: cherry-pick patch to fix segfault when linux-dmabuf device is not accessible `` |
| [`8312bb0b`](https://github.com/NixOS/nixpkgs/commit/8312bb0b55cd633cfaa6d655b0bb262188da105c) | `` xorg.bdftopcf: 1.1.1 -> 1.1.2 ``                                                          |
| [`a24bbc04`](https://github.com/NixOS/nixpkgs/commit/a24bbc04f8e60c4b9f0c86166a2e45d83e22983e) | `` xorg.xf86videor128: 6.12.1 -> 6.13.0 ``                                                   |
| [`4a2eb2b7`](https://github.com/NixOS/nixpkgs/commit/4a2eb2b757b5e1509ef751a4b707d4aa03f964d5) | `` xorg.xf86videomga: 2.0.1 -> 2.1.0 ``                                                      |
| [`2e76155f`](https://github.com/NixOS/nixpkgs/commit/2e76155f6fc27cda3ef9502cc8c0afc1dbfec288) | `` xorg.xf86inputlibinput: 1.4.0 -> 1.5.0 ``                                                 |
| [`938e375c`](https://github.com/NixOS/nixpkgs/commit/938e375cf91dde8805dc3533a32725751b3fb1eb) | `` xorg.xf86inputevdev: 2.10.6 -> 2.11.0 ``                                                  |
| [`cf87a462`](https://github.com/NixOS/nixpkgs/commit/cf87a4623e5cce2c6d0c5750ec054d540f11282b) | `` xorg.xwud: 1.0.6 -> 1.0.7 ``                                                              |
| [`272d2b64`](https://github.com/NixOS/nixpkgs/commit/272d2b64b6465aaa8a212ce533173b7f6f893d8f) | `` xorg.xmag: 1.0.7 -> 1.0.8 ``                                                              |
| [`87b457a3`](https://github.com/NixOS/nixpkgs/commit/87b457a3781224c93aeba3702536eb1877e6318d) | `` xorg.xkbprint: 1.0.6 -> 1.0.7 ``                                                          |
| [`12d4c334`](https://github.com/NixOS/nixpkgs/commit/12d4c3341e8905d3de8f520d4df242a238827305) | `` xorg.xcmsdb: 1.0.6 -> 1.0.7 ``                                                            |
| [`3ac98865`](https://github.com/NixOS/nixpkgs/commit/3ac98865097574719645f25be7b2924486a9b40a) | `` xorg.fonttosfnt: 1.2.3 -> 1.2.4 ``                                                        |
| [`e4472d9e`](https://github.com/NixOS/nixpkgs/commit/e4472d9e6a96e849573d3ad6f548369b087894fb) | `` summoning-pixel-dungeon: use default gradle ``                                            |
| [`7640c698`](https://github.com/NixOS/nixpkgs/commit/7640c698053243c579b81715c965017f1456fcb3) | `` gradle_6: mark very insecure ``                                                           |
| [`1ae9ac5c`](https://github.com/NixOS/nixpkgs/commit/1ae9ac5c1dacfeb4e502e3e3e74c7d67ac95bd75) | `` discord: various updates (#352190) ``                                                     |
| [`d68e4cd1`](https://github.com/NixOS/nixpkgs/commit/d68e4cd1238422371e8d27b6abb40e6f52237f54) | `` libinput-gestures: fix rev link ``                                                        |
| [`11dc466d`](https://github.com/NixOS/nixpkgs/commit/11dc466d0183bde5925c70078b81a1d0feb3cb1a) | `` microcode-intel: 20240910 -> 20241029 ``                                                  |
| [`01d70c40`](https://github.com/NixOS/nixpkgs/commit/01d70c40cb5c611b9b76fefebcb9517cd55df572) | `` thunderbirdPackages.thunderbird-128: 128.3.1esr -> 128.4.0esr ``                          |
| [`0e80bdc8`](https://github.com/NixOS/nixpkgs/commit/0e80bdc8fd6ba0287ec86084a9d60453379be1e6) | `` firefox-devedition-bin-unwrapped: 132.0b9 -> 133.0b1 ``                                   |
| [`4b057d88`](https://github.com/NixOS/nixpkgs/commit/4b057d88661e2d9a9469a41dc27c95c8d9ccf1d1) | `` firefox-beta-bin-unwrapped: 132.0b9 -> 133.0b1 ``                                         |
| [`20b34006`](https://github.com/NixOS/nixpkgs/commit/20b340060a0b0d46a9c6d30ab4e5549da55c8686) | `` firefox-bin-unwrapped: 131.0.3 -> 132.0 ``                                                |
| [`013e9475`](https://github.com/NixOS/nixpkgs/commit/013e9475af7ed307fbad6b547bfbe9fdaec0c52d) | `` firefox-devedition-unwrapped: 132.0b9 -> 133.0b1 ``                                       |
| [`7127fc07`](https://github.com/NixOS/nixpkgs/commit/7127fc072efa1d0591ba3cb7b808aa42ec3c2c92) | `` firefox-beta-unwrapped: 132.0b9 -> 133.0b1 ``                                             |
| [`dafea717`](https://github.com/NixOS/nixpkgs/commit/dafea717dad060c8011684ce0376152f62d161d5) | `` firefox-esr-unwrapped: 128.3.1esr -> 128.4.0esr ``                                        |
| [`e8bf56e0`](https://github.com/NixOS/nixpkgs/commit/e8bf56e001ba1718562d8fee22ad986e877f31f7) | `` firefox-unwrapped: 131.0.3 -> 132.0 ``                                                    |
| [`866ebe4f`](https://github.com/NixOS/nixpkgs/commit/866ebe4f84d9c54070ea1496e18ba83f5a6a8a64) | `` buildMozillaMach: update system dir patch for Firefox 133+ ``                             |
| [`b06ca0fa`](https://github.com/NixOS/nixpkgs/commit/b06ca0fab3185980a7501d7db273bb9f864580d4) | `` nss_latest: 3.105 -> 3.106 (#350999) ``                                                   |
| [`ec4ab2e6`](https://github.com/NixOS/nixpkgs/commit/ec4ab2e60526f6dc3077425944c909ef914cbf04) | `` factorio: 2.0.7 -> 2.0.8 ``                                                               |
| [`4ba06b6a`](https://github.com/NixOS/nixpkgs/commit/4ba06b6a1b94ece8ae739bca145ffc6035901ef9) | `` factorio: fix space-age backport ``                                                       |
| [`08fc4775`](https://github.com/NixOS/nixpkgs/commit/08fc47756093b74c4e7679ac582d21d80005a93b) | `` factorio-space-age: init at 2.0.7 ``                                                      |
| [`c3d784c6`](https://github.com/NixOS/nixpkgs/commit/c3d784c69cdb7de7317f5ce287586151d2f76205) | `` factorio: 1.1.110 -> 2.0.7 ``                                                             |
| [`b40c0010`](https://github.com/NixOS/nixpkgs/commit/b40c001070fcdddf88b637e111d76f55440c29de) | `` factorio: introduce _1 and _2 packages ``                                                 |
| [`e75c44d6`](https://github.com/NixOS/nixpkgs/commit/e75c44d6af8f280f90897ef15181244c23a7109a) | `` powerpipe: 0.4.3 -> 0.4.4 ``                                                              |
| [`d0f1128d`](https://github.com/NixOS/nixpkgs/commit/d0f1128dfe929e4f69e5b7ebfacadb4a18fdb539) | `` forgejo: 7.0.9 -> 7.0.10 ``                                                               |
| [`0ab51709`](https://github.com/NixOS/nixpkgs/commit/0ab5170991a81a0c6b222107247b270dfe46db14) | `` guix: build user takeover patch ``                                                        |
| [`4fbe49d3`](https://github.com/NixOS/nixpkgs/commit/4fbe49d384c57ba894b3b1ffe05536a2f5d8d3be) | `` guix: format with rfc-style ``                                                            |
| [`fea7bbc0`](https://github.com/NixOS/nixpkgs/commit/fea7bbc03b0fc8fb9825b0f51f5fa7a753841114) | `` stats: 2.11.14 -> 2.11.16 ``                                                              |
| [`372bc515`](https://github.com/NixOS/nixpkgs/commit/372bc515b80a4ceea3b97124044d42e098d6da7c) | `` libinput-gestures: nixfmt-rfc-style ``                                                    |
| [`a1823213`](https://github.com/NixOS/nixpkgs/commit/a18232138f79ba63a7938c74e7b00eb20801d53b) | `` libinput-gestures: 2.76 -> 2.77 ``                                                        |
| [`c9dc635b`](https://github.com/NixOS/nixpkgs/commit/c9dc635ba271dbda429ed5e3e5612598e2c2f945) | `` factorio: 1.1.109 -> 1.1.110 ``                                                           |
| [`83cc511e`](https://github.com/NixOS/nixpkgs/commit/83cc511efa76d9e810b574bf4742bd73b928b04f) | `` factorio: 1.1.107 -> 1.1.109 ``                                                           |
| [`6a288da9`](https://github.com/NixOS/nixpkgs/commit/6a288da98d43b0b4558ddbad65c2897ff3817883) | `` mozillavpn: 2.24.0 → 2.24.1 ``                                                            |
| [`5527334c`](https://github.com/NixOS/nixpkgs/commit/5527334c0bd7eb2fee825c50e2db5f8339c37b7b) | `` mozillavpn: add updateScript ``                                                           |
| [`b245c984`](https://github.com/NixOS/nixpkgs/commit/b245c98430f87c80dde19b9c340af9a53767ee2c) | `` mozillavpn: extract netfilter derivation for updateScript ``                              |
| [`8fe0cc0f`](https://github.com/NixOS/nixpkgs/commit/8fe0cc0f75c946f68f422ec225e908294576f26f) | `` envision: init at 0-unstable-2024-06-25 ``                                                |