### PR TITLE
chore(flake/spicetify-nix): `f8f8cac5` -> `068214cd`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -416,11 +416,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1731644206,
-        "narHash": "sha256-J4HjGCDIJTBjlzhHDjQpbci/fMIE8eNcgOAKbDJUlBs=",
+        "lastModified": 1731759572,
+        "narHash": "sha256-wJfvdHRAQNIiWxvgFemX0ZsTCskq3QnD7HCG5Na7NLc=",
         "owner": "Gerg-L",
         "repo": "spicetify-nix",
-        "rev": "f8f8cac5aabb30009610e7ee4b56f04291577a12",
+        "rev": "068214cd7f099b8ed9388986c6792b387f3b4276",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                          |
| ----------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------- |
| [`068214cd`](https://github.com/Gerg-L/spicetify-nix/commit/068214cd7f099b8ed9388986c6792b387f3b4276) | `` Bump DeterminateSystems/nix-installer-action from 15 to 16 `` |
| [`bec1abb9`](https://github.com/Gerg-L/spicetify-nix/commit/bec1abb9826ddb6f13c621c1092b1396e8cf1b10) | `` CI update 2024-11-16 ``                                       |