### PR TITLE
chore(flake/spicetify-nix): `025aefe4` -> `31e976ab`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -392,11 +392,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1732162609,
-        "narHash": "sha256-fC6UxF+P8bLspHFaVhX7t19UA6FzUa7yYjA2jH7P3Ok=",
+        "lastModified": 1732248994,
+        "narHash": "sha256-ZVX0BPZkyn8M9JD+62xml6ir6ejzdG5hwhiulDeym9M=",
         "owner": "Gerg-L",
         "repo": "spicetify-nix",
-        "rev": "025aefe4dba52c7fef6723f3efe659b5dbab27ca",
+        "rev": "31e976ab41721e156ef44e0e7b6b0bd46c80dedd",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                    |
| ----------------------------------------------------------------------------------------------------- | -------------------------- |
| [`31e976ab`](https://github.com/Gerg-L/spicetify-nix/commit/31e976ab41721e156ef44e0e7b6b0bd46c80dedd) | `` CI update 2024-11-22 `` |