### PR TITLE
chore(flake/nixpkgs-stable): `d063c1dd` -> `dba41493`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -324,11 +324,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1730741070,
-        "narHash": "sha256-edm8WG19kWozJ/GqyYx2VjW99EdhjKwbY3ZwdlPAAlo=",
+        "lastModified": 1730883749,
+        "narHash": "sha256-mwrFF0vElHJP8X3pFCByJR365Q2463ATp2qGIrDUdlE=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "d063c1dd113c91ab27959ba540c0d9753409edf3",
+        "rev": "dba414932936fde69f0606b4f1d87c5bc0003ede",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                 |
| ---------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------- |
| [`03b710ef`](https://github.com/NixOS/nixpkgs/commit/03b710ef07e110d795da4d9410e5f8078036d7c7) | `` redmine: 5.1.3 -> 5.1.4 ``                                           |
| [`6aa321b9`](https://github.com/NixOS/nixpkgs/commit/6aa321b9c7f74f7862855631a1edee478e2c4640) | `` morgen: bump electron version to electron_32 ``                      |
| [`79276acb`](https://github.com/NixOS/nixpkgs/commit/79276acb24ce4017a11f283a699340ed329955e9) | `` discord: bump all versions ``                                        |
| [`1d55ba22`](https://github.com/NixOS/nixpkgs/commit/1d55ba221c00d184a42cc02397d56be3ffdc0221) | `` gallery-dl: 1.27.6 -> 1.27.7 ``                                      |
| [`b9eab875`](https://github.com/NixOS/nixpkgs/commit/b9eab875728d3f39ba2b92e549d663c0af596478) | `` linuxPackages.nvidiaPackages.legacy_535: 535.154.05 -> 535.216.01 `` |
| [`66de022b`](https://github.com/NixOS/nixpkgs/commit/66de022b5703a658eb53921f6d7676694aeba328) | `` firefox-bin-unwrapped: 132.0 -> 132.0.1 ``                           |
| [`3b81e995`](https://github.com/NixOS/nixpkgs/commit/3b81e99526c384e79d185c8bc5e124586118e6cc) | `` firefox-unwrapped: 132.0 -> 132.0.1 ``                               |
| [`f29d7fc1`](https://github.com/NixOS/nixpkgs/commit/f29d7fc1f5515985051e581571d03c4c351654f9) | `` raycast: 1.84.8 → 1.84.10 ``                                         |
| [`5cdd60e3`](https://github.com/NixOS/nixpkgs/commit/5cdd60e34ce1bca60bee361314f79bd9b4425fee) | `` raycast: fix path to pkg in passthru.updateScript ``                 |
| [`d7cfcf60`](https://github.com/NixOS/nixpkgs/commit/d7cfcf60b79fb7190d4a9aeca0589e10b3f5cf1c) | `` raycast: add jakecleary (shout@jakecleary.net) as maintainer ``      |
| [`41285948`](https://github.com/NixOS/nixpkgs/commit/41285948c54dd2def653dd55e0c4ca6fcf044af1) | `` raycast: move to `pkgs/by-name` ``                                   |
| [`d68e08ef`](https://github.com/NixOS/nixpkgs/commit/d68e08efe9a88efee26c88e8fa3563de04e929b7) | `` raycast: 1.84.2 -> 1.84.8 ``                                         |
| [`44cd53a4`](https://github.com/NixOS/nixpkgs/commit/44cd53a4de1b8c504414b93a481ad76bd6b8aea1) | `` nixos.tests.musescore: fix and improve ``                            |
| [`253baa22`](https://github.com/NixOS/nixpkgs/commit/253baa22206ecef4afd5ea3904ba816a574bc46a) | `` suricata: 7.0.6 -> 7.0.7 ``                                          |
| [`53d0bd57`](https://github.com/NixOS/nixpkgs/commit/53d0bd57bdf4f05f2b9a3d6a891bbac56d05ed61) | `` electron_31-bin: 31.6.0 -> 32.7.2 ``                                 |
| [`e9326a1d`](https://github.com/NixOS/nixpkgs/commit/e9326a1d76cec4717331bbbbbcff1b29fc013d2a) | `` electron_31-bin: 31.4.0 -> 31.6.0 ``                                 |
| [`8b10db1e`](https://github.com/NixOS/nixpkgs/commit/8b10db1e7def045c3943b968e99d3b3a9aa81cae) | `` electron_33-bin: 33.0.0 -> 33.0.2 ``                                 |
| [`0889e433`](https://github.com/NixOS/nixpkgs/commit/0889e433849e3fe5354955cb1dac7ffffa5f3187) | `` electron-source: fix update script for electron >= 33 ``             |
| [`f90b9845`](https://github.com/NixOS/nixpkgs/commit/f90b984558b60e6258e0ddefd60e1a061a1ae060) | `` electron-chromedriver_33: 33.0.0 -> 33.0.2 ``                        |
| [`788b512a`](https://github.com/NixOS/nixpkgs/commit/788b512ae17aa3d8795a5020eda7dc07382d4d20) | `` electron-source.electron_33: 33.0.0 -> 33.0.2 ``                     |
| [`fbb27952`](https://github.com/NixOS/nixpkgs/commit/fbb27952b4489188fc1256e6f2d3194dbdf7dfe0) | `` electron-chromedriver_32: 32.2.1 -> 32.2.2 ``                        |
| [`e5fc5430`](https://github.com/NixOS/nixpkgs/commit/e5fc543078c90a6103e0fbe2f98a3964a5e8a235) | `` electron-source.electron_32: 32.2.1 -> 32.2.2 ``                     |
| [`d8fe26bc`](https://github.com/NixOS/nixpkgs/commit/d8fe26bcbd16ac56c8fd2e173566b69150f2d1e9) | `` electron-chromedriver_31: 31.6.0 -> 31.7.2 ``                        |
| [`ce7e79ea`](https://github.com/NixOS/nixpkgs/commit/ce7e79ea4bc105c7f464db8f71cc0d03118d5098) | `` electron-source.electron_31: 31.6.0 -> 31.7.2 ``                     |
| [`c3ebcfc8`](https://github.com/NixOS/nixpkgs/commit/c3ebcfc84e84b00e439f389ab97a65dbf0d94df6) | `` musescore: explicitly use stdenv.hostPlatform ``                     |
| [`159de791`](https://github.com/NixOS/nixpkgs/commit/159de791a3b5bca2d42a75a77522398f1c4c5b9f) | `` musescore: Fix muse-sounds-manager issue ``                          |
| [`e587e0db`](https://github.com/NixOS/nixpkgs/commit/e587e0db6b179d55cc5c884463632e06b4a6ac8d) | `` musescore: fix GTK3 wrapping, for file dialogs ``                    |
| [`85731745`](https://github.com/NixOS/nixpkgs/commit/857317452af2e10f05b6c7e906ddca13d4c915ff) | `` musescore: 4.4.1 -> 4.4.3 ``                                         |
| [`4a35d449`](https://github.com/NixOS/nixpkgs/commit/4a35d449e0949bde0ed03bf4569cd55477407ff6) | `` electron_32-bin: 32.2.1 -> 32.2.2 ``                                 |
| [`451c0bb0`](https://github.com/NixOS/nixpkgs/commit/451c0bb00853e2ac77a678b51149afd12c11479e) | `` electron_32-bin: 32.1.2 -> 32.2.1 ``                                 |
| [`af09b3c1`](https://github.com/NixOS/nixpkgs/commit/af09b3c108c87fb56e976e21a04fae69f6edee0e) | `` electron_33-bin: init at 33.0.0 ``                                   |
| [`7ee74aca`](https://github.com/NixOS/nixpkgs/commit/7ee74aca406d5d806cbc54123b756badcaf88cb5) | `` electron_32-bin: 32.1.1 -> 32.1.2 ``                                 |
| [`d5fde32e`](https://github.com/NixOS/nixpkgs/commit/d5fde32e8cfc913d3fef9aec3ad6365ebe5a3b36) | `` electron-source.electron_31: 31.4.0 -> 31.6.0 ``                     |
| [`06addefc`](https://github.com/NixOS/nixpkgs/commit/06addefce2a6e02f63dcc1c448bb0dd5b8a1a8ff) | `` electron-chromedriver_32: 32.1.2 -> 32.2.1 ``                        |
| [`839a8715`](https://github.com/NixOS/nixpkgs/commit/839a871567ba954068d29821b5f8120ea93451b6) | `` electron-chromedriver_33: init at 33.0.0 ``                          |
| [`96598314`](https://github.com/NixOS/nixpkgs/commit/965983145c14a4343b6d4fbd4b34dc013edcaf65) | `` electron-chromedriver_32: 32.1.1 -> 32.1.2 ``                        |
| [`0ca7bbe0`](https://github.com/NixOS/nixpkgs/commit/0ca7bbe0b6484e874257474db3e4585027aad009) | `` electron-source.electron_33: init at 33.0.0 ``                       |
| [`30c4af5a`](https://github.com/NixOS/nixpkgs/commit/30c4af5a6fb2809aef5dbd6e6a4d026aa75a2590) | `` electron-source.electron_32: 32.1.2 -> 32.2.1 ``                     |
| [`9dec3060`](https://github.com/NixOS/nixpkgs/commit/9dec30608a8f65a3ed9f5f6ee2818c7f37f1df5c) | `` electron-source.electron_32: 32.1.1 -> 32.1.2 ``                     |
| [`fba62033`](https://github.com/NixOS/nixpkgs/commit/fba62033cde38a4f6226941885d4a78d475c20d1) | `` electron-source.electron_30: 30.4.0 -> 30.5.1 ``                     |
| [`4e28ed9c`](https://github.com/NixOS/nixpkgs/commit/4e28ed9c51d4fc545b42b7a09531b2f8bc61583f) | `` redmine: Update vulnerable gems where possible ``                    |