### PR TITLE
chore(flake/nixpkgs-unstable): `55d15ad1` -> `d0797a04`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -375,11 +375,11 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1733212471,
-        "narHash": "sha256-M1+uCoV5igihRfcUKrr1riygbe73/dzNnzPsmaLCmpo=",
+        "lastModified": 1733392399,
+        "narHash": "sha256-kEsTJTUQfQFIJOcLYFt/RvNxIK653ZkTBIs4DG+cBns=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "55d15ad12a74eb7d4646254e13638ad0c4128776",
+        "rev": "d0797a04b81caeae77bcff10a9dde78bc17f5661",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                                                      |
| ---------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------- |
| [`897a55c3`](https://github.com/NixOS/nixpkgs/commit/897a55c324ae42633aeabe78d7c3a413e547c438) | `` hyprlauncher: 0.2.2 -> 0.2.7 ``                                                                                           |
| [`57efa159`](https://github.com/NixOS/nixpkgs/commit/57efa159d816a2229cb5d2a8a3e2ec1db850c373) | `` jq-lsp: 0.1.4 -> 0.1.9 ``                                                                                                 |
| [`c87fec8a`](https://github.com/NixOS/nixpkgs/commit/c87fec8a4f94400fe4914cf154c076a64a773d53) | `` nodePackages.insect: drop ``                                                                                              |
| [`47b5e2e5`](https://github.com/NixOS/nixpkgs/commit/47b5e2e54c47453fbd223eee2ad49fa4880ff1e8) | `` urh: 2.9.6 -> 2.9.8; install desktop file (#357930) ``                                                                    |
| [`1d0e98f2`](https://github.com/NixOS/nixpkgs/commit/1d0e98f2f9976d805dd02ffe298574b2ebe7f88b) | `` ndcurves: init at 1.4.1 (#347703) ``                                                                                      |
| [`c434c919`](https://github.com/NixOS/nixpkgs/commit/c434c9198d11ab499921e99150f04dc996cdd726) | `` expr: update repository owner ``                                                                                          |
| [`e23bacc8`](https://github.com/NixOS/nixpkgs/commit/e23bacc84412715346d68bcde6448fa9e46d8d16) | `` nexttrace: build with go 1.22 to fix darwin build (#352581) ``                                                            |
| [`49c1d7a3`](https://github.com/NixOS/nixpkgs/commit/49c1d7a3df0271023bddd0cb737dbe7b4443cbb0) | `` python312Packages.tesla-fleet-api: 0.8.4 -> 0.8.5 ``                                                                      |
| [`c78ef18e`](https://github.com/NixOS/nixpkgs/commit/c78ef18e9c2a548082de547c80e5cbdd9c10de71) | `` rosa: 1.2.46 -> 1.2.48 (#359440) ``                                                                                       |
| [`ad884b3b`](https://github.com/NixOS/nixpkgs/commit/ad884b3b02321d68812c4d5975fc321e9635e36c) | `` php82Packages.phing: 3.0.0 -> 3.0.1 ``                                                                                    |
| [`69f9ca4b`](https://github.com/NixOS/nixpkgs/commit/69f9ca4bc0108ebbc47b8aa416c7f74ca81b0629) | `` enkei: init at 0.9.3 (#233095) ``                                                                                         |
| [`8e4cf359`](https://github.com/NixOS/nixpkgs/commit/8e4cf35970d666f6f9154abeaf642a26d2340647) | `` nodePackages.ganache: drop (#361285) ``                                                                                   |
| [`6f8001fa`](https://github.com/NixOS/nixpkgs/commit/6f8001faa372c5e22c516058b7bdbb198d425fef) | `` mainsail: 2.12.0 -> 2.13.0 ``                                                                                             |
| [`64131d53`](https://github.com/NixOS/nixpkgs/commit/64131d53638f112f8c9ffae12567ab3f286eca74) | `` zed-editor: 0.163.3 -> 0.164.2 ``                                                                                         |
| [`63721dc5`](https://github.com/NixOS/nixpkgs/commit/63721dc5cf4d0646abbb321c20adbfd907f068a6) | `` jay: remove `/usr` prefix from installed files ``                                                                         |
| [`fafd0c1f`](https://github.com/NixOS/nixpkgs/commit/fafd0c1fb285125b5584ec35c73da3649c7c6496) | `` sslscan: 2.1.5 -> 2.1.6 ``                                                                                                |
| [`b5ef4ed3`](https://github.com/NixOS/nixpkgs/commit/b5ef4ed35c5698c1dca77ef6e1aa7bbf92d228fe) | `` python312Packages.blis: 1.0.1 -> 1.0.2 ``                                                                                 |
| [`c378f493`](https://github.com/NixOS/nixpkgs/commit/c378f493f3815d94be74baafa72926e3d5f8e29a) | `` terraform: 1.10.0 -> 1.10.1 ``                                                                                            |
| [`61edc1b4`](https://github.com/NixOS/nixpkgs/commit/61edc1b4e370a556547567b8e0125e922f3c2340) | `` typstyle: 0.12.6 -> 0.12.7 ``                                                                                             |
| [`017d36cb`](https://github.com/NixOS/nixpkgs/commit/017d36cb17ffbe882cd32447144287359c99b4f9) | `` materialize: add nix-update-script ``                                                                                     |
| [`fcf5d17d`](https://github.com/NixOS/nixpkgs/commit/fcf5d17df5f539cf16ac6870cdfd35b3360d50d9) | `` materialize: add versionCheckHook ``                                                                                      |
| [`560b52ac`](https://github.com/NixOS/nixpkgs/commit/560b52ac96c82f86f6f7c045d86798e8a59d8444) | `` materialize: drop useless libclang ``                                                                                     |
| [`85bd7b3b`](https://github.com/NixOS/nixpkgs/commit/85bd7b3bce73d8af44460e6b2f62c537eba9e64b) | `` materialize: fix build on darwin ``                                                                                       |
| [`17358c64`](https://github.com/NixOS/nixpkgs/commit/17358c6418d3f5324cb14c8d58df182fb31e6022) | `` materialize: switch to fetchCargoVendor ``                                                                                |
| [`c5184c74`](https://github.com/NixOS/nixpkgs/commit/c5184c7481b9032f6899a036e8f290067d26bd66) | `` materialize: clean ``                                                                                                     |
| [`0809ab66`](https://github.com/NixOS/nixpkgs/commit/0809ab66023a80d45328f4f3b23f954b13b4887b) | `` materialize: move to by-name ``                                                                                           |
| [`162733d9`](https://github.com/NixOS/nixpkgs/commit/162733d9a2740b5a319484f0ffb8cc5a1cac9fc8) | `` materialize: format ``                                                                                                    |
| [`bf3c05ab`](https://github.com/NixOS/nixpkgs/commit/bf3c05abb19a1e149a0a128cde913d36b6fe24fd) | `` kdePackages.qtutilities: 6.14.3 -> 6.14.4 ``                                                                              |
| [`f3be6634`](https://github.com/NixOS/nixpkgs/commit/f3be6634ab1c932a2e96f3aa667102b769bc812e) | `` neovim-node-client: minor fixes ``                                                                                        |
| [`a8f2acee`](https://github.com/NixOS/nixpkgs/commit/a8f2acee56f25fb884b8230ced0b1abc5b101a6a) | `` kuttl: 0.19.0 -> 0.20.0 ``                                                                                                |
| [`67a56f27`](https://github.com/NixOS/nixpkgs/commit/67a56f27f2ac90a289ff9182b9ea3d4ea50bd53f) | `` doc/build-helpers/testers: Fix command renamed to script (#352713) ``                                                     |
| [`140ab9e6`](https://github.com/NixOS/nixpkgs/commit/140ab9e66d38faf06bb5f83c2470768d57237e7e) | `` python312Packages.pyathena: 3.9.0 -> 3.10.0 ``                                                                            |
| [`ccf9d87f`](https://github.com/NixOS/nixpkgs/commit/ccf9d87fe681599ee5df3220c37927bc6ce10e7e) | `` nixos/cinnamon: Switch notExcluded to disablePackageByName ``                                                             |
| [`162f4339`](https://github.com/NixOS/nixpkgs/commit/162f4339ef33f8b1bec9de8e652c455e81e3f4d1) | `` nixos/gnome: Switch notExcluded to disablePackageByName ``                                                                |
| [`c4ed78b5`](https://github.com/NixOS/nixpkgs/commit/c4ed78b5a09727ffce5f57ca82290eecbf7d96a5) | `` nixos/pantheon: Switch notExcluded to disablePackageByName ``                                                             |
| [`e221971e`](https://github.com/NixOS/nixpkgs/commit/e221971ee79cf529ebe60a4f1a09d29f037f6d24) | `` nixos/budgie: Switch notExcluded to disablePackageByName ``                                                               |
| [`8fe87559`](https://github.com/NixOS/nixpkgs/commit/8fe87559a9040cba66cbacfc60f6f1b1fc84cf1c) | `` nixos/lib: Add disablePackageByName ``                                                                                    |
| [`cb3de357`](https://github.com/NixOS/nixpkgs/commit/cb3de3579d9b1c0a7934dc0f96e33cde2bccad40) | `` nixfmt-rfc-style: 2024-11-26 -> 2024-12-04 ``                                                                             |
| [`6db3c2f6`](https://github.com/NixOS/nixpkgs/commit/6db3c2f63358afbecb4ebe839b20538b8dc79f73) | `` forgejo.updateScript: fix the regex escape ``                                                                             |
| [`b9829aec`](https://github.com/NixOS/nixpkgs/commit/b9829aec83ea9e7f1e165b980b980259686d68df) | `` highfive-mpi: 2.10.0 -> 2.10.1 ``                                                                                         |
| [`05130d56`](https://github.com/NixOS/nixpkgs/commit/05130d5666f88f02d275ea41625a81f770c1ce75) | `` hck: 0.10.1 -> 0.11.0 ``                                                                                                  |
| [`20d4eb3b`](https://github.com/NixOS/nixpkgs/commit/20d4eb3bc6059ed3824c7e6be82b287915fd89b5) | `` python312Packages.reproject: 0.14.0 -> 0.14.1 ``                                                                          |
| [`0b7ca90a`](https://github.com/NixOS/nixpkgs/commit/0b7ca90aa9f8aef4c12261d10869396df20fde50) | `` python3Packages.pynput: 1.7.6 → 1.7.7 ``                                                                                  |
| [`1538a54c`](https://github.com/NixOS/nixpkgs/commit/1538a54cb06a25c296bda62c7b7e134ff2fccd79) | `` obs-studio-plugins.obs-ndi: fix deprecation errors ``                                                                     |
| [`52643c64`](https://github.com/NixOS/nixpkgs/commit/52643c64cdceadb3e9bb317e6033469586c66ec4) | `` nixos/unl0kr: add a `package` option ``                                                                                   |
| [`c561fb91`](https://github.com/NixOS/nixpkgs/commit/c561fb91a7c6861dddf613f93d5e781c2cadaf12) | `` detect-it-easy: add aarch64-linux ``                                                                                      |
| [`093a8945`](https://github.com/NixOS/nixpkgs/commit/093a8945a9cd1e8cdeffd8938186c6947aadf5ea) | `` python312Packages.comicon: 1.2.0 -> 1.2.1 ``                                                                              |
| [`52acf63d`](https://github.com/NixOS/nixpkgs/commit/52acf63da445e81198a77b07591d02ce62826f6c) | `` ci/nixpkgs-vet: use the get-merge-commit workflow ``                                                                      |
| [`5ddb63fe`](https://github.com/NixOS/nixpkgs/commit/5ddb63fe13c213a7cd1e0866186cbed933fbfbc1) | `` ci/eval: use the get-merge-commit workflow ``                                                                             |
| [`b5a6aeb5`](https://github.com/NixOS/nixpkgs/commit/b5a6aeb5df0e0bbfc505c9f9a9760bd08f98acc8) | `` ci: init get-merge-commit workflow ``                                                                                     |
| [`b188947d`](https://github.com/NixOS/nixpkgs/commit/b188947db956257e5e43da1bc244e89990cc425c) | `` mixxx: fix source hash (#361718) ``                                                                                       |
| [`c82bf952`](https://github.com/NixOS/nixpkgs/commit/c82bf95274382eab4aa72a9d03a13fc0514ac9ac) | `` nixos/exwm: remove option enableDefaultConfig ``                                                                          |
| [`d637b85e`](https://github.com/NixOS/nixpkgs/commit/d637b85e25894c4039026967e7105c82d32ceab1) | `` treewide: replace `--enable-wayland-ime` with `--enable-wayland-ime=true` for the arguments to properly work (#361341) `` |
| [`00bcf5cb`](https://github.com/NixOS/nixpkgs/commit/00bcf5cb457368df62bd1448e6f34b3c8f9792ff) | `` python3Packages.django_5: 5.1.3 -> 5.1.4 ``                                                                               |
| [`2b676625`](https://github.com/NixOS/nixpkgs/commit/2b6766253ec69951ca59833addaaea99c3b5869c) | `` mpvScripts.modernz: init at 0.2.1 (#360681) ``                                                                            |
| [`8fb6a2e7`](https://github.com/NixOS/nixpkgs/commit/8fb6a2e74df334879b97864ade46c91c02e42a35) | `` python312Packages.pulsectl: 24.8.0 -> 24.11.0 ``                                                                          |
| [`8439c493`](https://github.com/NixOS/nixpkgs/commit/8439c49361f43801512a8a5e37dac4b23abdfa8d) | `` sage: 10.5.rc0 -> 10.5 ``                                                                                                 |
| [`ad02718e`](https://github.com/NixOS/nixpkgs/commit/ad02718eab7c48093522ac80db95093da78a99ec) | `` python312Packages.torchsnapshot: skip failing test and enable on python 3.12 ``                                           |
| [`3c8a1553`](https://github.com/NixOS/nixpkgs/commit/3c8a1553fb53be2be75da881c8cab71d1d17d0ac) | `` tgt: 1.0.93 -> 1.0.94 ``                                                                                                  |
| [`797444df`](https://github.com/NixOS/nixpkgs/commit/797444df0ffc6292dd56ae6a88abec97043377e8) | `` nixos/aesmd: fix incorrect `mkRemovedOptionModule` option path ``                                                         |
| [`cc006aed`](https://github.com/NixOS/nixpkgs/commit/cc006aed5e75d43ca4b463f679fa2594764f553b) | `` git-lfs: disable network tests on darwin ``                                                                               |
| [`4847bcf3`](https://github.com/NixOS/nixpkgs/commit/4847bcf397de30ac0c407b1fc4508ff94b2fc231) | `` plasticity: format ``                                                                                                     |
| [`eb7910a7`](https://github.com/NixOS/nixpkgs/commit/eb7910a7e7e88824adf71630570ae1dca0170cf5) | `` python312Packages.types-aiobotocore: 2.15.2 -> 2.15.2.post3 ``                                                            |
| [`09f79860`](https://github.com/NixOS/nixpkgs/commit/09f7986029c04ce50e67818ada9f2fca1c21e1c4) | `` plasticity: 24.2.4 -> 24.2.6 ``                                                                                           |
| [`719b30ae`](https://github.com/NixOS/nixpkgs/commit/719b30aeb3c06744480f754f7ad5109d1de46c08) | `` git-lfs: minor improvements ``                                                                                            |
| [`381e6525`](https://github.com/NixOS/nixpkgs/commit/381e652552f5ed8c80364d413dd1f69ba236d7ab) | `` git-lfs: move to by-name ``                                                                                               |
| [`966ee2be`](https://github.com/NixOS/nixpkgs/commit/966ee2be2f107e2c47e42d110de56ec376a3fef5) | `` git-lfs: format ``                                                                                                        |
| [`b66069df`](https://github.com/NixOS/nixpkgs/commit/b66069df877c80ba505445e5842149ed414f75e7) | `` nixos/invoiceplane: fix sites option description (#316699) ``                                                             |
| [`f85ff70f`](https://github.com/NixOS/nixpkgs/commit/f85ff70f0a56d1d1d4115376dbc14f4de90ca7fb) | `` trufflehog: migrate to versionCheckHook ``                                                                                |
| [`73877ce1`](https://github.com/NixOS/nixpkgs/commit/73877ce1aac336af947f1e9006c3ce05f96e9879) | `` trufflehog: 3.84.1 -> 3.84.2 ``                                                                                           |
| [`79a1daab`](https://github.com/NixOS/nixpkgs/commit/79a1daab1471e4e0ab1585808cb6f65c95b07e32) | `` trivy: 0.57.1 -> 0.58.0 ``                                                                                                |
| [`178f5f70`](https://github.com/NixOS/nixpkgs/commit/178f5f70becc76eedf8b432d6ba2f1ce3e96d3e0) | `` ripasso-cursive: skip failing test on darwin ``                                                                           |
| [`443c0315`](https://github.com/NixOS/nixpkgs/commit/443c03154fca4c8fda80394947f73d634fabe7be) | `` python312Packages.vt-py: 0.18.4 -> 0.19.0 ``                                                                              |
| [`95f9644a`](https://github.com/NixOS/nixpkgs/commit/95f9644af62d13335fa999ab030cc4e5774a48e8) | `` blendfarm: update to net8, apply upstream fixes ``                                                                        |
| [`e51dba85`](https://github.com/NixOS/nixpkgs/commit/e51dba85caef3d1bcb9dc1a0914c30dde23678e0) | `` python312Packages.types-awscrt: 0.23.1 -> 0.23.3 ``                                                                       |
| [`82bbde75`](https://github.com/NixOS/nixpkgs/commit/82bbde758e4af122968c020e5693a254f67d65d9) | `` python312Packages.mypy-boto3-s3: 1.35.72 -> 1.35.74 ``                                                                    |
| [`af78af7b`](https://github.com/NixOS/nixpkgs/commit/af78af7b5532ed4b989ffd8e4630885738cf87d1) | `` python312Packages.mypy-boto3-redshift-serverless: 1.35.52 -> 1.35.74 ``                                                   |
| [`38d9aee2`](https://github.com/NixOS/nixpkgs/commit/38d9aee2a55c793f767b3f00dd2d875f0d187833) | `` python312Packages.mypy-boto3-redshift: 1.35.61 -> 1.35.74 ``                                                              |
| [`32326673`](https://github.com/NixOS/nixpkgs/commit/32326673bd9f2e45b75ae1ac9abcd6c47020dd83) | `` python312Packages.mypy-boto3-quicksight: 1.35.68 -> 1.35.74 ``                                                            |
| [`44eec474`](https://github.com/NixOS/nixpkgs/commit/44eec4746ce7f071c340284146eb05d54b8c7b50) | `` python312Packages.mypy-boto3-lakeformation: 1.35.55 -> 1.35.74 ``                                                         |
| [`89c43e9a`](https://github.com/NixOS/nixpkgs/commit/89c43e9a6b3a0735d30836439e410370552b673d) | `` python312Packages.mypy-boto3-glue: 1.35.65 -> 1.35.74 ``                                                                  |
| [`804c5eff`](https://github.com/NixOS/nixpkgs/commit/804c5eff20bff2e2ee3f46cafe5f9f8ccb318a23) | `` python312Packages.mypy-boto3-dynamodb: 1.35.60 -> 1.35.74 ``                                                              |
| [`f1b481d5`](https://github.com/NixOS/nixpkgs/commit/f1b481d546713c7f0566749712b902e995ab69d3) | `` python312Packages.mypy-boto3-cloudwatch: 1.35.63 -> 1.35.74 ``                                                            |
| [`d1ce1b77`](https://github.com/NixOS/nixpkgs/commit/d1ce1b77200bedfdc55c97aa563b5a955a2cea28) | `` python312Packages.mypy-boto3-athena: 1.35.44 -> 1.35.74 ``                                                                |
| [`2179c422`](https://github.com/NixOS/nixpkgs/commit/2179c422dc306f6def76faa364c4a199beaaed5e) | `` python312Packages.git-filter-repo: 2.45.0 -> 2.47.0 ``                                                                    |
| [`d1d84c06`](https://github.com/NixOS/nixpkgs/commit/d1d84c06853c2af6851addaa40dd30ec1cdc7395) | `` python312Packages.bc-detect-secrets: 1.5.28 -> 1.5.32 ``                                                                  |
| [`b0ee9e61`](https://github.com/NixOS/nixpkgs/commit/b0ee9e616d8fda45a9673e59ad4332598ee482c6) | `` zapret: 67 -> 69.5 ``                                                                                                     |
| [`dd9c90a7`](https://github.com/NixOS/nixpkgs/commit/dd9c90a7305ed80e7a165e73edc867994b8ef596) | `` checkov: 3.2.327 -> 3.2.328 ``                                                                                            |
| [`62ecaec6`](https://github.com/NixOS/nixpkgs/commit/62ecaec63a3e9e5040c871fdbbe76db8ddb1c123) | `` coqPackages.mathcomp-analysis: 1.5.0 -> 1.7.0 (#361371) ``                                                                |
| [`0f642863`](https://github.com/NixOS/nixpkgs/commit/0f64286316d4cf0edd7ac84c89c7d778f6d918cd) | `` nixos/exwm: rename emacsWithPackages ``                                                                                   |
| [`161a5699`](https://github.com/NixOS/nixpkgs/commit/161a56994befd4659fdbd8710e80c80f9a8375bf) | `` python312Packages.toggl-cli: 2.4.4 -> 3.0.2 ``                                                                            |
| [`cf49f728`](https://github.com/NixOS/nixpkgs/commit/cf49f728a07c6ed15f89096e7ad2b3e2d06fccb1) | `` python312Packages.oauthenticator: 17.1.0 -> 17.2.0 ``                                                                     |
| [`efab2bbe`](https://github.com/NixOS/nixpkgs/commit/efab2bbe79c1aed8a0492ce5a1b7a57fb4a44378) | `` kandim: fix update script and limit to main package ``                                                                    |
| [`90840cdb`](https://github.com/NixOS/nixpkgs/commit/90840cdb052d76d53fe9cdfbf3741db67f04ae9a) | `` nixos/kanidm: set default package version based on stateVersion ``                                                        |
| [`dda17ad2`](https://github.com/NixOS/nixpkgs/commit/dda17ad20cc35c65b1147f16bae76f0dc3c5c5da) | `` kanidm: support multiple versions, 1.4 and 1.3 ``                                                                         |
| [`ffc48e4c`](https://github.com/NixOS/nixpkgs/commit/ffc48e4c5186ad746e893cc86af749a597494781) | `` python312Packages.heudiconv: 1.2.0 -> 1.3.2 ``                                                                            |