### PR TITLE
chore(flake/nixpkgs-stable): `0c582677` -> `c71ad5c3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -374,11 +374,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1732350895,
-        "narHash": "sha256-GcOQbOgmwlsRhpLGSwZJwLbo3pu9ochMETuRSS1xpz4=",
+        "lastModified": 1732824227,
+        "narHash": "sha256-fYNXgpu1AEeLyd3fQt4Ym0tcVP7cdJ8wRoqJ+CtTRyY=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "0c582677378f2d9ffcb01490af2f2c678dcb29d3",
+        "rev": "c71ad5c34d51dcbda4c15f44ea4e4aa6bb6ac1e9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                             |
| ---------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------- |
| [`9a4addbe`](https://github.com/NixOS/nixpkgs/commit/9a4addbe70db03e2f5bd3138e7386a659c49bb20) | `` nixos/goatcounter: Fix typo in link ``                                           |
| [`d55940bd`](https://github.com/NixOS/nixpkgs/commit/d55940bd521ef016e46d2ba420a4ae1cf8218df2) | `` coqPackages.ssprove: 0.2.1 → 0.2.2 ``                                            |
| [`21534ca8`](https://github.com/NixOS/nixpkgs/commit/21534ca8dd99de1303ef59c88ff24a5f3b76a67f) | `` coqPackages.Ordinal: init at 0.5.3 ``                                            |
| [`f003d151`](https://github.com/NixOS/nixpkgs/commit/f003d151c3d1c78b6798594fafdef89580c27ab0) | `` maintainers: add damhiya ``                                                      |
| [`8fdfa86a`](https://github.com/NixOS/nixpkgs/commit/8fdfa86ab5c8004e75c07d1c591de8d312333dbf) | `` scheherazade-new: 4.000 → 4.300 ``                                               |
| [`8e93d097`](https://github.com/NixOS/nixpkgs/commit/8e93d0978f408108556f0028b9e52585db8901b6) | `` dissent: 0.0.30 -> 0.0.31 ``                                                     |
| [`ff31b814`](https://github.com/NixOS/nixpkgs/commit/ff31b814b62c760b1abbedc43d9b34d2dc75b351) | `` nixos/lib/test-driver: fix linting after compatibility clean‐up ``               |
| [`edc274db`](https://github.com/NixOS/nixpkgs/commit/edc274db49578f33d3ee9918e2693bc31004dc1d) | `` nixos/mailman: wrap mailman cli to start as mailman user ``                      |
| [`4526fd51`](https://github.com/NixOS/nixpkgs/commit/4526fd515ae533c5a7c803ed6a4f4ee6b890a952) | `` golangci-lint: 1.62.0 -> 1.62.2 ``                                               |
| [`1954fcac`](https://github.com/NixOS/nixpkgs/commit/1954fcacf742fe9820683de042229e8ebf17c733) | `` audiobookshelf: 2.17.1 -> 2.17.2 ``                                              |
| [`825d771d`](https://github.com/NixOS/nixpkgs/commit/825d771d1cfe71f43446f43e707a92ecd1913011) | `` audiobookshelf: 2.16.2 -> 2.17.1 ``                                              |
| [`cdbc3998`](https://github.com/NixOS/nixpkgs/commit/cdbc3998e979bbd17f251fdd3addb183075f583e) | `` paperlib: fix darwin build ``                                                    |
| [`8a0e223c`](https://github.com/NixOS/nixpkgs/commit/8a0e223c355aaad0b9e627a5149eba851de7af4e) | `` mullvad-browser: 14.0 -> 14.0.3 ``                                               |
| [`744a43af`](https://github.com/NixOS/nixpkgs/commit/744a43afc795466e17e432b664cbe7aafbca0958) | `` tor-browser: 14.0.2 -> 14.0.3 ``                                                 |
| [`c91fc57c`](https://github.com/NixOS/nixpkgs/commit/c91fc57c064df0d96b4f685cf5aed3f9c103165c) | `` opam: 2.2.0 → 2.3.0 ``                                                           |
| [`72c61c0a`](https://github.com/NixOS/nixpkgs/commit/72c61c0a9e9d01657d3580bd45b75cefc16779d2) | `` magic-vlsi: 8.3.497 -> 8.3.501 ``                                                |
| [`6bb2fb7b`](https://github.com/NixOS/nixpkgs/commit/6bb2fb7b039ca62124bb9ece6cdfc13f8b37f3a6) | `` stdenv/custom: avoid aliases ``                                                  |
| [`dd0c4f01`](https://github.com/NixOS/nixpkgs/commit/dd0c4f01cc0a5103b2f9de2a74cf0e93fc6e75d8) | `` wlvncc: unstable-2023-01-05 -> unstable-2024-11-24 ``                            |
| [`112703b9`](https://github.com/NixOS/nixpkgs/commit/112703b9ab9558e3b22e3f4a367554c7873bcf72) | `` eyedropper: 1.0.0 -> 2.0.1 ``                                                    |
| [`e2c2f879`](https://github.com/NixOS/nixpkgs/commit/e2c2f879c12bacee9aa1727dcbbccf87b8b77b34) | `` angular-language-server: remove overjealous templating ``                        |
| [`28ba9e2c`](https://github.com/NixOS/nixpkgs/commit/28ba9e2c27b6226cf640b4f6c7cc5e7f7f2fd8a1) | `` nixos/acme: Set /var/lib/acme permissions to 755 ``                              |
| [`f5495b97`](https://github.com/NixOS/nixpkgs/commit/f5495b97ea3d3512beb11522f25f34d9959a9c84) | `` nginx: fix compatibility with zlib-ng ``                                         |
| [`3d38f8e2`](https://github.com/NixOS/nixpkgs/commit/3d38f8e24d2a2474721b2015809704056395a991) | `` vivaldi: use coreutils from nixpkgs ``                                           |
| [`795e9562`](https://github.com/NixOS/nixpkgs/commit/795e9562690468f6f828b68bc6fb480625cc57a4) | `` rofi-wayland: add patch for niri ``                                              |
| [`85e78131`](https://github.com/NixOS/nixpkgs/commit/85e78131c304c5f4800e552a665c48b555103a95) | `` jasmin-compiler: 2024.07.1 → 2024.07.2 ``                                        |
| [`1bdcf396`](https://github.com/NixOS/nixpkgs/commit/1bdcf3961943a6caaea27661e3c620dc74610d93) | `` woodpecker-server: 2.7.1 -> 2.7.3 ``                                             |
| [`18780567`](https://github.com/NixOS/nixpkgs/commit/18780567b20aa2a8b2091fed2fe21d836537ae1d) | `` singular: 4.3.2p16 -> 4.4.0p6 ``                                                 |
| [`3a0d0057`](https://github.com/NixOS/nixpkgs/commit/3a0d00575400185da63f649477ca3278d498e3c5) | `` cobang: fix build ``                                                             |
| [`3a65adc3`](https://github.com/NixOS/nixpkgs/commit/3a65adc3d1d781b4089587759d16128b84291eab) | `` cobang: nixfmt ``                                                                |
| [`a1171ab1`](https://github.com/NixOS/nixpkgs/commit/a1171ab131f324451a1bf038500198b2e970c332) | `` cobang: move to by-name ``                                                       |
| [`11a0cab6`](https://github.com/NixOS/nixpkgs/commit/11a0cab61e65d51025f56fc8de3c42b52e12660c) | `` cutter: fix build against PySide 6.8 ``                                          |
| [`1afcd07c`](https://github.com/NixOS/nixpkgs/commit/1afcd07cb79164877f15cc45f84dff4941845b74) | `` discord: bump all versions ``                                                    |
| [`b23e3901`](https://github.com/NixOS/nixpkgs/commit/b23e3901b7deeb8ad8ec8cbfd102ae63e69dd095) | `` toot: 0.45.0 -> 0.47.0 ``                                                        |
| [`d3bfb6cb`](https://github.com/NixOS/nixpkgs/commit/d3bfb6cbfeed7b35c64bc012c6adfea605cd081d) | `` python313Packages.pycurl: 7.45.3 -> 7.45.3-unstable-2024-10-17 ``                |
| [`dc1dae47`](https://github.com/NixOS/nixpkgs/commit/dc1dae4730e95fdf3d4a9fb1166bb39f1d651624) | `` devtoolbox: 1.2 -> 1.2.1 ``                                                      |
| [`ad161316`](https://github.com/NixOS/nixpkgs/commit/ad161316a4322107ec4177ea488efd035db7ace5) | `` firefox-esr-128-unwrapped: 128.4.0esr -> 128.5.0esr ``                           |
| [`d9fcbee0`](https://github.com/NixOS/nixpkgs/commit/d9fcbee0c4c731e1c264e5913a0068aeee1bc487) | `` firefox-bin-unwrapped: 132.0.2 -> 133.0 ``                                       |
| [`e77539a8`](https://github.com/NixOS/nixpkgs/commit/e77539a846d36f4a2a9f561583f07947f7d4208e) | `` firefox-unwrapped: 132.0.2 -> 133.0 ``                                           |
| [`8ac17c6c`](https://github.com/NixOS/nixpkgs/commit/8ac17c6cfa679cf33a32fe253b6e9e1366a2a297) | `` htmldoc: 1.9.18 -> 1.9.19 ``                                                     |
| [`f8da7d85`](https://github.com/NixOS/nixpkgs/commit/f8da7d855a242030eb6ef6decd7d417c401f66af) | `` floorp: 11.20.0 -> 11.21.0 ``                                                    |
| [`08aa8c0b`](https://github.com/NixOS/nixpkgs/commit/08aa8c0b49302dff6e6bfbe92c99cb7f414e85f0) | `` goreleaser: 2.4.5 -> 2.4.8 ``                                                    |
| [`3881f806`](https://github.com/NixOS/nixpkgs/commit/3881f80699f10c234d52ae2e23b9fce3d748e1f0) | `` goreleaser: 2.4.4 -> 2.4.5 ``                                                    |
| [`a4e48c23`](https://github.com/NixOS/nixpkgs/commit/a4e48c2394d132e9933262e6679fe8f3597a37d8) | `` gh: 2.61.0 -> 2.62.0 ``                                                          |
| [`87d3ec4c`](https://github.com/NixOS/nixpkgs/commit/87d3ec4ce53556638b51add1d6ffca73fb1b4484) | `` prometheus-redis-exporter: 1.65.0 -> 1.66.0 ``                                   |
| [`98301426`](https://github.com/NixOS/nixpkgs/commit/98301426f47fea6e2301ada0a6df1de18575751e) | `` tracexec: 0.5.2 -> 0.8.0 ``                                                      |
| [`e8353e46`](https://github.com/NixOS/nixpkgs/commit/e8353e465fb472b972cbbe70d2ebb250a212491f) | `` forge-sparks: 0.3.0 -> 0.4.0 ``                                                  |
| [`4f8fa5b2`](https://github.com/NixOS/nixpkgs/commit/4f8fa5b2cc25ce6e15a8f0187055e7d5ef90fcab) | `` reposilite: 3.5.18 -> 3.5.19 ``                                                  |
| [`b436bc31`](https://github.com/NixOS/nixpkgs/commit/b436bc31a0cfeb5b09287ae3a218a9b18e7807ff) | `` perlPackages.ModuleScanDeps: 1.34 -> 1.37 ``                                     |
| [`8b1b4b09`](https://github.com/NixOS/nixpkgs/commit/8b1b4b09c781e83de4fe6a53a81285d150e3780d) | `` cloudflare-warp: 2024.9.346 -> 2024.11.309 ``                                    |
| [`1ed4bc56`](https://github.com/NixOS/nixpkgs/commit/1ed4bc56478d51419a92db5d81b30725e0275615) | `` sunvox: Add back wayback machine fallback src ``                                 |
| [`bd45261c`](https://github.com/NixOS/nixpkgs/commit/bd45261c631bf61493a4918e81682d0d52e0abb5) | `` television: 0.5.0 -> 0.5.1 ``                                                    |
| [`b7293cb7`](https://github.com/NixOS/nixpkgs/commit/b7293cb72eaf932d1f7e2eb228abc74b27c73a41) | `` diesel-cli: 2.2.4 -> 2.2.5 ``                                                    |
| [`307e66c8`](https://github.com/NixOS/nixpkgs/commit/307e66c8954759660cc617a4acad9ef1efb5bbc2) | `` coqPackages.fourcolor: 1.3.1 → 1.4.0 ``                                          |
| [`04c50608`](https://github.com/NixOS/nixpkgs/commit/04c506083c4065a23212f0164f1251caa53e14d6) | `` nixos/binfmt: add option `addEmulatedSystemsToNixSandbox` ``                     |
| [`907f8267`](https://github.com/NixOS/nixpkgs/commit/907f826782f05f9076976881be762041bad190a3) | `` kdePackages: Plasma 6.2.3 -> 6.2.4 ``                                            |
| [`daa840d2`](https://github.com/NixOS/nixpkgs/commit/daa840d22b27f2110e99b1493feea5ff52604b57) | `` llama-cpp: 3887 -> 4154 ``                                                       |
| [`18590eed`](https://github.com/NixOS/nixpkgs/commit/18590eedeb0293fba5af33cda1cf376ac7050f62) | `` linuxPackages.nvidiaPackages.production: 550.127.05 -> 550.135 ``                |
| [`39a8e720`](https://github.com/NixOS/nixpkgs/commit/39a8e7207549d5f36124f5fe614f0d0985fb5d8e) | `` gitea: 1.22.3 -> 1.22.4 ``                                                       |
| [`4507801b`](https://github.com/NixOS/nixpkgs/commit/4507801b845aa407d4ea525c8f07fd13f0d3c740) | `` xfce.xfce4-settings: Fix screen locked but lockscreen invisible after suspend `` |
| [`397e5167`](https://github.com/NixOS/nixpkgs/commit/397e5167bd8df73841f3b5c886a693ef7b275b91) | `` ocamlPackages.findlib: 1.9.7 → 1.9.8 ``                                          |
| [`9ef99f0d`](https://github.com/NixOS/nixpkgs/commit/9ef99f0d5832e92cc0e7a1c01c3b5dc7c5f669ec) | `` abracadabra: 2.7.0 -> 2.7.1 ``                                                   |
| [`f22d8a10`](https://github.com/NixOS/nixpkgs/commit/f22d8a108e4993071420433b73592b91f8b39dc9) | `` yggdrasil: 0.5.9 -> 0.5.10 ``                                                    |
| [`13089627`](https://github.com/NixOS/nixpkgs/commit/13089627c58cb73c3faf9a138bcad1d4984c2039) | `` cups-kyocera-3500-4500: reorder source URLs ``                                   |
| [`2c0156fe`](https://github.com/NixOS/nixpkgs/commit/2c0156fe93599450e8bf44505efaaf4528d61ed1) | `` cbmc: 6.0.1 -> 6.4.0 ``                                                          |
| [`cb94f600`](https://github.com/NixOS/nixpkgs/commit/cb94f600feecb160629cd97c8447b9b694c9c104) | `` cbmc: nixfmt ``                                                                  |
| [`d738fdba`](https://github.com/NixOS/nixpkgs/commit/d738fdbadf01e564e29d942f68ad9b07d0d27b4d) | `` manifold: 2.5.1-unstable-2024-11-08 -> 3.0.0 ``                                  |
| [`e426c485`](https://github.com/NixOS/nixpkgs/commit/e426c485742e9c221c870f3a1ab8c77dd8ab462c) | `` tidal-hifi: 5.16.0 -> 5.17.0 ``                                                  |
| [`f359e9af`](https://github.com/NixOS/nixpkgs/commit/f359e9af16ca434153ea6b05880b7ab469071e99) | `` cinny-desktop: fix build failure ``                                              |
| [`b85e22dc`](https://github.com/NixOS/nixpkgs/commit/b85e22dca15e1e5394fdfcb7830de15443e7071d) | `` xpadneo: fix build issues for kernel 6.12 ``                                     |
| [`20a84aef`](https://github.com/NixOS/nixpkgs/commit/20a84aefc477966070615e279445a3b572512ee3) | `` ladybird: 0-unstable-2024-11-06 -> 0-unstable-2024-11-21 ``                      |
| [`2484d9a7`](https://github.com/NixOS/nixpkgs/commit/2484d9a7b155e1a8c2b6e21fcd41980b4414b2df) | `` rmapi: 0.25 -> 0.0.27.1 and switching to a maintained fork (#355090) ``          |
| [`0993fd20`](https://github.com/NixOS/nixpkgs/commit/0993fd202f9d604c3c6275086b1b7c1c7b5be67b) | `` skypeforlinux: 8.132.0.201 -> 8.133.0.202 ``                                     |
| [`46a104a5`](https://github.com/NixOS/nixpkgs/commit/46a104a5874b9e0ab7922b263f125c3755a58f7e) | `` chromium: resolve ref to rev for blink version string ``                         |
| [`681d6c1e`](https://github.com/NixOS/nixpkgs/commit/681d6c1eb861d651abd64da228cb0d609293bef8) | `` firefox-beta-unwrapped: 133.0b1 -> 133.0b9 ``                                    |
| [`bc61211c`](https://github.com/NixOS/nixpkgs/commit/bc61211c613aa9023efb77712fddd7ac0f61f4f9) | `` flutter: revert remove usages of aliases {build,host,target}Platform ``          |
| [`f9471154`](https://github.com/NixOS/nixpkgs/commit/f947115454160a60fcf0ce0d1b63277c0e45bf97) | `` ocamlPackages.eio: 1.1 → 1.2 ``                                                  |
| [`82ab7feb`](https://github.com/NixOS/nixpkgs/commit/82ab7feba5735d42aa0e89a0f8746091f7f56dc9) | `` boost175: drop ``                                                                |
| [`60ae5024`](https://github.com/NixOS/nixpkgs/commit/60ae502470bb252e212b320dd938c69efe400e72) | `` libbitcoin{,-client,-explorer,-network,-protocol}: drop ``                       |
| [`9eab322f`](https://github.com/NixOS/nixpkgs/commit/9eab322f639422a6d95ba78c96ce6114b92fefae) | `` nvc: 1.14.1 -> 1.14.2 ``                                                         |
| [`d0874fdd`](https://github.com/NixOS/nixpkgs/commit/d0874fdd1a9eef6539f090fb9f1e7e630e6a3bc3) | `` nvc: reformat ``                                                                 |
| [`9d7bceb7`](https://github.com/NixOS/nixpkgs/commit/9d7bceb7bed84912fe371b44efab601a06bfb851) | `` nvc: move to pkgs/by-name ``                                                     |
| [`7f7717e8`](https://github.com/NixOS/nixpkgs/commit/7f7717e820c58a664e29a71c7186f63121a314ea) | `` wordpress: 6.7 -> 6.7.1 ``                                                       |
| [`70a44f40`](https://github.com/NixOS/nixpkgs/commit/70a44f40ac53e0ba9486ad9d2a49a29dfee429c6) | `` rippled{,-validator-keys-tool}: drop ``                                          |
| [`f1df7f88`](https://github.com/NixOS/nixpkgs/commit/f1df7f88e3c3396f17cc811fabc6889c5ff51f76) | `` sumokoin: drop ``                                                                |
| [`b7a98a07`](https://github.com/NixOS/nixpkgs/commit/b7a98a07f88d90c664efd6d114da4a6fcc5e1611) | `` python312Packages.pinocchio: Disable test that fails on darwin ``                |
| [`7e95760b`](https://github.com/NixOS/nixpkgs/commit/7e95760be02a04db4f8ae995e1513ded2d10d338) | `` ossia-score: 3.2.4 -> 3.3.2 ``                                                   |
| [`7388f023`](https://github.com/NixOS/nixpkgs/commit/7388f02319f9a5bd0f2ce26d0850b4086070d766) | `` nixos/manticore: fix mkKeyValueDefault ``                                        |
| [`8e16fb43`](https://github.com/NixOS/nixpkgs/commit/8e16fb43443fc8e09de915e78b0a430e30ac6af1) | `` cups-kyocera-3500-4500: fix broken download URL ``                               |
| [`08f43bdf`](https://github.com/NixOS/nixpkgs/commit/08f43bdfbfa7e2eb373d1fc4d8e4e53016271cfe) | `` python3Packages.pyside2-tools: fix ``                                            |
| [`65589eea`](https://github.com/NixOS/nixpkgs/commit/65589eea8994dc9d8ea2b03d7161990b53adf402) | `` dotnet-{sdk,runtime,aspnetcore}_{6,7}: mark as EOL ``                            |
| [`79ff9e77`](https://github.com/NixOS/nixpkgs/commit/79ff9e77efc1ebd990245d616ecfb891c0fe641d) | `` certdump: mark broken on aarch64-darwin ``                                       |
| [`79663126`](https://github.com/NixOS/nixpkgs/commit/79663126a236ac49f63877625338ed8bb0e0b980) | `` dotnet: fetch hash from nuget.org in update.sh ``                                |
| [`c507a353`](https://github.com/NixOS/nixpkgs/commit/c507a3536d37e92da33ae4e953c31bdd883ca323) | `` dotnetCorePackages.dotnet_9: 9.0.0-rc.2 -> 9.0.0 ``                              |
| [`fe4964ef`](https://github.com/NixOS/nixpkgs/commit/fe4964efe53535af88945a4e9e044d99e832b1d1) | `` dotnetCorePackages.dotnet_8.vmr: 8.0.10 -> 8.0.11 ``                             |
| [`6839684b`](https://github.com/NixOS/nixpkgs/commit/6839684ba4feb159bc9cf15daf16e3b409ba537a) | `` dotnetCorePackages.sdk_9_0: 9.0.100-rc.2.24474.11 -> 9.0.100 ``                  |
| [`1bbc2058`](https://github.com/NixOS/nixpkgs/commit/1bbc2058d765143f00a44040212320e924e37a28) | `` dotnet-sdk_6: 6.0.427 -> 6.0.428 ``                                              |
| [`ae1d013c`](https://github.com/NixOS/nixpkgs/commit/ae1d013c1ec5a80d16bf4f071cc3250a12b7e32a) | `` dotnet-sdk: 8.0.403 -> 8.0.404 ``                                                |
| [`0a3cb330`](https://github.com/NixOS/nixpkgs/commit/0a3cb330f8e3aa35a7c10a42d9c918b5ab0741f9) | `` godot_4-mono: fix nuget dependencies ``                                          |
| [`ae68bd1f`](https://github.com/NixOS/nixpkgs/commit/ae68bd1f4e81f11b988d93aaf20c38e0fea5f9df) | `` maintainers/scripts/update: add dependencies to nativeBuildInputs ``             |
| [`64c24273`](https://github.com/NixOS/nixpkgs/commit/64c242730612fef315f4c1712dec93a64bebcee8) | `` maintainers/scripts/update-dotnet-lockfiles.nix: use update.nix ``               |
| [`a54b1119`](https://github.com/NixOS/nixpkgs/commit/a54b1119d9b95f99425e2f8d443b0f591b97e20a) | `` maintainers/scripts/update: disable aliases ``                                   |
| [`d0fb0200`](https://github.com/NixOS/nixpkgs/commit/d0fb02003aceed1d182c6cabe49e63fce070f1ad) | `` dotnet-sdk/runtime/aspnetcore: 6.0 -> 8.0 ``                                     |
| [`84d42e92`](https://github.com/NixOS/nixpkgs/commit/84d42e9280f7cca6a9692aebecb250cc3cf2d938) | `` dotnet: add passthru.runtime/aspnetcore to sdk packages ``                       |
| [`a86d0a97`](https://github.com/NixOS/nixpkgs/commit/a86d0a97b6aa20e8cd43323a3be49acb4e4d29a8) | `` boogie: format with nixfmt ``                                                    |
| [`2eca911d`](https://github.com/NixOS/nixpkgs/commit/2eca911d7100e67bc6e5a3f5e8830fb5cae1d356) | `` buildDotnetModule: allow selfContainedBuild property to be omitted with null ``  |
| [`29708947`](https://github.com/NixOS/nixpkgs/commit/29708947b1fb329b9da0bef47e03b2c8871876f1) | `` avalonia: remove unnecessary use of sdk_7_0 ``                                   |
| [`7fea2bde`](https://github.com/NixOS/nixpkgs/commit/7fea2bdeae2f4dc2fb13a52c6e1399ae8b260350) | `` netcoredbg: explicitly disable dotnet-runtime ``                                 |
| [`fc393baf`](https://github.com/NixOS/nixpkgs/commit/fc393bafdd8e95a542947d7038dc636259e2babc) | `` buildDotnetModule: respect self-contained setting in restore ``                  |
| [`4b3f9d76`](https://github.com/NixOS/nixpkgs/commit/4b3f9d764ba1dff9c899a8bdffe40915d18686bf) | `` buildDotnetModule: make dotnet-runtime optional ``                               |
| [`3d250dc9`](https://github.com/NixOS/nixpkgs/commit/3d250dc979653175ce342f2fc8a0c24c5e6998f5) | `` dotnet/update.sh: nix-hash -> nix hash convert ``                                |
| [`c5b49e35`](https://github.com/NixOS/nixpkgs/commit/c5b49e35978b10c12bc2b6825d823897b0e1d38f) | `` csharp-ls: fix updateScript ``                                                   |
| [`e9921389`](https://github.com/NixOS/nixpkgs/commit/e99213898e0b15bb7bf703e6e5ae00094eb3d1af) | `` dotnet: fix missing targetPackages in source-built sdk packages ``               |
| [`a806e40c`](https://github.com/NixOS/nixpkgs/commit/a806e40c867f41e173fb915743e217df0479111a) | `` dotnet: run postFixup based on hostPlatform ``                                   |
| [`28b89dbc`](https://github.com/NixOS/nixpkgs/commit/28b89dbc6c6511c60a70f9c86cbb52a7638511fd) | `` dotnet: install man pages for source-built sdk ``                                |
| [`0baba701`](https://github.com/NixOS/nixpkgs/commit/0baba70113bc1b834f5a27d66a265c8286d86540) | `` dotnet: move dotnet_root to $out/share/dotnet ``                                 |
| [`987ece3e`](https://github.com/NixOS/nixpkgs/commit/987ece3e2b2bad65e24a56729b40ee57bed1fb05) | `` dotnet: split setup hooks into wrapper for runtime/sdk ``                        |
| [`7f19c836`](https://github.com/NixOS/nixpkgs/commit/7f19c836429569e8bfed171349264a6f7719c85c) | `` dotnet: use stdenvNoCC for runtime/sdk ``                                        |
| [`2aa27651`](https://github.com/NixOS/nixpkgs/commit/2aa2765136e5d18f365fdff5c5a86f7098aa63ba) | `` fsautocomplete: add version test ``                                              |
| [`b3c67083`](https://github.com/NixOS/nixpkgs/commit/b3c670835a67ba06086fd0de7fa6d17b4610010f) | `` fsautocomplete: format with nixfmt ``                                            |
| [`134b3796`](https://github.com/NixOS/nixpkgs/commit/134b3796f923c8a533bcb310d0fd485c6c888608) | `` openutau: bump dotnet version 7 -> 8 ``                                          |
| [`d4bf0c4a`](https://github.com/NixOS/nixpkgs/commit/d4bf0c4a1304e7ad7709deafa4de3c780822fa15) | `` factorio: fix `updateScript` definition ``                                       |
| [`d1ae6774`](https://github.com/NixOS/nixpkgs/commit/d1ae6774ca87f07b5e078f2b5f4878cf06d63b45) | `` python312Packages.radicale-infcloud: modernize ``                                |
| [`47785a4b`](https://github.com/NixOS/nixpkgs/commit/47785a4bce32c3db88a1b6a7ea39e682eb9481cd) | `` radicale: format with nixfmt-rfc-style ``                                        |
| [`ceb4fe2f`](https://github.com/NixOS/nixpkgs/commit/ceb4fe2f20efc5294a83a5242d9456f9891d3589) | `` radicale: 3.3.0 -> 3.3.1 ``                                                      |
| [`775ed0c3`](https://github.com/NixOS/nixpkgs/commit/775ed0c3700f145654eb12fa31fa9ab9b7df6f9b) | `` fcitx5-mozc: quickfix build ``                                                   |
| [`8625e368`](https://github.com/NixOS/nixpkgs/commit/8625e368f0e9118290b2e743d8c48e92232eece7) | `` epson-escpr2: 1.2.20 -> 1.2.21 ``                                                |
| [`1bae0b56`](https://github.com/NixOS/nixpkgs/commit/1bae0b56e5cecdc8d6641e60c3377b33261c61ad) | `` vivaldi: 7.0.3495.6 -> 7.0.3495.18 ``                                            |
| [`4f93cb29`](https://github.com/NixOS/nixpkgs/commit/4f93cb29a0e7cde1dc7332e87526eb83af44a5b7) | `` Revert "singularity-tools: don't preserve store content ownership" ``            |
| [`df0d5f97`](https://github.com/NixOS/nixpkgs/commit/df0d5f97044244e6d1861b8229bcbcf7f6ba4f19) | `` flyctl: 0.3.37 -> 0.3.40 ``                                                      |
| [`99a30fea`](https://github.com/NixOS/nixpkgs/commit/99a30fea338c6cf544ef1297f8b72e63fbebaefa) | `` notmuch-mailmover: 0.4.0 -> 0.5.0 ``                                             |
| [`79046bb4`](https://github.com/NixOS/nixpkgs/commit/79046bb48d306a0656a0935e01ba4ff02d2dacb8) | `` ncmpc: fails on darwin ``                                                        |
| [`dca22514`](https://github.com/NixOS/nixpkgs/commit/dca2251489bcd82bb3519292feae7bc4bb710c68) | `` ncmpc: build manpage and enable regex ``                                         |
| [`37afec21`](https://github.com/NixOS/nixpkgs/commit/37afec21601e1c500ceed17580a5aa76b4df456c) | `` ncmpc: reformat with nixfmt-rfc-style ``                                         |
| [`ed59324f`](https://github.com/NixOS/nixpkgs/commit/ed59324fad14b7496a9dce1ca507fbec47d7169e) | `` ncmpc: 0.49 -> 0.51 ``                                                           |
| [`76879e26`](https://github.com/NixOS/nixpkgs/commit/76879e26eb2b522d1c673fb205fcf2577e76fafb) | `` lunatask: 2.0.12 -> 2.0.13 ``                                                    |
| [`45a26102`](https://github.com/NixOS/nixpkgs/commit/45a26102a04103a601388e466dcd974eeea2019a) | `` librewolf: 132.0.1-1 -> 132.0.2-1 ``                                             |
| [`d7b9bc51`](https://github.com/NixOS/nixpkgs/commit/d7b9bc51c07f7ddfd600af46c0c076959eb6757f) | `` librewolf: 132.0.1 -> 132.0.1-1 ``                                               |
| [`7b1d1b00`](https://github.com/NixOS/nixpkgs/commit/7b1d1b00e49a40a6ce91357b4c05667194377b90) | `` maintainers: add dwrege ``                                                       |
| [`332d86c3`](https://github.com/NixOS/nixpkgs/commit/332d86c328470d843bb180fe1afe585617c7ed6d) | `` doc: notice freecad customization an changelog ``                                |
| [`f507f5c6`](https://github.com/NixOS/nixpkgs/commit/f507f5c6a58aa577c42c42f5ddc1582c111c4e34) | `` freecad: add tests for modules ``                                                |
| [`4b61cab4`](https://github.com/NixOS/nixpkgs/commit/4b61cab400d8c4d90479d42edb34036a22d71704) | `` freecad: make customizable ``                                                    |
| [`d91b5cc8`](https://github.com/NixOS/nixpkgs/commit/d91b5cc8b0dbf13eb624c64ef546211fd83a5b73) | `` freecad: take in account module-path argument ``                                 |
| [`92cdd8fc`](https://github.com/NixOS/nixpkgs/commit/92cdd8fccfb152b03e42de55994f8a4255be6456) | `` lan-mouse: 0.9.1 → 0.10.0 ``                                                     |
| [`8c4d6f13`](https://github.com/NixOS/nixpkgs/commit/8c4d6f13e5295060c649c91691f25df87c45f9ea) | `` lan-mouse: reformat ``                                                           |