### PR TITLE
chore(flake/home-manager): `5056a1cf` -> `f3a2ff69`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -272,11 +272,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1731832479,
-        "narHash": "sha256-icDDuYwJ0avTMZTxe1qyU/Baht5JOqw4pb5mWpR+hT0=",
+        "lastModified": 1731887066,
+        "narHash": "sha256-uw7K/RsYioJicV79Nl39yjtfhdfTDU2aRxnBgvFhkZ8=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "5056a1cf0ce7c2a08ab50713b6c4af77975f6111",
+        "rev": "f3a2ff69586f3a54b461526e5702b1a2f81e740a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                    |
| ----------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------- |
| [`f3a2ff69`](https://github.com/nix-community/home-manager/commit/f3a2ff69586f3a54b461526e5702b1a2f81e740a) | `` zsh-abbr: update source path (#6084) ``                 |
| [`05d3b621`](https://github.com/nix-community/home-manager/commit/05d3b6215afa733fed6f025a59a562f98330acc3) | `` home-manager: prepare 25.05-pre ``                      |
| [`0918bb02`](https://github.com/nix-community/home-manager/commit/0918bb02385a6897e7a0180d23ee4587491eb0d4) | `` ci: make dependabot consider release-24.11 ``           |
| [`aecd341d`](https://github.com/nix-community/home-manager/commit/aecd341dfead1c3ef7a3c15468ecd71e8343b7c6) | `` firefox: improve search engine disclaimer generation `` |