### PR TITLE
chore(flake/spicetify-nix): `4841814c` -> `626e9d49`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -459,11 +459,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1732508213,
-        "narHash": "sha256-0rfdpRO1KnesH0XHv8mAHmfsPQXnHiwiu79sN3nCy/0=",
+        "lastModified": 1732594596,
+        "narHash": "sha256-XGAdvRhat+DST+bRBsGYYyno9MKMUCPu6/KTKnRgpj4=",
         "owner": "Gerg-L",
         "repo": "spicetify-nix",
-        "rev": "4841814c6e22958aff9dd8c68fd2153237fbf15e",
+        "rev": "626e9d49eb7f5122a60e0500f08051267484ebee",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                    |
| ----------------------------------------------------------------------------------------------------- | -------------------------- |
| [`626e9d49`](https://github.com/Gerg-L/spicetify-nix/commit/626e9d49eb7f5122a60e0500f08051267484ebee) | `` CI update 2024-11-26 `` |