### PR TITLE
chore(flake/home-manager): `a46e7020` -> `8cf9cb2e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -272,11 +272,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1732025103,
-        "narHash": "sha256-qjEI64RKvDxRyEarY0jTzrZMa8ebezh2DEZmJJrpVdo=",
+        "lastModified": 1732303962,
+        "narHash": "sha256-5Umjb5AdtxV5jSJd5jxoCckh5mlg+FBQDsyAilu637g=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "a46e702093a5c46e192243edbd977d5749e7f294",
+        "rev": "8cf9cb2ee78aa129e5b8220135a511a2be254c0c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                           |
| ----------------------------------------------------------------------------------------------------------- | --------------------------------- |
| [`8cf9cb2e`](https://github.com/nix-community/home-manager/commit/8cf9cb2ee78aa129e5b8220135a511a2be254c0c) | `` tests: fix integration test `` |