### PR TITLE
chore(flake/alejandra): `e518b235` -> `04fe4d17`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -9,11 +9,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1732398303,
-        "narHash": "sha256-U2vP8wrs6KPSFoK3eJzWqLj/3SlJHUq1eNh5b8ROGVQ=",
+        "lastModified": 1732419807,
+        "narHash": "sha256-fxWG4fSgViAfBCYNr8V9w8uWfBpdXWT41ssNQGoHYck=",
         "owner": "kamadorueda",
         "repo": "alejandra",
-        "rev": "e518b235150f5f27a9b99830e2b629e832e63cca",
+        "rev": "04fe4d17dc488744879008f9a8e5cb9affefa2ec",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                 | Message                                |
| ------------------------------------------------------------------------------------------------------ | -------------------------------------- |
| [`04fe4d17`](https://github.com/kamadorueda/alejandra/commit/04fe4d17dc488744879008f9a8e5cb9affefa2ec) | `` refac: simplify config mechanism `` |
| [`6cf7503e`](https://github.com/kamadorueda/alejandra/commit/6cf7503e4f37f07379b9c1bc9de4146fed16368b) | `` feat: update yarn.lock.nix ``       |
| [`df0195f0`](https://github.com/kamadorueda/alejandra/commit/df0195f0c01f56f58407c44101cf3b8ad51294da) | `` . ``                                |
| [`316ff0d5`](https://github.com/kamadorueda/alejandra/commit/316ff0d58917803e0182ab82b6699c86f7efdcb2) | `` feat: make dev env work again ``    |
| [`45ee2b25`](https://github.com/kamadorueda/alejandra/commit/45ee2b250a8cd3c7e2fa93c8f4da6d6cae3d1634) | `` feat: update readme ``              |