### PR TITLE
chore(flake/nixpkgs-stable): `83fb6c02` -> `9256f7c7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -324,11 +324,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1730963269,
-        "narHash": "sha256-rz30HrFYCHiWEBCKHMffHbMdWJ35hEkcRVU0h7ms3x0=",
+        "lastModified": 1731239293,
+        "narHash": "sha256-q2yjIWFFcTzp5REWQUOU9L6kHdCDmFDpqeix86SOvDc=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "83fb6c028368e465cd19bb127b86f971a5e41ebc",
+        "rev": "9256f7c71a195ebe7a218043d9f93390d49e6884",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                       |
| ---------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------- |
| [`853c6449`](https://github.com/NixOS/nixpkgs/commit/853c6449d358403cd1e2e9b6e92b49c57238223e) | `` php: 8.3.12 -> 8.3.13 ``                                                   |
| [`b7171053`](https://github.com/NixOS/nixpkgs/commit/b7171053118aa2b289daaa2e7f796f598140e832) | `` nix-unit: 2.18.0 -> 2.18.8 ``                                              |
| [`290b3690`](https://github.com/NixOS/nixpkgs/commit/290b3690c89f1818a6043d1e8b8907c4e2f65163) | `` arc-browser: 1.66.0-55166 -> 1.67.0-55463 ``                               |
| [`8725cb3a`](https://github.com/NixOS/nixpkgs/commit/8725cb3a65a99e17173d5d15dc0fa04ad6c9e97f) | `` linux_5_4: 5.4.284 -> 5.4.285 ``                                           |
| [`eebc0198`](https://github.com/NixOS/nixpkgs/commit/eebc0198e2b872815c9c6b9160aaf12caf7be387) | `` linux/update-mainline: fix oldest version check ``                         |
| [`825f4654`](https://github.com/NixOS/nixpkgs/commit/825f46549ecf3996e19bbf08e5d3920e8abfc730) | `` linux_latest-libre: 19643 -> 19663 ``                                      |
| [`4658556b`](https://github.com/NixOS/nixpkgs/commit/4658556b598eb9d7922c156e5d3571edf2ac573a) | `` linux-rt_6_6: 6.6.52-rt43 -> 6.6.58-rt45 ``                                |
| [`41292648`](https://github.com/NixOS/nixpkgs/commit/4129264892d6b82420c396597bfca6e77a119395) | `` linux-rt_6_1: 6.1.111-rt42 -> 6.1.112-rt43 ``                              |
| [`5cd235d6`](https://github.com/NixOS/nixpkgs/commit/5cd235d69bd0ca1e79f8e8b0d6e04d24809cf12f) | `` linux-rt_5_15: 5.15.167-rt79 -> 5.15.170-rt81 ``                           |
| [`1b650514`](https://github.com/NixOS/nixpkgs/commit/1b650514fb539623c69aded14c395f95079f6c34) | `` linux_5_10: 5.10.228 -> 5.10.229 ``                                        |
| [`a42585bd`](https://github.com/NixOS/nixpkgs/commit/a42585bd7309ebb111641d97c1a6ba030055df4f) | `` linux_5_15: 5.15.170 -> 5.15.171 ``                                        |
| [`90f458ca`](https://github.com/NixOS/nixpkgs/commit/90f458caa065d0b6a888ead626b5567bbcac5e47) | `` linux_6_1: 6.1.115 -> 6.1.116 ``                                           |
| [`09b86495`](https://github.com/NixOS/nixpkgs/commit/09b8649516d8d66ffd6efa425901807a22709d0a) | `` linux_6_6: 6.6.59 -> 6.6.60 ``                                             |
| [`f808d4b5`](https://github.com/NixOS/nixpkgs/commit/f808d4b5207a12e4788551a5dfc9a59383517091) | `` linux_6_11: 6.11.6 -> 6.11.7 ``                                            |
| [`5d0fe029`](https://github.com/NixOS/nixpkgs/commit/5d0fe029528e167e41dad626247a6d721ea6f1f5) | `` linux_testing: 6.12-rc5 -> 6.12-rc6 ``                                     |
| [`7ec70a66`](https://github.com/NixOS/nixpkgs/commit/7ec70a662817ea226924bb19f57fc5971c4b8cce) | `` meshcentral: 1.1.32 -> 1.1.33 ``                                           |
| [`35f4d899`](https://github.com/NixOS/nixpkgs/commit/35f4d8990a4fbbe74696bdac46dd93a8486afe8b) | `` grafana: 10.4.11 -> 10.4.12 ``                                             |
| [`a5980a48`](https://github.com/NixOS/nixpkgs/commit/a5980a48fbd3ca9b15a1f77d02bf3ead8651021c) | `` spotify: 1.2.45.454.gc16ec9f6 -> 1.2.48.405.gf2c48e6f ``                   |
| [`478e0165`](https://github.com/NixOS/nixpkgs/commit/478e016585431fa4fd1f939ebc6ce6dd1e476360) | `` xfce.xfce4-weather-plugin: 0.11.2 -> 0.11.3 ``                             |
| [`f4ae6695`](https://github.com/NixOS/nixpkgs/commit/f4ae6695ce041145f855a8b0a772f0ea2c10abde) | `` linux-firmware: fix build when cross-compiling ``                          |
| [`98cea74e`](https://github.com/NixOS/nixpkgs/commit/98cea74e4987edfeb7aafa646998f29e2c5847bb) | `` signal-desktop-(generic): use --replace-fail ``                            |
| [`c82de520`](https://github.com/NixOS/nixpkgs/commit/c82de5208dc2d4d1ed4f106344badceadc3d9208) | `` signal-desktop-beta:7.32.0-beta.1 -> 7.33.0-beta.1 ``                      |
| [`13a9721f`](https://github.com/NixOS/nixpkgs/commit/13a9721f53a4e92ae5e74cb3a24ae3ca8379f198) | `` signal-desktop-(generic): add libpulseaudio to bui ``                      |
| [`480b60e5`](https://github.com/NixOS/nixpkgs/commit/480b60e5006f70b30c07c9f7760108e9396110f8) | `` signal-desktop: 7.31.0 -> 7.32.0 ``                                        |
| [`20da57f9`](https://github.com/NixOS/nixpkgs/commit/20da57f9e78205df71b9775409563cdffd0a56ec) | `` powerpipe: 0.4.4 -> 1.0.0 ``                                               |
| [`f627c88a`](https://github.com/NixOS/nixpkgs/commit/f627c88a501fbbfd2180ba93437d4c65c962ea76) | `` nixos/swapspace: add tests ``                                              |
| [`f12598ef`](https://github.com/NixOS/nixpkgs/commit/f12598eff21699acfd059df42a9f7ea2eef17cee) | `` nixos/swapspace: init module ``                                            |
| [`ee8d1665`](https://github.com/NixOS/nixpkgs/commit/ee8d16654c8e1a78d99606f55bd316a751394f24) | `` maintainers: add phanirithvij ``                                           |
| [`db2c89f3`](https://github.com/NixOS/nixpkgs/commit/db2c89f3e1f88593ddbcdd163e3f82513015bc06) | `` edk2: fix subhook submodule URL ``                                         |
| [`69bb146a`](https://github.com/NixOS/nixpkgs/commit/69bb146aa9cc8fa05efa7441f7f68de1836ab7f7) | `` OWNERS: Add fabianhjr to hardened kernel ``                                |
| [`83312cd5`](https://github.com/NixOS/nixpkgs/commit/83312cd55d7cf5c76060aa54018dde99977f28e4) | `` linux/hardened/patches/6.11: init at v6.11.6-hardened1 ``                  |
| [`db254c29`](https://github.com/NixOS/nixpkgs/commit/db254c2944cb2bdb9013441fea1a53d39bf8e053) | `` linux/hardened/patches/6.6: v6.6.53-hardened1 -> v6.6.59-hardened1 ``      |
| [`5d0826ca`](https://github.com/NixOS/nixpkgs/commit/5d0826ca2776d0025439e08d95b5199a7390c2da) | `` linux/hardened/patches/6.1: v6.1.112-hardened1 -> v6.1.115-hardened1 ``    |
| [`f7bbcbaa`](https://github.com/NixOS/nixpkgs/commit/f7bbcbaa378ed96f74b2893e949c125130decabf) | `` linux/hardened/patches/5.15: v5.15.167-hardened1 -> v5.15.170-hardened1 `` |
| [`95dba5df`](https://github.com/NixOS/nixpkgs/commit/95dba5dfd77c5ff96ea28e58f5e10871447c8591) | `` linux/hardened/patches/5.10: v5.10.226-hardened1 -> v5.10.228-hardened1 `` |
| [`6d91e36a`](https://github.com/NixOS/nixpkgs/commit/6d91e36ac82b2989725dfffb979121e1a37fc572) | `` maintainers: add cjshearer ``                                              |
| [`eb0fa852`](https://github.com/NixOS/nixpkgs/commit/eb0fa85291f3045402ed2d7d0c821aece4efa775) | `` electron-source.electron_30: remove as it's EOL ``                         |
| [`5a95481d`](https://github.com/NixOS/nixpkgs/commit/5a95481d7af11f7ea5f3ad562a29cb6351a3a9fd) | ``  electron_30-bin: mark as insecure because it's EOL ``                     |
| [`80400bb7`](https://github.com/NixOS/nixpkgs/commit/80400bb74fb6babdb602d7dc0184232ae93fd6c5) | `` ytmdesktop: 2.0.5 -> 2.0.6 ``                                              |
| [`c958436e`](https://github.com/NixOS/nixpkgs/commit/c958436e8419c16844576a8efbdae9fab5fd3060) | `` ytmdesktop: StartupWMClass, desktopName Capitalisation ``                  |
| [`0a1e4157`](https://github.com/NixOS/nixpkgs/commit/0a1e4157ca9c405631f7ad31a161a14c68483b32) | `` ytmdesktop: fix desktop file, removed unused stuff ``                      |
| [`49cf6366`](https://github.com/NixOS/nixpkgs/commit/49cf63666ea8e70e148877edabb414a6e12b4831) | `` ytmdesktop: init at 2.0.5 ``                                               |
| [`ea889473`](https://github.com/NixOS/nixpkgs/commit/ea8894738b988497a8e56c24b2582a30beb8d87c) | `` asleap: move to by-name ``                                                 |
| [`28e73368`](https://github.com/NixOS/nixpkgs/commit/28e7336834348bc6e5d89f06e0b40f346666560d) | `` asleap: add meta.platforms ``                                              |
| [`304aa23b`](https://github.com/NixOS/nixpkgs/commit/304aa23ba284f6b33b09673473350959af6ec26b) | `` asleap: modernize ``                                                       |
| [`0f26ec60`](https://github.com/NixOS/nixpkgs/commit/0f26ec60aabf53bcca95af7e1792c7daa7d8296f) | `` asleap: format ``                                                          |
| [`5710f9e8`](https://github.com/NixOS/nixpkgs/commit/5710f9e8636b465c0afe09933e9bd2776c1ac9e4) | `` added prometheus-borgmatic-exporter module ``                              |
| [`5fc7f12b`](https://github.com/NixOS/nixpkgs/commit/5fc7f12bc406c7e2530a383608c990ba5647a2c7) | `` prometheus-borgmatic-exporter: init at 0.2.5 ``                            |