### PR TITLE
chore(flake/stylix): `be94701c` -> `e0a27887`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -448,11 +448,11 @@
         "tinted-tmux": "tinted-tmux"
       },
       "locked": {
-        "lastModified": 1731537763,
-        "narHash": "sha256-dOjxeHAXbQ4KRe5j9uClFp8SyYY2r62bbsdraETtO84=",
+        "lastModified": 1731577695,
+        "narHash": "sha256-ohxX2gG7zDWIA3slEbiSyAVSiO98clCoL+CmiEiYwVU=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "be94701ce7b746cb020e667f71492e398ed470f4",
+        "rev": "e0a278871b63b1800ccdda568861b5324dd93797",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                        | Message                                                                    |
| --------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------- |
| [`e0a27887`](https://github.com/danth/stylix/commit/e0a278871b63b1800ccdda568861b5324dd93797) | `` zellij: write theme file instead of writing theme into config (#616) `` |
| [`f361071a`](https://github.com/danth/stylix/commit/f361071a1bc4c411ff6131537f73b3009883cd64) | `` hyprlock: init (#619) ``                                                |