### PR TITLE
chore(flake/spicetify-nix): `aac6c814` -> `62ac6a29`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -392,11 +392,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1731989835,
-        "narHash": "sha256-Y1S+x2jWLQB9hn4aG04/213ZlTp+30itKe9KcSsrFgw=",
+        "lastModified": 1732076204,
+        "narHash": "sha256-FnPuD4CnVos1vlHcLceBvv4hHkv2zHive7OzC4xy6ys=",
         "owner": "Gerg-L",
         "repo": "spicetify-nix",
-        "rev": "aac6c81489f61034916efa4ed62840dc1d72c413",
+        "rev": "62ac6a2953a8bdfe7a0f7451f8a76ca1d73a6c9f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                    |
| ----------------------------------------------------------------------------------------------------- | -------------------------- |
| [`62ac6a29`](https://github.com/Gerg-L/spicetify-nix/commit/62ac6a2953a8bdfe7a0f7451f8a76ca1d73a6c9f) | `` CI update 2024-11-20 `` |