### PR TITLE
chore(flake/alejandra): `5351e71b` -> `264e2354`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -9,11 +9,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1730690705,
-        "narHash": "sha256-pQtTjLVTmr/5VAGAMFH8MiARAz8uCXB+I8PGte5/QPk=",
+        "lastModified": 1730773997,
+        "narHash": "sha256-nOo970Pm12BK1DH7hfS800i8mg5h8me1IxokGUKMgb8=",
         "owner": "kamadorueda",
         "repo": "alejandra",
-        "rev": "5351e71b10c4de2068aa450def3c9beb8b8df406",
+        "rev": "264e23546663a5676a77174cab31340a81aa2cc0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                 | Message                                                                           |
| ------------------------------------------------------------------------------------------------------ | --------------------------------------------------------------------------------- |
| [`264e2354`](https://github.com/kamadorueda/alejandra/commit/264e23546663a5676a77174cab31340a81aa2cc0) | `` add formatting for doc-comments ``                                             |
| [`0f7f0afa`](https://github.com/kamadorueda/alejandra/commit/0f7f0afa428dca2bc24c17925d8b3610d135192f) | `` build(deps): bump the npm_and_yarn group across 1 directory with 15 updates `` |
| [`15c14e17`](https://github.com/kamadorueda/alejandra/commit/15c14e1751e70d96064c0176fc64a9e493a2697f) | `` feat: add pkg readme ``                                                        |