### PR TITLE
chore(flake/spicetify-nix): `8a832957` -> `ebe9e466`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -460,11 +460,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1733372233,
-        "narHash": "sha256-nEpd7QFcjHXop4Km9ldh1fXq0K10/u7kPlchPXl44/g=",
+        "lastModified": 1733458623,
+        "narHash": "sha256-52PZbQysGpULrOehi4+807Qj3jSa3fXGJw0wuRxQfvo=",
         "owner": "Gerg-L",
         "repo": "spicetify-nix",
-        "rev": "8a832957847b643f758263293ccca6e801614a1c",
+        "rev": "ebe9e466f8eb5b1ae3079d9c44cb4d8a56f8e5c2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                    |
| ----------------------------------------------------------------------------------------------------- | -------------------------- |
| [`ebe9e466`](https://github.com/Gerg-L/spicetify-nix/commit/ebe9e466f8eb5b1ae3079d9c44cb4d8a56f8e5c2) | `` CI update 2024-12-06 `` |