### PR TITLE
chore(flake/nixpkgs-stable): `057f63b6` -> `0c582677`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -374,11 +374,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1731755305,
-        "narHash": "sha256-v5P3dk5JdiT+4x69ZaB18B8+Rcu3TIOrcdG4uEX7WZ8=",
+        "lastModified": 1732350895,
+        "narHash": "sha256-GcOQbOgmwlsRhpLGSwZJwLbo3pu9ochMETuRSS1xpz4=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "057f63b6dc1a2c67301286152eb5af20747a9cb4",
+        "rev": "0c582677378f2d9ffcb01490af2f2c678dcb29d3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                        |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------ |
| [`8b86f744`](https://github.com/NixOS/nixpkgs/commit/8b86f7440934ada35224a0050501d3d4cf132082) | `` vuze: drop ``                                                               |
| [`6e7e43e6`](https://github.com/NixOS/nixpkgs/commit/6e7e43e6879ed4d9f789684450daa79d254aea63) | `` pantheon.elementary-gtk-theme: 8.1.0 -> 8.2.0 ``                            |
| [`1c3b66ae`](https://github.com/NixOS/nixpkgs/commit/1c3b66ae873521f4bea7c1b95dc5f6453e5e485e) | `` pantheon.sideload: 6.2.2 -> 6.3.0 ``                                        |
| [`d08c1b67`](https://github.com/NixOS/nixpkgs/commit/d08c1b677f58abb91967c38b8bd7fc53394afff0) | `` nixos/activation: Add pre-switch checks ``                                  |
| [`4324f311`](https://github.com/NixOS/nixpkgs/commit/4324f3111332c205192f09cccabe1dd1c5226c5a) | `` frigate: patch path to birdseye graphic ``                                  |
| [`8f1c9f20`](https://github.com/NixOS/nixpkgs/commit/8f1c9f2047cfcf8ffa35aa725c86047329112bb5) | `` nixos/frigate: allow configuring a libva driver ``                          |
| [`18b4fbf0`](https://github.com/NixOS/nixpkgs/commit/18b4fbf0ae016a14d9aa7cd8d01955939320abe2) | `` nixos/frigate: allow GPU use for video acceleration ``                      |
| [`0e388c27`](https://github.com/NixOS/nixpkgs/commit/0e388c2711c8f6e3a61eabd5fd6297c700062bae) | `` nixos/frigate: use shellscript to clear frigate cache ``                    |
| [`667e6ade`](https://github.com/NixOS/nixpkgs/commit/667e6ade5cf00cd807e377c98d1b386234179363) | `` nixos/frigate: inherit required functions from lib ``                       |
| [`8865962b`](https://github.com/NixOS/nixpkgs/commit/8865962bb845c260258388c3700f92154114f702) | `` linuxPackages_latest.gasket: fix build with 6.12 ``                         |
| [`92f37555`](https://github.com/NixOS/nixpkgs/commit/92f37555a09450ea06a2edf4bae0d74a155d66d5) | `` nixos/frigate: provide ffmpeg-full for nvidia hw accel ``                   |
| [`a7fcb556`](https://github.com/NixOS/nixpkgs/commit/a7fcb556e32dba6b2522c010a37047a0d1e516f5) | `` frigate: provide the tflite audio model ``                                  |
| [`2b70df74`](https://github.com/NixOS/nixpkgs/commit/2b70df74d3b7ef7db8222e080a2da73c19e257dc) | `` nixos/frigate: stop enabling recommendedProxySettings globally ``           |
| [`71fd123b`](https://github.com/NixOS/nixpkgs/commit/71fd123b9513161ecf66beaeaa1640f3897e0dc4) | `` nixos/frigate: add support for Coral devices ``                             |
| [`58082a70`](https://github.com/NixOS/nixpkgs/commit/58082a70d1fe0c27830b2571a9f3c98b264a651e) | `` nixos/coral: init ``                                                        |
| [`b4a6089a`](https://github.com/NixOS/nixpkgs/commit/b4a6089ab895628a6670c54faaf5fd67f23aa87f) | `` libedgetpu: use dedicated coral group ``                                    |
| [`fb667288`](https://github.com/NixOS/nixpkgs/commit/fb6672887bf91ac0669f2dc8a290419213cc4595) | `` lib.systems.examples: set `rust.rustcTarget` for ucrtAarch64 ``             |
| [`c5f764a2`](https://github.com/NixOS/nixpkgs/commit/c5f764a2326755e1616b09feb07f830640977f0c) | `` nixos/netbird: fix port conflict on metrics endpoint ``                     |
| [`7ca49469`](https://github.com/NixOS/nixpkgs/commit/7ca49469b80ae93fd71f69ab123030750ef8d7ae) | `` phpExtensions.soap: re-add soap patch ``                                    |
| [`5c02d071`](https://github.com/NixOS/nixpkgs/commit/5c02d07188585d340d4b8453fcca2c93f87a28be) | `` linux_6_1: 6.1.118 -> 6.1.119 ``                                            |
| [`7777f247`](https://github.com/NixOS/nixpkgs/commit/7777f2477c872c74931d24c95a2c5e4aae263861) | `` linux_6_6: 6.6.62 -> 6.6.63 ``                                              |
| [`951e64ff`](https://github.com/NixOS/nixpkgs/commit/951e64ffd7df04c60b0c00c1b07ef58c85fce82a) | `` linux_6_11: 6.11.9 -> 6.11.10 ``                                            |
| [`cca92665`](https://github.com/NixOS/nixpkgs/commit/cca9266546583e756c0d47d2f1cfbc356c99f5ea) | `` linux_6_12: 6.12 -> 6.12.1 ``                                               |
| [`69156c3e`](https://github.com/NixOS/nixpkgs/commit/69156c3e43b9bceb298f502be0b3b7ff5f99ea53) | `` algia: init at 0.0.74 ``                                                    |
| [`284904aa`](https://github.com/NixOS/nixpkgs/commit/284904aa746faa64a7fd2eb88be93432c93a95dc) | `` arc-browser: 1.69.0-55816 -> 1.70.0-56062 ``                                |
| [`c5d4dcd5`](https://github.com/NixOS/nixpkgs/commit/c5d4dcd5c5a6e3c3e26c7d474624b350f8b0890c) | `` nixos/kanidm: allow origin url ending without slash ``                      |
| [`a4985f26`](https://github.com/NixOS/nixpkgs/commit/a4985f263e0a427abf8e03716a0293fc49af69e6) | `` ocamlPackages.typerep: 0.17.0 → 0.17.1 ``                                   |
| [`a05edf9d`](https://github.com/NixOS/nixpkgs/commit/a05edf9d7d1b1a7857f9794102860309c1c99249) | `` php84Extensions.apcu: 5.1.23 -> 5.1.24 ``                                   |
| [`d6d48f0c`](https://github.com/NixOS/nixpkgs/commit/d6d48f0c6b05d878be7aa793a44356c754bc2957) | `` php-packages: remove the merged soap patch ``                               |
| [`d3cfac63`](https://github.com/NixOS/nixpkgs/commit/d3cfac63d68243d2e6b95390ce665e5a92fcf56d) | `` php84: 8.4.0RC4 -> 8.4.1 ``                                                 |
| [`b2b3ac3c`](https://github.com/NixOS/nixpkgs/commit/b2b3ac3c75b753037f8b60e6293f2b1018174b74) | `` grafana: 11.3.0+security-01 -> 11.3.1 ``                                    |
| [`30419f9d`](https://github.com/NixOS/nixpkgs/commit/30419f9d845ea705f55a0e5902ededc6cc5ae3a9) | `` linux/hardened/patches/6.6: v6.6.60-hardened1 -> v6.6.62-hardened1 ``       |
| [`09c7a395`](https://github.com/NixOS/nixpkgs/commit/09c7a3955f4a5b36ce18c51d3f53a48a33ed04b1) | `` linux/hardened/patches/6.11: v6.11.7-hardened1 -> v6.11.9-hardened1 ``      |
| [`d6e8bbb5`](https://github.com/NixOS/nixpkgs/commit/d6e8bbb5717c4d073bc911b9e103c43326f8b731) | `` linux/hardened/patches/6.1: v6.1.116-hardened1 -> v6.1.118-hardened1 ``     |
| [`90f6f12a`](https://github.com/NixOS/nixpkgs/commit/90f6f12abee52c628e573a7bd9733c3b02b5c3fe) | `` linux/hardened/patches/5.4: v5.4.285-hardened1 -> v5.4.286-hardened1 ``     |
| [`001e859f`](https://github.com/NixOS/nixpkgs/commit/001e859f34ffcca44acb6d0d18b4c72f1303d883) | `` linux/hardened/patches/5.15: v5.15.171-hardened1 -> v5.15.173-hardened1 ``  |
| [`0d6ec28e`](https://github.com/NixOS/nixpkgs/commit/0d6ec28e8aa7e61eb772808196edb46c42c98070) | `` linux/hardened/patches/5.10: v5.10.229-hardened1 -> v5.10.230-hardened1 ``  |
| [`1e54c20b`](https://github.com/NixOS/nixpkgs/commit/1e54c20bd26344e4a8bbb72848457b94e2eba81c) | `` nixos/netbox: switch to symlink to check for upgrades ``                    |
| [`2d04bf7e`](https://github.com/NixOS/nixpkgs/commit/2d04bf7ee48413ae0219078115552acbe499b0e9) | `` nixos/netbox: clear old static files on upgrade ``                          |
| [`0bb9e130`](https://github.com/NixOS/nixpkgs/commit/0bb9e130fab30ca54cc81a1df3cab78c085d1a1a) | `` nextcloud: add news app ``                                                  |
| [`1e6f2258`](https://github.com/NixOS/nixpkgs/commit/1e6f2258fbabfc47c3297fc281ac85d8a156a00a) | `` snac2: 2.59 -> 2.63 ``                                                      |
| [`77df5605`](https://github.com/NixOS/nixpkgs/commit/77df5605410db2a06dbb4499ccc18e01d5b072d0) | `` television: init at 0.5.0 ``                                                |
| [`79413523`](https://github.com/NixOS/nixpkgs/commit/794135230fb6f48ba99716fb933f0eb9eece6a6e) | `` finamp: 0.9.11-beta -> 0.9.12-beta ``                                       |
| [`a813961b`](https://github.com/NixOS/nixpkgs/commit/a813961ba05be11fd0d7806e7e174695a7df86d8) | `` perf_data_converter: fix fixed derivation hash. ``                          |
| [`db015df7`](https://github.com/NixOS/nixpkgs/commit/db015df7ebc6803e9b9172d3a6e41a913bf8a4f4) | `` bant: fix output derivation hash. ``                                        |
| [`95d85eca`](https://github.com/NixOS/nixpkgs/commit/95d85eca5a742336e1bbf54363ed4b7cccf799c7) | `` kicad: 8.0.5 -> 8.0.6 ``                                                    |
| [`321173b3`](https://github.com/NixOS/nixpkgs/commit/321173b3e1be6104c018d3d2f2484aea39a3d7c6) | `` vikunja: 0.24.4 -> 0.24.5 ``                                                |
| [`f274fabf`](https://github.com/NixOS/nixpkgs/commit/f274fabfe4bee52ab39d2c29849f08a1a6c5d66a) | `` python314: 3.14.0a1 -> 3.14.0a2 ``                                          |
| [`92eaaf76`](https://github.com/NixOS/nixpkgs/commit/92eaaf76e6b9f3ad645e8d06896b7fd4de4a8119) | `` amazon-ssm-agent: skip additional flaky test ``                             |
| [`92153485`](https://github.com/NixOS/nixpkgs/commit/92153485eb063c91e271dc114020129d92c984ce) | `` vimPlugins.lspecho-nvim: init at 2024-10-06 ``                              |
| [`c43d490c`](https://github.com/NixOS/nixpkgs/commit/c43d490c0713343896758d49ad1f53407667dfaf) | `` nixos/meilisearch: fix disabling analytics ``                               |
| [`bc37b708`](https://github.com/NixOS/nixpkgs/commit/bc37b708c6aaa33fb36cc9f11a83510962a07226) | `` immich: 1.120.1 -> 1.121.0 ``                                               |
| [`ae85bb3a`](https://github.com/NixOS/nixpkgs/commit/ae85bb3af91a488a4450be93f8d60a520e52809f) | `` rat-king-adventure: 2.0.1 -> 2.0.2 ``                                       |
| [`1ecfae6d`](https://github.com/NixOS/nixpkgs/commit/1ecfae6d716cfa55f1bf94095f2be5d449d3bcf8) | `` freecad: 1.0rc4 -> 1.0 ``                                                   |
| [`48d3b308`](https://github.com/NixOS/nixpkgs/commit/48d3b3084864df1e55a9e03e981e9d71561865f2) | `` freecad: 1.0rc2 -> 1.0rc4 ``                                                |
| [`0af4eb37`](https://github.com/NixOS/nixpkgs/commit/0af4eb37cbdd94d99493ec972671a125684a79cf) | `` python312Packages.distutils: unbreak on Darwin ``                           |
| [`b3371aa1`](https://github.com/NixOS/nixpkgs/commit/b3371aa123c564e987c62afd52380602f348188b) | `` koboldcpp: `gitUpdater` -> `nix-update-script` ``                           |
| [`300c96ed`](https://github.com/NixOS/nixpkgs/commit/300c96ed8211194a18a10d181cb823ac8e238ac8) | `` koboldcpp: drop `postPatch` ``                                              |
| [`a7da1c2d`](https://github.com/NixOS/nixpkgs/commit/a7da1c2d131ec06d691139d2420a1cd62b923308) | `` koboldcpp: drop `stdenv.hostPlatform.isAarch64` requirement ``              |
| [`0847c9c9`](https://github.com/NixOS/nixpkgs/commit/0847c9c98d9d5cf817c17efa121962653e481235) | `` koboldcpp: migrate to `apple-sdk_12` ``                                     |
| [`86563a9d`](https://github.com/NixOS/nixpkgs/commit/86563a9d0f5a99a03f48c48160b3620bc55d6a7c) | `` koboldcpp: drop unused args ``                                              |
| [`0a99469b`](https://github.com/NixOS/nixpkgs/commit/0a99469b9a3c5d438aa4a789e8e889e17630fba5) | `` lyra-cursors: init at 0-unstable-2021-12-04 ``                              |
| [`77532ec6`](https://github.com/NixOS/nixpkgs/commit/77532ec658f11c5ed7d9a5a07bc27e577e4016c4) | `` maintainers: add lordmzte ``                                                |
| [`851859ca`](https://github.com/NixOS/nixpkgs/commit/851859ca2db3796b1f81547445e8fd6b36846721) | `` tuxguitar: nixfmt ``                                                        |
| [`00d31d1e`](https://github.com/NixOS/nixpkgs/commit/00d31d1e0354b938d40d2100f93c24726ad4c37c) | `` tuxguitar: format ``                                                        |
| [`0eae0473`](https://github.com/NixOS/nixpkgs/commit/0eae047357500e178929aee1e1262e25d5bbc41d) | `` tuxguitar: apply suggestions ``                                             |
| [`ba735daf`](https://github.com/NixOS/nixpkgs/commit/ba735dafdd4dab371dcbd3143b126913f146a281) | `` tuxguitar: fix start script ``                                              |
| [`6a2ae594`](https://github.com/NixOS/nixpkgs/commit/6a2ae59456b6f45546de66c1c97eb159b35b892b) | `` nixos/luksroot: make it harder to accidentially break cryptsetup ``         |
| [`a16378e5`](https://github.com/NixOS/nixpkgs/commit/a16378e5189d7e85d575c504e8d80db214a4b4e9) | `` oauth2c: 1.16.0 -> 1.17.0 ``                                                |
| [`7075f58a`](https://github.com/NixOS/nixpkgs/commit/7075f58aec5057a9392ca26e3e7f674eadf446af) | `` gpauth: limit platforms to *-linux ``                                       |
| [`0eb4201a`](https://github.com/NixOS/nixpkgs/commit/0eb4201af57c50b68b6f38f3ecb604315809de7c) | `` zoom-us: 6.2.5.* -> 6.2.10.* ``                                             |
| [`56a9afec`](https://github.com/NixOS/nixpkgs/commit/56a9afecffc159da40341b2a9a7c36294b9ea01a) | `` searxng: 0-unstable-2024-10-05 -> 0-unstable-2024-11-17 ``                  |
| [`48be85e7`](https://github.com/NixOS/nixpkgs/commit/48be85e7c78a6a4110225d0e76ab0f177eef2744) | `` nixos/kanidm: add provisioning secret directories to BindReadOnlyPaths ``   |
| [`8668fe03`](https://github.com/NixOS/nixpkgs/commit/8668fe03715ca1f58ec67b3fd7039f9035dcf9cb) | `` p4: fix darwin build ``                                                     |
| [`0aaaeb9d`](https://github.com/NixOS/nixpkgs/commit/0aaaeb9dd347344a87d04271220f7ab141d56495) | `` jami: 20240823 -> 20241031.0 ``                                             |
| [`05469c79`](https://github.com/NixOS/nixpkgs/commit/05469c7903277a5d2fc287993d05795ef138c231) | `` jami: fix build with libgit2 1.8.4 ``                                       |
| [`a8c339fe`](https://github.com/NixOS/nixpkgs/commit/a8c339fe1390ad284443ced9113abfd5755427d6) | `` opensc: fix darwin build ``                                                 |
| [`23d958c8`](https://github.com/NixOS/nixpkgs/commit/23d958c8e871cae6c6621760fa3b04bedf6a241a) | `` n8n: 1.61.0 -> 1.65.1 ``                                                    |
| [`6c443406`](https://github.com/NixOS/nixpkgs/commit/6c4434065a8b3763bed12f3c731790d7aa8530cb) | `` n8n: remove `with lib;` ``                                                  |
| [`7ab40491`](https://github.com/NixOS/nixpkgs/commit/7ab40491a31bb80570ade65c7bc3fb56504291ea) | `` n8n: drop maintainer freezeboy ``                                           |
| [`2cfbf28a`](https://github.com/NixOS/nixpkgs/commit/2cfbf28a8946bb0c3ee74022d5b64b796021979b) | `` doc: change allowInsecurePredicate example to a useful one ``               |
| [`9746c8b7`](https://github.com/NixOS/nixpkgs/commit/9746c8b7ee20023204fe5d4a1ba4a0ecc94c0e99) | `` nixos/tabby: fix typo ``                                                    |
| [`6aeb8982`](https://github.com/NixOS/nixpkgs/commit/6aeb89826cb4fc8963d31dec24fd25f9e760317e) | `` yt-dlp: 2024.11.4 -> 2024.11.18 ``                                          |
| [`113c6168`](https://github.com/NixOS/nixpkgs/commit/113c61683b78d9956e0091500cdd01401fbe859b) | `` doc/stdenv: fix a typo ``                                                   |
| [`4a21ed56`](https://github.com/NixOS/nixpkgs/commit/4a21ed568a072a3b440602a6041c1454a245f090) | `` ungoogled-chromium: 131.0.6778.69-1 -> 131.0.6778.85-1 ``                   |
| [`439ec33e`](https://github.com/NixOS/nixpkgs/commit/439ec33ea7b25f9549a5d14f9b6c1317c715f46a) | `` chromium: use cached dependencies from other attributes in update script `` |
| [`94389bb1`](https://github.com/NixOS/nixpkgs/commit/94389bb1ffe481edcabde7153345b30789b540ba) | `` urh: add wrapGAppsHook3 (#357400) ``                                        |
| [`0016cd3d`](https://github.com/NixOS/nixpkgs/commit/0016cd3dff745e42ff0d435b570636b4b6c3a560) | `` google-chrome: 131.0.6778.69 -> 131.0.6778.85 ``                            |
| [`bceb5630`](https://github.com/NixOS/nixpkgs/commit/bceb5630116645aa9860f375fc850f39b9399c73) | `` git-smash: init at 0.1.1 ``                                                 |
| [`4784023f`](https://github.com/NixOS/nixpkgs/commit/4784023f58f653ac0e10f4a9af9e8d50873943ab) | `` snipaste: add desktop entries ``                                            |
| [`f35a75e6`](https://github.com/NixOS/nixpkgs/commit/f35a75e6c58540e195c2cdf68a92de1434083555) | `` zls: fix build on Darwin ``                                                 |
| [`65933c9e`](https://github.com/NixOS/nixpkgs/commit/65933c9eb94c185430dfbebd57cf4db65e9ae9f5) | `` nixos/libreswan: use `environment.etc."ipsec.secrets".text` ``              |
| [`1503d1ca`](https://github.com/NixOS/nixpkgs/commit/1503d1ca19a7c4d253f09e9eda870fa2ccb2d182) | `` nixos/porn-vault: init module ``                                            |
| [`23121da8`](https://github.com/NixOS/nixpkgs/commit/23121da8f9939134df052e55fd889bf6990d1707) | `` porn-vault: init at 0.30.0-rc.11 ``                                         |
| [`703dfa49`](https://github.com/NixOS/nixpkgs/commit/703dfa49951d95fc36177cd6741f625d037c73c3) | `` maintainers: add luNeder ``                                                 |
| [`99a571ae`](https://github.com/NixOS/nixpkgs/commit/99a571aea7f70dbf835e58caf109af717f3080d4) | `` ibm-plex: add @ryanccn as maintainer ``                                     |
| [`e6db7d68`](https://github.com/NixOS/nixpkgs/commit/e6db7d68208585780c93c99ef9f331a2b9e23be9) | `` ibm-plex: 6.4.0 -> 1.1.0 ``                                                 |
| [`28c94e8d`](https://github.com/NixOS/nixpkgs/commit/28c94e8d11b7e25e0782ad1b1a2a0c0f0acf4c4e) | `` karlender: order `meta` attrs ``                                            |
| [`dbcc54cb`](https://github.com/NixOS/nixpkgs/commit/dbcc54cbec5b5e4f3cd7c9a840a7e41e8e9db01c) | `` karlender: 0.10.4 -> 0.10.11 ``                                             |
| [`929f3d6d`](https://github.com/NixOS/nixpkgs/commit/929f3d6d86cdbf7fc6c3b8ddb5fcd39764c0d06e) | `` cargo-gra: order `meta` attrs ``                                            |
| [`5e7f7636`](https://github.com/NixOS/nixpkgs/commit/5e7f76361c1d8f7c0b81e0957046236afabad02f) | `` cargo-gra: 0.6.0 -> 0.6.2 ``                                                |
| [`7b74a044`](https://github.com/NixOS/nixpkgs/commit/7b74a044f9d6af7d6204352c124ee00e6c369534) | `` chromium,chromedriver: 131.0.6778.69 -> 131.0.6778.85 ``                    |
| [`03b6fa3e`](https://github.com/NixOS/nixpkgs/commit/03b6fa3e21c3c35573ec08c8c43edc4ec593c480) | `` ungoogled-chromium: 130.0.6723.116-1 -> 131.0.6778.69-1 ``                  |
| [`ebd96b1e`](https://github.com/NixOS/nixpkgs/commit/ebd96b1e40b0adcddae9b21a1ebf69e5061ee840) | `` chromium,chromedriver: 130.0.6723.116 -> 131.0.6778.69 ``                   |
| [`7f0b52f1`](https://github.com/NixOS/nixpkgs/commit/7f0b52f1aaaf8344b8f2d9376b43565df047b972) | `` chromium: fetch src from git instead of using release tarball ``            |
| [`27a9cb11`](https://github.com/NixOS/nixpkgs/commit/27a9cb1168354c58baa853005955124fe041b83c) | `` chromium: remove "channel" argument ``                                      |
| [`f449f278`](https://github.com/NixOS/nixpkgs/commit/f449f2784a1561e2428d35cb3730de73087893a6) | `` evdi: 1.14.6 -> 1.14.7 ``                                                   |
| [`43aa8557`](https://github.com/NixOS/nixpkgs/commit/43aa85573a0084b3409a583f3d289e477e939c77) | `` nodejs_23: add patches to fix parallel-os test ``                           |
| [`458cfc16`](https://github.com/NixOS/nixpkgs/commit/458cfc165b5f6f0516086856fb9b82779a05bed5) | `` alembic: fix hash ``                                                        |
| [`bace2363`](https://github.com/NixOS/nixpkgs/commit/bace2363772ddc75f28d794d716fc50a15d2ee87) | `` nixos/release-notes-24.11: add scx module ``                                |
| [`67ca8113`](https://github.com/NixOS/nixpkgs/commit/67ca8113a1a2a1727b52b3fd8239ba5e2fe066f4) | `` nixos/scx: init ``                                                          |
| [`ed9f1d9c`](https://github.com/NixOS/nixpkgs/commit/ed9f1d9c581d960101f474c041b66001293e9b1f) | `` pantheon.switchboard-plug-sound: 8.0.0 -> 8.0.1 ``                          |
| [`6219a5a5`](https://github.com/NixOS/nixpkgs/commit/6219a5a59cd037b8249705dd6a1b6c05277f9666) | `` signal-desktop(darwin): 7.29.0 -> 7.33.0 ``                                 |
| [`6b7f035b`](https://github.com/NixOS/nixpkgs/commit/6b7f035b93731f0cda82901018a0b1d05d00ab80) | `` signal-desktop(aarch64-linux): 7.23.0 -> 7.33.0 ``                          |
| [`ece6812b`](https://github.com/NixOS/nixpkgs/commit/ece6812b8382065147822c72e74933957fe971c9) | `` linux_xanmod_latest: 6.11.7 -> 6.11.9 ``                                    |
| [`8cfb55ca`](https://github.com/NixOS/nixpkgs/commit/8cfb55ca6eaa9a3c88eda26cd9cf8ec9244874a4) | `` linux_xanmod: 6.6.60 -> 6.6.62 ``                                           |
| [`852f4f51`](https://github.com/NixOS/nixpkgs/commit/852f4f517559e6146e5a665c8502bf5184f4902d) | `` llvmPackages_19: 19.1.3 -> 19.1.4 ``                                        |
| [`982b6849`](https://github.com/NixOS/nixpkgs/commit/982b6849ca7a3bb5fb5ce5b165a88073e6bc1962) | `` gap: 4.12.2 -> 4.13.1 ``                                                    |
| [`b9654093`](https://github.com/NixOS/nixpkgs/commit/b96540931b88142b1523e16d8aba40fd340ef196) | `` sage: 10.4 -> 10.5.rc0 ``                                                   |
| [`ba65002b`](https://github.com/NixOS/nixpkgs/commit/ba65002b0b878e0696d002adfb9bcf38362ed234) | `` qdigidoc: fix TSL loading ``                                                |
| [`cb0c4e81`](https://github.com/NixOS/nixpkgs/commit/cb0c4e81487c527d503690aad7f17faa9ffaff06) | `` prowlarr: 1.25.4.4818 -> 1.26.1.4844 ``                                     |
| [`4edfea17`](https://github.com/NixOS/nixpkgs/commit/4edfea170d2f5c856e782c887e82488aae917700) | `` openasar: 0-unstable-2024-09-06 -> 0-unstable-2024-11-13 ``                 |
| [`d86a6878`](https://github.com/NixOS/nixpkgs/commit/d86a6878f54221ff5d1d4ddce0eb27864f1a472e) | `` mission-center: add getchoo to maintainers ``                               |
| [`cf5a1c32`](https://github.com/NixOS/nixpkgs/commit/cf5a1c32934569601207395e03b3fa7ad66dd625) | `` mission-center: use RUSTFLAGS to link libGL and libvulkan ``                |
| [`dcea4c5a`](https://github.com/NixOS/nixpkgs/commit/dcea4c5a240648636bdcfd6a288fa6084b20028e) | `` prowlarr: 1.24.3.4754 -> 1.25.4.4818 ``                                     |
| [`9444b574`](https://github.com/NixOS/nixpkgs/commit/9444b574fcb82bd4dbdfa51c7bfdf35d19ac1fae) | `` openmpi: 5.0.5 -> 5.0.6 ``                                                  |
| [`5556c77c`](https://github.com/NixOS/nixpkgs/commit/5556c77ca8236b804385970310510f7a5d8faf38) | `` prrte: 3.0.5 -> 3.0.6 ``                                                    |
| [`118f789e`](https://github.com/NixOS/nixpkgs/commit/118f789e951edfac20abb4d087fca16b65338bf0) | `` upscaler: init at 1.4.0 ``                                                  |
| [`0a20cfcf`](https://github.com/NixOS/nixpkgs/commit/0a20cfcf93cacf66f257fdb4c3160885d76430c8) | `` upscayl-ncnn: init at 20240601-103425 ``                                    |
| [`8a970598`](https://github.com/NixOS/nixpkgs/commit/8a970598f696c2af0b5aee837065a97fd3158c55) | `` python312Packages.vulkan: init at 1.3.275.1 ``                              |
| [`e03aa5c6`](https://github.com/NixOS/nixpkgs/commit/e03aa5c659f5d8cb797887c636a3f131ac3e5bf1) | `` coqPackages_8_20.dpdgraph: init at 1.0+8.20 ``                              |
| [`4a3b98d0`](https://github.com/NixOS/nixpkgs/commit/4a3b98d09fbebd9ac150ff27a04f46c89e0ae8a7) | `` febio-studio: fix qt 6.8 build ``                                           |
| [`38f1f2d1`](https://github.com/NixOS/nixpkgs/commit/38f1f2d1044713a935dd826cc4a6cbbf50595983) | `` febio-studio: darwin sdk refactor ``                                        |
| [`753ebc23`](https://github.com/NixOS/nixpkgs/commit/753ebc23ad95e5d92969cea1d33d7bd124f67470) | `` febio: darwin sdk refactor ``                                               |
| [`0bab9fc2`](https://github.com/NixOS/nixpkgs/commit/0bab9fc24a04048953a8b52bb5a44f92455b4fec) | `` postgresqlPackages.repmgr: 5.4.1 -> 5.5.0 ``                                |
| [`92710380`](https://github.com/NixOS/nixpkgs/commit/92710380e7eb8bb59c809f2eb003ca19bc98c9aa) | `` postgresqlPackages.plpgsql_check: 2.7.5 -> 2.7.12 ``                        |
| [`d2a46a16`](https://github.com/NixOS/nixpkgs/commit/d2a46a16936e184425e76a371c2d98a1b31e1b2c) | `` postgresqlPackages.pgvector: 0.6.2 -> 0.8.0 ``                              |
| [`05e219b5`](https://github.com/NixOS/nixpkgs/commit/05e219b55a9b598478e91a3556fcdeee06eee7c6) | `` postgresqlPackages.pgsql-http: 1.6.0 -> 1.6.1 ``                            |
| [`a15548f8`](https://github.com/NixOS/nixpkgs/commit/a15548f815d9831d54870db3dda10327ff4a4144) | `` postgresqlPackages.pgrouting: 3.6.3 -> 3.7.0 ``                             |
| [`42108ff5`](https://github.com/NixOS/nixpkgs/commit/42108ff589ee681de1522f0122b4a17b1c896356) | `` postgresqlPackages.pgroonga: 3.2.3 -> 3.2.4 ``                              |
| [`cc000088`](https://github.com/NixOS/nixpkgs/commit/cc000088e630ce9f28773d893804aaa79c7f5fd8) | `` postgresqlPackages.pgmq: 1.4.4 -> 1.4.5 ``                                  |
| [`8cb8a741`](https://github.com/NixOS/nixpkgs/commit/8cb8a741f3a53e0499f0862ef2fe5a73a94a15dc) | `` postgresqlPackages.pg_uuidv7: 1.5.0 -> 1.6.0 ``                             |
| [`128e34ed`](https://github.com/NixOS/nixpkgs/commit/128e34ede19b7d27751294d69239d307e626d2f1) | `` postgresqlPackages.pg_repack: 1.5.0 -> 1.5.1 ``                             |
| [`09b40f80`](https://github.com/NixOS/nixpkgs/commit/09b40f80d4a8cbe1cc875ee189cd86d2b185315d) | `` postgresqlPackages.pg_net: 0.8.0 -> 0.13.0 ``                               |