### PR TITLE
chore(flake/stylix): `7689e621` -> `d13ffb38`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -491,11 +491,11 @@
         "tinted-tmux": "tinted-tmux"
       },
       "locked": {
-        "lastModified": 1732608183,
-        "narHash": "sha256-T5k5ill+PNIEW6KuS4CpUacMtZNJe2J2q5eBOF4xWuU=",
+        "lastModified": 1732993760,
+        "narHash": "sha256-t1J6wgzGjvvGNfdd0ei8HnZf9sTw+SpvCNAX0i6Qgwc=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "7689e621f87bce7b6ab1925dfd70ad1f4c80f334",
+        "rev": "d13ffb381c83b6139b9d67feff7addf18f8408fe",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                        | Message                                                         |
| --------------------------------------------------------------------------------------------- | --------------------------------------------------------------- |
| [`d13ffb38`](https://github.com/danth/stylix/commit/d13ffb381c83b6139b9d67feff7addf18f8408fe) | `` vim: add target attribute to prevent build failure (#652) `` |
| [`5f912cec`](https://github.com/danth/stylix/commit/5f912cecb4e1c5c794316c4b79b9b5d57d43e100) | `` river: init (#651) ``                                        |
| [`f3c2f5a1`](https://github.com/danth/stylix/commit/f3c2f5a1796cbba1e1685270cf0f5a66f118ea96) | `` stylix: set GTK icon theme (#603) ``                         |