### PR TITLE
chore(flake/nixpkgs-stable): `080166c1` -> `3c2f1c4c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -324,11 +324,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1730327045,
-        "narHash": "sha256-xKel5kd1AbExymxoIfQ7pgcX6hjw9jCgbiBjiUfSVJ8=",
+        "lastModified": 1730602179,
+        "narHash": "sha256-efgLzQAWSzJuCLiCaQUCDu4NudNlHdg2NzGLX5GYaEY=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "080166c15633801df010977d9d7474b4a6c549d7",
+        "rev": "3c2f1c4ca372622cb2f9de8016c9a0b1cbd0f37c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                   |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------- |
| [`9fa29994`](https://github.com/NixOS/nixpkgs/commit/9fa299946fecb9f6fbb7d0fcc426394c1ec83f2d) | `` miniflux: 2.2.1 -> 2.2.2 ``                                            |
| [`92217a08`](https://github.com/NixOS/nixpkgs/commit/92217a0870d0b5848f8b19edef142d09843e34fa) | `` miniflux: 2.2.0 -> 2.2.1 ``                                            |
| [`adc2d965`](https://github.com/NixOS/nixpkgs/commit/adc2d9650dca3cc0483a8ec7995e55c691e04cda) | `` zrythm: 1.0.0-rc.1 -> 1.0.0-rc.2 ``                                    |
| [`7aa7691d`](https://github.com/NixOS/nixpkgs/commit/7aa7691dfedc00916084dfa4822bc37a5479825a) | `` koboldcpp: 1.76 -> 1.77 ``                                             |
| [`26b6d772`](https://github.com/NixOS/nixpkgs/commit/26b6d7729dadaa0de3925484f45880aac25f6067) | `` oraclejdk_*: mark insecure and not updated ``                          |
| [`b42eea8d`](https://github.com/NixOS/nixpkgs/commit/b42eea8db5e952173dc68b5f2f7f2c6bd30214ca) | `` cifs-utils: add optional dependencies ``                               |
| [`860d9d8b`](https://github.com/NixOS/nixpkgs/commit/860d9d8bf8ff00698a5307f913c41db8372159db) | `` cifs-utils: format with nixfmt-rfc-style ``                            |
| [`768921f2`](https://github.com/NixOS/nixpkgs/commit/768921f2492f8c015c77e378a750293eb3402f6c) | `` scx.cscheds: fix typo in name ``                                       |
| [`391df1d6`](https://github.com/NixOS/nixpkgs/commit/391df1d65e962c520e912b504511b2dc46f35d79) | `` brave: 1.71.118 -> 1.71.121 ``                                         |
| [`582d3616`](https://github.com/NixOS/nixpkgs/commit/582d3616719c83aa69deea84c16136ac24e1d5bc) | `` linux: remove patch backport ``                                        |
| [`362cbc9b`](https://github.com/NixOS/nixpkgs/commit/362cbc9b976b302d16aa0dfdf78b7580791ad682) | `` linux_5_15: 5.15.169 -> 5.15.170 ``                                    |
| [`2977c7ed`](https://github.com/NixOS/nixpkgs/commit/2977c7ed44d8108351b1a6fbb2629122337de3d4) | `` linux_6_1: 6.1.114 -> 6.1.115 ``                                       |
| [`5a2e08e6`](https://github.com/NixOS/nixpkgs/commit/5a2e08e6c2958631bdf97a07f0ee5f3b470bbb90) | `` linux_6_6: 6.6.58 -> 6.6.59 ``                                         |
| [`98949753`](https://github.com/NixOS/nixpkgs/commit/98949753ff42831d69e8d3be8fbf4288f771fc89) | `` linux_6_11: 6.11.5 -> 6.11.6 ``                                        |
| [`2dc388ec`](https://github.com/NixOS/nixpkgs/commit/2dc388ec1c258f5a24e95542291b452e0a8cab5c) | `` linux_testing: 6.12-rc4 -> 6.12-rc5 ``                                 |
| [`2e3fd638`](https://github.com/NixOS/nixpkgs/commit/2e3fd6383a37914261922b0dd604e8bcc6d462f9) | `` tailscale: 1.76.1 -> 1.76.3 ``                                         |
| [`2cf8505d`](https://github.com/NixOS/nixpkgs/commit/2cf8505dcc63e0db2b88841d59b3e827aaeb1e87) | `` [Backport release-24.05] rustdesk-flutter: 1.3.1 -> 1.3.2 (#352520) `` |
| [`c3e63d6b`](https://github.com/NixOS/nixpkgs/commit/c3e63d6bc0a648b4075e670012bc62489ded4c70) | `` epson-escpr2: 1.2.18 -> 1.2.20 ``                                      |
| [`591df381`](https://github.com/NixOS/nixpkgs/commit/591df381f5454005c931aaf5e240abc486f53f28) | `` matrix-synapse-unwrapped: 1.117.0 -> 1.118.0 ``                        |
| [`fd9a9c49`](https://github.com/NixOS/nixpkgs/commit/fd9a9c498a292677ce3a28c4d37f76ad6e49594e) | `` qbittorrent: add knownVulnerabilities ``                               |
| [`4505fb5f`](https://github.com/NixOS/nixpkgs/commit/4505fb5fbee1453dd6204d2bf3c1b67f7bffec77) | `` mullvad-browser: 13.5.7 -> 13.5.9 ``                                   |
| [`7e501f75`](https://github.com/NixOS/nixpkgs/commit/7e501f7582a2f02a66203fa7d0f6f6922025751b) | `` nifi: 1.27.0 -> 1.28.0 ``                                              |
| [`f4f14173`](https://github.com/NixOS/nixpkgs/commit/f4f141733d03fcd92877f0b8b45e4a1cdd1936eb) | `` nifi: 1.26.0 -> 1.27.0 ``                                              |
| [`beebf573`](https://github.com/NixOS/nixpkgs/commit/beebf57323e92cb7f82583676168572f0b0f38a4) | `` versatiles: init at 0.12.10 ``                                         |
| [`fb38af2a`](https://github.com/NixOS/nixpkgs/commit/fb38af2ad99998d0cf8296be55d4f7fc6f9861c6) | `` maintainers: add wilhelmines ``                                        |
| [`98df381d`](https://github.com/NixOS/nixpkgs/commit/98df381dd3d2c4f0494cd037059a41f1dfe99689) | `` floorp: 11.19.1 -> 11.20.0 ``                                          |
| [`05ad4067`](https://github.com/NixOS/nixpkgs/commit/05ad4067ee147b8eb8953df070431194c4649e98) | `` kin-openapi: init at 0.128.0 ``                                        |
| [`99960e86`](https://github.com/NixOS/nixpkgs/commit/99960e8654b656b7f488274f20e0a6020f3573bb) | `` gitaly: Embed git binaries ``                                          |
| [`99e49676`](https://github.com/NixOS/nixpkgs/commit/99e496765b1e3be2f0926e6a4d507bba4e996441) | `` gitlab: 17.2.9 -> 17.3.6 ``                                            |
| [`189df8bf`](https://github.com/NixOS/nixpkgs/commit/189df8bf7e58bebdd764dc575d15b7b4d1bc7cd1) | `` imagemagick: 7.1.1-38 -> 7.1.1-39 ``                                   |