### PR TITLE
chore(flake/nixpkgs-stable): `9256f7c7` -> `689fed12`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -324,11 +324,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1731239293,
-        "narHash": "sha256-q2yjIWFFcTzp5REWQUOU9L6kHdCDmFDpqeix86SOvDc=",
+        "lastModified": 1731386116,
+        "narHash": "sha256-lKA770aUmjPHdTaJWnP3yQ9OI1TigenUqVC3wweqZuI=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "9256f7c71a195ebe7a218043d9f93390d49e6884",
+        "rev": "689fed12a013f56d4c4d3f612489634267d86529",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                       |
| ---------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------- |
| [`56c49765`](https://github.com/NixOS/nixpkgs/commit/56c497653c76a1644a8d5298cd91357795313906) | `` bashly: 1.1.10 -> 1.2.6 ``                                                 |
| [`ecf8fd85`](https://github.com/NixOS/nixpkgs/commit/ecf8fd850875cb728413eb5905fdd2b0bea06f05) | `` vaultwarden.webvault: 2024.6.2b -> 2024.6.2c ``                            |
| [`476f5072`](https://github.com/NixOS/nixpkgs/commit/476f5072a6034bdf6c376fb592bd279bcecb5bfa) | `` vaultwarden.webvault: unbreak on aarch64 (#327019) ``                      |
| [`0d0af1fc`](https://github.com/NixOS/nixpkgs/commit/0d0af1fcc5af2d50415929754608c6bcb85b9af0) | `` vaultwarden: 1.32.3 -> 1.32.4 ``                                           |
| [`5d0c6e33`](https://github.com/NixOS/nixpkgs/commit/5d0c6e335ca0fc879c69f33c60567ae730373f98) | `` vaultwarden: 1.32.2 -> 1.32.3 ``                                           |
| [`aec97180`](https://github.com/NixOS/nixpkgs/commit/aec97180f1269c4a42d13d348bbc72bfb79966b0) | `` cargo,clippy,rustc,rustfmt: 1.79.0 -> 1.80.0 ``                            |
| [`3c6674ce`](https://github.com/NixOS/nixpkgs/commit/3c6674cefa18c71ca4ee242fa5f1ea90f0ecedb2) | `` Revert "[release-24.05] vaultwarden: 1.32.1 -> 1.32.4" ``                  |
| [`dff192f9`](https://github.com/NixOS/nixpkgs/commit/dff192f9c010ddcc48c66d3b34df88ea922df005) | `` vaultwarden: 1.32.3 -> 1.32.4 ``                                           |
| [`e849ec66`](https://github.com/NixOS/nixpkgs/commit/e849ec66ca4a9100e04bfcd63f29e1f27d58c02f) | `` vaultwarden: 1.32.2 -> 1.32.3 ``                                           |
| [`39a32bce`](https://github.com/NixOS/nixpkgs/commit/39a32bcebd3e15097e6aec0aca501d5338023aa2) | `` vaultwarden: 1.32.1 -> 1.32.2 ``                                           |
| [`037b712e`](https://github.com/NixOS/nixpkgs/commit/037b712e4d1a3fdb60cbd4972473c59e4ad401e1) | `` vaultwarden: 1.32.1 -> 1.32.2 ``                                           |
| [`08d0aec1`](https://github.com/NixOS/nixpkgs/commit/08d0aec1df27c369aab447e354fe4fb6310bc14c) | `` ungoogled-chromium: 130.0.6723.91-1 -> 130.0.6723.116-1 ``                 |
| [`504aae86`](https://github.com/NixOS/nixpkgs/commit/504aae8601e65cb3c09b0a6d136b1fda6b746847) | `` chromium,chromedriver: 130.0.6723.91 -> 130.0.6723.116 ``                  |
| [`170a7d43`](https://github.com/NixOS/nixpkgs/commit/170a7d43526426e52e4a93a6f30aa8687b112858) | `` ci/OWNERS: remove ckiee ``                                                 |
| [`abe8e044`](https://github.com/NixOS/nixpkgs/commit/abe8e044d36ba7f744aa2976baaf25e1c93b433b) | `` python311Packages.imap-tools: backport regression fix ``                   |
| [`87b09b98`](https://github.com/NixOS/nixpkgs/commit/87b09b986cfb257a84ef95d9a33b0366626de303) | `` linux/hardened/patches/6.6: v6.6.59-hardened1 -> v6.6.60-hardened1 ``      |
| [`b57b947b`](https://github.com/NixOS/nixpkgs/commit/b57b947b0c0fe70ac2170f69cbed51dbaab36007) | `` linux/hardened/patches/6.11: v6.11.6-hardened1 -> v6.11.7-hardened1 ``     |
| [`749e6db1`](https://github.com/NixOS/nixpkgs/commit/749e6db17a6fe6bd0ae2fdc24faacca93c7df278) | `` linux/hardened/patches/6.1: v6.1.115-hardened1 -> v6.1.116-hardened1 ``    |
| [`40a3ca3b`](https://github.com/NixOS/nixpkgs/commit/40a3ca3b32b29e31294415900dce4d3d10fa0483) | `` linux/hardened/patches/5.4: v5.4.284-hardened1 -> v5.4.285-hardened1 ``    |
| [`b71bdd02`](https://github.com/NixOS/nixpkgs/commit/b71bdd02a3fcb32d166eec8930ee488630d16636) | `` linux/hardened/patches/5.15: v5.15.170-hardened1 -> v5.15.171-hardened1 `` |
| [`9c665175`](https://github.com/NixOS/nixpkgs/commit/9c665175ceb935f1fc1e320b39b54b9ce4ea2b54) | `` linux/hardened/patches/5.10: v5.10.228-hardened1 -> v5.10.229-hardened1 `` |
| [`ea4fc520`](https://github.com/NixOS/nixpkgs/commit/ea4fc520ec2b9fc035f29b346d59c859e2ba90c2) | `` linux_xanmod_latest: 6.11.6 -> 6.11.7 ``                                   |
| [`1e6a8ef8`](https://github.com/NixOS/nixpkgs/commit/1e6a8ef84d989bc176964020c29d4eb15856daa5) | `` linux_xanmod: 6.6.59 -> 6.6.60 ``                                          |
| [`dbc8a7e4`](https://github.com/NixOS/nixpkgs/commit/dbc8a7e467d04a2ab5d98dc529e8aeff23334a1e) | `` panoply: 5.5.4 -> 5.5.5 ``                                                 |
| [`75d09da6`](https://github.com/NixOS/nixpkgs/commit/75d09da6967c6f81fa5ac28090d9672d4a34c445) | `` palemoon-bin: 33.4.0.1 -> 33.4.1 ``                                        |