### PR TITLE
chore(flake/nixpkgs-stable): `dba41493` -> `83fb6c02`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -324,11 +324,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1730883749,
-        "narHash": "sha256-mwrFF0vElHJP8X3pFCByJR365Q2463ATp2qGIrDUdlE=",
+        "lastModified": 1730963269,
+        "narHash": "sha256-rz30HrFYCHiWEBCKHMffHbMdWJ35hEkcRVU0h7ms3x0=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "dba414932936fde69f0606b4f1d87c5bc0003ede",
+        "rev": "83fb6c028368e465cd19bb127b86f971a5e41ebc",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                         |
| ---------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------- |
| [`acd9547b`](https://github.com/NixOS/nixpkgs/commit/acd9547b5f85007dc3243a2e55e252ac4554538e) | `` tailscale: 1.76.3 -> 1.76.6 ``                                                               |
| [`8a0904e2`](https://github.com/NixOS/nixpkgs/commit/8a0904e266470b6ce445f8b705a7df77076cd74d) | `` jujutsu: mark as vulnerable ``                                                               |
| [`c75b5e0e`](https://github.com/NixOS/nixpkgs/commit/c75b5e0e0bd1001b9e6555eee657c2da98ecc2a7) | `` vencord: 1.10.5 -> 1.10.6 ``                                                                 |
| [`c8da03e1`](https://github.com/NixOS/nixpkgs/commit/c8da03e1bd24a17977e8d934efefccfef960648e) | `` python3Packages.cupy: 13.2.0 -> 13.3.0 ``                                                    |
| [`072cb131`](https://github.com/NixOS/nixpkgs/commit/072cb131bdbdc4b58a21e8628a408f60e7587df6) | `` python3Packages.cupy: fix symlink join for build ``                                          |
| [`1eafca5d`](https://github.com/NixOS/nixpkgs/commit/1eafca5d7949fbabefa846f97bcb1696c2cdc4a8) | `` cupy: 13.0->13.2, patch to find libcudart-static ``                                          |
| [`04b7d6ee`](https://github.com/NixOS/nixpkgs/commit/04b7d6ee7b286f788ab37a188d8dad9e653535d6) | `` python3Packages.cupy: 13.0.0 -> 13.2.0 ``                                                    |
| [`00ec7e04`](https://github.com/NixOS/nixpkgs/commit/00ec7e0442f9ab8cc5f480ab96894e9eec7af977) | `` element-desktop: 1.11.82 -> 1.11.84 ``                                                       |
| [`b924b0d1`](https://github.com/NixOS/nixpkgs/commit/b924b0d1b37170f9c1fdf94418fe39c638f5e1fa) | `` nixos/amdvlk: don't set "amdgpu" xserver driver ``                                           |
| [`d2eca908`](https://github.com/NixOS/nixpkgs/commit/d2eca9089077018af6eb0f80d0ec4acc4d193cac) | `` raycast: 1.84.10 -> 1.84.12 ``                                                               |
| [`17f1f5ca`](https://github.com/NixOS/nixpkgs/commit/17f1f5ca890148cfc3d67a8e7efb80566c3969c9) | `` linux_xanmod_latest: 6.11.5 -> 6.11.6 ``                                                     |
| [`16b11aa3`](https://github.com/NixOS/nixpkgs/commit/16b11aa3414f9e58c089c3e482a4a14e81b9f36f) | `` linux_xanmod: 6.6.58 -> 6.6.59 ``                                                            |
| [`42c96f8c`](https://github.com/NixOS/nixpkgs/commit/42c96f8c78b24be146955873b722082bca77bd92) | `` linux_xanmod: switch from GitHub to GitLab ``                                                |
| [`d5dd9ae2`](https://github.com/NixOS/nixpkgs/commit/d5dd9ae25cd1f43b504afde1a1da2e573ad969e5) | `` linux_xanmod: apply nixfmt ``                                                                |
| [`38752e42`](https://github.com/NixOS/nixpkgs/commit/38752e425381ab8833a81ba5a25a38cec5c54d52) | `` webcord: 4.9.2 -> 4.10.2 ``                                                                  |
| [`1010211a`](https://github.com/NixOS/nixpkgs/commit/1010211a1ca958273b444c503a7814d902ba77f6) | `` antares: remove redundant Electron override ``                                               |
| [`3457141a`](https://github.com/NixOS/nixpkgs/commit/3457141a2c3e0579434a3edc72f75085fb3d1d91) | `` antares: fix desktop icon ``                                                                 |
| [`fbba7e38`](https://github.com/NixOS/nixpkgs/commit/fbba7e3835bae737f83ca3e7c9ccaa39c1698798) | `` antares: modernize derivation ``                                                             |
| [`6e6014a7`](https://github.com/NixOS/nixpkgs/commit/6e6014a78c6f869dca097eea4d2f3b63881335bf) | `` antares: add .desktop file install ``                                                        |
| [`aa17d314`](https://github.com/NixOS/nixpkgs/commit/aa17d314d0abf7594a1bb2abf130a58c369c0fe0) | `` antares: remove unused input fetchPatch ``                                                   |
| [`7262fb23`](https://github.com/NixOS/nixpkgs/commit/7262fb23bb8026829429df9aee7ede7495ac01d9) | `` antares: 0.7.28 -> 0.7.29 ``                                                                 |
| [`3ad02c51`](https://github.com/NixOS/nixpkgs/commit/3ad02c51d6c351b8f0e3217eced1797bd4f3dcde) | `` python311Packages.moto: disable regressed tests ``                                           |
| [`0dcfecb2`](https://github.com/NixOS/nixpkgs/commit/0dcfecb20acfd9ce8fa0ebe2adeeb39823f998a0) | `` python312Packages.pymdown-extensions: disable a failing test ``                              |
| [`ee811e17`](https://github.com/NixOS/nixpkgs/commit/ee811e17c0a76e97ef03ba1f8b5e7b87e11d98cc) | `` python3Packages.twisted: backport Python 3.12.6 fix ``                                       |
| [`f3d21d75`](https://github.com/NixOS/nixpkgs/commit/f3d21d75d16d7cfeafdddbecfc9a127477294400) | `` signal-desktop-beta: 7.30.0-beta.2-> 7.32.0-beta.1 ``                                        |
| [`4ca221be`](https://github.com/NixOS/nixpkgs/commit/4ca221bea56f79c89d1d7c095046764f4d224a98) | `` signal-desktop: 7.29.0 -> 7.31.0 ``                                                          |
| [`cd682045`](https://github.com/NixOS/nixpkgs/commit/cd6820453aca7e9eff94d7c568362259c10f441a) | `` postgresql: fix regress tests after tzdata update ``                                         |
| [`53968103`](https://github.com/NixOS/nixpkgs/commit/539681036f859a5bb61c3771ee2142cb51652c13) | `` python3Packages.executing: 2.0.1 -> 2.1.0 ``                                                 |
| [`e716bbbc`](https://github.com/NixOS/nixpkgs/commit/e716bbbc2211e6ddfd24e9005f6d543161f35594) | `` tree-wide: switch initrd generators back to gnu cpio ``                                      |
| [`2e7f25a1`](https://github.com/NixOS/nixpkgs/commit/2e7f25a12b54877834207f9e372702090453cb37) | `` mpg123: 1.32.7 -> 1.32.8 ``                                                                  |
| [`231faefa`](https://github.com/NixOS/nixpkgs/commit/231faefa4af31c2ef099070e7ae17cae5ad1cb1c) | `` mpg123: 1.32.6 -> 1.32.7 ``                                                                  |
| [`18697353`](https://github.com/NixOS/nixpkgs/commit/18697353ab4a9a1368a8f919abc64cbae522cf8f) | `` xorg.xorgserver: 21.1.13 -> 21.1.14 ``                                                       |
| [`28d718b5`](https://github.com/NixOS/nixpkgs/commit/28d718b5bf4e42c0918068d7b7d8b09cddafaa5a) | `` libarchive: 3.7.6 -> 3.7.7 ``                                                                |
| [`234892a1`](https://github.com/NixOS/nixpkgs/commit/234892a11c0f9443a01fd069a1c9ee3a19b2c615) | `` nss_latest: 3.105 -> 3.106 ``                                                                |
| [`aa3ba8d7`](https://github.com/NixOS/nixpkgs/commit/aa3ba8d7a9da661ff94e6ce6fe0b36db457e3f70) | `` python311Packages.starlette: fix CVE-2024-47874 ``                                           |
| [`cbee41d9`](https://github.com/NixOS/nixpkgs/commit/cbee41d91e44f247d6ba8723074b7f2264fb9b10) | `` pipewire: 1.0.8 -> 1.0.9 ``                                                                  |
| [`f88339ae`](https://github.com/NixOS/nixpkgs/commit/f88339aeefeb01946b090b56bec1e26d30d4d20b) | `` python3Packages.libarchive-c: apply patch fixing a test with recent `libarchive` versions `` |
| [`34176efd`](https://github.com/NixOS/nixpkgs/commit/34176efd70ce1e820870fabe37703ccb3d187942) | `` nspr: 4.35 -> 4.36 ``                                                                        |
| [`d55d8255`](https://github.com/NixOS/nixpkgs/commit/d55d82553d4b13a02c4ef0d64fc5253c50157f5b) | `` rsync: fix missing ipv6 support (again) ``                                                   |
| [`fc25a7bd`](https://github.com/NixOS/nixpkgs/commit/fc25a7bd34f8ebe8b0d77d3627dfd91fd75d0889) | `` git: 2.44.1 -> 2.44.2 ``                                                                     |
| [`74cf736a`](https://github.com/NixOS/nixpkgs/commit/74cf736a463e529c59f1f913c639ab20c95e68c5) | `` dropbox: add libGL to the FHS environment ``                                                 |
| [`1803bbe2`](https://github.com/NixOS/nixpkgs/commit/1803bbe22530813bb8f9b6fe1ebe3986e0140c96) | `` libarchive: 3.7.4 -> 3.7.6 ``                                                                |
| [`4646eadb`](https://github.com/NixOS/nixpkgs/commit/4646eadb9b9f6ff918b783919292b777cddfd5e1) | `` unzip: apply patch for CVE-2021-4217 ``                                                      |
| [`fca7ec4d`](https://github.com/NixOS/nixpkgs/commit/fca7ec4d5e39d2f3bf0a08047d290cc47801453b) | `` python3Packages.furl: disable failing test for all python version ``                         |
| [`9c951255`](https://github.com/NixOS/nixpkgs/commit/9c9512558bd3801613a1f69fafebd64257a48e14) | `` vim: 9.1.0707 -> 9.1.0765 ``                                                                 |
| [`29a87b94`](https://github.com/NixOS/nixpkgs/commit/29a87b949a220ed29e4b9d1e46f65f7d3472cd94) | `` unbound: apply patch for CVE-2024-8508 ``                                                    |
| [`34f547ce`](https://github.com/NixOS/nixpkgs/commit/34f547ce60278285b27a9a4242b7d80a7697f279) | `` redis: 7.2.5 -> 7.2.6 ``                                                                     |
| [`4b6bea1b`](https://github.com/NixOS/nixpkgs/commit/4b6bea1b6098c31632fd15185a6a33bc0c9220a6) | `` redis: 7.2.4 -> 7.2.5 ``                                                                     |
| [`dc5b3301`](https://github.com/NixOS/nixpkgs/commit/dc5b3301f53817d7871259a0367f48ebd8df72ac) | `` go_1_22: 1.22.6 -> 1.22.8 ``                                                                 |
| [`d604aca5`](https://github.com/NixOS/nixpkgs/commit/d604aca5a029db2fa7e7551479b270013558e1f9) | `` sqlitebrowser: 3.12.2 -> 3.13.0 ``                                                           |
| [`247ca23a`](https://github.com/NixOS/nixpkgs/commit/247ca23aa0425ba1e2b5a026e8f2c57d71e3fe5d) | `` cups: apply patches for CVE-2024-47175 ``                                                    |
| [`9ae4df1c`](https://github.com/NixOS/nixpkgs/commit/9ae4df1c00ece2015ca3011d88b06fae4cf80faf) | `` libpcap: 1.10.4 -> 1.10.5 ``                                                                 |
| [`8e36f664`](https://github.com/NixOS/nixpkgs/commit/8e36f66467172c0b996eb04a40f5ebb7aa469a92) | `` python3Packages.werkzeug: 3.0.3 -> 3.0.4 ``                                                  |
| [`c664307c`](https://github.com/NixOS/nixpkgs/commit/c664307c7f73b02f5dc6d80994e6451b7240b8fd) | `` pipewire: 1.0.7 -> 1.0.8 ``                                                                  |
| [`d385ce1d`](https://github.com/NixOS/nixpkgs/commit/d385ce1df7afdc22e0ddadd1606c1c9d58adc5f8) | `` tzdata: 2024a -> 2024b ``                                                                    |
| [`cec77165`](https://github.com/NixOS/nixpkgs/commit/cec77165fac53ba302c8bed4adf6252bc28aa5b3) | `` tzdata: disable network access ``                                                            |
| [`8acdb01e`](https://github.com/NixOS/nixpkgs/commit/8acdb01eff0c91ab23d3c1860b9da8865f91d9e9) | `` ghostscript: 10.03.1 -> 10.04.0 ``                                                           |
| [`c23b03c7`](https://github.com/NixOS/nixpkgs/commit/c23b03c781d650dc70cd5a83cae358b3d2df3abe) | `` [24.05 backport] nodejs changes (#336570) ``                                                 |
| [`b8d6d046`](https://github.com/NixOS/nixpkgs/commit/b8d6d046746a46369efb5cad0f43bcd88c9eb135) | `` python3Packages.poetry-core: backport test fix for Python 3.12.6 ``                          |
| [`95e8350e`](https://github.com/NixOS/nixpkgs/commit/95e8350e11fc7139eea9f33d5c2864095e41ae73) | `` libtiff: patch for CVE-2023-52356 & CVE-2024-7006 ``                                         |
| [`529f2051`](https://github.com/NixOS/nixpkgs/commit/529f2051255fe5153f0a8308aad0eb929f892525) | `` python311: 3.11.9 -> 3.11.10 ``                                                              |
| [`21938878`](https://github.com/NixOS/nixpkgs/commit/2193887893d81bd02a36aa4e51550fd00ee9b2c3) | `` python312: 3.12.5 -> 3.12.6 ``                                                               |
| [`ec05d037`](https://github.com/NixOS/nixpkgs/commit/ec05d037c8d0676f2ec258a016e42d9e4636b924) | `` lutok: update meta.description ``                                                            |