### PR TITLE
chore(flake/alejandra): `04fe4d17` -> `6db88764`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -9,11 +9,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1732419807,
-        "narHash": "sha256-fxWG4fSgViAfBCYNr8V9w8uWfBpdXWT41ssNQGoHYck=",
+        "lastModified": 1733729059,
+        "narHash": "sha256-5xYai0KZirUX2EQpNMMCWoC27932n/i1E4KeVRIss7s=",
         "owner": "kamadorueda",
         "repo": "alejandra",
-        "rev": "04fe4d17dc488744879008f9a8e5cb9affefa2ec",
+        "rev": "6db88764334bd6a8b7a33cb312c318baad1d5e93",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                 | Message                                                |
| ------------------------------------------------------------------------------------------------------ | ------------------------------------------------------ |
| [`6db88764`](https://github.com/kamadorueda/alejandra/commit/6db88764334bd6a8b7a33cb312c318baad1d5e93) | `` test: add cli tests ``                              |
| [`cdc093ab`](https://github.com/kamadorueda/alejandra/commit/cdc093ab719c41b436d17aeb3ec0c6edb7c6a43c) | `` doc: experimental configuration options ``          |
| [`e03130a3`](https://github.com/kamadorueda/alejandra/commit/e03130a339f9f5c0d4b475d392679c63e4c4dffa) | `` refac: rm no longer supported pre-built binaries `` |
| [`25281a25`](https://github.com/kamadorueda/alejandra/commit/25281a25c93017395062fdf974963c430ecd4e36) | `` feat: toml config ``                                |
| [`1bd3c583`](https://github.com/kamadorueda/alejandra/commit/1bd3c5832a652f0798aedda79468d8e788be9ba5) | `` refac: update thanks ``                             |
| [`ac93a779`](https://github.com/kamadorueda/alejandra/commit/ac93a779e79da589aae39912dfe819064a86e553) | `` feat: rebase Vladimir's pr ``                       |
| [`d9618476`](https://github.com/kamadorueda/alejandra/commit/d96184764606db0a9279c6f28d810f852d3f111a) | `` Allow tabs and spaces ``                            |