### PR TITLE
chore(flake/home-manager): `e38d3dd1` -> `c7ffc972`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -290,11 +290,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1733482664,
-        "narHash": "sha256-ZD+h1fwvZs+Xvg46lzTWveAqyDe18h9m7wZnTIJfFZ4=",
+        "lastModified": 1733572789,
+        "narHash": "sha256-zjO6m5BqxXIyjrnUziAzk4+T4VleqjstNudSqWcpsHI=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "e38d3dd1d355a003cc63e8fe6ff66ef2257509ed",
+        "rev": "c7ffc9727d115e433fd884a62dc164b587ff651d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                  |
| ----------------------------------------------------------------------------------------------------------- | -------------------------------------------------------- |
| [`c7ffc972`](https://github.com/nix-community/home-manager/commit/c7ffc9727d115e433fd884a62dc164b587ff651d) | `` nix: simplify tests ``                                |
| [`9afd809a`](https://github.com/nix-community/home-manager/commit/9afd809a3c69edfd78eb48cadc0930b1e5bf6fad) | `` xresources: simplify tests ``                         |
| [`f79a81d3`](https://github.com/nix-community/home-manager/commit/f79a81d300033dd4036fb26b80a16c21ffb10a7e) | `` cmus: reduce test closure ``                          |
| [`901bce8b`](https://github.com/nix-community/home-manager/commit/901bce8b37d5fb041da3936d37f57e639288e41d) | `` fcitx5: fix package reference in test ``              |
| [`176a1078`](https://github.com/nix-community/home-manager/commit/176a1078a51c655ba42ab89960b45d21de748998) | `` lorri: fix ReadWritePaths for new gcroots behavior `` |