### PR TITLE
chore(flake/nixpkgs-stable): `689fed12` -> `c21b7791`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -324,11 +324,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1731386116,
-        "narHash": "sha256-lKA770aUmjPHdTaJWnP3yQ9OI1TigenUqVC3wweqZuI=",
+        "lastModified": 1731652201,
+        "narHash": "sha256-XUO0JKP1hlww0d7mm3kpmIr4hhtR4zicg5Wwes9cPMg=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "689fed12a013f56d4c4d3f612489634267d86529",
+        "rev": "c21b77913ea840f8bcf9adf4c41cecc2abffd38d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                   |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------- |
| [`8da22aeb`](https://github.com/NixOS/nixpkgs/commit/8da22aeb4d09056c6db841ef5e6f5f86cd0e5eb5) | `` linux_5_15: 5.15.171 -> 5.15.172 ``                                    |
| [`679e0c77`](https://github.com/NixOS/nixpkgs/commit/679e0c771b4a9f47a047ae0c2299eeb1feb1341f) | `` linux_6_1: 6.1.116 -> 6.1.117 ``                                       |
| [`f4d4113c`](https://github.com/NixOS/nixpkgs/commit/f4d4113c2fd60c2a847f22eae75d571367fd3225) | `` linux_6_6: 6.6.60 -> 6.6.61 ``                                         |
| [`6ceaba8a`](https://github.com/NixOS/nixpkgs/commit/6ceaba8ab984c4b9bd0b8f69e645ca912a803606) | `` linux_6_11: 6.11.7 -> 6.11.8 ``                                        |
| [`adf6cb5f`](https://github.com/NixOS/nixpkgs/commit/adf6cb5f7ebe3a6a85650aae6b11d2628cd22684) | `` linux_testing: 6.12-rc6 -> 6.12-rc7 ``                                 |
| [`c23c8325`](https://github.com/NixOS/nixpkgs/commit/c23c832503576757d3cabe5e9d953a977c900b41) | `` discord: various updates (#355721) ``                                  |
| [`0fa2b345`](https://github.com/NixOS/nixpkgs/commit/0fa2b34536085d266f3596f9417464660a8fc579) | `` fritz-exporter: 2.5.0 -> 2.5.1 ``                                      |
| [`f7576f13`](https://github.com/NixOS/nixpkgs/commit/f7576f13390d0ee049d164fc7eaab4be65475280) | `` discord: 0.0.73 -> 0.0.74 ``                                           |
| [`b7ea0dba`](https://github.com/NixOS/nixpkgs/commit/b7ea0dba7d0955f7da78474ed37c9f304f69fd26) | `` nodejs_18: 18.20.4 -> 18.20.5 ``                                       |
| [`a19284e7`](https://github.com/NixOS/nixpkgs/commit/a19284e7ee19cbbd5bd3c611359d2360a3d8abec) | `` nodejs_22: 22.9.0 -> 22.10.0 (#349157) ``                              |
| [`9eb9f687`](https://github.com/NixOS/nixpkgs/commit/9eb9f6872c2a192767e1a5e93a45be1668503595) | `` nodejs_22: 22.8.0 -> 22.9.0 ``                                         |
| [`a25ae8ca`](https://github.com/NixOS/nixpkgs/commit/a25ae8ca5aa45b2d5c1e6c87f87407edbfba4d53) | `` google-chrome: 130.0.6723.91 -> 131.0.6778.69 ``                       |
| [`9d23dec6`](https://github.com/NixOS/nixpkgs/commit/9d23dec6d6d5622b7a29e011f6393adc84b8c616) | `` guymager: init at 0.8.13 ``                                            |
| [`ed493374`](https://github.com/NixOS/nixpkgs/commit/ed493374376f2ffe5ef60411a9c61e756604fffb) | `` libguytools: init at 2.1.0 ``                                          |
| [`f5140376`](https://github.com/NixOS/nixpkgs/commit/f51403765e9c1edf886fad5e420079afb9d11176) | `` [Backport release-24.05] icinga2: 2.14.2 -> 2.14.3 (#355448) ``        |
| [`1ad84cc5`](https://github.com/NixOS/nixpkgs/commit/1ad84cc52331c9ff06ee8e379ce28dc09fe18b8b) | `` microcode-intel: 20241029 -> 20241112 ``                               |
| [`162418f0`](https://github.com/NixOS/nixpkgs/commit/162418f07182e68fb6921154838d38d07013d005) | `` miniflux: 2.2.2 -> 2.2.3 ``                                            |
| [`87fcfe9e`](https://github.com/NixOS/nixpkgs/commit/87fcfe9eb7c5a5051e2137578d6f59bd31838c4a) | `` miniflux: add adamcstephens as maintainer ``                           |
| [`2b37e7f6`](https://github.com/NixOS/nixpkgs/commit/2b37e7f6b837191adffe47550c3848b3026d1ad9) | `` firefox-bin-unwrapped: 132.0.1 -> 132.0.2 ``                           |
| [`8ef49014`](https://github.com/NixOS/nixpkgs/commit/8ef49014ef771c5c620cd9e1eb53655e99954fb6) | `` firefox-unwrapped: 132.0.1 -> 132.0.2 ``                               |
| [`96048196`](https://github.com/NixOS/nixpkgs/commit/960481963becb6cdaa9402526d5bf7e5dfeb5e9c) | `` linuxPackages.rtl8821cu: unstable-2024-05-03 -> unstable-2024-09-27 `` |
| [`24b55291`](https://github.com/NixOS/nixpkgs/commit/24b55291b74ff490f060239447bed7f38dcc129a) | `` element-desktop: 1.11.84 -> 1.11.85 ``                                 |
| [`a110a7e9`](https://github.com/NixOS/nixpkgs/commit/a110a7e9a1a53e8955ead0cdf3fdee306120e007) | `` invidious: 2.20240825.2 -> 2.20241110.0 ``                             |
| [`6ef267a9`](https://github.com/NixOS/nixpkgs/commit/6ef267a95332f66269a30b1f4f2170e9e663c66b) | `` nextcloud30: 30.0.1 -> 30.0.2 ``                                       |
| [`f0b4fb65`](https://github.com/NixOS/nixpkgs/commit/f0b4fb65386f3d86869f97b668e6826dfd8839a7) | `` nextcloud29: 29.0.8 -> 29.0.9 ``                                       |
| [`2e50445f`](https://github.com/NixOS/nixpkgs/commit/2e50445f6f683703fa9b58a91b6b325e46095bf5) | `` nextcloud28: 28.0.11 -> 28.0.12 ``                                     |
| [`8a60a99c`](https://github.com/NixOS/nixpkgs/commit/8a60a99cb229dc97491cc204265039aa0db039cb) | `` nextcloud30Packages: update ``                                         |
| [`d1053436`](https://github.com/NixOS/nixpkgs/commit/d1053436c1629f3647505afdec5b629b498b5a24) | `` nextcloud29Packages: update ``                                         |
| [`7bfaa415`](https://github.com/NixOS/nixpkgs/commit/7bfaa415afbee7afbc76cd118b74cec62be460be) | `` nextcloud28Packages: update ``                                         |
| [`2cbc31f8`](https://github.com/NixOS/nixpkgs/commit/2cbc31f85c0de6e3ff83cdda38cc7cdb894c1840) | `` mattermost: 9.5.11 -> 9.5.12 ``                                        |
| [`47a97769`](https://github.com/NixOS/nixpkgs/commit/47a97769880ba74950079d77dafcc6f80a4f563e) | `` thunderbird-128-unwrapped: 128.4.0esr -> 128.4.2esr ``                 |
| [`9634e129`](https://github.com/NixOS/nixpkgs/commit/9634e12903b81eb16cfc11bd515b8f705448eb42) | `` clickhouse: fix compilation on aarch64-linux ``                        |
| [`3f89de10`](https://github.com/NixOS/nixpkgs/commit/3f89de10ef49e32fa34a264f81dce9b7b4f76d45) | `` raycast: 1.84.12 -> 1.85.0 ``                                          |
| [`652ae9c9`](https://github.com/NixOS/nixpkgs/commit/652ae9c9a8b3eef700fa9cc288d6fe299e4a6833) | `` rubyPackages.puma: 6.4.2 -> 6.4.3 ``                                   |
| [`6497e4e4`](https://github.com/NixOS/nixpkgs/commit/6497e4e4b3a8a459a280db8b13a6d75dd02914ef) | `` nixos/tailscale: document tailscale-autoconnect ``                     |
| [`7cfb7afd`](https://github.com/NixOS/nixpkgs/commit/7cfb7afd210e5b8a9266fbb0c5e19d547a5a3754) | `` scrcpy: 2.6.1 -> 2.7 ``                                                |
| [`40e094b4`](https://github.com/NixOS/nixpkgs/commit/40e094b48071635fb18db2a47ae073da4cbfa75d) | `` scrcpy: 2.6 -> 2.6.1 ``                                                |
| [`5a338310`](https://github.com/NixOS/nixpkgs/commit/5a3383102b998324f3049067938f8582fbfc30b9) | `` scrcpy: 2.5 -> 2.6; migrate to pkgs/by-name ``                         |
| [`8784ad52`](https://github.com/NixOS/nixpkgs/commit/8784ad52de00b72a15424bd5adbede9923778692) | `` scrcpy: 2.4 -> 2.5 ``                                                  |
| [`aa948158`](https://github.com/NixOS/nixpkgs/commit/aa948158a84946fe40c1670ce67a94efebfe16cb) | `` maintainers: add ryand56 ``                                            |
| [`8eddb2ee`](https://github.com/NixOS/nixpkgs/commit/8eddb2eed84bb204797c00433df4def1d8d97bdd) | `` opera: 111.0.5168.61 -> 113.0.5230.47 ``                               |
| [`67ee9a7b`](https://github.com/NixOS/nixpkgs/commit/67ee9a7b75ef3cfac6878def29a28996a5846847) | `` ddev: 1.23.1 -> 1.23.2 ``                                              |
| [`ebacd403`](https://github.com/NixOS/nixpkgs/commit/ebacd4037752a55b18468c0a90b5c34bdd41be98) | `` simplex-chat-desktop: 6.0.3 -> 6.0.4 ``                                |