### PR TITLE
chore(flake/stylix): `be94701c` -> `f8699483`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -293,11 +293,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1724435763,
-        "narHash": "sha256-UNky3lJNGQtUEXT2OY8gMxejakSWPTfWKvpFkpFlAfM=",
+        "lastModified": 1730837930,
+        "narHash": "sha256-0kZL4m+bKBJUBQse0HanewWO0g8hDdCvBhudzxgehqc=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "c2cd2a52e02f1dfa1c88f95abeb89298d46023be",
+        "rev": "2f607e07f3ac7e53541120536708e824acccfaa8",
         "type": "github"
       },
       "original": {
@@ -448,11 +448,11 @@
         "tinted-tmux": "tinted-tmux"
       },
       "locked": {
-        "lastModified": 1731537763,
-        "narHash": "sha256-dOjxeHAXbQ4KRe5j9uClFp8SyYY2r62bbsdraETtO84=",
+        "lastModified": 1731920923,
+        "narHash": "sha256-Pqe38TdvfyywhlhpR1WLJlD7uTOGXRRuzpHIh2edOz0=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "be94701ce7b746cb020e667f71492e398ed470f4",
+        "rev": "f8699483e46972f64b0dee5d5e41bf4bb142629b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                        | Message                                                                        |
| --------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------ |
| [`f8699483`](https://github.com/danth/stylix/commit/f8699483e46972f64b0dee5d5e41bf4bb142629b) | `` hyprlock: use a string instead of a path for background.path (#633) ``      |
| [`9b61cc39`](https://github.com/danth/stylix/commit/9b61cc39b2c82f01b63bb0ae85865d7372697fc4) | `` stylix: don't split autoloaded modules into a separate derivation (#631) `` |
| [`cf5be812`](https://github.com/danth/stylix/commit/cf5be812bdc889f10ada644e4736138c5757e1e9) | `` hyprland: add testbed (#611) ``                                             |
| [`5ab1207b`](https://github.com/danth/stylix/commit/5ab1207b2fdeb5a022f2dd7cccf6be760f1b150f) | `` hyprland: adapt breaking changes (#610) ``                                  |
| [`e0a27887`](https://github.com/danth/stylix/commit/e0a278871b63b1800ccdda568861b5324dd93797) | `` zellij: write theme file instead of writing theme into config (#616) ``     |
| [`f361071a`](https://github.com/danth/stylix/commit/f361071a1bc4c411ff6131537f73b3009883cd64) | `` hyprlock: init (#619) ``                                                    |