### PR TITLE
chore(flake/nixpkgs-stable): `c21b7791` -> `e8c38b73`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -324,11 +324,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1731652201,
-        "narHash": "sha256-XUO0JKP1hlww0d7mm3kpmIr4hhtR4zicg5Wwes9cPMg=",
+        "lastModified": 1731797254,
+        "narHash": "sha256-df3dJApLPhd11AlueuoN0Q4fHo/hagP75LlM5K1sz9g=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "c21b77913ea840f8bcf9adf4c41cecc2abffd38d",
+        "rev": "e8c38b73aeb218e27163376a2d617e61a2ad9b59",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                     |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------- |
| [`04f8f6b3`](https://github.com/NixOS/nixpkgs/commit/04f8f6b3737ee2265c017598b763d870f2eca29d) | `` {firefox{,-beta,-devedition,-esr-128},floorp,librewolf}-unwrapped: make override work `` |
| [`99922c94`](https://github.com/NixOS/nixpkgs/commit/99922c941dc7faa9c592d4267bce197f24f817bb) | `` forgejo: 7.0.10 -> 7.0.11 ``                                                             |
| [`c7ecbb31`](https://github.com/NixOS/nixpkgs/commit/c7ecbb31641b2c47bf71107c2ad713fd9b3d607d) | `` emacsPackages.emacsql: fix build for versions >= 20241115.1939 ``                        |
| [`218400f0`](https://github.com/NixOS/nixpkgs/commit/218400f000374b2a16ec4b94d5c6dda4396fdd24) | `` postgresql_16: 16.4 -> 16.5 ``                                                           |
| [`e13094a6`](https://github.com/NixOS/nixpkgs/commit/e13094a6f5a13eaf47d853c8d579d7cc3850ae90) | `` Revert "postgresql_15: 15.8 -> 15.9" ``                                                  |
| [`0b35a2d3`](https://github.com/NixOS/nixpkgs/commit/0b35a2d379ce83c54c62544fda509a34af713b41) | `` gitlab: 17.3.6 -> 17.3.7 ``                                                              |
| [`4ac00ce9`](https://github.com/NixOS/nixpkgs/commit/4ac00ce93c6066087c39840e4e15aaf33a983a10) | `` mullvad-browser: 13.5.9 -> 14.0 ``                                                       |
| [`f9cee68f`](https://github.com/NixOS/nixpkgs/commit/f9cee68f4731b94926f934005b24fdc1c3ab37bc) | `` thunderbird-bin: 128.4.0esr -> 128.4.3esr ``                                             |
| [`7a20b18b`](https://github.com/NixOS/nixpkgs/commit/7a20b18b470d67e3d5e5baa629376ce02d00a4b3) | `` btrbk: add mainProgram ``                                                                |
| [`d9e447c2`](https://github.com/NixOS/nixpkgs/commit/d9e447c2221a412b9ddac3aeb2726c5765d2859a) | `` postgresql_15: 15.8 -> 15.9 ``                                                           |
| [`ae66cb6e`](https://github.com/NixOS/nixpkgs/commit/ae66cb6e3983bd144462dc0c31dfcee5047595b2) | `` postgresql_14: 14.13 -> 14.14 ``                                                         |
| [`e18ad100`](https://github.com/NixOS/nixpkgs/commit/e18ad10054d39e231197ffc9c1f62c1336693bc3) | `` postgresql_13: 13.16 -> 13.17 ``                                                         |
| [`f19edf78`](https://github.com/NixOS/nixpkgs/commit/f19edf78d4d7cdc7ded6e94d646b4775c43f5c19) | `` postgresql_12: 12.20 -> 12.21 ``                                                         |
| [`de709a8f`](https://github.com/NixOS/nixpkgs/commit/de709a8f6628cb375985750aaee60439cd0e5e94) | `` firefox{,-beta,-devedition,-esr-128}-unwrapped: fix location of update script ``         |
| [`a510ba4c`](https://github.com/NixOS/nixpkgs/commit/a510ba4c21cadb0abb500d75c44a53aa11dbc2de) | `` firefox{,-beta,-devedition,-esr-128}-unwrapped: split into sperated files ``             |
| [`b4137f3f`](https://github.com/NixOS/nixpkgs/commit/b4137f3fbbc4e5993d57639578b7b8b777465b4c) | `` buildMozillaMach: change tests to an attrset ``                                          |
| [`b6eafc35`](https://github.com/NixOS/nixpkgs/commit/b6eafc3545444135ac2d4b49dcf350c2281893fa) | `` raycast: 1.85.0 -> 1.85.2 ``                                                             |
| [`158059b8`](https://github.com/NixOS/nixpkgs/commit/158059b8205ac2aa2a5693846828fb4f3ebf793b) | `` soundsource: 5.7.1 -> 5.7.3 ``                                                           |
| [`a7dfff7e`](https://github.com/NixOS/nixpkgs/commit/a7dfff7ec4306b4b1a43d7574b49daf08d4b382a) | `` matrix-synapse: 1.118.0 -> 1.119.0 ``                                                    |
| [`aafa788a`](https://github.com/NixOS/nixpkgs/commit/aafa788aa24de79847d74bddc268f69482da589e) | `` octoprint: 1.10.2 -> 1.10.3 ``                                                           |
| [`92a98f12`](https://github.com/NixOS/nixpkgs/commit/92a98f122dd6075edddbfc3bebfadc8ed2436d5a) | `` qemu: 8.2.6 -> 8.2.7 ``                                                                  |