### PR TITLE
chore(flake/stylix): `d13ffb38` -> `072a313b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -269,16 +269,16 @@
     "gnome-shell": {
       "flake": false,
       "locked": {
-        "lastModified": 1713702291,
-        "narHash": "sha256-zYP1ehjtcV8fo+c+JFfkAqktZ384Y+y779fzmR9lQAU=",
+        "lastModified": 1732369855,
+        "narHash": "sha256-JhUWbcYPjHO3Xs3x9/Z9RuqXbcp5yhPluGjwsdE2GMg=",
         "owner": "GNOME",
         "repo": "gnome-shell",
-        "rev": "0d0aadf013f78a7f7f1dc984d0d812971864b934",
+        "rev": "dadd58f630eeea41d645ee225a63f719390829dc",
         "type": "github"
       },
       "original": {
         "owner": "GNOME",
-        "ref": "46.1",
+        "ref": "47.2",
         "repo": "gnome-shell",
         "type": "github"
       }
@@ -312,15 +312,16 @@
         ]
       },
       "locked": {
-        "lastModified": 1733085484,
-        "narHash": "sha256-dVmNuUajnU18oHzBQWZm1BQtANCHaqNuxTHZQ+GN0r8=",
+        "lastModified": 1733572789,
+        "narHash": "sha256-zjO6m5BqxXIyjrnUziAzk4+T4VleqjstNudSqWcpsHI=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "c1fee8d4a60b89cae12b288ba9dbc608ff298163",
+        "rev": "c7ffc9727d115e433fd884a62dc164b587ff651d",
         "type": "github"
       },
       "original": {
         "owner": "nix-community",
+        "ref": "release-24.11",
         "repo": "home-manager",
         "type": "github"
       }
@@ -492,11 +493,11 @@
         "tinted-tmux": "tinted-tmux"
       },
       "locked": {
-        "lastModified": 1732993760,
-        "narHash": "sha256-t1J6wgzGjvvGNfdd0ei8HnZf9sTw+SpvCNAX0i6Qgwc=",
+        "lastModified": 1733859110,
+        "narHash": "sha256-Tg2uBKzy0mHhmMJqYTWhAEal0JafVDNGh6hnNUaMENE=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "d13ffb381c83b6139b9d67feff7addf18f8408fe",
+        "rev": "072a313b45f960758f449cab51378bc084c413c2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                        | Message                                                            |
| --------------------------------------------------------------------------------------------- | ------------------------------------------------------------------ |
| [`072a313b`](https://github.com/danth/stylix/commit/072a313b45f960758f449cab51378bc084c413c2) | `` emacs: set font for all frames, not just for new ones (#656) `` |
| [`8dd09884`](https://github.com/danth/stylix/commit/8dd098840ed79f14d6e3d8054c300415f20746f7) | `` stylix: lock nixpkgs and home-manager to 24.11 (#671) ``        |
| [`f05a3c0e`](https://github.com/danth/stylix/commit/f05a3c0e89fd51668190fa0e3e41c4ad0ffe388c) | `` gnome: update to GNOME 47.2 (#658) ``                           |
| [`4402f960`](https://github.com/danth/stylix/commit/4402f96014169c430e879c3969e5e0a7a6a79050) | `` sway: handle cursor names containing spaces (#654) ``           |
| [`f5c12c10`](https://github.com/danth/stylix/commit/f5c12c10a53ff082e349f652e01804ee9f4fb02c) | `` vscode: extensive fonts ``                                      |