### PR TITLE
chore(flake/nixpkgs): `7ffd9ae6` -> `4aa36568`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -308,11 +308,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1730531603,
-        "narHash": "sha256-Dqg6si5CqIzm87sp57j5nTaeBbWhHFaVyG7V6L8k3lY=",
+        "lastModified": 1730785428,
+        "narHash": "sha256-Zwl8YgTVJTEum+L+0zVAWvXAGbWAuXHax3KzuejaDyo=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "7ffd9ae656aec493492b44d0ddfb28e79a1ea25d",
+        "rev": "4aa36568d413aca0ea84a1684d2d46f55dbabad7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                    |
| ---------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------- |
| [`aa689c67`](https://github.com/NixOS/nixpkgs/commit/aa689c679c90ea9a84c99cfb1ef5a7ab4ddbbf9b) | `` dialect: 2.4.2 -> 2.5.0 (#353294) ``                                    |
| [`8e8f6c00`](https://github.com/NixOS/nixpkgs/commit/8e8f6c00e85cf1beb457917ccd9a14d064f4bd41) | `` ripgrep: switch to apple-sdk_11 ``                                      |
| [`dbcea082`](https://github.com/NixOS/nixpkgs/commit/dbcea0828a0865b89534a81f1e3df3f5ea780a9c) | `` vimv-rs: switch to apple-sdk_11 ``                                      |
| [`580741f0`](https://github.com/NixOS/nixpkgs/commit/580741f0fa29e698ee6b88af35b917e1e3c00ea8) | `` git-interactive-rebase-tool: switch to apple-sdk_11 ``                  |
| [`2aa42ec6`](https://github.com/NixOS/nixpkgs/commit/2aa42ec64465970a2dd12b2e6e83a168c599fea7) | `` delta: switch to apple-sdk_11 ``                                        |
| [`bda767ef`](https://github.com/NixOS/nixpkgs/commit/bda767efc949a2d50ad48b7b14d1524ce59f68d7) | `` lsd: switch to apple-sdk_11 ``                                          |
| [`7495125f`](https://github.com/NixOS/nixpkgs/commit/7495125f91eaf57f565196c2183c3be3b670d8cf) | `` bat: switch to apple-sdk_11 ``                                          |
| [`3e9783d8`](https://github.com/NixOS/nixpkgs/commit/3e9783d8cc60378d1a474032343c5cede617bc2b) | `` firefox-bin-unwrapped: 132.0 -> 132.0.1 ``                              |
| [`239ef2ff`](https://github.com/NixOS/nixpkgs/commit/239ef2ff2d89e2f164b485f72a50ff01866f9d25) | `` firefox-unwrapped: 132.0 -> 132.0.1 ``                                  |
| [`e7d6ea8c`](https://github.com/NixOS/nixpkgs/commit/e7d6ea8ca61cd654dd8a5a5087ad3925a0560299) | `` ld64: set Darwin team as maintainers ``                                 |
| [`02f20000`](https://github.com/NixOS/nixpkgs/commit/02f20000a25fd19ddf49c0915496285d44cd5dc5) | `` cctools: set Darwin team as maintainers ``                              |
| [`b975612e`](https://github.com/NixOS/nixpkgs/commit/b975612ef13f177db2d8b093b055e87f7c121c55) | `` python312Packages.django-haystack: disable tests on darwin ``           |
| [`6f42eff1`](https://github.com/NixOS/nixpkgs/commit/6f42eff1defa62cd751cba0988069b9e08dc475f) | `` ruby_3_2: 3.2.4 -> 3.2.5 (#352560) ``                                   |
| [`b818e0cb`](https://github.com/NixOS/nixpkgs/commit/b818e0cbb858871397a7c5a07168c15e0119b602) | `` docker-buildx: 0.17.1 -> 0.18.0 (#352575) ``                            |
| [`6760f0a7`](https://github.com/NixOS/nixpkgs/commit/6760f0a702b1fa562be952451e4cad3ddece665e) | `` brave: fix qt theming (#352667) ``                                      |
| [`05e26cb3`](https://github.com/NixOS/nixpkgs/commit/05e26cb37392ea4f706b3220ef7b017a7a4aa57d) | `` python312Packages.xmlschema: 3.4.2 -> 3.4.3 (#352700) ``                |
| [`560626d0`](https://github.com/NixOS/nixpkgs/commit/560626d0d617069bee5f0609257eb5f02b3eba07) | `` python312Packages.mando: 0.7.1 -> 0.8.2 (#352777) ``                    |
| [`0ea31d13`](https://github.com/NixOS/nixpkgs/commit/0ea31d130cc50ed6bb62e201c24705e998bd0547) | `` alacritty: use new darwin SDK pattern ``                                |
| [`137f3729`](https://github.com/NixOS/nixpkgs/commit/137f3729455cee4ee75ac38c7b18b936a3e94db8) | `` vimPlugins.lze: 0.1.4 -> 0.4.4 (#353109) ``                             |
| [`174ef9b8`](https://github.com/NixOS/nixpkgs/commit/174ef9b84ac4286e298d9283f5a2ca27baafb258) | `` transmission_4: fix build on Darwin ``                                  |
| [`2e99cc48`](https://github.com/NixOS/nixpkgs/commit/2e99cc48c7715a036b89f93c3dd297de4b386368) | `` transmission_4: update for the new SDK pattern on Darwin ``             |
| [`0e68d7bd`](https://github.com/NixOS/nixpkgs/commit/0e68d7bdfb1640f1053cda5fd06be862520064dd) | `` lightningcss: enable aarch64-linux builds and set platform to all ``    |
| [`6d3cc742`](https://github.com/NixOS/nixpkgs/commit/6d3cc7422121699491d4368c153c2928d49d9bc8) | `` spnavcfg: add X11 to the build inputs ``                                |
| [`e8fd2805`](https://github.com/NixOS/nixpkgs/commit/e8fd280532ab2bd7d88679db92760cd06748faf4) | `` maid: update dependencies ``                                            |
| [`5058251d`](https://github.com/NixOS/nixpkgs/commit/5058251dd857233ac0e7f191583d957400d87696) | `` CONTRIBUTING.md: Add note about nixpkgs-merge-bot restricted authors `` |
| [`88e1c5d4`](https://github.com/NixOS/nixpkgs/commit/88e1c5d40464bb8a0b329efb77e86b963c5e97e8) | `` plandex-server: add git to path ``                                      |
| [`9aeabf40`](https://github.com/NixOS/nixpkgs/commit/9aeabf401af8aa70f73cd9713ec5c544f985f697) | `` yt-dlp: 2024.10.22 -> 2024.11.4, use constant changlog URL ``           |
| [`9a4e945c`](https://github.com/NixOS/nixpkgs/commit/9a4e945cebb27a363a4d150affdade25258d3207) | `` nixos/tests/forgejo: fix after git v2.47 bump ``                        |
| [`e15b1502`](https://github.com/NixOS/nixpkgs/commit/e15b1502f8540d95ebea6d0d8c37e89e4f9423d9) | `` fastfetch: 2.28.0 -> 2.29.0 ``                                          |
| [`f9c15bce`](https://github.com/NixOS/nixpkgs/commit/f9c15bce32490d67e25aa14fb5a876c65b2f681d) | `` lightningcss: 1.27.0 → 1.28.0 ``                                        |
| [`45bb433c`](https://github.com/NixOS/nixpkgs/commit/45bb433c54e34ce846f5bfcaee42c6359ad56ca0) | `` paperless-ngx: 2.13.2 -> 2.13.4 ``                                      |
| [`af9131fa`](https://github.com/NixOS/nixpkgs/commit/af9131fa6de1bd184ad5e8d20a4034c425d3b7d2) | `` yabai: 7.1.4 -> 7.1.5 ``                                                |
| [`550d4a2a`](https://github.com/NixOS/nixpkgs/commit/550d4a2af43d74f0fded665f01f3b4651af835d7) | `` yabai: modernize ``                                                     |
| [`b2607dee`](https://github.com/NixOS/nixpkgs/commit/b2607dee162817714049169785310ea52684cb0f) | `` yabai: add versionCheckHook ``                                          |
| [`88eb0fcc`](https://github.com/NixOS/nixpkgs/commit/88eb0fcca4d46cb4f2211394b213d6175add582e) | `` yabai: switch to apple-sdk_15 ``                                        |
| [`4457d955`](https://github.com/NixOS/nixpkgs/commit/4457d955d01a4f8e0187448063e146bc36e4745f) | `` yabai: refactor to new sdk pattern ``                                   |
| [`74561ffe`](https://github.com/NixOS/nixpkgs/commit/74561ffeac40631621af34a6d469c6571a8cdf23) | `` python3Packages.torch-tb-profiler: 0.3.1 -> 0.4.0 ``                    |
| [`a1f1c849`](https://github.com/NixOS/nixpkgs/commit/a1f1c849ad9d67ad0151f610e2955b43ffdfd7e8) | `` vscode-extensions.antyos.openscad 1.1.1 → 1.3.1 ``                      |
| [`24a2d2a2`](https://github.com/NixOS/nixpkgs/commit/24a2d2a261aa8d030728bb70581ab3a3f7890846) | `` tree-sitter-grammars: add river (#347752) ``                            |
| [`e7e66352`](https://github.com/NixOS/nixpkgs/commit/e7e66352e9c5f525de6dd44c4d463f472ad2ca06) | `` cbconvert: init at 1.0.4 ``                                             |
| [`a0df5569`](https://github.com/NixOS/nixpkgs/commit/a0df55691923a6c542a7b33f61ad289850863e34) | `` python312Packages.h5py-mpi: fix build by relaxing mpi4py dependency ``  |
| [`cc275e64`](https://github.com/NixOS/nixpkgs/commit/cc275e641f1a0fb82616e84817bf21b65650767d) | `` python312Packages.h5py-mpi: remove unused patch ``                      |
| [`bdef0396`](https://github.com/NixOS/nixpkgs/commit/bdef0396f569727e127977acc56b9fd5c6eb3832) | `` florist: init at 24.2 ``                                                |
| [`c4edf939`](https://github.com/NixOS/nixpkgs/commit/c4edf939886aa9e61a9e266c776056b9f5d79cbc) | `` Cleanup helsinki maintainer (#353611) ``                                |
| [`5a37bac4`](https://github.com/NixOS/nixpkgs/commit/5a37bac414ff58ca4d36ed9fc4642035d4597b7d) | `` sile: 0.14.17 -> 0.15.5 ``                                              |
| [`b2b573e3`](https://github.com/NixOS/nixpkgs/commit/b2b573e39ac0644730c4dc8f04e2b4d152a2c81e) | `` maintainers: update entry for kloenk ``                                 |
| [`6df0b10d`](https://github.com/NixOS/nixpkgs/commit/6df0b10df6903be10245355ef35dd8435084bd95) | `` Revert "less: Fix withSecure regression" ``                             |
| [`e2a21bdd`](https://github.com/NixOS/nixpkgs/commit/e2a21bddefb8cbd10710d9dcd4a2293d01325e27) | `` python312Packages.openusd: add gador as co-maintainer ``                |
| [`fbd18886`](https://github.com/NixOS/nixpkgs/commit/fbd188864020b9a1226d35b9df1fe465e1f378c1) | `` re-add libsandbox ``                                                    |
| [`caa10b05`](https://github.com/NixOS/nixpkgs/commit/caa10b055f92d4bfc8da3e4a71fb7264d715c492) | `` nix: update fallback paths automatically ``                             |
| [`6b90fbc9`](https://github.com/NixOS/nixpkgs/commit/6b90fbc91f0aec54d30d5e6756392223eb8afbc5) | `` sile: use lib.optionals for Darwin specific inputs ``                   |
| [`e37658c6`](https://github.com/NixOS/nixpkgs/commit/e37658c6f144b627231cce1be5b12918bb728a01) | `` sile: reorder callPackage arguments like in expression ``               |
| [`9f1a0fde`](https://github.com/NixOS/nixpkgs/commit/9f1a0fde5c45c5017c36832bc4577c88a86e0caf) | `` sile: allow easier override of luaEnv ``                                |
| [`fca1f18d`](https://github.com/NixOS/nixpkgs/commit/fca1f18de9448d0861879ac454b5382bc32d221f) | `` sile: use finalAttrs.finalPackage when needed ``                        |
| [`0a5b0c8c`](https://github.com/NixOS/nixpkgs/commit/0a5b0c8cd928ebe29f99f27927b94f6030f4e727) | `` sile: don't use with lib; in meta ``                                    |
| [`3618ec6a`](https://github.com/NixOS/nixpkgs/commit/3618ec6a0ad2cd68599694eb11b1f400e68c4f20) | `` sile: nixfmt; move to pkgs/by-name ``                                   |
| [`8b274c80`](https://github.com/NixOS/nixpkgs/commit/8b274c8054e5f56c839f6efc6dbf38bc4074fdf0) | `` iverilog: Update homepage link ``                                       |
| [`c0aef2b9`](https://github.com/NixOS/nixpkgs/commit/c0aef2b9dc49dbc696ee2b68844a0427a63b14a5) | `` python312Packages.tencentcloud-sdk-python: 3.0.1257 -> 3.0.1259 ``      |
| [`7819e574`](https://github.com/NixOS/nixpkgs/commit/7819e57453b6f2b86228d4dbae3ee0f00ba72814) | `` pylyzer: 0.0.68 -> 0.0.69 ``                                            |
| [`08790dff`](https://github.com/NixOS/nixpkgs/commit/08790dff7907b73811efbdc3eef8c4662b8c9b68) | `` xorg.libAppleWM: constrain to darwin targets ``                         |
| [`0a0e61b0`](https://github.com/NixOS/nixpkgs/commit/0a0e61b073536683e611506ceec0230f526efd15) | `` apachetomcatscanner: add missing dependencies ``                        |
| [`5dee69a2`](https://github.com/NixOS/nixpkgs/commit/5dee69a240e48f250918fd57e91e4a66910909d2) | `` git-fast-export: 221024 -> 231118 ``                                    |
| [`5d9ac946`](https://github.com/NixOS/nixpkgs/commit/5d9ac94606923cadc983c508dc065213e64e055f) | `` nixos/activation-script: Make `installBootLoader` default a script ``   |
| [`f92ec1bc`](https://github.com/NixOS/nixpkgs/commit/f92ec1bc93990197895f4ce4bcf29354a738f830) | `` nixos/tests/switchTest: Add test for dbus reloading ``                  |
| [`a7cda683`](https://github.com/NixOS/nixpkgs/commit/a7cda6835fc042a0a70d3e1983863aad0183d229) | `` nixos/tests/switchTest: Remove spurious dbus reload checks ``           |
| [`6e66b546`](https://github.com/NixOS/nixpkgs/commit/6e66b546a1e0c6e93426ff7b44afbc2f4705293d) | `` git-fast-export: add passthru.updateScript ``                           |
| [`2ff0c93a`](https://github.com/NixOS/nixpkgs/commit/2ff0c93a65b60a40f12a326f3a98133d1e026be8) | `` git-fast-export: nixfmt ``                                              |
| [`a36cf528`](https://github.com/NixOS/nixpkgs/commit/a36cf528f76468419d6e7df22ad652607b21e195) | `` git-fast-export: move to by-name ``                                     |
| [`efd6331c`](https://github.com/NixOS/nixpkgs/commit/efd6331c95521d24bc7802fc380af9509cf44a15) | `` pytrainer: unpin python 3.10 ``                                         |
| [`40b7674b`](https://github.com/NixOS/nixpkgs/commit/40b7674b98ea79a540908b36c2d72add66a35218) | `` nixos/tests/switchTest: Test no boot loader ``                          |
| [`25d33b8c`](https://github.com/NixOS/nixpkgs/commit/25d33b8c78e7f99a454cce1c37be65df9d0afcdf) | `` dnsdiag: 2.5.0 -> 2.6.0 ``                                              |
| [`84bf4842`](https://github.com/NixOS/nixpkgs/commit/84bf48421f7381924b218075110af2b569f2434b) | `` checkov: 3.2.276 -> 3.2.277 ``                                          |
| [`c495d970`](https://github.com/NixOS/nixpkgs/commit/c495d97060a31295c66cfd157b6299fcc61b9a31) | `` edge-runtime: 1.53.4 -> 1.60.1 ``                                       |
| [`1221b2e0`](https://github.com/NixOS/nixpkgs/commit/1221b2e0daa370561a6b8d48b42d63927880e5bf) | `` edge-runtime: nixfmt ``                                                 |
| [`64c924e0`](https://github.com/NixOS/nixpkgs/commit/64c924e098fb8c2c2055f81317865fb8602c8c66) | `` edge-runtime: move to by-name ``                                        |
| [`76c8e15a`](https://github.com/NixOS/nixpkgs/commit/76c8e15a8ae9e8df62cdd230491d7fb1a4faa932) | `` ostree: 2024.4 -> 2024.8 ``                                             |
| [`affa833b`](https://github.com/NixOS/nixpkgs/commit/affa833b2aebe455a637860da5b3f968c3fcea38) | `` python312Packages.hap-python: refactor ``                               |
| [`a182a532`](https://github.com/NixOS/nixpkgs/commit/a182a53243828257018c6ef4c7d2edbe89fd63e5) | `` buildFHSEnv: rewrite env building ``                                    |
| [`15e07bd8`](https://github.com/NixOS/nixpkgs/commit/15e07bd8205e174b42acb8db510246be6fa738ed) | `` emacsPackages: Don't add nix to melpa updater shell ``                  |
| [`ab522505`](https://github.com/NixOS/nixpkgs/commit/ab5225054b0839958a4207b924af506ec23e89df) | `` utf8cpp: 4.0.5 -> 4.0.6 ``                                              |
| [`8218cc6b`](https://github.com/NixOS/nixpkgs/commit/8218cc6bd1ad641f3137493b5514e0df6d94124e) | `` wechat-uos: 1.0.0.241 -> 4.0.0.21 ``                                    |
| [`69245718`](https://github.com/NixOS/nixpkgs/commit/692457183faf7d1ae8b61e9336ff2262564382a7) | `` python312Packages.openusd: apply upsteam's new license ``               |
| [`8f55121f`](https://github.com/NixOS/nixpkgs/commit/8f55121f7f7921b2ea7f601fa425d6b8266c6bd7) | `` lib/licenses.nix: add tost ``                                           |
| [`eb2009ec`](https://github.com/NixOS/nixpkgs/commit/eb2009ec57598911cdfdb6e148abd092fbcb2d9f) | `` dgen-sdl: fix darwin build ``                                           |
| [`c6585ad0`](https://github.com/NixOS/nixpkgs/commit/c6585ad0077d8f122440d40d30ba5e4dd5a6e587) | `` tart: 2.18.5 -> 2.19.3 ``                                               |
| [`4ddef40c`](https://github.com/NixOS/nixpkgs/commit/4ddef40cb938ec937c0082a2b82a8b3369361140) | `` agg: disable sdltest on darwin ``                                       |
| [`e19b0195`](https://github.com/NixOS/nixpkgs/commit/e19b0195b43079bac31c27b911a4cd1da3d5944d) | `` SDL_sound: fix sdltest flag ``                                          |
| [`20fff77f`](https://github.com/NixOS/nixpkgs/commit/20fff77fcc33876e4e897562d81b9c83d57769e6) | `` vix: limit package to x86_64-linux (#353569) ``                         |
| [`776f433b`](https://github.com/NixOS/nixpkgs/commit/776f433b9bae66b135357ba35c169a30b7899e4d) | `` quick-lookup: 2.1.1 -> 2.1.2 ``                                         |