### PR TITLE
chore(flake/spicetify-nix): `31e976ab` -> `5a608edd`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -392,11 +392,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1732248994,
-        "narHash": "sha256-ZVX0BPZkyn8M9JD+62xml6ir6ejzdG5hwhiulDeym9M=",
+        "lastModified": 1732335344,
+        "narHash": "sha256-67eg6CecbBPEYeHFS8K7Xqrg3zhUVoCBYP20dcfHSK4=",
         "owner": "Gerg-L",
         "repo": "spicetify-nix",
-        "rev": "31e976ab41721e156ef44e0e7b6b0bd46c80dedd",
+        "rev": "5a608edd5d050ab47af4e301437684441955ece0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                    |
| ----------------------------------------------------------------------------------------------------- | -------------------------- |
| [`5a608edd`](https://github.com/Gerg-L/spicetify-nix/commit/5a608edd5d050ab47af4e301437684441955ece0) | `` CI update 2024-11-23 `` |