### PR TITLE
chore(flake/nixpkgs-stable): `3c2f1c4c` -> `d063c1dd`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -324,11 +324,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1730602179,
-        "narHash": "sha256-efgLzQAWSzJuCLiCaQUCDu4NudNlHdg2NzGLX5GYaEY=",
+        "lastModified": 1730741070,
+        "narHash": "sha256-edm8WG19kWozJ/GqyYx2VjW99EdhjKwbY3ZwdlPAAlo=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "3c2f1c4ca372622cb2f9de8016c9a0b1cbd0f37c",
+        "rev": "d063c1dd113c91ab27959ba540c0d9753409edf3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                           |
| ---------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------- |
| [`7b9bbd82`](https://github.com/NixOS/nixpkgs/commit/7b9bbd82bbc7bc0422a593b3beaa907fa399beb6) | `` guix: fix build user takeover patch ``                                         |
| [`2ca242c3`](https://github.com/NixOS/nixpkgs/commit/2ca242c3d2c3334e9620ac203bd446fc03e5ef11) | `` google-chrome: 130.0.6723.69 -> 130.0.6723.92 ``                               |
| [`4ed74bfa`](https://github.com/NixOS/nixpkgs/commit/4ed74bfaf70aedb61483bdd6f4a6ce47f0da576c) | `` Revert "woodpecker-server: 2.7.1 -> 2.7.2" ``                                  |
| [`38008f81`](https://github.com/NixOS/nixpkgs/commit/38008f81f7a57b957058e4febd294316185bba7d) | `` woodpecker-server: 2.7.1 -> 2.7.2 ``                                           |
| [`e8dac459`](https://github.com/NixOS/nixpkgs/commit/e8dac4597d0a29881044479ac614058af6e6717e) | `` mysql84: 8.4.2 -> 8.4.3 ``                                                     |
| [`bc449572`](https://github.com/NixOS/nixpkgs/commit/bc4495722d698b4f2b52165178f6a45f16f506a6) | `` vesktop: fix darwin extension `.App` -> `.app` ``                              |
| [`6e464775`](https://github.com/NixOS/nixpkgs/commit/6e464775320de73b472b5d0402826b89c975b631) | `` vesktop: add updateScript ``                                                   |
| [`52a12798`](https://github.com/NixOS/nixpkgs/commit/52a127986db1c781be6d2079c336b70b447eb86c) | `` vesktop: 1.5.2 -> 1.5.3 ``                                                     |
| [`0d93e2df`](https://github.com/NixOS/nixpkgs/commit/0d93e2dfba04b478c01fd1ec1b35e31d5d2b0530) | `` vesktop: Add option for middle click scroll ``                                 |
| [`30d06e26`](https://github.com/NixOS/nixpkgs/commit/30d06e26f780e3c26b5adc7569352cf9f42dadd1) | `` vesktop: fix icon file locations ``                                            |
| [`6726645f`](https://github.com/NixOS/nixpkgs/commit/6726645f1056af20469e2d8729e2171d435e746f) | `` vesktop: use attrset for env vars ``                                           |
| [`df65131d`](https://github.com/NixOS/nixpkgs/commit/df65131d878f9bf4a6595404042cba14bdfb0435) | `` vesktop: add support for darwin ``                                             |
| [`d6ac88a0`](https://github.com/NixOS/nixpkgs/commit/d6ac88a00534bd1fad61e1ad0c08c1fa7254cda7) | `` vesktop: use pnpm.fetchDeps ``                                                 |
| [`4b2c5237`](https://github.com/NixOS/nixpkgs/commit/4b2c5237dac7a70bc235dc2eb9d3376319ccb8b2) | `` ungoogled-chromium: 130.0.6723.69-1 -> 130.0.6723.91-1 ``                      |
| [`4abbefa6`](https://github.com/NixOS/nixpkgs/commit/4abbefa6655620694104c9a6f5558e6d003e542e) | `` chromium,chromedriver: 130.0.6723.69 -> 130.0.6723.91 ``                       |
| [`e8a977c0`](https://github.com/NixOS/nixpkgs/commit/e8a977c015fcd17710ce2b0009cf2c93a8d4fa95) | `` consul: 1.18.4 -> 1.18.5 ``                                                    |
| [`eceb2f6c`](https://github.com/NixOS/nixpkgs/commit/eceb2f6c7e7166b574670aaf67d96ab43b6c3c89) | `` warp-terminal: 0.2024.10.23.14.49.stable_00 -> 0.2024.10.29.08.02.stable_02 `` |
| [`76134085`](https://github.com/NixOS/nixpkgs/commit/76134085a641e17bf0f7c41d4b33935930b19583) | `` warp-terminal: 0.2024.10.15.08.02.stable_03 -> 0.2024.10.23.14.49.stable_00 `` |
| [`dace7f99`](https://github.com/NixOS/nixpkgs/commit/dace7f997a5af72a3ac28048b4483ce63fd1961a) | `` warp-terminal: 0.2024.10.15.08.02.stable_02 -> 0.2024.10.15.08.02.stable_03 `` |
| [`3c57ea6b`](https://github.com/NixOS/nixpkgs/commit/3c57ea6b53cd8ecc48a54dbd21455322cbddb1f5) | `` warp-terminal: 0.2024.10.08.08.02.stable_02 -> 0.2024.10.15.08.02.stable_02 `` |
| [`ec99d106`](https://github.com/NixOS/nixpkgs/commit/ec99d10692ef06cada71b80a347b2f1d6e11f19a) | `` duckstation-bin: init at 0.1-7294 ``                                           |
| [`ad449e18`](https://github.com/NixOS/nixpkgs/commit/ad449e1864b1235e1f611f0a8860813bc61ed830) | `` libcsa: init at 1.26-unstable-2024-03-22 ``                                    |
| [`20ae197d`](https://github.com/NixOS/nixpkgs/commit/20ae197d94fbe5a604ba2bc490812d6f6c7d2a47) | `` nixos/mediawiki: check if LocalConfig.php is valid syntax ``                   |