### PR TITLE
chore(flake/home-manager): `60bb1109` -> `35b05500`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -272,11 +272,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1731235328,
-        "narHash": "sha256-NjavpgE9/bMe/ABvZpyHIUeYF1mqR5lhaep3wB79ucs=",
+        "lastModified": 1731535640,
+        "narHash": "sha256-2EckCJn4wxran/TsRiCOFcmVpep2m9EBKl99NBh2GnM=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "60bb110917844d354f3c18e05450606a435d2d10",
+        "rev": "35b055009afd0107b69c286fca34d2ad98940d57",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                           |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------- |
| [`35b05500`](https://github.com/nix-community/home-manager/commit/35b055009afd0107b69c286fca34d2ad98940d57) | `` kanshi: add package to home.packages ``        |
| [`3c044aef`](https://github.com/nix-community/home-manager/commit/3c044aefe610ceeec9cf3e83e55fa62715df27e2) | `` git-sync: add example to repository option ``  |
| [`cd21d2e6`](https://github.com/nix-community/home-manager/commit/cd21d2e61b2da9cc5b96f848ac6fd3c4dc377a1b) | `` git-sync: fix crash when whitespace in path `` |
| [`ee8ff6d5`](https://github.com/nix-community/home-manager/commit/ee8ff6d53fca9adec60238f63eb632300d0dffa0) | `` espanso: fix test for nixpkgs update ``        |
| [`7e42a37b`](https://github.com/nix-community/home-manager/commit/7e42a37bf7dffd7fe4c2b14e42161433d7182d66) | `` spotify-player: fix test for nixpkgs update `` |
| [`40746b5c`](https://github.com/nix-community/home-manager/commit/40746b5c77e9ab3fc2196802b637676574aaeb48) | `` alacritty: fix test for nixpkgs update ``      |
| [`149a48da`](https://github.com/nix-community/home-manager/commit/149a48da315988e36a6e12a82c49667a90d8031f) | `` flake.lock: Update ``                          |