### PR TITLE
chore(flake/home-manager): `8cf9cb2e` -> `92fef254`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -272,11 +272,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1732303962,
-        "narHash": "sha256-5Umjb5AdtxV5jSJd5jxoCckh5mlg+FBQDsyAilu637g=",
+        "lastModified": 1732397793,
+        "narHash": "sha256-2jaf/zkug22hzlldm1PKdKJLVKgdjVXbf47SF+5mroU=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "8cf9cb2ee78aa129e5b8220135a511a2be254c0c",
+        "rev": "92fef254a9071fa41a13908281284e6a62b9c92e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                 |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------------- |
| [`92fef254`](https://github.com/nix-community/home-manager/commit/92fef254a9071fa41a13908281284e6a62b9c92e) | `` podman: install package and create config files ``   |
| [`ba9367b5`](https://github.com/nix-community/home-manager/commit/ba9367b5a98402fb3d2afe7aa58c432c43996720) | `` emacs: add darwin service ``                         |
| [`16fe7818`](https://github.com/nix-community/home-manager/commit/16fe78182e924c9a2b0cffa1f343efea80945ef2) | `` conky: update systemd exec path to config package `` |
| [`445d721e`](https://github.com/nix-community/home-manager/commit/445d721ecfbd92d83f857f12f1f99f5c8fa79951) | `` home-cursor: add hyprcursor support ``               |