### PR TITLE
chore(flake/spicetify-nix): `577b6a4e` -> `a0fa48ec`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -460,11 +460,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1733717814,
-        "narHash": "sha256-/io+y0T0V7rDWnticOP2b5/wMFFBObP+NPw0pAPNEkQ=",
+        "lastModified": 1733804223,
+        "narHash": "sha256-xEalVFfRxx2kpVbMnfDFBV6srCFWzbpdi7h+FofgHGo=",
         "owner": "Gerg-L",
         "repo": "spicetify-nix",
-        "rev": "577b6a4e513c9a8d987fb5d331a19976b391d48e",
+        "rev": "a0fa48ec6348f88598b3ef2b4581a9f4c8ccd178",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                    |
| ----------------------------------------------------------------------------------------------------- | -------------------------- |
| [`a0fa48ec`](https://github.com/Gerg-L/spicetify-nix/commit/a0fa48ec6348f88598b3ef2b4581a9f4c8ccd178) | `` CI update 2024-12-10 `` |