### PR TITLE
chore(flake/nix-gaming): `b395d1c4` -> `89887483`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -332,11 +332,11 @@
         "umu": "umu"
       },
       "locked": {
-        "lastModified": 1733670029,
-        "narHash": "sha256-CxorsZ6WyGpWRFmWJlnFRBEV54Rof9VQbTXoOj/hcPI=",
+        "lastModified": 1733821969,
+        "narHash": "sha256-JYAnT6hfRXdBNRCmhZa3XPFv19zbWXi8DDcY9AeNiQI=",
         "owner": "fufexan",
         "repo": "nix-gaming",
-        "rev": "b395d1c43776b252427ff0cb879c257ac5ee52d8",
+        "rev": "89887483a47f9e7e849d43e5992f9da54b3e8e0e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                              | Message                                                           |
| --------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------- |
| [`89887483`](https://github.com/fufexan/nix-gaming/commit/89887483a47f9e7e849d43e5992f9da54b3e8e0e) | `` osu-lazer-bin: fix build failure due to missing icon (#224) `` |
| [`8563347a`](https://github.com/fufexan/nix-gaming/commit/8563347a85fd3735dec7b22e172c0c5d6f756ea0) | `` Update packages ``                                             |