### PR TITLE
chore(flake/home-manager): `a9953635` -> `2f7739d0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -290,11 +290,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1732482255,
-        "narHash": "sha256-GUffLwzawz5WRVfWaWCg78n/HrBJrOG7QadFY6rtV8A=",
+        "lastModified": 1732793095,
+        "narHash": "sha256-6TrknJ8CpvSSF4gviQSeD+wyj3siRcMvdBKhOXkEMKU=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "a9953635d7f34e7358d5189751110f87e3ac17da",
+        "rev": "2f7739d01080feb4549524e8f6927669b61c6ee3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                              |
| ----------------------------------------------------------------------------------------------------------- | ---------------------------------------------------- |
| [`2f7739d0`](https://github.com/nix-community/home-manager/commit/2f7739d01080feb4549524e8f6927669b61c6ee3) | `` kakoune: add colorSchemePackage option ``         |
| [`b7219652`](https://github.com/nix-community/home-manager/commit/b7219652387ce4331ae49ddac8b0286f50e0ed68) | `` mopidy: ignore collisions between extensions ``   |
| [`de7d67b8`](https://github.com/nix-community/home-manager/commit/de7d67b8bae8aa2ac920fa10918c89ce44b66d00) | `` mopidy: make makeWrapper a native build input ``  |
| [`21396857`](https://github.com/nix-community/home-manager/commit/21396857fdceb61239a7ae67b9be4dbfd90c12c1) | `` kdeconnect: upgrade default version ``            |
| [`f83dc9f2`](https://github.com/nix-community/home-manager/commit/f83dc9f25a5915c70b013102e30f3ee2a72ba633) | `` tmux: set `sensibleOnTop = false` as a default `` |
| [`0941a2e1`](https://github.com/nix-community/home-manager/commit/0941a2e14486ee30e2088afa1d2869f2486dd3b8) | `` flake.lock: Update ``                             |