### PR TITLE
chore(flake/nixpkgs-stable): `62c435d9` -> `f9f0d5c5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -374,11 +374,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1732981179,
-        "narHash": "sha256-F7thesZPvAMSwjRu0K8uFshTk3ZZSNAsXTIFvXBT+34=",
+        "lastModified": 1733120037,
+        "narHash": "sha256-En+gSoVJ3iQKPDU1FHrR6zIxSLXKjzKY+pnh9tt+Yts=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "62c435d93bf046a5396f3016472e8f7c8e2aed65",
+        "rev": "f9f0d5c5380be0a599b1fb54641fa99af8281539",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                      |
| ---------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------- |
| [`cc8f14f3`](https://github.com/NixOS/nixpkgs/commit/cc8f14f3ead93e55886a68af3e6ea1ff454f76c1) | `` folio: 24.13 -> 24.14 ``                                                                  |
| [`f6879ca8`](https://github.com/NixOS/nixpkgs/commit/f6879ca8abf1da2e5579e91a65500f75aa405af7) | `` webkitgtk_6_0: 2.46.3 → 2.46.4 ``                                                         |
| [`2ef71cdc`](https://github.com/NixOS/nixpkgs/commit/2ef71cdcfa4a6e6eeebf178e2a67d9753bc356e4) | `` nixos/netbird: fix coturn configuration ``                                                |
| [`de88e36b`](https://github.com/NixOS/nixpkgs/commit/de88e36b62905eb5b63b6cb3c91e84b25ed5370c) | `` gitlab-runner: Try fixing #356717 ``                                                      |
| [`70a1330d`](https://github.com/NixOS/nixpkgs/commit/70a1330dc06ed7921e27e8782b422ef4f3282764) | `` virt-manager: 4.1.0 -> 5.0.0 ``                                                           |
| [`8265d51a`](https://github.com/NixOS/nixpkgs/commit/8265d51a3cb3f7c1f242f951ab8a0f3a3e8360d3) | `` ci: fix GHA's rebuild-xxx: 5001+ labels ``                                                |
| [`df4fb1f5`](https://github.com/NixOS/nixpkgs/commit/df4fb1f5c98cb946e0d9d3b638bc42d10a578324) | `` hyprlandPlugins.hyprscroller: 0-unstable-2024-11-09 -> 0-unstable-2024-11-23 ``           |
| [`d94d1a5c`](https://github.com/NixOS/nixpkgs/commit/d94d1a5c2562f0102dd706855356f177b23d84ad) | `` calamares: escape unfree package selection text quote ``                                  |
| [`d8e354a7`](https://github.com/NixOS/nixpkgs/commit/d8e354a78471293652e36cab7e5ecb905d1a92f8) | `` deno: 2.1.1 -> 2.1.2 ``                                                                   |
| [`950d2a9b`](https://github.com/NixOS/nixpkgs/commit/950d2a9b557b577de25e6b14944a6c462bb8ce4a) | `` nixos/hostapd: allow octothorpe characters in SAE password ``                             |
| [`4ddfda63`](https://github.com/NixOS/nixpkgs/commit/4ddfda63838ef96c82705603c7e8014a20d5997b) | `` gh-copilot: add auto-updating ``                                                          |
| [`9c202d8b`](https://github.com/NixOS/nixpkgs/commit/9c202d8bd54885a2e9763401f6aace0d4b7dd2ad) | `` hardinfo2: init at 2.2.4 ``                                                               |
| [`89b0e12f`](https://github.com/NixOS/nixpkgs/commit/89b0e12f3e3326812f09881ee387c5a0bfd26fd2) | `` php84Extensions.vld: 0.18.0 -> 0.18.0-unstable-2024-08-22 ``                              |
| [`c55b2597`](https://github.com/NixOS/nixpkgs/commit/c55b2597885e60b566b69cc3639dde0f02699af5) | `` sudo: 1.9.16 -> 1.9.16p2 ``                                                               |
| [`f9642445`](https://github.com/NixOS/nixpkgs/commit/f9642445474b1087f0d76df6d8e7b5aa071fecac) | `` protonmail-bridge: 3.14.0 -> 3.15.0 ``                                                    |
| [`9fabd0e4`](https://github.com/NixOS/nixpkgs/commit/9fabd0e4ce37212800dd4dd695143d6410e80cdf) | `` jellyfin{,-web}: 10.10.2 → 10.10.3 ``                                                     |
| [`7e1f3186`](https://github.com/NixOS/nixpkgs/commit/7e1f3186e5e16e3cd2776806d9e6d675d29d4e64) | `` jellyfin{,-web}: 10.10.1 → 10.10.2 ``                                                     |
| [`66d76787`](https://github.com/NixOS/nixpkgs/commit/66d76787906ad80a3e2635599f627d48679cc792) | `` haskellPackages.ghcide: apply patch for GHC 9.8.3 compat ``                               |
| [`239d6664`](https://github.com/NixOS/nixpkgs/commit/239d66642598dc1e9e235db8a2fab633a426a658) | `` haskellPackages.haskell-language-server: refactor override ``                             |
| [`50ea2b14`](https://github.com/NixOS/nixpkgs/commit/50ea2b14522e85461e90ddf233d08d7c29861a55) | `` haskell.packages.ghcHEAD: start compiler config for GHC 9.14 ``                           |
| [`6cf09dcc`](https://github.com/NixOS/nixpkgs/commit/6cf09dcce9fc93a0d11c8c455fa9473cf8710af4) | `` haskell.compiler.ghcHEAD: bootstrap using GHC 9.10 ``                                     |
| [`22388692`](https://github.com/NixOS/nixpkgs/commit/223886925458bde6309590a46c4f23d16d8276d9) | `` haskellPackages.unordered-containers: disable hanging tests on 32bit ``                   |
| [`e3f6b854`](https://github.com/NixOS/nixpkgs/commit/e3f6b854a2e04fc69454b475a4f151d923b22902) | `` openssh: add initrd-network-ssh nixos test to passthru.tests ``                           |
| [`59bdd588`](https://github.com/NixOS/nixpkgs/commit/59bdd588033142859e4269716569d76fc3e85f09) | `` haskell.compiler.ghcHEAD: disable --hyperlinked-source on aarch64 ``                      |
| [`8e5d2ec2`](https://github.com/NixOS/nixpkgs/commit/8e5d2ec24ad2289718e644706f7d3577ae69c75e) | `` orca-slicer: remove FLATPAK option ``                                                     |
| [`50d4da47`](https://github.com/NixOS/nixpkgs/commit/50d4da4721cd9abc1bab2611f27475f153ffd020) | `` frog-protocols: don't use pulled commit ``                                                |
| [`4559447f`](https://github.com/NixOS/nixpkgs/commit/4559447fa1805f99edc0de2c628636aff5c94f6b) | `` privatebin: fix description typo ``                                                       |
| [`73ce0446`](https://github.com/NixOS/nixpkgs/commit/73ce0446289b1b91396e0244a05af8bcad971231) | `` texlive.combine: fix requiredTexPackages ``                                               |
| [`f87e3eb7`](https://github.com/NixOS/nixpkgs/commit/f87e3eb79cb830b6be73bed06093886cc2101837) | `` php84Extensions.imagick: fix darwin build ``                                              |
| [`30d95a87`](https://github.com/NixOS/nixpkgs/commit/30d95a87b7b4c90460dbc454aa099dc490e81c31) | `` nixos/firefly-iii-data-importer: Changes to clear cache more consistently upon updates `` |
| [`c6ee9916`](https://github.com/NixOS/nixpkgs/commit/c6ee991659646472212f8f92942db47cdc20c0bf) | `` firefly-iii-data-importer: 1.5.6 -> 1.5.7 ``                                              |
| [`d465dba9`](https://github.com/NixOS/nixpkgs/commit/d465dba95c8ba4d077477bfeaa42fd9fe9723323) | `` nixos/firefly-iii: Changes to clear cache more consistently upon updates ``               |
| [`f7b79369`](https://github.com/NixOS/nixpkgs/commit/f7b79369811dbd3721a8b997c970d65e34319483) | `` firefly-iii: 6.1.21 -> 6.1.24 ``                                                          |
| [`d73d74b3`](https://github.com/NixOS/nixpkgs/commit/d73d74b3eb9c62674275fc7f4ccb4f29c74a9f7c) | `` nixos/java: No bashisms in `environment.shellInit` script ``                              |
| [`b18e6316`](https://github.com/NixOS/nixpkgs/commit/b18e6316988a2a85f8966b44f5f9e5ef9a5ed5f3) | `` pt2-clone: 1.70 -> 1.71 ``                                                                |
| [`0bf4eb2b`](https://github.com/NixOS/nixpkgs/commit/0bf4eb2b653bd760de5be22eb35cb888c685177b) | `` gerrit: Apply nixfmt ``                                                                   |
| [`009bb034`](https://github.com/NixOS/nixpkgs/commit/009bb03444fc44e26b9c976d33dea02fd794edf3) | `` gerrit: 3.10.2 -> 3.10.3 ``                                                               |
| [`c9302bd2`](https://github.com/NixOS/nixpkgs/commit/c9302bd2b9b882684593fe4c065ea1a301e2ba87) | `` php83Packages.phpstan: fix hash ``                                                        |
| [`176ae8f3`](https://github.com/NixOS/nixpkgs/commit/176ae8f347c0bb2e5db86494f23b31748e375126) | `` php83Packages.psalm: fix hash ``                                                          |
| [`f5dedc11`](https://github.com/NixOS/nixpkgs/commit/f5dedc11d16c57b9e868be15e86156e8ca333c1b) | `` vencord: 1.10.7 -> 1.10.8 ``                                                              |
| [`b37aa9a4`](https://github.com/NixOS/nixpkgs/commit/b37aa9a41217d6a1f60c402fd9718dcf3a556ce3) | `` goodvibes: 0.8.0 -> 0.8.1 ``                                                              |
| [`eb31e4e4`](https://github.com/NixOS/nixpkgs/commit/eb31e4e439d3f806e29871198342c6d21b4f3c21) | `` python312Packages.mss: 9.0.2 -> 10.0.0 (#359644) ``                                       |
| [`0b16abf5`](https://github.com/NixOS/nixpkgs/commit/0b16abf55a9b01cb4f3327e3e0bf81d32656e5d9) | `` radicale3: move to aliases ``                                                             |
| [`077d1c6a`](https://github.com/NixOS/nixpkgs/commit/077d1c6ac189c6c472e5113c953920b68ef816c7) | `` radicale2: drop ``                                                                        |
| [`ce19e300`](https://github.com/NixOS/nixpkgs/commit/ce19e30079bfe4e21961cdc7a19f6fb968e5e46c) | `` legcord: 1.0.4 -> 1.0.5 ``                                                                |
| [`00e58b94`](https://github.com/NixOS/nixpkgs/commit/00e58b946559d09d7ca928ce799b5479e2f4f584) | `` gitlab: 17.3.7 -> 17.5.2 ``                                                               |
| [`c717f7aa`](https://github.com/NixOS/nixpkgs/commit/c717f7aa570c2bb0617226a9065b079c93f54d89) | `` git-graph: Add matthiasbeyer as maintainer ``                                             |
| [`64a4e67f`](https://github.com/NixOS/nixpkgs/commit/64a4e67f75501d651c2ca139b63a3fb83dc9c75e) | `` git-graph: unstable-23-01-14 -> 0.6.0 ``                                                  |
| [`9def9189`](https://github.com/NixOS/nixpkgs/commit/9def9189a9ee91d897af5651ee5e5454a431da46) | `` nagstamon: 3.14.0 -> 3.16.2 ``                                                            |
| [`b2c29d18`](https://github.com/NixOS/nixpkgs/commit/b2c29d185a07234c3e670f4e48c2b499ca42b442) | `` nagstamon: format ``                                                                      |
| [`3fccbf07`](https://github.com/NixOS/nixpkgs/commit/3fccbf074c5cca1815a1ec9c294326305f92d034) | `` nagstamon: move to by-name ``                                                             |
| [`745eddbf`](https://github.com/NixOS/nixpkgs/commit/745eddbf3a4a2777ef8a16b65f521631e0c7f3a7) | `` nixos/iso-image: fix `isoImage.grubTheme = null;` ``                                      |
| [`01b8ef02`](https://github.com/NixOS/nixpkgs/commit/01b8ef02ee5036c8efe46ff74f1314ce3e4c9ad3) | `` nginxModules.subsFilter: 2022-01-24 (#359905) ``                                          |
| [`c913753d`](https://github.com/NixOS/nixpkgs/commit/c913753dae951d2a658fb7f0709bdd5e4fed9767) | `` ocamlPackages.sedlex: 3.2 → 3.3 ``                                                        |
| [`6d62db4c`](https://github.com/NixOS/nixpkgs/commit/6d62db4cffa1f623029278dcfe3732d9a0a1532d) | `` fastly: 10.16.0 -> 10.17.0 ``                                                             |
| [`f8a2b02e`](https://github.com/NixOS/nixpkgs/commit/f8a2b02ed2d042b8ab3e327c7081d99e7a955452) | `` nixos/mailman: add option to expand the uwsgi settings ``                                 |
| [`2487dd47`](https://github.com/NixOS/nixpkgs/commit/2487dd479b69ed3fca87b746c1df00a713b39918) | `` linuxPackages.openafs: Patch for Linux kernel 6.12. ``                                    |
| [`4d45bec8`](https://github.com/NixOS/nixpkgs/commit/4d45bec8b836bd924456e35d7f9f6f80dd5b4b6a) | `` python312Packages.soxr: fix build on x86_64-darwin ``                                     |
| [`87cb5bd7`](https://github.com/NixOS/nixpkgs/commit/87cb5bd712012ccc8eff7a4fc28b8ddc506fe669) | `` fire: Move to pkgs/by-name ``                                                             |
| [`6406bb9a`](https://github.com/NixOS/nixpkgs/commit/6406bb9af15a37ae97e7b4c9d3c1fe3dfebf0280) | `` fire: Modernise, nixfmt ``                                                                |
| [`90a076c9`](https://github.com/NixOS/nixpkgs/commit/90a076c9fd7f6744bc54195270c3907a7435a63b) | `` fire: 1.0.0.3 -> 1.0.1-unstable-2024-10-22 ``                                             |
| [`abd7b92c`](https://github.com/NixOS/nixpkgs/commit/abd7b92c5759a83216e76f6c43d791f1ed39df12) | `` dexed: Move to pkgs/by-name ``                                                            |
| [`9abdb0d4`](https://github.com/NixOS/nixpkgs/commit/9abdb0d4b88af61b97fae715ab5a0cd905851515) | `` dexed: Modernise, nixfmt ``                                                               |
| [`ed847efb`](https://github.com/NixOS/nixpkgs/commit/ed847efbf44bc301a3f445ac840470007e83c27c) | `` dexed: unstable-2022-07-09 -> 0.9.8 ``                                                    |
| [`45f0351a`](https://github.com/NixOS/nixpkgs/commit/45f0351a680808d570c8b9523d64a2f7e313f6c0) | `` fuzzel: support building with librsvg backend ``                                          |
| [`633a8be5`](https://github.com/NixOS/nixpkgs/commit/633a8be565a4b507868c901b3db92dc5a6ec45b7) | `` vault-tasks: init at 0.4.0 ``                                                             |
| [`d41eb13d`](https://github.com/NixOS/nixpkgs/commit/d41eb13df920879badd654687d3e8f121d5c6f7f) | `` krop: pin pypdf2 version ``                                                               |
| [`e231cf8d`](https://github.com/NixOS/nixpkgs/commit/e231cf8d48be1279284244f077d7ff330d9c0d28) | `` python312Packages.scikit-survival: 0.23.0 -> 0.23.1 ``                                    |
| [`bdcfd19a`](https://github.com/NixOS/nixpkgs/commit/bdcfd19ab0ad45a61da8f990c3991b495618d24a) | `` python312Packages.scikit-survival: use github src; fix build ``                           |
| [`86c19103`](https://github.com/NixOS/nixpkgs/commit/86c19103ecbb380e2c8c7a0d67141c96dd4b4b28) | `` lock: 1.1.3 -> 1.2.0 ``                                                                   |
| [`bcec3e7a`](https://github.com/NixOS/nixpkgs/commit/bcec3e7a5c8b738e1500b549b7264f04bd23ba83) | `` nixos/lvm: expand enable description to better inform users about their actions ``        |
| [`5bea575b`](https://github.com/NixOS/nixpkgs/commit/5bea575bfa45c0f50aa6939dff9e846f7a41affb) | `` horizon-eda: fix build ``                                                                 |
| [`f839dd46`](https://github.com/NixOS/nixpkgs/commit/f839dd466edd2a4c80f056a96e848b49291c8f41) | `` horizon-eda: nixfmt ``                                                                    |
| [`d40bf1f0`](https://github.com/NixOS/nixpkgs/commit/d40bf1f00bef8c07db4768ed576d14ca8dd075c2) | `` exegol: add charB66 as maintainer ``                                                      |
| [`6e2bf76d`](https://github.com/NixOS/nixpkgs/commit/6e2bf76d6e49199abd0359e1f7e51b1ad17addd5) | `` maintainers: add charB66 ``                                                               |
| [`8518646c`](https://github.com/NixOS/nixpkgs/commit/8518646c3536ade5b1a95309a478d333beeb9988) | `` exegol: 4.3.1 -> 4.3.8 ``                                                                 |
| [`0b569765`](https://github.com/NixOS/nixpkgs/commit/0b569765a22df1679807e08506449c1cd0cc4842) | `` microsoft-edge: 130.0.2849.46 -> 131.0.2903.70 ``                                         |
| [`193899c8`](https://github.com/NixOS/nixpkgs/commit/193899c87e75ffee1079cfa1b7b61b4c8ba7c7af) | `` nixos/wg-access-server: bugfix dns.enabled (yaml) ``                                      |
| [`b97c6132`](https://github.com/NixOS/nixpkgs/commit/b97c6132741726c1347c24eb134a20a7be847e68) | `` jetbrains.clion: fix .NET version for Clion 2024.3 ``                                     |
| [`983ef119`](https://github.com/NixOS/nixpkgs/commit/983ef119e40e037daed0a4c3fc16b202fdb6a7ad) | `` jetbrains.plugins: update ``                                                              |
| [`2f41d76d`](https://github.com/NixOS/nixpkgs/commit/2f41d76d82a540c57e7a218349f05a1b196082ad) | `` jetbrains.clion: 2024.2.3 -> 2024.3 ``                                                    |
| [`baef8a05`](https://github.com/NixOS/nixpkgs/commit/baef8a05f0f55908c96dae242937632439d8fe87) | `` fpc: fix darwin build ``                                                                  |
| [`4e295837`](https://github.com/NixOS/nixpkgs/commit/4e295837cc1325eab2276c1451a5e226f3c2c080) | `` nixos/logrotate: allow change mode of a file ``                                           |
| [`8ebae5d0`](https://github.com/NixOS/nixpkgs/commit/8ebae5d05555fdc0a070f9d3a1a57b1080505877) | `` scrcpy: 2.7 -> 3.0 ``                                                                     |
| [`64ea3106`](https://github.com/NixOS/nixpkgs/commit/64ea31066c3953e082c15ab1681360c38d9722c5) | `` sysdig-cli-scanner: do not use --dbpath arg when --iac is set ``                          |
| [`e140db30`](https://github.com/NixOS/nixpkgs/commit/e140db30473e82a13f44aba5d249e67217235a7a) | `` deno: 2.0.6 -> 2.1.1 ``                                                                   |