### PR TITLE
chore(flake/zen-browser): `a1c38bb8` -> `5a765451`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -599,11 +599,11 @@
         "nixpkgs": "nixpkgs_3"
       },
       "locked": {
-        "lastModified": 1732785687,
-        "narHash": "sha256-dkh/Ff2nxZvMdRnkUq+mo8I1IOk/ASjBM7HEanKV290=",
+        "lastModified": 1732933979,
+        "narHash": "sha256-Z7X++lKZMNBu67BJl2LP23e7RBadp2C/RuRrygLehaE=",
         "owner": "0xc000022070",
         "repo": "zen-browser-flake",
-        "rev": "a1c38bb83c32339b1b0ee6a3f740c0dd677d43be",
+        "rev": "5a765451af1db68acceae07b98e5c768f238210c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                          | Message                                                                                      |
| --------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------- |
| [`5a765451`](https://github.com/0xc000022070/zen-browser-flake/commit/5a765451af1db68acceae07b98e5c768f238210c) | `` Update Zen Browser to v1.0.1-a.22 ``                                                      |
| [`5c342274`](https://github.com/0xc000022070/zen-browser-flake/commit/5c342274b37fc1ed8a9d2770fde3f53b489b2067) | `` ci(github/new-version): removed control characters for compatibility with jq ``           |
| [`1af793fc`](https://github.com/0xc000022070/zen-browser-flake/commit/1af793fcfb60bb57a811b6b2f2f5ac6b04371cc9) | `` ci(github/new-version): added debug logs ``                                               |
| [`a9cf2b29`](https://github.com/0xc000022070/zen-browser-flake/commit/a9cf2b2957e54f53df6fc864b3ff0343cd88ac45) | `` ci(github/new-version): removed verbose output from curl command to get latest release `` |