### PR TITLE
chore(flake/nixpkgs): `b681065d` -> `4dc2fc4e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -391,11 +391,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1733261153,
-        "narHash": "sha256-eq51hyiaIwtWo19fPEeE0Zr2s83DYMKJoukNLgGGpek=",
+        "lastModified": 1733412085,
+        "narHash": "sha256-FillH0qdWDt/nlO6ED7h4cmN+G9uXwGjwmCnHs0QVYM=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "b681065d0919f7eb5309a93cea2cfa84dec9aa88",
+        "rev": "4dc2fc4e62dbf62b84132fe526356fbac7b03541",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                   |
| ---------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------- |
| [`26b4a405`](https://github.com/NixOS/nixpkgs/commit/26b4a4051248817afa4dc5de77f20593f8cacfe6) | `` doc/dotnet: bump .NET versions from 6, 7 to 8, 9 ``                                    |
| [`d92c141d`](https://github.com/NixOS/nixpkgs/commit/d92c141de31fbd816d99380fdae43d59fbce9102) | `` roslyn-ls: 4.12.0-3.24470.4 -> 4.13.0-3.24577.4 ``                                     |
| [`2b801c6f`](https://github.com/NixOS/nixpkgs/commit/2b801c6f7d24577adf29b959ea941be5fec7a2bf) | `` ytdl-sub: relax yt-dlp dependency ``                                                   |
| [`f4cb86a0`](https://github.com/NixOS/nixpkgs/commit/f4cb86a086a043037b46a9577d18a67e7bd72bb7) | `` television: 0.5.1 -> 0.5.3 ``                                                          |
| [`b4f19238`](https://github.com/NixOS/nixpkgs/commit/b4f1923831686ff6c63eaaa8c8662edb54d76879) | `` gnomeExtensions.pano: 22 -> v23-alpha3 ``                                              |
| [`6b6a449c`](https://github.com/NixOS/nixpkgs/commit/6b6a449cb46b4b521e27616bd813474b6d0bbce0) | `` corectrl: 1.4.2 -> 1.4.3 ``                                                            |
| [`5e269190`](https://github.com/NixOS/nixpkgs/commit/5e2691906fb5f2464766e39bd7ee36ee8dddc8f8) | `` wordbook: unstable-2022-11-02 -> 0.4.0 ``                                              |
| [`e4daa19f`](https://github.com/NixOS/nixpkgs/commit/e4daa19f5ff49d4c7ae9ad7ed745e991483e5aec) | `` eintopf: 0.14.2 -> 0.14.3 ``                                                           |
| [`61fb6330`](https://github.com/NixOS/nixpkgs/commit/61fb633029b2465b970a41f5343511bfd70c7ecf) | `` cargo-sort: revert to 1.0.9 (from 1.1.0) ``                                            |
| [`a448c4b1`](https://github.com/NixOS/nixpkgs/commit/a448c4b18fc66855d1c92d8624e9c715536abd05) | `` urh: 2.9.6 -> 2.9.8; install desktop file (#357930) ``                                 |
| [`3cf6b5e1`](https://github.com/NixOS/nixpkgs/commit/3cf6b5e1d70a575290304ce32163e8aa9802c58b) | `` obs-studio-plugins.obs-ndi: fix deprecation errors ``                                  |
| [`4499ea2a`](https://github.com/NixOS/nixpkgs/commit/4499ea2a6999790c04561930f1f4cd34e922cbb8) | `` nexttrace: build with go 1.22 to fix darwin build (#352581) ``                         |
| [`c40228fe`](https://github.com/NixOS/nixpkgs/commit/c40228fe72cf7fa960f682e5ea0cc93c40922463) | `` upscaler: 1.4.0 -> 1.4.1 ``                                                            |
| [`79a75cbc`](https://github.com/NixOS/nixpkgs/commit/79a75cbc947677420778917e03f1484942a5aadb) | `` [Backport release-24.11] nixfmt-rfc-style: 2024-11-26 -> 2024-12-04 (#361894) ``       |
| [`936ce511`](https://github.com/NixOS/nixpkgs/commit/936ce511d53ff2f6375483ffbdd7e85ecc04f28b) | `` gnomeExtensions.argos: Update to more recent revision with support for GNOME 47 ``     |
| [`c8642811`](https://github.com/NixOS/nixpkgs/commit/c864281140a954289d4189075b968601d3e61214) | `` warp-terminal: 0.2024.11.19.08.02.stable_01 -> 0.2024.11.19.08.02.stable_03 ``         |
| [`59211dc6`](https://github.com/NixOS/nixpkgs/commit/59211dc6df38ae0898649e7c03f329402a7114a7) | `` nixos/espanso: remove unused wayland option ``                                         |
| [`8d6a9668`](https://github.com/NixOS/nixpkgs/commit/8d6a9668f24ed201b77b5741823e12602fb5720a) | `` python310Packages.onlykey-solo-python: fix compatibility with fido2 1.1.3 ``           |
| [`994b5f49`](https://github.com/NixOS/nixpkgs/commit/994b5f499da39ebf2ab8b6e9289c9ecca264d80a) | `` nixos/exwm: remove option enableDefaultConfig ``                                       |
| [`feed52b6`](https://github.com/NixOS/nixpkgs/commit/feed52b6089c8de153b3fde1eb271a040dda2bcf) | `` nixos/exwm: rename emacsWithPackages ``                                                |
| [`3083116c`](https://github.com/NixOS/nixpkgs/commit/3083116c4f249485a1e39fe90475a91736747ca8) | `` sage: 10.5.rc0 -> 10.5 ``                                                              |
| [`8bba08c5`](https://github.com/NixOS/nixpkgs/commit/8bba08c5a61e50cf30b3740ebdc250681f94540c) | `` coqPackages.mathcomp-analysis: 1.5.0 -> 1.7.0 (#361371) ``                             |
| [`f6b162d9`](https://github.com/NixOS/nixpkgs/commit/f6b162d9947740fdab587df755eacf0808ba0f80) | `` Remove rane as maintainer ``                                                           |
| [`2ea2b185`](https://github.com/NixOS/nixpkgs/commit/2ea2b185c51a2d6b4c164097155ac6756b042741) | `` eza: use new darwin sdk pattern ``                                                     |
| [`0adf8577`](https://github.com/NixOS/nixpkgs/commit/0adf857739425571d22c78b1f2c65cea44c00ade) | `` cargo-unfmt: use new darwin sdk pattern ``                                             |
| [`fc0bc413`](https://github.com/NixOS/nixpkgs/commit/fc0bc41321d8f1c99c8949e0df49ca669280781f) | `` cargo-feature: use new darwin sdk pattern ``                                           |
| [`9cb0e366`](https://github.com/NixOS/nixpkgs/commit/9cb0e3666793dbdbefb3e84b050ce67269fc3cee) | `` cargo-fuzz: use new darwin sdk pattern ``                                              |
| [`a251d672`](https://github.com/NixOS/nixpkgs/commit/a251d6722631ac949a95d3c5ba67c921d071f26f) | `` cargo-limit: use new darwin sdk pattern ``                                             |
| [`cc693178`](https://github.com/NixOS/nixpkgs/commit/cc6931780f0174a2ae2ba088f6c380240d58eebb) | `` reindeer: use new darwin sdk pattern ``                                                |
| [`d93c443f`](https://github.com/NixOS/nixpkgs/commit/d93c443f896f4f9d2e34b629f51444b693508edc) | `` ostree-rs-ext: use new darwin sdk pattern ``                                           |
| [`9067aec2`](https://github.com/NixOS/nixpkgs/commit/9067aec267e23dc4f7c61ba6202fcefbd9ab7b0f) | `` sequoia-chameleon-gnupg: use new darwin sdk pattern ``                                 |
| [`5df80e9f`](https://github.com/NixOS/nixpkgs/commit/5df80e9ff9a65cce3cd0f9adb432dfd3cd9f0a25) | `` openpgp-card-tools: use new darwin sdk pattern ``                                      |
| [`6e4463e0`](https://github.com/NixOS/nixpkgs/commit/6e4463e042cde22cec5f6b1487b8fb8860c72fd2) | `` python312Packages.cryptg: use new darwin sdk pattern ``                                |
| [`522fe1a0`](https://github.com/NixOS/nixpkgs/commit/522fe1a08fc39b64fa9aca416d7df1fc6d567b33) | `` garage: use new darwin sdk pattern ``                                                  |
| [`2a9955d0`](https://github.com/NixOS/nixpkgs/commit/2a9955d0f8d54ef570e678587f69e82649e1ce51) | `` python313: 3.13.0 -> 3.13.1 ``                                                         |
| [`def5b738`](https://github.com/NixOS/nixpkgs/commit/def5b738ed7b217c707259d10ef9637f9d925141) | `` nixos/invoiceplane: fix sites option description (#316699) ``                          |
| [`86d71e66`](https://github.com/NixOS/nixpkgs/commit/86d71e66e7c4083dc49d5a8184e553959f333de8) | `` minecraft-server: 1.21.3 -> 1.21.4 ``                                                  |
| [`d3f6f9a3`](https://github.com/NixOS/nixpkgs/commit/d3f6f9a33533b8c44eb817545e94c3eb746cb80f) | `` kdePackages.merkuro: add missing dependency on qtlocation ``                           |
| [`7dfbf00c`](https://github.com/NixOS/nixpkgs/commit/7dfbf00cd597fc7d68840834b5f70395c292d5c9) | `` python312Packages.argos-translate-files: 1.1.4 -> 1.2.0 ``                             |
| [`f88a4010`](https://github.com/NixOS/nixpkgs/commit/f88a4010d273e71d9fe22a43f67e197d208dba78) | `` cldr-annotations: fix hash ``                                                          |
| [`63067550`](https://github.com/NixOS/nixpkgs/commit/63067550b02e26357acaf3ad5edab590b63194cf) | `` ocamlformat_0_27_0: init ``                                                            |
| [`8b2d4b61`](https://github.com/NixOS/nixpkgs/commit/8b2d4b61927a0433176d3297823a435f18175610) | `` kanidm: 1.4.3 -> 1.4.4 ``                                                              |
| [`ef84dacd`](https://github.com/NixOS/nixpkgs/commit/ef84dacd02c350c8d9fc47e0f8f2f14a0ae9789a) | `` python312Packages.lottie: 0.7.0 -> 0.7.1 ``                                            |
| [`a7d3440d`](https://github.com/NixOS/nixpkgs/commit/a7d3440de1569d0140ab0a1a34bfa39edfab1fb1) | `` linuxKernel.kernels.linux_lqx: 6.11.5-lqx1 -> v6.12.1-lqx1 ``                          |
| [`b98ccf3d`](https://github.com/NixOS/nixpkgs/commit/b98ccf3dd2f5c1641f84157bc5303bffdbc6993a) | `` linuxKernel.kernels.linux_zen: 6.11.5-zen1 -> v6.12.1-zen1 ``                          |
| [`203f6438`](https://github.com/NixOS/nixpkgs/commit/203f6438e0033148d4ef3d4b4c31cbee14b41d01) | `` uhubctl: fix darwin build ``                                                           |
| [`c3b08708`](https://github.com/NixOS/nixpkgs/commit/c3b08708334cca32db70df24516608e73f645136) | `` ocamlformat: Build on OCaml 4.14 (#361404) ``                                          |
| [`00756c37`](https://github.com/NixOS/nixpkgs/commit/00756c37c2b9aacbc220f5aa11ecd6c737a2dabe) | `` chromium,chromedriver: 131.0.6778.85 -> 131.0.6778.108 ``                              |
| [`d8c111fc`](https://github.com/NixOS/nixpkgs/commit/d8c111fc7bc948805b38d163a816c183e680e842) | `` zotero: 7.0.8 → 7.0.10 ``                                                              |
| [`44293830`](https://github.com/NixOS/nixpkgs/commit/44293830513a6c512225e8d7c100b2252c52f211) | `` authentik: flag with `knownVulnerabilities` ``                                         |
| [`a670d9a6`](https://github.com/NixOS/nixpkgs/commit/a670d9a6b237eca30ea48e655da8a3ccc55dfca0) | `` vault-tasks: 0.4.0 -> 0.5.0 ``                                                         |
| [`6802b27d`](https://github.com/NixOS/nixpkgs/commit/6802b27da6a233a0ff7ab8f328e982fb7053e31e) | `` dmd: patch test needspkgmod.d ``                                                       |
| [`ebe24fe9`](https://github.com/NixOS/nixpkgs/commit/ebe24fe90d28ec79052264dfce8b69f59abe3cda) | `` doc/tauri: use tauri 2.0 dependencies & new darwin SDK pattern in example (#357148) `` |
| [`3829613b`](https://github.com/NixOS/nixpkgs/commit/3829613bf8bb78d6b84ddc94b25b09f9b02f644e) | `` python3Packages.pyhepmc: 2.13.4 -> 2.14.0 (#360461) ``                                 |
| [`bfbc8238`](https://github.com/NixOS/nixpkgs/commit/bfbc8238aa09cd02183a51267bf77c5028986693) | `` hepmc3: fix HepMC3-config on darwin (#360478) ``                                       |
| [`b31c456a`](https://github.com/NixOS/nixpkgs/commit/b31c456aa83d95c948d65d7fc70b948c37421b05) | `` helvum: remove unused clang from build closure ``                                      |
| [`1b468e32`](https://github.com/NixOS/nixpkgs/commit/1b468e3255a38dc5e111025390e326a5189470ee) | `` niri: remove unused clang from build closure ``                                        |
| [`dddc01dd`](https://github.com/NixOS/nixpkgs/commit/dddc01dd367a87c826d5237c76e6f10548476428) | `` xen-guest-agent: remove unused clang from build closure ``                             |
| [`31ea1047`](https://github.com/NixOS/nixpkgs/commit/31ea10473f3de6694b5ed64a51ca1664ef8ae755) | `` linux/hardened/patches/6.6: v6.6.62-hardened1 -> v6.6.63-hardened1 ``                  |
| [`5b910cd8`](https://github.com/NixOS/nixpkgs/commit/5b910cd82ce923c0c6772de55a75199c9c05ebbc) | `` linux/hardened/patches/6.11: v6.11.9-hardened1 -> v6.11.10-hardened1 ``                |
| [`e51f3c1b`](https://github.com/NixOS/nixpkgs/commit/e51f3c1be9e6cea21e7e7b0164c6eb27141777b0) | `` linux/hardened/patches/6.1: v6.1.118-hardened1 -> v6.1.119-hardened1 ``                |
| [`f5a37c28`](https://github.com/NixOS/nixpkgs/commit/f5a37c28d0096fcc9b4f7d1f4fd6a906fedab5aa) | `` linux-rt_6_6: 6.6.58-rt45 -> 6.6.63-rt46 ``                                            |
| [`cf25c42f`](https://github.com/NixOS/nixpkgs/commit/cf25c42ff05af6a5da18f6869049b648eaea3bb6) | `` linux-rt_6_1: 6.1.112-rt43 -> 6.1.119-rt45 ``                                          |
| [`850fd87f`](https://github.com/NixOS/nixpkgs/commit/850fd87f32e90bb74f8e3c06832ab1fc140d3710) | `` linux-rt_5_4: 5.4.278-rt91 -> 5.4.285-rt93 ``                                          |
| [`98db855b`](https://github.com/NixOS/nixpkgs/commit/98db855bc8f9f7032fded3a64b90e697e66c8f55) | `` linux-rt_5_10: 5.10.225-rt117 -> 5.10.229-rt121 ``                                     |
| [`9970d3e8`](https://github.com/NixOS/nixpkgs/commit/9970d3e8cc511084f340561460f1f48ab950ce2e) | `` linux_testing: 6.12-rc7 -> 6.13-rc1 ``                                                 |
| [`d06d0862`](https://github.com/NixOS/nixpkgs/commit/d06d0862320d124cfc238f095aeec556c1462ea4) | `` yt-dlp: 2024.11.18 -> 2024.12.3 ``                                                     |
| [`3bf2866e`](https://github.com/NixOS/nixpkgs/commit/3bf2866e5c7a2e06dd22ef1708b5c2fab353db8f) | `` maintainers: fix typo ``                                                               |
| [`58adc337`](https://github.com/NixOS/nixpkgs/commit/58adc33755adc77bb7c0ed4ddbd93b210a206151) | `` otpauth: 0.5.2 -> 0.5.3 ``                                                             |
| [`d0d2c66e`](https://github.com/NixOS/nixpkgs/commit/d0d2c66e5cd92ee5abfba4742fe4192f321e9bfe) | `` mediamtx: 1.9.2 -> 1.9.3 ``                                                            |
| [`9fe4aae0`](https://github.com/NixOS/nixpkgs/commit/9fe4aae0557d0252231ef3ec35ad354c95625d04) | `` cplay-ng: 5.2.0 -> 5.3.1 ``                                                            |
| [`369ae257`](https://github.com/NixOS/nixpkgs/commit/369ae257282e3cb44441df1d5ab3b55ddbc9fec5) | `` cyclonedx-cli: add team cyberus to maintainers ``                                      |
| [`33979da7`](https://github.com/NixOS/nixpkgs/commit/33979da71c4a23189e46e174075ae7316c80fee4) | `` cyclonedx-cli: 0.25.1 -> 0.27.2 ``                                                     |
| [`91ed26fe`](https://github.com/NixOS/nixpkgs/commit/91ed26fe418f164c5655436253d7797dec883675) | `` pcloud: 1.14.7 -> 1.14.8 ``                                                            |
| [`a4473252`](https://github.com/NixOS/nixpkgs/commit/a4473252ecd60a1746d0ad6b483371e78946916f) | `` dotnet-outdated: don't build for EOL sdks ``                                           |
| [`1945b44d`](https://github.com/NixOS/nixpkgs/commit/1945b44dabdb9d00406bd3ccc7efd7712272807f) | `` nixos/knot: add missing CLIs to wrapper ``                                             |
| [`5f9c9d62`](https://github.com/NixOS/nixpkgs/commit/5f9c9d62d152732a90945ca4e63852178d36a546) | `` neovim-node-client: init at 5.3.0 ``                                                   |
| [`e337522b`](https://github.com/NixOS/nixpkgs/commit/e337522b794731de3c688f41c17924d14ea6bbac) | `` envision-unwrapped: 0-unstable-2024-10-20 -> 1.1.1 ``                                  |
| [`d9e24401`](https://github.com/NixOS/nixpkgs/commit/d9e244012378d25d7bb3e9b62ae4853767eefa57) | `` ci: Update pinned Nixpkgs ``                                                           |
| [`8e81cf47`](https://github.com/NixOS/nixpkgs/commit/8e81cf4763e08a8bfabadb4a21743ba8192a7162) | `` archivebox: add SingleFile ``                                                          |
| [`faaf37f5`](https://github.com/NixOS/nixpkgs/commit/faaf37f5c8dd7797420136ced1430e978c268b7a) | `` archivebox: fix build ``                                                               |
| [`16ad918c`](https://github.com/NixOS/nixpkgs/commit/16ad918cadafd560cd5a56244b1eae6e956648e8) | `` netlify-cli: 12.2.4 -> 17.37.1, migrate to buildNpmPackage ``                          |
| [`350180d0`](https://github.com/NixOS/nixpkgs/commit/350180d0850cd392ca94de1c2cce9852015a6626) | `` jetbrains.rider: use dotnet sdk 8 as sdk 7 has been marked insecure ``                 |
| [`98124c17`](https://github.com/NixOS/nixpkgs/commit/98124c1789589d7934d950ce58eae6fdfd250464) | `` nixos/dockerTools: fixup proot/fakeroot code - exclude also dev ``                     |
| [`7631c88a`](https://github.com/NixOS/nixpkgs/commit/7631c88a6f60ed538f169f9422fbecf3cea49797) | `` t-rex: broken with rust 1.80, won't be fixed upstream ``                               |
| [`4530800e`](https://github.com/NixOS/nixpkgs/commit/4530800eabeff9ccdbd69dc40b594a8315846e27) | `` libadwaita: 1.6.1 -> 1.6.2 ``                                                          |
| [`8c71fb2e`](https://github.com/NixOS/nixpkgs/commit/8c71fb2edc7967b2ca11d3ead2ceda0d7127203a) | `` python312Packages.py3status: 3.59 -> 3.60 ``                                           |
| [`fad260b2`](https://github.com/NixOS/nixpkgs/commit/fad260b26e9c21a48ee47839d9d42f4430b5a792) | `` python312Packages.py3status: Fix typelib ``                                            |
| [`76d5d368`](https://github.com/NixOS/nixpkgs/commit/76d5d368fa9c4f6f8274806da5c18bc68f3aa0ac) | `` quilt: enable strictDeps ``                                                            |
| [`58b0f6b4`](https://github.com/NixOS/nixpkgs/commit/58b0f6b4b4db759d39f9b2718ca9d3c4055f7ed6) | `` moodle: 4.4.1 -> 4.4.3 ``                                                              |
| [`45f72acd`](https://github.com/NixOS/nixpkgs/commit/45f72acd6f648e6b15c6f176e44325c02551bb60) | `` samba: add pkgsCross.aarch64-multiplatform.samba to passthru.tests ``                  |
| [`d1f113ef`](https://github.com/NixOS/nixpkgs/commit/d1f113efe4488e065e38a71d5ce0ab57fc4f32e2) | `` samba: set correct pythondir ``                                                        |
| [`8554bc27`](https://github.com/NixOS/nixpkgs/commit/8554bc2738ac4e1a0714422defaab6d6788f0283) | `` samba: resurrect cross compilation patch ``                                            |
| [`f3824582`](https://github.com/NixOS/nixpkgs/commit/f3824582c027c4b39433cb039d648ed9370e6573) | `` nextcloud-client: 3.14.3 -> 3.14.4 ``                                                  |
| [`25336ade`](https://github.com/NixOS/nixpkgs/commit/25336ade492a455108a0948cb12edf82512dcb42) | `` uwsm: add missing systemd dependency ``                                                |
| [`eea9575a`](https://github.com/NixOS/nixpkgs/commit/eea9575a0680feb6f090b9f47ba7553f2a8d0937) | `` uwsm: prefer user env binaries ``                                                      |
| [`0c84ae77`](https://github.com/NixOS/nixpkgs/commit/0c84ae77e2c83c9a3e004c56463ee5d78efb08e0) | `` Format ``                                                                              |
| [`fd872e4b`](https://github.com/NixOS/nixpkgs/commit/fd872e4bd790ef9d894351f395ae88b62245005b) | `` hercules-ci-cnix-store/nix: 2.18 -> 2.24 ``                                            |
| [`8d7ad668`](https://github.com/NixOS/nixpkgs/commit/8d7ad66813ec0724124b89a7497a9bbf188ad9ca) | `` haskellPackages.hercules-ci-agent: 0.10.4 -> 0.10.5 ``                                 |
| [`273082d5`](https://github.com/NixOS/nixpkgs/commit/273082d596b584639ded8e42ceb31732c0c69739) | `` haskellPackages.hercules-ci-cnix-expr: 0.3.6.4 -> 0.3.6.5 ``                           |
| [`b7faf9c1`](https://github.com/NixOS/nixpkgs/commit/b7faf9c17673a571e25cfde4f4d1c777dcaf79c2) | `` haskellPackages.hercules-ci-cnix-store: 0.3.6.0 -> 0.3.6.1 ``                          |
| [`49360c2f`](https://github.com/NixOS/nixpkgs/commit/49360c2f822811870934a3347f5b4da82629f86e) | `` haskell-modules: Add replacements-by-name ``                                           |
| [`942f21f9`](https://github.com/NixOS/nixpkgs/commit/942f21f944d193209992bbed032d348026f5fd86) | `` nixos/monado: add forceDefaultRuntime option ``                                        |
| [`443aea21`](https://github.com/NixOS/nixpkgs/commit/443aea210cfe6fa608c60a95d98e25802e258eaa) | `` nixos/monado: nixfmt ``                                                                |
| [`aa88b3ca`](https://github.com/NixOS/nixpkgs/commit/aa88b3cae5a9174c520b49ecb4e0ba48015ea65b) | `` nixos/pgbouncer: rework RFC42 integration ``                                           |