### PR TITLE
chore(flake/nixpkgs-stable): `f9f0d5c5` -> `b681065d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -374,11 +374,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1733120037,
-        "narHash": "sha256-En+gSoVJ3iQKPDU1FHrR6zIxSLXKjzKY+pnh9tt+Yts=",
+        "lastModified": 1733261153,
+        "narHash": "sha256-eq51hyiaIwtWo19fPEeE0Zr2s83DYMKJoukNLgGGpek=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "f9f0d5c5380be0a599b1fb54641fa99af8281539",
+        "rev": "b681065d0919f7eb5309a93cea2cfa84dec9aa88",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                          |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------ |
| [`6a6f5974`](https://github.com/NixOS/nixpkgs/commit/6a6f5974bd2e78895e75c03f8734036d40f177f2) | `` [Backport release-24.11] ntpd-rs: 1.3.0 -> 1.3.1 (#361508) ``                                 |
| [`c736f446`](https://github.com/NixOS/nixpkgs/commit/c736f4460b5f38cbe525e27022d73886d88e3d70) | `` static-web-server: 2.33.0 -> 2.33.1 ``                                                        |
| [`b2777df3`](https://github.com/NixOS/nixpkgs/commit/b2777df352fa5ecaaed322d169f79c8e1d1914a1) | `` janus-gateway: 1.2.4 -> 1.3.0 ``                                                              |
| [`5a1659c0`](https://github.com/NixOS/nixpkgs/commit/5a1659c0efd506ed3abb1766ba1db37135d908e6) | `` nixos/fireqos: modernize ``                                                                   |
| [`243c725b`](https://github.com/NixOS/nixpkgs/commit/243c725b8c71280d233a917e0b9aecaafe99169a) | `` nixos/fireqos: fix service not being enabled ``                                               |
| [`46f4a716`](https://github.com/NixOS/nixpkgs/commit/46f4a716da7ec187f5bc1ba632887a7d895cfc93) | `` mastodon: 4.3.1 -> 4.3.2 ``                                                                   |
| [`12fddc42`](https://github.com/NixOS/nixpkgs/commit/12fddc422a4caa0b64d013fec95a2ea9e0c3bcd5) | `` chrpath: 0.17 -> 0.18 ``                                                                      |
| [`417168ec`](https://github.com/NixOS/nixpkgs/commit/417168ec46513be38edfc1f91b5e6ae28e3b997c) | `` ton: fix build on Darwin ``                                                                   |
| [`772b4dc7`](https://github.com/NixOS/nixpkgs/commit/772b4dc7c893cb7306d68ba132b94e7bfbb0c5a5) | `` organicmaps: 2024.09.08-7 -> 2024.11.12-7 ``                                                  |
| [`37edd275`](https://github.com/NixOS/nixpkgs/commit/37edd275c12412a26ce106347624e9444c99fe09) | `` deconz: 2.28.0 -> 2.28.1 ``                                                                   |
| [`efac62d4`](https://github.com/NixOS/nixpkgs/commit/efac62d4cda62dc9a00fdc063ec300eaf4f90055) | `` lftp: 4.9.2 -> 4.9.3 ``                                                                       |
| [`8c0b47f7`](https://github.com/NixOS/nixpkgs/commit/8c0b47f7419e2c14b1c83d9387b939beee8dea2a) | `` homebox: 0.15.2 -> 0.16.0 ``                                                                  |
| [`dc46d676`](https://github.com/NixOS/nixpkgs/commit/dc46d67666cf012dc9ac4c6dc7ad9c984a70d717) | `` ankama-launcher: init at 3.12.24 ``                                                           |
| [`6e0275ec`](https://github.com/NixOS/nixpkgs/commit/6e0275ecfdc94e009f987d201f011e9a44852eb8) | `` maintainers: add harbiinger ``                                                                |
| [`64401ed0`](https://github.com/NixOS/nixpkgs/commit/64401ed03ed2f93181118d485ea879c22037401a) | `` matrix-synapse: 1.120.0 -> 1.120.2 ``                                                         |
| [`b81696e1`](https://github.com/NixOS/nixpkgs/commit/b81696e1270919a8cd11da226b0372009ae5ca76) | `` python3Packages.dbus-next: remove sfrijters as maintainer ``                                  |
| [`34c1c993`](https://github.com/NixOS/nixpkgs/commit/34c1c9930b37116b54749232f1ef4155589743cb) | `` python3Packages.dbus-next: disable tests ``                                                   |
| [`9fd387be`](https://github.com/NixOS/nixpkgs/commit/9fd387bebbdbb4db33982185a8b3638cd96f6fe2) | `` nixos/frr: make runtime directory world-readable ``                                           |
| [`1c91a0a7`](https://github.com/NixOS/nixpkgs/commit/1c91a0a70d0ae86c4c99d065511eee8aeab70487) | `` eintopf.frontend: cleanup and modernize ``                                                    |
| [`d77a5faf`](https://github.com/NixOS/nixpkgs/commit/d77a5faf26c6a22ff5670c741b532f20e05b45c9) | `` eintopf: reformat ``                                                                          |
| [`62b5dc44`](https://github.com/NixOS/nixpkgs/commit/62b5dc443280e1b57e156fe5b00403a23b94350e) | `` eintopf.frontend: reformat ``                                                                 |
| [`0c05d5b3`](https://github.com/NixOS/nixpkgs/commit/0c05d5b34a8aebdb7e1f35e95af3b8191ac4949b) | `` eintopf.frontend: 0.14.1 -> 0.14.2 ``                                                         |
| [`142bb4e0`](https://github.com/NixOS/nixpkgs/commit/142bb4e03f9c5399b326b1f3d05ea082688290a5) | `` eintopf: 0.14.1 -> 0.14.2 ``                                                                  |
| [`ac05f29c`](https://github.com/NixOS/nixpkgs/commit/ac05f29ce91033796ecf9c7dea8cc3d2f378f8bb) | `` python312Packages.pythonnet: use correct dotnet sdk in fetch-deps ``                          |
| [`c86746d6`](https://github.com/NixOS/nixpkgs/commit/c86746d6cfb510a030e49dadfe83e24c6bd0260b) | `` python312Packages.clr-loader: use correct dotnet sdk in fetch-deps ``                         |
| [`1be59ef6`](https://github.com/NixOS/nixpkgs/commit/1be59ef62f275b8cbdf971ef1e7b286fd325bc74) | `` dotnet-{sdk,runtime,aspnetcore}_9: add as top-level packages ``                               |
| [`a65508ca`](https://github.com/NixOS/nixpkgs/commit/a65508ca52d7919cf406383335d4bd73aa71ce26) | `` nixos/localtimed: fix 'geoclue2Package' doc ``                                                |
| [`d3d83fa6`](https://github.com/NixOS/nixpkgs/commit/d3d83fa66ebcfbcace4517ab1b6fb8d30022e41a) | `` nixos/gitwatch: fix module accounting ``                                                      |
| [`361b6c70`](https://github.com/NixOS/nixpkgs/commit/361b6c703cb6d35f1d2f8d4960738d1fb3fd427e) | `` vscode-extensions.streetsidesoftware.code-spell-checker: 4.0.16 -> 4.0.21 ``                  |
| [`d216b20b`](https://github.com/NixOS/nixpkgs/commit/d216b20b39f5adf66fda24354341753e58f33940) | `` virt-manager: Add back gstreamer plugins ``                                                   |
| [`dec42676`](https://github.com/NixOS/nixpkgs/commit/dec42676f28cefb5526ba3085e6fde0db486aadd) | `` [Backport release-24.11] cargo-spellcheck: move to pkgs/by-name (#361331) ``                  |
| [`171b08a5`](https://github.com/NixOS/nixpkgs/commit/171b08a518f84a359b9a237bb6bfd4a2446d6e92) | `` notepadqq: fix build ``                                                                       |
| [`34e3c70f`](https://github.com/NixOS/nixpkgs/commit/34e3c70f7565d3c016c93980a58002cbb98f58fd) | `` python312Packages.python-etcd: fix on darwin ``                                               |
| [`c1bc1120`](https://github.com/NixOS/nixpkgs/commit/c1bc1120d96804c4f80b7f801ecea7cac010e333) | `` patroni: 4.0.3 -> 4.0.4 ``                                                                    |
| [`f1ca465d`](https://github.com/NixOS/nixpkgs/commit/f1ca465d849e8ac5eef7f49176882f5ac7cd2a48) | `` patroni: format ``                                                                            |
| [`e6881bcf`](https://github.com/NixOS/nixpkgs/commit/e6881bcf8cd1689497fd2931fbeceb4b07484877) | `` shairport-sync-airplay2: 4.3.4 -> 4.3.5 ``                                                    |
| [`03a1d1f0`](https://github.com/NixOS/nixpkgs/commit/03a1d1f093a17c4db1b811ead8c3929dc9a1b201) | `` dashy-ui: fix uncalled settings override phase (#360933) ``                                   |
| [`d7ba9d09`](https://github.com/NixOS/nixpkgs/commit/d7ba9d09cb0705ac2803cc41ef9c0f603c69cd80) | `` ci/eval: Also count added packages as rebuilds ``                                             |
| [`98b5f437`](https://github.com/NixOS/nixpkgs/commit/98b5f437e0b095465ce20e670da2ca1b097f80e8) | `` poac: 0.5.1 -> 0.10.1 ``                                                                      |
| [`7ea19651`](https://github.com/NixOS/nixpkgs/commit/7ea19651d6607742efc31eab9a35e9558f2699b4) | `` github/workflows/eval: add nixos package search links and wrap sections in a summary list ``  |
| [`bd1bcde2`](https://github.com/NixOS/nixpkgs/commit/bd1bcde2ecc01fe0fc3a42e8b8a93187165ed471) | `` github/workflows/eval: limit number of packages in markdown ``                                |
| [`432bc2ce`](https://github.com/NixOS/nixpkgs/commit/432bc2ceacd6d801fb74acebe6093fa00cb11be4) | `` github/workflows/eval: add markdown of added, removed and changed ``                          |
| [`9771416c`](https://github.com/NixOS/nixpkgs/commit/9771416c965fb7bdd37a1727ea6045a5638faed5) | `` workflows/eval: Clear unnecessary rebuild labels ``                                           |
| [`9f8839dc`](https://github.com/NixOS/nixpkgs/commit/9f8839dcaec2d4d23b5c1bca366bea5d194d9250) | `` workflows/eval: Make sure to compare against the push run ``                                  |
| [`e4e9f713`](https://github.com/NixOS/nixpkgs/commit/e4e9f713cb501775d6c21e2e739d0ac7bb8c6044) | `` ci/eval: don't allow IFD ``                                                                   |
| [`8ea3a596`](https://github.com/NixOS/nixpkgs/commit/8ea3a59601ae4841bca2e418186b7e0e0b356256) | `` ci: use nix 2.24 ``                                                                           |
| [`61f43697`](https://github.com/NixOS/nixpkgs/commit/61f4369789ad1d3b23d10f06900130f13de6024b) | `` python312Packages.torchrl: skip flaky tests ``                                                |
| [`55a395f5`](https://github.com/NixOS/nixpkgs/commit/55a395f52325083d3b9f8f922433bb00e1de73cb) | `` python312Packages.tensordict: disable flaky test_map_iter_interrupt_early on all platforms `` |
| [`7e3c498d`](https://github.com/NixOS/nixpkgs/commit/7e3c498dbf64ce9c3d440149cf99300722716e8b) | `` python312Packages.tensordict: enable now succeeding tests ``                                  |
| [`095ff5ff`](https://github.com/NixOS/nixpkgs/commit/095ff5ff7077cf5165480befd0bdcb75dc527091) | `` wireplumber: 0.5.6 -> 0.5.7 ``                                                                |
| [`4f14c4fb`](https://github.com/NixOS/nixpkgs/commit/4f14c4fb606223f5a696ac6a5d31458ad01abb19) | `` nixos/searxng: limiter.toml reference moved ``                                                |
| [`c1ade4a4`](https://github.com/NixOS/nixpkgs/commit/c1ade4a4668a4cfada106013177e8db7c9d88efe) | `` xivlauncher 1.1.0 -> 1.1.1 ``                                                                 |
| [`3654a2e2`](https://github.com/NixOS/nixpkgs/commit/3654a2e26d087c7bdcc8e402b0f41e037acb183c) | `` python3Packages.sopel: Added missing package and missing meta.MainProgram ``                  |
| [`95c0a4d3`](https://github.com/NixOS/nixpkgs/commit/95c0a4d380bab74cf1ca9d2132ff4d8aabde23b7) | `` linuxPackages_latest.prl-tools: update maintainers as requested ``                            |
| [`71466e22`](https://github.com/NixOS/nixpkgs/commit/71466e22d69ecf4d64d0ed40244cba681ce9b1ad) | `` linuxPackages_latest.prl-tools: 20.1.1-55740 -> 20.1.2-55742 ``                               |
| [`feca72e2`](https://github.com/NixOS/nixpkgs/commit/feca72e20750ca45c76c823a3edca799dee710ed) | `` nixos/kea: fix settings example ``                                                            |
| [`36852127`](https://github.com/NixOS/nixpkgs/commit/368521271adeb56306ac9a29aeb6601ef6039cc9) | `` invidious: fix playback for proxied video streaming ``                                        |
| [`9c2b0070`](https://github.com/NixOS/nixpkgs/commit/9c2b00707f4baf6ef05c569cc7e59223b338285b) | `` invidious: clean derivation ``                                                                |
| [`66667c3f`](https://github.com/NixOS/nixpkgs/commit/66667c3fa7cd1603fb3f23fff477f915a61adcc7) | `` invidious: format ``                                                                          |
| [`878c4f15`](https://github.com/NixOS/nixpkgs/commit/878c4f154fbc588d406c9b46cf579fb7957a3999) | `` ocaml: 5.2.0 → 5.2.1 ``                                                                       |
| [`7c310bd1`](https://github.com/NixOS/nixpkgs/commit/7c310bd122f5be8ce441eb8425be57c122e181c8) | `` shotcut: fix reference to ffmpeg in patch ``                                                  |
| [`8a3b3f90`](https://github.com/NixOS/nixpkgs/commit/8a3b3f90feff621b3bbbc8969665baba75b6a66d) | `` proton-ge-bin: keep version information in `$steamcompattool/version` ``                      |
| [`be7a7ebd`](https://github.com/NixOS/nixpkgs/commit/be7a7ebde8696a824bb02dc447ad7e66d98d2678) | `` proton-ge-bin: Automate switching to new GE-Proton version after update ``                    |
| [`db59a350`](https://github.com/NixOS/nixpkgs/commit/db59a350e1e14ebb4d2f96b491e96e6ba847a3a9) | `` bitmask-vpn: fix calyx build (#348299) ``                                                     |
| [`bd6a9830`](https://github.com/NixOS/nixpkgs/commit/bd6a9830ea944cc46b579166dd5de922b06ce633) | `` nixos/shairport-sync: restart the systemd service on failure ``                               |
| [`eb39a51f`](https://github.com/NixOS/nixpkgs/commit/eb39a51fe8be6928a9dbc32a2d8b32ae107ca6a0) | `` ruby_3_2: 3.2.5 -> 3.2.6 ``                                                                   |
| [`9a13d997`](https://github.com/NixOS/nixpkgs/commit/9a13d9974bced19a624e8136805483a11cb78094) | `` nixos/installation-cd-base: add git & rsync ``                                                |
| [`c38784b4`](https://github.com/NixOS/nixpkgs/commit/c38784b4a4ec4fa59c05c1c3342faa6a924f6759) | `` kubefetch: 0.7.2 -> 0.8.0 ``                                                                  |
| [`924df79d`](https://github.com/NixOS/nixpkgs/commit/924df79d21053691b8fa500af2b80291cc712563) | `` apko: 0.19.6 -> 0.20.1 ``                                                                     |
| [`9d1f58b6`](https://github.com/NixOS/nixpkgs/commit/9d1f58b6453cdc3316d107b021985417ba9d828e) | `` omnisharp-roslyn: bump from .NET 6 to 8, add support for 9 ``                                 |
| [`41c538fe`](https://github.com/NixOS/nixpkgs/commit/41c538fe8ac7fc2e22ae4b955ba925b709769112) | `` amazon-ssm-agent: 3.3.987.0 -> 3.3.1345.0 ``                                                  |
| [`f70d0304`](https://github.com/NixOS/nixpkgs/commit/f70d03042f6295275fec24af127f3e080fa27b83) | `` python312Packages.pytransportnswv2: fix build ``                                              |
| [`c3caea70`](https://github.com/NixOS/nixpkgs/commit/c3caea70e82042e041d2360780c99bbe1b74f977) | `` python312Packages.boltztrap2: fix build ``                                                    |
| [`bf63d8b0`](https://github.com/NixOS/nixpkgs/commit/bf63d8b0fa19a7807694636a4cd3d9049c4de18a) | `` jetbrains.rider: Use unwrapped location of sdk ``                                             |
| [`ee9a27a8`](https://github.com/NixOS/nixpkgs/commit/ee9a27a87a7b387bc265a1e11d905cdad46cc1ed) | `` thunderbird-bin-unwrapped: 128.4.3esr -> 128.5.0esr ``                                        |
| [`00cf265f`](https://github.com/NixOS/nixpkgs/commit/00cf265f6e84d8e2cf558c4e4f474040b175fbd9) | `` dxvk_2: 2.4 -> 2.5 ``                                                                         |