### PR TITLE
chore(flake/nixpkgs): `4dc2fc4e` -> `e2605d07`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -391,11 +391,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1733412085,
-        "narHash": "sha256-FillH0qdWDt/nlO6ED7h4cmN+G9uXwGjwmCnHs0QVYM=",
+        "lastModified": 1733550349,
+        "narHash": "sha256-NcGumB4Lr6KSDq+nIqXtNA8QwAQKDSZT7N9OTGWbTrs=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "4dc2fc4e62dbf62b84132fe526356fbac7b03541",
+        "rev": "e2605d0744c2417b09f8bf850dfca42fcf537d34",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                            |
| ---------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------- |
| [`864365ad`](https://github.com/NixOS/nixpkgs/commit/864365ad6c199dfe48ae40910884b6c6c4eac24f) | `` chromium: remove ofborg maintainer ping workaround, use CODEOWNERS ``           |
| [`fc51dc2a`](https://github.com/NixOS/nixpkgs/commit/fc51dc2a83592a68ee51c4477fb7862d248a77b1) | `` onedrive: patch missed paths ``                                                 |
| [`edf08dc2`](https://github.com/NixOS/nixpkgs/commit/edf08dc28776fe23084d8545e6b2120a8bf7e88e) | `` qtscrcpy: 2.2.1 -> 3.0.0 ``                                                     |
| [`8d65080d`](https://github.com/NixOS/nixpkgs/commit/8d65080d5f146b327cf550512ee3ecea98d8f85d) | `` scrcpy: 3.0 -> 3.0.2 ``                                                         |
| [`ed86e568`](https://github.com/NixOS/nixpkgs/commit/ed86e5684dd5df9ada115350ae83cad20e66cc5b) | `` vagrant: 2.4.1 -> 2.4.3 ``                                                      |
| [`8b27a36b`](https://github.com/NixOS/nixpkgs/commit/8b27a36b52d79a774bcda17dc1a2e9dad1bdce19) | `` [Backport release-24.11] eza: 0.20.7 -> 0.20.11 (#362501) ``                    |
| [`7a7288f1`](https://github.com/NixOS/nixpkgs/commit/7a7288f1ff016bcb792c0779918413757ed7e058) | `` signal-desktop: 7.34.0 -> 7.35.0 (#361881) ``                                   |
| [`b0631ca2`](https://github.com/NixOS/nixpkgs/commit/b0631ca260186ec47508853ad9d45a07bdd670b0) | `` ci: add Nixpkgs lib-tests workflow ``                                           |
| [`24c4cdd8`](https://github.com/NixOS/nixpkgs/commit/24c4cdd84cf8d71cca3e6e8c0eafb78c4eafec86) | `` ci/nixpkgs-vet: use the get-merge-commit workflow ``                            |
| [`d9b5d047`](https://github.com/NixOS/nixpkgs/commit/d9b5d04727886b684c7c42f5c147b065f7cff8f5) | `` ci/eval: use the get-merge-commit workflow ``                                   |
| [`dc17bb7c`](https://github.com/NixOS/nixpkgs/commit/dc17bb7c124ee1a3e97767992b1bb416b83a3109) | `` ci: init get-merge-commit workflow ``                                           |
| [`36cd40a4`](https://github.com/NixOS/nixpkgs/commit/36cd40a401b351dbbff2963c494c2a2187949ffe) | `` workflows/eval: add eval summary to commit statuses ``                          |
| [`881fc2f3`](https://github.com/NixOS/nixpkgs/commit/881fc2f305b0f4f898c2b80a0d0623f388e37528) | `` workflows/backport: Use GitHub App to create PRs to make GHA trigger on them `` |
| [`85ac223c`](https://github.com/NixOS/nixpkgs/commit/85ac223cdd9c0c905ae35d20c8be6a46e72c64e1) | `` ci/eval: test aliases ``                                                        |
| [`ed36a1b9`](https://github.com/NixOS/nixpkgs/commit/ed36a1b90d222e3e49c1ea389f7858a435337de0) | `` workflows/check-nix-format: reminder to rebase ``                               |
| [`348ad731`](https://github.com/NixOS/nixpkgs/commit/348ad7310030c696171a05251e3055328d09efaa) | `` timeshift: fix meta.longDescription (the wrapper part) ``                       |
| [`384a3890`](https://github.com/NixOS/nixpkgs/commit/384a3890e9efd6c9a91b07671851f4d8f8c475e4) | `` timeshift: 24.06.3 -> 24.06.5 ``                                                |
| [`11aaf6f6`](https://github.com/NixOS/nixpkgs/commit/11aaf6f6dab619ce7439363e924dbac3c9a57370) | `` google-chrome: 131.0.6778.85 -> 131.0.6778.108 ``                               |
| [`9d4e7ff7`](https://github.com/NixOS/nixpkgs/commit/9d4e7ff7cb8ffafb827f8208d8dfe74c844ba76e) | `` python312Packages.libknot: 3.4.1 -> 3.4.2 ``                                    |
| [`8b56b0a2`](https://github.com/NixOS/nixpkgs/commit/8b56b0a23940aa30764ce16881fb0d32f04552c3) | `` prometheus-knot-exporter: 3.4.1 -> 3.4.2 ``                                     |
| [`79ec474d`](https://github.com/NixOS/nixpkgs/commit/79ec474d80e77ec76411783ff7d773cf7840ee2a) | `` dotnetCorePackages.dotnet_9.vmr: 9.0.0 -> 9.0.101 ``                            |
| [`83318de9`](https://github.com/NixOS/nixpkgs/commit/83318de9f839f52363cf2be3ab9edc966be9fb42) | `` dotnet/update.nix: use tag name to check for updates ``                         |
| [`518a5f83`](https://github.com/NixOS/nixpkgs/commit/518a5f83554f3fd4938ca6a2511e1e244187a8fe) | `` dotnet/update.nix: remove stray debug print ``                                  |
| [`5f71945e`](https://github.com/NixOS/nixpkgs/commit/5f71945ecb996631a194890b16162e58a1f5e65f) | `` dotnet-sdk_9: 9.0.100 -> 9.0.101 ``                                             |
| [`cec889cb`](https://github.com/NixOS/nixpkgs/commit/cec889cb5efdb3b6ad4c43ccec7056aa07033351) | `` dotnet/update.sh: check sdk version when updating ``                            |
| [`b06afe66`](https://github.com/NixOS/nixpkgs/commit/b06afe66d894bb04f722ae4d34f6bdb1fe529a12) | `` ptyxis: 47.4 -> 47.5 ``                                                         |
| [`aacfed49`](https://github.com/NixOS/nixpkgs/commit/aacfed49df4e532b08497242a099b7c5f2852e98) | `` apptainer, singularity: fix the update instructions in the comment ``           |
| [`7f3ddefe`](https://github.com/NixOS/nixpkgs/commit/7f3ddefeb7fd9a32b54de6b2aed1cd54d3aaed2e) | `` lock: 1.2.0 -> 1.3.0 ``                                                         |
| [`6b38eeda`](https://github.com/NixOS/nixpkgs/commit/6b38eeda14e609051b0f58b5135002f8c6ac2350) | `` nostui: use upstream lock file ``                                               |
| [`56125e27`](https://github.com/NixOS/nixpkgs/commit/56125e272794454d81e21f593e4fd1ad3b2baf39) | `` buildRustPackage: fix passing depsExtraArgs to fetchCargoVendor ``              |
| [`fbce9ea7`](https://github.com/NixOS/nixpkgs/commit/fbce9ea74a09d90adb48435b76c1710abc41a375) | `` rustPlatform.buildRustPackage: allow specifying cargoDeps ``                    |
| [`11cf000a`](https://github.com/NixOS/nixpkgs/commit/11cf000ad624a4d9ba9834b9e0f37f01477ab25f) | `` rustPlatform.fetchCargoVendor: retry fetching tarballs ``                       |
| [`23fca587`](https://github.com/NixOS/nixpkgs/commit/23fca587e71008dfdbe42d05952d37f10d61f54b) | `` rustPlatform.fetchCargoVendor: decrease concurrency ``                          |
| [`4755af43`](https://github.com/NixOS/nixpkgs/commit/4755af4354ed904fb0153c047ca7bb3a507cde52) | `` sqlline: init at 1.12 ``                                                        |
| [`877948aa`](https://github.com/NixOS/nixpkgs/commit/877948aa11de2d934d5defe9962eba6d10ccd409) | `` rustPlatform.fetchCargoVendor: fetch git submodules ``                          |
| [`d82acb33`](https://github.com/NixOS/nixpkgs/commit/d82acb33c89af2c2ab1243af83680411772a69af) | `` python312Packages.certbot-dns-route53: refactor ``                              |
| [`0df80aa2`](https://github.com/NixOS/nixpkgs/commit/0df80aa2195428ab39136918f517ba5e45a1b967) | `` python312Packages.certbot-dns-route53: ignore DeprecationWarning ``             |
| [`1e48ec17`](https://github.com/NixOS/nixpkgs/commit/1e48ec178039cb6f3a175486d2c323839489c55c) | `` python312Packages.certbot-dns-rfc2136: ignore DeprecationWarning ``             |
| [`f06339b8`](https://github.com/NixOS/nixpkgs/commit/f06339b83535d3e2cc6bd80bc0981eb8ff1e27a0) | `` python312Packages.certbot-dns-cloudflare: ignore DeprecationWarning ``          |
| [`7917f080`](https://github.com/NixOS/nixpkgs/commit/7917f08099ca299a6e3155dd8822ecf31d595725) | `` python312Packages.certbot-dns-ovh: ignore DeprecationWarning ``                 |
| [`78e43343`](https://github.com/NixOS/nixpkgs/commit/78e43343a2e08158aa9fa3c405401e8ef0252c7b) | `` python312Packages.tldextract: 5.1.2 -> 5.1.3 ``                                 |
| [`deac370e`](https://github.com/NixOS/nixpkgs/commit/deac370e00880317f86869c60daebe2089f96b4b) | `` ocamlPackages.js_of_ocaml: 5.8.2 → 5.9.1 ``                                     |
| [`ad52b9e6`](https://github.com/NixOS/nixpkgs/commit/ad52b9e60ad49ac0a83122cd37126e2c7f5334bc) | `` linux_6_12: 6.12.2 -> 6.12.3 ``                                                 |
| [`d3b34dad`](https://github.com/NixOS/nixpkgs/commit/d3b34dad9f11cc3078d6bed827f2722d459e44d5) | `` linux_6_11: 6.11.10 -> 6.11.11 ``                                               |
| [`cc1ae798`](https://github.com/NixOS/nixpkgs/commit/cc1ae798741f77155c013eefe78de68ecb3a8fc3) | `` linux_6_12: 6.12.1 -> 6.12.2 ``                                                 |
| [`8d9ce6aa`](https://github.com/NixOS/nixpkgs/commit/8d9ce6aa45a9a0bc08b18c04448de646747b36b1) | `` nixos/tests/networking: fix flaky scripted.dhcpSimple test ``                   |
| [`87d81d78`](https://github.com/NixOS/nixpkgs/commit/87d81d780b0116eb4f1fb38caea85b8d37c1e962) | `` python312Packages.azure-mgmt-relay: slightly modernize ``                       |
| [`4777e74d`](https://github.com/NixOS/nixpkgs/commit/4777e74d3055038a9191e299913a5c626e4c26d4) | `` python312Packages.azure-mgmt-relay: remove unused dependencies ``               |
| [`9cf937e9`](https://github.com/NixOS/nixpkgs/commit/9cf937e9d9050a6c86e0c34732b8dec6c3795f21) | `` resources: 1.6.0 -> 1.7.0 ``                                                    |
| [`cfcb289f`](https://github.com/NixOS/nixpkgs/commit/cfcb289f48a97c51e822040052100c7caf255221) | `` nixos/victoriametrics: the prometheusConfig option isn't null by default ``     |
| [`16e6b01a`](https://github.com/NixOS/nixpkgs/commit/16e6b01aa5b86a896243afe8bd530c0ac77a8fa1) | `` cargo-shuttle: migrate to new fetcher ``                                        |
| [`807afb58`](https://github.com/NixOS/nixpkgs/commit/807afb58a5078c91dab8ff885eff040c4089100a) | `` python312Packages.json-stream-rs-tokenizer: migrate to new fetcher ``           |
| [`09bbd3ce`](https://github.com/NixOS/nixpkgs/commit/09bbd3ceabae3f39d039b38d7901afd95ac61c10) | `` popsicle: migrate to new fetcher ``                                             |
| [`b15f91c5`](https://github.com/NixOS/nixpkgs/commit/b15f91c5c93ad22ff49b8c331b3a62697404fe7c) | `` hieroglypic: migrate to new fetcher ``                                          |
| [`b03f4f11`](https://github.com/NixOS/nixpkgs/commit/b03f4f116f4e9191f20c608136b96efa5cc8b986) | `` docs: mention fetchCargoVendor ``                                               |
| [`ed988d47`](https://github.com/NixOS/nixpkgs/commit/ed988d4763e445da88035af763e0e4ac1a0da2f8) | `` buildRustPackage: add useFetchCargoVendor flag ``                               |
| [`d4f68d74`](https://github.com/NixOS/nixpkgs/commit/d4f68d747c844263d069bf637fbde4a19a53a2ec) | `` rustPlatform.fetchCargoVendor: init ``                                          |
| [`9a1c489a`](https://github.com/NixOS/nixpkgs/commit/9a1c489af61e65f0e7b912e2dd52a67d70cddc0e) | `` hypr-dynamic-cursors: 0-unstable-2024-11-10 -> 0-unstable-2024-11-19 ``         |
| [`10dc2603`](https://github.com/NixOS/nixpkgs/commit/10dc2603fc49188fec66b0e426008ca12fdba036) | `` [Backport release-24.11] tailscale: 1.78.0 -> 1.78.1 (#362283) ``               |
| [`b85b83ef`](https://github.com/NixOS/nixpkgs/commit/b85b83ef6f10903a2b608d19d8858603e7f4a1b4) | `` davinci-resolve: 19.0.2 -> 19.1 ``                                              |
| [`1046a972`](https://github.com/NixOS/nixpkgs/commit/1046a972e479fb7eb24871ea501a21b5a2e2f44b) | `` python312Packages.pyhanko: 0.25.1 -> 0.25.3 ``                                  |
| [`c2670766`](https://github.com/NixOS/nixpkgs/commit/c26707662d01bbd5010acf85db39f6205e39b3ac) | `` python312Packages.certomancer: 0.12.0 -> 0.12.3 ``                              |
| [`42d231ac`](https://github.com/NixOS/nixpkgs/commit/42d231acd17f2bd4e7c99c820dba6e8e4af4184d) | `` python312Packages.pyhanko-certvalidator: 0.26.3 -> 0.26.5 ``                    |
| [`8337ec8b`](https://github.com/NixOS/nixpkgs/commit/8337ec8b20301b9244569ce52d474051dc6239fa) | `` jprofiler: 13.0.6 -> 14.0.5 ``                                                  |
| [`fdef5ed1`](https://github.com/NixOS/nixpkgs/commit/fdef5ed12337f9ea1fa79a1c374c3f4b8b603932) | `` jprofiler: format ``                                                            |
| [`e9724568`](https://github.com/NixOS/nixpkgs/commit/e97245686865ba9357fba8773767a1be6af142c7) | `` jprofiler: remove catap as maintainer ``                                        |
| [`b955fd21`](https://github.com/NixOS/nixpkgs/commit/b955fd21d835e4d3d825cd1a03016564f651a451) | `` [Backport release-24.11] tailscale: 1.76.6 -> 1.78.0 (#362228) ``               |
| [`1b5c19e8`](https://github.com/NixOS/nixpkgs/commit/1b5c19e8c895d2ed1604a9246100ce2d09beb33d) | `` komac: add shell completions ``                                                 |
| [`b7e3f1fa`](https://github.com/NixOS/nixpkgs/commit/b7e3f1fa54d9291b7484650062d9b109c8d71f31) | `` Revert "scarab: remove nuget patch" ``                                          |
| [`c196cdbc`](https://github.com/NixOS/nixpkgs/commit/c196cdbc5c38afa1fb7478c5c52cbf093e17b54e) | `` dotnet: use fallback target packages from current binary sdk ``                 |
| [`d309782f`](https://github.com/NixOS/nixpkgs/commit/d309782f8e7e856f8a03e38dbdc3a304719c7d84) | `` dotnet: nixfmt output of nuget-to-nix ``                                        |
| [`074f814e`](https://github.com/NixOS/nixpkgs/commit/074f814e62608953e7c6a22d56b9d385346aaf21) | `` python312Packages.azure-multiapi-storage: modernize and fix metadata ``         |
| [`c16a0343`](https://github.com/NixOS/nixpkgs/commit/c16a0343db3fbb4ea441290df0140cbfa3f3083a) | `` python312Packages.azure-multiapi-storage: fix build ``                          |
| [`d8c4e855`](https://github.com/NixOS/nixpkgs/commit/d8c4e8552f8c91d806cb55d9257c250af4439aba) | `` python3Packages.mandown: relax pillow dependency ``                             |
| [`f8022f1e`](https://github.com/NixOS/nixpkgs/commit/f8022f1ea7022ecfe5746f0e31a3bde5c1f1dc59) | `` ibus: fix cross compilation ``                                                  |
| [`7f9b799e`](https://github.com/NixOS/nixpkgs/commit/7f9b799ebfbca75a6b128b4bd5670036ce222c67) | `` kopia: enable doCheck ``                                                        |
| [`487ac4a7`](https://github.com/NixOS/nixpkgs/commit/487ac4a71f75933d8fa70f8ab791d0dfcbdafc98) | `` apptainer: 1.3.5 -> 1.3.6 ``                                                    |
| [`36b57485`](https://github.com/NixOS/nixpkgs/commit/36b5748513cab3bcd99813eecfcf406388d0de6a) | `` canon-cups-ufr2: fix color printing issues ``                                   |
| [`b2e3d297`](https://github.com/NixOS/nixpkgs/commit/b2e3d297a0cb88fb501fb6530a003da4bf5e6c4b) | `` canon-cups-ufr2: 5.90 -> 6.00 ``                                                |
| [`f021b318`](https://github.com/NixOS/nixpkgs/commit/f021b31858680b524f8f6ebdbe6148ac58d65d50) | `` fetchgit{,hub}: assert illegal tag + rev combinations ``                        |
| [`7adab4cf`](https://github.com/NixOS/nixpkgs/commit/7adab4cf93c6cdf3ced78db90cecaa9353a04c05) | `` fetchgit{,hub}: add tag argument ``                                             |
| [`5b83d363`](https://github.com/NixOS/nixpkgs/commit/5b83d363191d263a48b0dbedeea7c048365cecb8) | `` element-desktop: 1.11.86 -> 1.11.87 ``                                          |
| [`4cb2ad40`](https://github.com/NixOS/nixpkgs/commit/4cb2ad4084f8ccc6fbea92fdd69153cb05a31f01) | `` soundsource: 5.7.3 -> 5.7.4 ``                                                  |
| [`7ee3ce6e`](https://github.com/NixOS/nixpkgs/commit/7ee3ce6e749a0b2304127b22cc8f57bc52b257fc) | `` soundsource: quote paths ``                                                     |
| [`c12b9a2e`](https://github.com/NixOS/nixpkgs/commit/c12b9a2e86a65caee41a149834f7d38f9d088b7d) | `` soundsource: refactor meta ``                                                   |
| [`c8c63e9e`](https://github.com/NixOS/nixpkgs/commit/c8c63e9ef9ba00b5a79d36671844e0f91d54fee3) | `` raycast: 1.86.0 -> 1.87.2 ``                                                    |
| [`d23cb71a`](https://github.com/NixOS/nixpkgs/commit/d23cb71a153d6eac97de8392c1dcfffeacf58eee) | `` dependency-track: 4.12.1 -> 4.12.2 ``                                           |
| [`24c96647`](https://github.com/NixOS/nixpkgs/commit/24c96647b030fc798b8b9934d6471e39b361a725) | `` scarab: avoid rebuild after `meta` changes ``                                   |
| [`abad4bc3`](https://github.com/NixOS/nixpkgs/commit/abad4bc3c9a7716fa17a2188b6c53cc9ad446bd9) | `` scarab: explicit `rev` and `pname` in `fetchFromGitHub`, migrate to hash ``     |
| [`ca435f75`](https://github.com/NixOS/nixpkgs/commit/ca435f752dcd33d6add5bf1fb22eff493afcd47d) | `` scarab: remove nuget patch ``                                                   |
| [`71bd746e`](https://github.com/NixOS/nixpkgs/commit/71bd746e9c766656b3be709a4723ad24ea112e0d) | `` scarab: .NET 6 -> 8 ``                                                          |
| [`b5437cb5`](https://github.com/NixOS/nixpkgs/commit/b5437cb50c5ebbde0b3a548a7655e8947fa6e469) | `` scarab: migrate to by-name ``                                                   |
| [`761b2912`](https://github.com/NixOS/nixpkgs/commit/761b29121aec8cfdb27888076152c938e6e3f179) | `` intel-gmmlib: 22.5.2 -> 22.5.4 ``                                               |
| [`d218a31a`](https://github.com/NixOS/nixpkgs/commit/d218a31ae7a64ae20eeba9ed4586360c3da01747) | `` dotnet-ef: init at 9.0.0 ``                                                     |
| [`109c0fab`](https://github.com/NixOS/nixpkgs/commit/109c0fabea40d43bc99b7311e1fbc083dc5cbb71) | `` maintainers: add lostmsu ``                                                     |
| [`3926ab22`](https://github.com/NixOS/nixpkgs/commit/3926ab2272b310ba2204e1fd07e9496dea5ee5f1) | `` msgraph-cli: init a 1.9.0 ``                                                    |
| [`b42ddfea`](https://github.com/NixOS/nixpkgs/commit/b42ddfeac3dcc4e2f49a9247aa554b0ce36960a3) | `` angular-language-server: 18.2.0 -> 19.0.3 ``                                    |
| [`e37f2166`](https://github.com/NixOS/nixpkgs/commit/e37f2166d5f85b495ead606cc9112ff0f1c09d92) | `` spot: 0.4.1 -> 0.5.0 ``                                                         |
| [`0fc0f88b`](https://github.com/NixOS/nixpkgs/commit/0fc0f88bf31a144841a7aa10fd4c2a87aa1eef89) | `` koboldcpp: 1.78 -> 1.79.1 ``                                                    |
| [`44ddb266`](https://github.com/NixOS/nixpkgs/commit/44ddb2664c27f121b9e5a9fd659096792ad5b424) | `` doc/build-helpers/testers: Fix command renamed to script (#352713) ``           |
| [`624963ad`](https://github.com/NixOS/nixpkgs/commit/624963ad36c2c1ee6fa2eff9572c298b6acab8c2) | `` python3Packages.django_5: 5.1.3 -> 5.1.4 ``                                     |
| [`3a26cd0c`](https://github.com/NixOS/nixpkgs/commit/3a26cd0c58f71531c864a94c38e41a6ed7309715) | `` remove old Darwin SDK pattern (#354146) ``                                      |
| [`c611b0f9`](https://github.com/NixOS/nixpkgs/commit/c611b0f945c00e7965b3a639cea2928a44c9ecf9) | `` qsv: use `useFetchCargoVendor` instead of vendoring Cargo.lock ``               |
| [`9612ae35`](https://github.com/NixOS/nixpkgs/commit/9612ae3505357e3420158cfae16fd2175b945246) | `` qsv: 0.131.1 -> 0.138.0 ``                                                      |
| [`a94fecaf`](https://github.com/NixOS/nixpkgs/commit/a94fecaf6740bd1c5a65aac97beffa506a6c555f) | `` doc: fix/improve NIXOS_LUSTRATE installation instructions ``                    |
| [`69a6f699`](https://github.com/NixOS/nixpkgs/commit/69a6f6998021a704c928208529f421d8152af743) | `` switch-to-configuration-ng: prevent error during NIXOS_LUSTRATE install ``      |
| [`8afc2f82`](https://github.com/NixOS/nixpkgs/commit/8afc2f8220c8803106d23db856e73a94f56b8bcb) | `` nixos/activation: prevent error during NIXOS_LUSTRATE install ``                |
| [`d660d51b`](https://github.com/NixOS/nixpkgs/commit/d660d51b515e0d6fb51c9342813ec2bd04461bab) | `` desktopToDarwinBundle: fix 16x, 32x app icons ``                                |
| [`6849349f`](https://github.com/NixOS/nixpkgs/commit/6849349f8c93f3aedc33d69fe4bf5c40d140ae39) | `` icnsutil: include pillow dependency ``                                          |
| [`308bd93a`](https://github.com/NixOS/nixpkgs/commit/308bd93ad1a67bfeb187e3aa56017f40433b9a04) | `` gdcm: switch to new sdk pattern on darwin ``                                    |
| [`86ebf424`](https://github.com/NixOS/nixpkgs/commit/86ebf4240cb984c7866b90980339b5b97aa188eb) | `` vtk: switch to new sdk pattern on darwin ``                                     |