### PR TITLE
chore(flake/nixpkgs): `4633a7c7` -> `970e93b9`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -390,11 +390,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1732521221,
-        "narHash": "sha256-2ThgXBUXAE1oFsVATK1ZX9IjPcS4nKFOAjhPNKuiMn0=",
+        "lastModified": 1732837521,
+        "narHash": "sha256-jNRNr49UiuIwaarqijgdTR2qLPifxsVhlJrKzQ8XUIE=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "4633a7c72337ea8fd23a4f2ba3972865e3ec685d",
+        "rev": "970e93b9f82e2a0f3675757eb0bfc73297cc6370",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                           |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------- |
| [`970e93b9`](https://github.com/NixOS/nixpkgs/commit/970e93b9f82e2a0f3675757eb0bfc73297cc6370) | `` terraform-providers.doppler: 1.11.0 -> 1.12.0 ``                                               |
| [`f8b32a49`](https://github.com/NixOS/nixpkgs/commit/f8b32a49213a9ccc1c1a38379aa071c532f1e29c) | `` terraform-providers.yandex: 0.130.0 -> 0.133.0 ``                                              |
| [`199ab2b3`](https://github.com/NixOS/nixpkgs/commit/199ab2b32194fd3995ae34223bcac0f8d02f2db6) | `` terraform-providers.mongodbatlas: 1.21.1 -> 1.22.0 ``                                          |
| [`d5845527`](https://github.com/NixOS/nixpkgs/commit/d5845527960ef61b02b25d3596f6d4ea1a6dbd6a) | `` diffstat: add a trivial updater ``                                                             |
| [`5706049c`](https://github.com/NixOS/nixpkgs/commit/5706049cf6a0beb57326b1c6d5914ee3372da552) | `` diffstat: 1.66 -> 1.67 ``                                                                      |
| [`bfe7bb41`](https://github.com/NixOS/nixpkgs/commit/bfe7bb410f3cad92dd291ba3a97831f7aa04972e) | `` nixos/printing: fix ShellCheck issues ``                                                       |
| [`3c02da21`](https://github.com/NixOS/nixpkgs/commit/3c02da2176bc41d67d75fb804465ee42e3ed1287) | `` n98-magerun2: 7.4.0 -> 7.5.0 ``                                                                |
| [`115b31f2`](https://github.com/NixOS/nixpkgs/commit/115b31f2a3631a1cd63c76b9a83574c0d8be9d24) | `` php81Packages.phpstan: 1.11.8 -> 2.0.2 ``                                                      |
| [`edd47f7c`](https://github.com/NixOS/nixpkgs/commit/edd47f7c850c41445313fec14a9959c728fceb8e) | `` nixfmt-rfc-style: 2024-08-16 -> 2024-11-26 (#359904) ``                                        |
| [`47048ebe`](https://github.com/NixOS/nixpkgs/commit/47048ebe1e895f1ba08127a0275456aa153bdcdb) | `` vscode-extensions.visualjj.visualjj: 0.12.5 -> 0.13.0 ``                                       |
| [`ae933cb7`](https://github.com/NixOS/nixpkgs/commit/ae933cb7df57095a299187f6d17486097af74813) | `` vscode-extensions.github.copilot: 1.243.1191 -> 1.246.1233 ``                                  |
| [`acd9b02b`](https://github.com/NixOS/nixpkgs/commit/acd9b02b6dccd71313ff1accbb03994df98cb7d9) | `` webkitgtk_6_0: 2.46.3 → 2.46.4 ``                                                              |
| [`99d776a6`](https://github.com/NixOS/nixpkgs/commit/99d776a64ce3cd3c4a2a058cd72eb97dd5e5781d) | `` phpactor: 2024.11.05.0 -> 2024.11.28.0 ``                                                      |
| [`265b3aa4`](https://github.com/NixOS/nixpkgs/commit/265b3aa46a81596ec8dac3c3574893c6605863e2) | `` php81Packages.grumphp: 2.6.0 -> 2.9.0 ``                                                       |
| [`f34a7855`](https://github.com/NixOS/nixpkgs/commit/f34a78551414deb7a8260f3660ae7142c4aab3dd) | `` croc: 10.1.0 -> 10.1.1 ``                                                                      |
| [`7b404c8a`](https://github.com/NixOS/nixpkgs/commit/7b404c8aee95b17a7ebc436b0d0122de0af1e4a4) | `` open-webui: add `env.NODE_OPTIONS` ``                                                          |
| [`9bdf42fe`](https://github.com/NixOS/nixpkgs/commit/9bdf42fec35dfc757fe700cb28c68c7a56f228c1) | `` taler-exchange,taler-merchant: fix description ``                                              |
| [`9884d892`](https://github.com/NixOS/nixpkgs/commit/9884d8921a594e5cc10b20b66fa6ec839dec9e08) | `` rclip: 1.10.3 -> 1.11.0 ``                                                                     |
| [`e79c1007`](https://github.com/NixOS/nixpkgs/commit/e79c1007de55aae226eb50d22f3597d78887604e) | `` rclip: format ``                                                                               |
| [`4b27a143`](https://github.com/NixOS/nixpkgs/commit/4b27a143520b654e484d73056ee327c3f060e48b) | `` python312Packages.rawpy: init at 0.23.2 ``                                                     |
| [`7fa0fa45`](https://github.com/NixOS/nixpkgs/commit/7fa0fa45a8843743ceeec96b6c9230ccda13626b) | `` buildkite-agent: 3.87.0 -> 3.87.1 (#359617) ``                                                 |
| [`6822ad5d`](https://github.com/NixOS/nixpkgs/commit/6822ad5dba254b1cb965f4b67dc3059df7ef9569) | `` sequoia-sq: 0.39.0 -> 0.40.0 ``                                                                |
| [`595e00cb`](https://github.com/NixOS/nixpkgs/commit/595e00cbcac55249c2f27998472210b71c129227) | `` mpvScripts: handle nested attrsets (#359625) ``                                                |
| [`6f7f4883`](https://github.com/NixOS/nixpkgs/commit/6f7f48833e8e256fa5f2d26faa44a93abd88508a) | `` terraform-providers.pagerduty: 3.16.0 -> 3.18.1 ``                                             |
| [`b22393b7`](https://github.com/NixOS/nixpkgs/commit/b22393b73f76f9341fddeae675f538f00acfe12c) | `` python312Packages.qcodes: 0.50.0 -> 0.50.1 ``                                                  |
| [`aef7105b`](https://github.com/NixOS/nixpkgs/commit/aef7105b3dda48a445f639cda7e261d2ce97f362) | `` jwt-cli: 6.1.1 -> 6.2.0 ``                                                                     |
| [`92285378`](https://github.com/NixOS/nixpkgs/commit/922853783af475ca7ae8d2352a9573d5940fb4cd) | `` python312Packages.cleanlab: disabled failing test on python 3.12 ``                            |
| [`d3021e55`](https://github.com/NixOS/nixpkgs/commit/d3021e5509bdd7a6969b4f9928cc6aa5858540f1) | `` python312Packagesfastnlo-toolkit: fix build ``                                                 |
| [`17399d38`](https://github.com/NixOS/nixpkgs/commit/17399d3824abc5b64e9a3af22784a8cf55cba507) | `` fastnlo-toolkit: nixfmt ``                                                                     |
| [`c417f415`](https://github.com/NixOS/nixpkgs/commit/c417f4153b4d1e6ef6de2998dab6816b0c1c6fb4) | `` mycelium: 0.5.6 -> 0.5.7 ``                                                                    |
| [`03454a0c`](https://github.com/NixOS/nixpkgs/commit/03454a0cac7a3606ae2f327f20328a7d785e1be7) | `` python312Packages.coinmetrics-api-client: 2024.10.31.17 -> 2024.11.21.20 ``                    |
| [`a4dd838b`](https://github.com/NixOS/nixpkgs/commit/a4dd838b660170591c6a4c415a326e3f4456b8bb) | `` terraform-providers.alicloud: 1.231.0 -> 1.235.0 ``                                            |
| [`aa8b4401`](https://github.com/NixOS/nixpkgs/commit/aa8b44010845cecf81dd43f7a35b2179e7e57603) | `` python312Packages.aiorwlock: 1.4.0 -> 1.5.0 ``                                                 |
| [`ae281b2c`](https://github.com/NixOS/nixpkgs/commit/ae281b2cbafad5c1db36b68a62c006a9b0f42885) | `` python3Packages.python-pptx: 0.6.23 -> 1.0.2 ``                                                |
| [`d4265a89`](https://github.com/NixOS/nixpkgs/commit/d4265a89973f62efcd30f3c45b9a143224f8fd92) | `` python312Packages.aiolifx-themes: 0.5.6 -> 0.5.7 ``                                            |
| [`14d8890f`](https://github.com/NixOS/nixpkgs/commit/14d8890fb9edffcfe0aaa296ffc44547c7be04ab) | `` coqPackages.ssprove: 0.2.1 → 0.2.2 ``                                                          |
| [`a944e46c`](https://github.com/NixOS/nixpkgs/commit/a944e46c81d59aaed8fe53a3c683aa0863f23e4d) | `` outline: 0.81.0 -> 0.81.1 ``                                                                   |
| [`e1e6f5ac`](https://github.com/NixOS/nixpkgs/commit/e1e6f5acd33b387c4ff2d7ef7b8033e28ef55e28) | `` python312Packages.tencentcloud-sdk-python: 3.0.1272 -> 3.0.1273 ``                             |
| [`cf4e92a0`](https://github.com/NixOS/nixpkgs/commit/cf4e92a0109075006051264d47faf5827a3ff9b9) | `` python312Packages.mypy-boto3-fsx: 1.35.27 -> 1.35.71 ``                                        |
| [`2310dcb7`](https://github.com/NixOS/nixpkgs/commit/2310dcb750f73c9056b082788a5d0f3534ab27d6) | `` python312Packages.mypy-boto3-ec2: 1.35.67 -> 1.35.70 ``                                        |
| [`1a986185`](https://github.com/NixOS/nixpkgs/commit/1a98618560bf8709cdcffce4d769bb2cec753e49) | `` python312Packages.mypy-boto3-connect: 1.35.68 -> 1.35.70 ``                                    |
| [`c9fba96d`](https://github.com/NixOS/nixpkgs/commit/c9fba96dba465aa514e0c8fdb2119271db59f6bb) | `` python312Packages.mypy-boto3-config: 1.35.0 -> 1.35.71 ``                                      |
| [`a19d9041`](https://github.com/NixOS/nixpkgs/commit/a19d9041fd532ffd6e34cbb2330f06ccc428f9dd) | `` python312Packages.meshtastic: 2.5.4 -> 2.5.5 ``                                                |
| [`e820bbfd`](https://github.com/NixOS/nixpkgs/commit/e820bbfd879d7ec0a2929c46a1af23aa5ab1cc14) | `` python312Packages.stable-baselines3: 2.3.2-unstable-2024-11-04 -> 2.4.0 ``                     |
| [`79d58249`](https://github.com/NixOS/nixpkgs/commit/79d58249978f11feceec0896888fc59ffa2ac73c) | `` python312Packages.findimports: 2.5.1 -> 2.5.2 ``                                               |
| [`8e642985`](https://github.com/NixOS/nixpkgs/commit/8e6429857088a66ba59f7ca270791a49bac5b887) | `` python312Packages.elmax-api: 0.0.6.1 -> 0.0.6.2 ``                                             |
| [`8142620c`](https://github.com/NixOS/nixpkgs/commit/8142620c3719d62a6a442704b3a0220e8f7dabc9) | `` python312Packages.cyclopts: 3.1.0 -> 3.1.1 ``                                                  |
| [`89ff8b6b`](https://github.com/NixOS/nixpkgs/commit/89ff8b6b8d8f4ca5933c5aeaa254429f9ab34a6e) | `` python312Packages.aiortm: 0.9.32 -> 0.9.36 ``                                                  |
| [`62f028f4`](https://github.com/NixOS/nixpkgs/commit/62f028f40932364e86f876413cb2a718ad963ea6) | `` python312Packages.aioopenexchangerates: 0.6.13 -> 0.6.16 ``                                    |
| [`5020a1c8`](https://github.com/NixOS/nixpkgs/commit/5020a1c82a3879e6056bcedab64878226869dc62) | `` ocaml: don't add `bin-utils` for darwin ``                                                     |
| [`668d72c4`](https://github.com/NixOS/nixpkgs/commit/668d72c474b12cbe35fb7f875145b832e59e6115) | `` add python-updates to dev branches ``                                                          |
| [`f1745cb7`](https://github.com/NixOS/nixpkgs/commit/f1745cb78fecd70e6f7add3e61e581fc66378acc) | `` fh: 0.1.18 -> 0.1.19 ``                                                                        |
| [`e22a7656`](https://github.com/NixOS/nixpkgs/commit/e22a76560587846f1b45eaabd3ce1ceab1762b0b) | `` scheherazade-new: 4.000 → 4.300 ``                                                             |
| [`bdf12d1a`](https://github.com/NixOS/nixpkgs/commit/bdf12d1a06827bbd421858ddcd0613e693b5afaa) | `` vimPlugins.blink-cmp: 0.5.1. -> 0.6.2 ``                                                       |
| [`c78d3b84`](https://github.com/NixOS/nixpkgs/commit/c78d3b84652b24b0094becef1b0f3aae4edd2553) | `` coqPackages.Ordinal: init at 0.5.3 ``                                                          |
| [`bbe77e1e`](https://github.com/NixOS/nixpkgs/commit/bbe77e1e879ebf7657c9583c628fd43ac2f21bf9) | `` maintainers: add damhiya ``                                                                    |
| [`2685312b`](https://github.com/NixOS/nixpkgs/commit/2685312ba9cd7c7420e035543aea2c16a0dbcfd3) | `` bacon: 3.2.0 -> 3.3.0 ``                                                                       |
| [`b386cae5`](https://github.com/NixOS/nixpkgs/commit/b386cae5bad3d6d0ae3f15fc01cd26bc483d213d) | `` calcure: 3.0.2 -> 3.1 ``                                                                       |
| [`c49e0247`](https://github.com/NixOS/nixpkgs/commit/c49e02474547ac749080278a83ff4fac656ee2f6) | `` em100: Build and include makedpfw tool ``                                                      |
| [`7fbad767`](https://github.com/NixOS/nixpkgs/commit/7fbad767dfe1e4ccccf44a61a5054b16c980b89d) | `` python3Packages.django-apscheduler: init at 0.7.0 ``                                           |
| [`053ae2cf`](https://github.com/NixOS/nixpkgs/commit/053ae2cfff10077edf6f1223b445c3115fdaff6b) | `` sqlitestudio: 3.4.5 -> 3.4.6 ``                                                                |
| [`eba5e18f`](https://github.com/NixOS/nixpkgs/commit/eba5e18f5eada3d9318db90c05760a1a836ad8fd) | `` dissent: 0.0.30 -> 0.0.31 ``                                                                   |
| [`47866d72`](https://github.com/NixOS/nixpkgs/commit/47866d72ca0236feee53a96c19f8f79563eb4033) | `` php84Extensions.mongodb: 1.20.0 -> 1.20.1 ``                                                   |
| [`47e05fad`](https://github.com/NixOS/nixpkgs/commit/47e05fadce428f2f8a7de7ad086d36d710712a66) | `` aider-chat: 0.62.0 -> 0.65.0 ``                                                                |
| [`faf19837`](https://github.com/NixOS/nixpkgs/commit/faf198371acaab479d8e6f70b875b2f1ce940792) | `` python312Packages.litellm: 1.51.2 -> 1.52.16 ``                                                |
| [`b3756fbf`](https://github.com/NixOS/nixpkgs/commit/b3756fbfe1e4a3e16f0106575f7c87197003fefd) | `` castxml: 0.6.8 -> 0.6.10 ``                                                                    |
| [`95357bc9`](https://github.com/NixOS/nixpkgs/commit/95357bc93690450f0ba2e44fd8bdd17e37360c77) | `` cascadia-code: 2404.23 -> 2407.24 ``                                                           |
| [`142f3a52`](https://github.com/NixOS/nixpkgs/commit/142f3a52bc423ed4a8552b685a8bb86e3581807e) | `` gf: unstable-2023-08-09 -> 0-unstable-2024-08-21; include extensions and add plugin support `` |
| [`ffa0b587`](https://github.com/NixOS/nixpkgs/commit/ffa0b587db5112282a682abd912ec77bea060de5) | `` terraform-providers.tencentcloud: 1.81.133 -> 1.81.142 ``                                      |
| [`ab94a427`](https://github.com/NixOS/nixpkgs/commit/ab94a427287764185208db789d7005d8f3912565) | `` wdt: 1.27.1612021-unstable-2024-08-22 -> 1.27.1612021-unstable-2024-11-14 ``                   |
| [`2861fbe5`](https://github.com/NixOS/nixpkgs/commit/2861fbe572497784934999dde2a07ac5a57a4e02) | `` basedpyright: 1.21.1 -> 1.22.0 ``                                                              |
| [`24108765`](https://github.com/NixOS/nixpkgs/commit/241087650ac6022e8503890857116737515a2a6c) | `` docker-credential-gcr: 2.1.25 -> 2.1.26 ``                                                     |
| [`e58e1161`](https://github.com/NixOS/nixpkgs/commit/e58e1161de26151338265b3830f83c157a05b011) | `` discrete-scroll: 0.1.1 -> 1.2.1 ``                                                             |
| [`ad50df33`](https://github.com/NixOS/nixpkgs/commit/ad50df3384809cc6d733542cb4df649ff1d2d627) | `` discrete-scroll: refactor ``                                                                   |
| [`6bb8101a`](https://github.com/NixOS/nixpkgs/commit/6bb8101aaf2ba17bfd419e6390ba8a270980435e) | `` soundconverter: 4.0.5 -> 4.0.6 ``                                                              |
| [`64d681ac`](https://github.com/NixOS/nixpkgs/commit/64d681ac931f182518b09909a217bca527ff9a71) | `` gh: 2.62.0 -> 2.63.0 ``                                                                        |
| [`51503b1c`](https://github.com/NixOS/nixpkgs/commit/51503b1c36b861b343354093eb8812950a08b990) | `` renode-dts2repl: 0-unstable-2024-10-09 -> 0-unstable-2024-11-27 ``                             |
| [`54313579`](https://github.com/NixOS/nixpkgs/commit/54313579bb0f5b6b5f3657ee776479d2229a03f0) | `` protobuf: format ``                                                                            |
| [`07fc04c4`](https://github.com/NixOS/nixpkgs/commit/07fc04c4595cc4391274d9a5fd3c013dc4db65bb) | `` terraform: 1.9.8 -> 1.10.0 ``                                                                  |
| [`817e1ed8`](https://github.com/NixOS/nixpkgs/commit/817e1ed8f409c53fd08e173b8a5027d1fcbde598) | `` terraform-providers.minio: 2.5.1 -> 3.2.1 ``                                                   |
| [`3b074e28`](https://github.com/NixOS/nixpkgs/commit/3b074e283e3465b050d44ba2a04fd5dbde151cf1) | `` terraform-providers.tfe: 0.59.0 -> 0.60.1 ``                                                   |
| [`9ea0de63`](https://github.com/NixOS/nixpkgs/commit/9ea0de6394c7b7d616b55f369ab19c63fce45894) | `` protobuf_29: init at 29.0 ``                                                                   |
| [`cc114432`](https://github.com/NixOS/nixpkgs/commit/cc114432567f90ffe149430047b7425f5855fa4b) | `` factorio-mods: drop ``                                                                         |
| [`10eb3ebd`](https://github.com/NixOS/nixpkgs/commit/10eb3ebd781c70473fd1e0e933b9c8a0a613318c) | `` haskellPackages.unordered-containers: disable hanging tests on 32bit ``                        |
| [`d4b44717`](https://github.com/NixOS/nixpkgs/commit/d4b44717863b0ce49e8171af97a073692f413a16) | `` pandoc-include: 1.4.0 -> 1.4.1 ``                                                              |
| [`bd1f484c`](https://github.com/NixOS/nixpkgs/commit/bd1f484c05055a197371649e9cd7b9bfabf7a956) | `` lomiri.lomiri-url-dispatcher: Fix libexec binary location in services ``                       |
| [`b50564b9`](https://github.com/NixOS/nixpkgs/commit/b50564b9387d507d0d28f9fbd1378e1f4f86e52c) | `` dropbox: add version and pname ``                                                              |
| [`07fb8bb1`](https://github.com/NixOS/nixpkgs/commit/07fb8bb1a6e8c05ee6c8169a80cc167a2e5f74fe) | `` level-zero: 1.18.3 -> 1.19.2 ``                                                                |
| [`e2d3e2e3`](https://github.com/NixOS/nixpkgs/commit/e2d3e2e33ce88f26aa59f68a05a61fd50a3ab10e) | `` jx: 3.10.156 -> 3.11.1 ``                                                                      |
| [`d99f51ac`](https://github.com/NixOS/nixpkgs/commit/d99f51ac601a91cf5fe1497a7bbf871f2169a306) | `` opentofu: patch plugins to use opentofu plugin registry ``                                     |
| [`187ef4d6`](https://github.com/NixOS/nixpkgs/commit/187ef4d65ba3382effedac243256d2fd12d5567e) | `` opentofu: apply nixfmt ``                                                                      |
| [`567a36cf`](https://github.com/NixOS/nixpkgs/commit/567a36cf623e5b66fddaad3481dff72146e0e94d) | `` vimPlugins: cleanup with self ``                                                               |
| [`83ebb5d0`](https://github.com/NixOS/nixpkgs/commit/83ebb5d0316ec0845abfa93af7027a39a92d4d25) | `` vimPlugins: add missing dependencies ``                                                        |
| [`a8ae141e`](https://github.com/NixOS/nixpkgs/commit/a8ae141ee912559c7c0578ee6e9ffbd77abdbd4d) | `` discord-canary: 0.0.527 -> 0.0.528 ``                                                          |
| [`ac08a31d`](https://github.com/NixOS/nixpkgs/commit/ac08a31d7feaffabc06142042df1e5776ea16d78) | `` discord: add `pipewire` to fix screensharing ``                                                |
| [`79e34d35`](https://github.com/NixOS/nixpkgs/commit/79e34d35d6b645990a9c44147aa4ec10d0c434b1) | `` vimPlugins.{spacevim, SpaceVim}: point to top-level `spacevim` instead ``                      |
| [`e93754bc`](https://github.com/NixOS/nixpkgs/commit/e93754bc37d928567e48ab9a2e47b2cd1974cd4a) | `` spacevim: change maintainer ``                                                                 |
| [`507333f4`](https://github.com/NixOS/nixpkgs/commit/507333f48465ef52de7de08ff23fe2a57997f30a) | `` spacevim: update and add general improvements ``                                               |
| [`238f0190`](https://github.com/NixOS/nixpkgs/commit/238f0190ba7e6caa681162e371566cfdd22e2983) | `` python312Packages.aemet-opendata: 0.5.5 -> 0.6.3 ``                                            |
| [`6a579d58`](https://github.com/NixOS/nixpkgs/commit/6a579d58434a094cdd3ce716819430c4662e7a39) | `` plex: 1.41.0.8994-f2c27da23 -> 1.41.2.9200-c6bbc1b53 ``                                        |