### PR TITLE
chore(flake/home-manager): `6c3a7a0b` -> `0daaded6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -290,11 +290,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1733304249,
-        "narHash": "sha256-o6wNhr1ONxMuBJUGC9v0hEjFdv5rN6XzHJEL/rQJLjA=",
+        "lastModified": 1733354384,
+        "narHash": "sha256-foZG2PLwumxYZkpXq7ajHDhuQlXaUeKfOpFfQpMviLM=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "6c3a7a0b72c19ec994b85c57a1712d177bd809b2",
+        "rev": "0daaded612b0e6eaed0a63fc9d0778d8f05940fe",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                      |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------ |
| [`0daaded6`](https://github.com/nix-community/home-manager/commit/0daaded612b0e6eaed0a63fc9d0778d8f05940fe) | `` starship: replace `eval` with `source` for fish ``        |
| [`86ee1290`](https://github.com/nix-community/home-manager/commit/86ee1290d76bcd5f7ee6c80f181288a28ab0dca0) | `` starship: add `enableInteractive` option for fish ``      |
| [`1cd17a2f`](https://github.com/nix-community/home-manager/commit/1cd17a2f76f7711b06d5d59f1746cef602974498) | `` mangohud: fix a non-working example ``                    |
| [`3a7fc9cd`](https://github.com/nix-community/home-manager/commit/3a7fc9cd71a844aae9c6b6bb44700cea9539bc13) | `` zsh: make autosuggest strategy accept more options ``     |
| [`ad48eb25`](https://github.com/nix-community/home-manager/commit/ad48eb25cd0b00ce730da00fa1f8e6e6c27b397d) | `` etesync-dav: update default server URL ``                 |
| [`b1c19f1d`](https://github.com/nix-community/home-manager/commit/b1c19f1dcbc2429c16d5e6259dbff4f12dd8a89d) | `` home-cursor: use `profileExtra` instead of `initExtra` `` |
| [`30f66eaa`](https://github.com/nix-community/home-manager/commit/30f66eaa3209e13f32f98df5a150542baf2d72af) | `` xresources: use `profileExtra` instead of `initExtra` ``  |