### PR TITLE
chore(flake/plasma-manager): `f634d5f6` -> `6cb0aedf`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -364,11 +364,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1730366788,
-        "narHash": "sha256-0Ezvv4KkyFdLAblPBFDgZbiMLlJZtpHruT2i4KC2wIY=",
+        "lastModified": 1730481339,
+        "narHash": "sha256-Y1yWhjt/38N5IMgWoGnUTzJ6F4kGnpti/l2AOJWPUOY=",
         "owner": "pjones",
         "repo": "plasma-manager",
-        "rev": "f634d5f6ee9be365b2ca08b2d00e0e3b0c240b9e",
+        "rev": "6cb0aedf6160725eee50425b4e8d908c09dcb7a3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                        | Message                                                                                            |
| ------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------- |
| [`6cb0aedf`](https://github.com/nix-community/plasma-manager/commit/6cb0aedf6160725eee50425b4e8d908c09dcb7a3) | `` fix(plasmusic-toolbar): remove unused preferredPlayerIdentity config to prevent error (#405) `` |