### PR TITLE
chore(flake/spicetify-nix): `3dc8f170` -> `aac6c814`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -416,11 +416,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1731903427,
-        "narHash": "sha256-EFY/yqF/5iTMIfuLfOVuYZws8ggrLn4vC61VjZ4mKag=",
+        "lastModified": 1731989835,
+        "narHash": "sha256-Y1S+x2jWLQB9hn4aG04/213ZlTp+30itKe9KcSsrFgw=",
         "owner": "Gerg-L",
         "repo": "spicetify-nix",
-        "rev": "3dc8f170802b3e4a33bcdf581fb8540dc53df1c2",
+        "rev": "aac6c81489f61034916efa4ed62840dc1d72c413",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                    |
| ----------------------------------------------------------------------------------------------------- | -------------------------- |
| [`aac6c814`](https://github.com/Gerg-L/spicetify-nix/commit/aac6c81489f61034916efa4ed62840dc1d72c413) | `` CI update 2024-11-19 `` |