### PR TITLE
chore(flake/home-manager): `a42fa14b` -> `a46e7020`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -272,11 +272,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1731968878,
-        "narHash": "sha256-+hTCwETOE9N8voTAaF+IzdUZz28Ws3LDpH90FWADrEE=",
+        "lastModified": 1732025103,
+        "narHash": "sha256-qjEI64RKvDxRyEarY0jTzrZMa8ebezh2DEZmJJrpVdo=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "a42fa14b53ceab66274a21da480c9f8e06204173",
+        "rev": "a46e702093a5c46e192243edbd977d5749e7f294",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                         |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------- |
| [`a46e7020`](https://github.com/nix-community/home-manager/commit/a46e702093a5c46e192243edbd977d5749e7f294) | `` espanso: fix test failure `` |
| [`d37f154d`](https://github.com/nix-community/home-manager/commit/d37f154dba0d4c015f17a24314e89b77a7ba5ff3) | `` flake.lock: Update ``        |