### PR TITLE
chore(flake/nixpkgs): `e2605d07` -> `a0f3e10d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -392,11 +392,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1733550349,
-        "narHash": "sha256-NcGumB4Lr6KSDq+nIqXtNA8QwAQKDSZT7N9OTGWbTrs=",
+        "lastModified": 1733808091,
+        "narHash": "sha256-KWwINTQelKOoQgrXftxoqxmKFZb9pLVfnRvK270nkVk=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "e2605d0744c2417b09f8bf850dfca42fcf537d34",
+        "rev": "a0f3e10d94359665dba45b71b4227b0aeb851f8e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                                            |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------ |
| [`a0f3e10d`](https://github.com/NixOS/nixpkgs/commit/a0f3e10d94359665dba45b71b4227b0aeb851f8e) | `` [Backport release-24.11] matomo_5: 5.1.1 -> 5.1.2 (#363745) ``                                                  |
| [`9a4e4996`](https://github.com/NixOS/nixpkgs/commit/9a4e4996683122f3ff6cbc7ab1239f5f5972aa99) | `` [Backport release-24.11] bird: 2.15.1 -> 2.16 (#363761) ``                                                      |
| [`80eaa475`](https://github.com/NixOS/nixpkgs/commit/80eaa475043d4a5d6d54d4450dc598d25a1daa0f) | `` [Backport release-24.11] deno: 2.1.2 -> 2.1.3 (#363667) ``                                                      |
| [`5526e3fa`](https://github.com/NixOS/nixpkgs/commit/5526e3fabdf4174bfdd2d26943f44dbd3c90e936) | `` [Backport release-24.11] meshcentral: 1.1.33 -> 1.1.35 (#363665) ``                                             |
| [`b5556c84`](https://github.com/NixOS/nixpkgs/commit/b5556c84b2d164234429a54d06fc4e581dd231d8) | `` [Backport release-24.11] github-runner: use finalAttrs to make it possible to override the version (#363758) `` |
| [`25f5acdd`](https://github.com/NixOS/nixpkgs/commit/25f5acddcfa7cb7cf38d7e003a795b604f8f6147) | `` ankama-launcher: 3.12.26 -> 3.12.27 ``                                                                          |
| [`a66059da`](https://github.com/NixOS/nixpkgs/commit/a66059da6b296af7251c369be27599a752d15c50) | `` [Backport release-24.11] commitlint-rs: 0.1.12 -> 0.2.2 (#363693) ``                                            |
| [`92d89a0c`](https://github.com/NixOS/nixpkgs/commit/92d89a0c62390b1b941783c6e259eee5d4ce78da) | `` [Backport release-24.11] mpris-timer: 1.1.1 -> 1.5 (#363397) ``                                                 |
| [`2c5c888e`](https://github.com/NixOS/nixpkgs/commit/2c5c888ec8c1aaf64ea00b8d4f8cc5b2e17b3943) | `` [Backport release-24.11] mangojuice: init at 0.7.8 (#363683) ``                                                 |
| [`3a324754`](https://github.com/NixOS/nixpkgs/commit/3a324754bca39a3b7532858156c2633ac115fe67) | `` ci: Update pinned Nixpkgs ``                                                                                    |
| [`4d2689f4`](https://github.com/NixOS/nixpkgs/commit/4d2689f44c24dcc718d8f212c95afaa1beead1bc) | `` nym:	2024.12-aero -> 2024.13-magura-patched ``                                                                  |
| [`216e2bcc`](https://github.com/NixOS/nixpkgs/commit/216e2bcc5eb388ebeac5d26323e152495bc3d6b3) | `` prowlarr: remove jdreaver as maintainer ``                                                                      |
| [`b1c84a3a`](https://github.com/NixOS/nixpkgs/commit/b1c84a3a94f3890c6a8fb307735146a81d6f118a) | `` maintainers: update jdreaver email ``                                                                           |
| [`d548edbc`](https://github.com/NixOS/nixpkgs/commit/d548edbcb80eb40ac2eb57877a8277fc434c16e6) | `` github-runner: fix wrong path in the config file ``                                                             |
| [`1d9360b2`](https://github.com/NixOS/nixpkgs/commit/1d9360b27cd51c2acca25c6f7789de24b2376b6f) | `` cargo-deny: 0.16.2 -> 0.16.3 ``                                                                                 |
| [`b9b19470`](https://github.com/NixOS/nixpkgs/commit/b9b194704b90cdff20c35eec028a6d9a57fd97b0) | `` cargo-deny: 0.16.1 -> 0.16.2 ``                                                                                 |
| [`28449906`](https://github.com/NixOS/nixpkgs/commit/2844990610a571b4581ee78117a0113ef2b0616b) | `` toot: 0.47.0 -> 0.47.1 ``                                                                                       |
| [`a3a18415`](https://github.com/NixOS/nixpkgs/commit/a3a184157cad3b9911bd3f73af89afc0f2576651) | `` immich: 1.122.1 -> 1.122.2 ``                                                                                   |
| [`d9150771`](https://github.com/NixOS/nixpkgs/commit/d9150771247163ef9de933e376bfec5c8a552439) | `` snac2: 2.63 -> 2.65 ``                                                                                          |
| [`6e82cbe7`](https://github.com/NixOS/nixpkgs/commit/6e82cbe7eb51d6a6317db30e4062ff0b7d89fc8a) | `` traefik: 3.1.4 -> 3.2.1 ``                                                                                      |
| [`0a40e566`](https://github.com/NixOS/nixpkgs/commit/0a40e566b1038692073964e82d33ac4ad2723340) | `` immich: 1.121.0 -> 1.122.1 ``                                                                                   |
| [`9e668706`](https://github.com/NixOS/nixpkgs/commit/9e668706262ebdbca56a6e44ee68dd3a58fae1bf) | `` nixos/nginx: don't disable IPC ``                                                                               |
| [`1a268398`](https://github.com/NixOS/nixpkgs/commit/1a2683987b3880e543c6703b92e7a03c2624dca1) | `` git-workspace: remove passthru.tests.version ``                                                                 |
| [`ae38fc6d`](https://github.com/NixOS/nixpkgs/commit/ae38fc6d3defde9bad7ad6112973fcf446082781) | `` git-workspace: 1.7.0 -> 1.8.0 ``                                                                                |
| [`a553e001`](https://github.com/NixOS/nixpkgs/commit/a553e001b6f7ce5add795e76dbee55d5e0a9802e) | `` racket_7_9: mark insecure ``                                                                                    |
| [`dde4c077`](https://github.com/NixOS/nixpkgs/commit/dde4c077d269024199853843b8de0033f64917d3) | `` nixos/networking-interfaces-scripted: use read -r ``                                                            |
| [`873ba8cc`](https://github.com/NixOS/nixpkgs/commit/873ba8cc0053d8ae83219ae1b81e75d813f261d7) | `` [Backport release-24.11] ocamlPackages.reason-react: init at 0.15.0 (#363211) ``                                |
| [`3c3ed762`](https://github.com/NixOS/nixpkgs/commit/3c3ed76243250a7440ff521f696ee824beef231b) | `` [Backport release-24.11] python3Packages.globus-sdk: 3.45.0 -> 3.48.0 (#363084) ``                              |
| [`1006b970`](https://github.com/NixOS/nixpkgs/commit/1006b970fa887e773082f27e8e52486950fbd72a) | `` [Backport release-24.11] abctl: 0.13.1 -> 0.22.0 (#363079) ``                                                   |
| [`65c27308`](https://github.com/NixOS/nixpkgs/commit/65c273082a9c21bdb65bfe597e0569266a76bc09) | `` [Backport release-24.11] gnome-decoder : 0.4.1 -> 0.6.1 (#363148) ``                                            |
| [`a5f4bf29`](https://github.com/NixOS/nixpkgs/commit/a5f4bf29616920f5e5f1d266723242540913a5f5) | `` [Backport release-24.11] turn-rs: 3.1.0 -> 3.2.0 (#363215) ``                                                   |
| [`4c4fe140`](https://github.com/NixOS/nixpkgs/commit/4c4fe140e3467fa082653ecd53243ac7706e45ca) | `` [Backport release-24.11] epic5: 3.0.1 -> 3.0.2 (#363216) ``                                                     |
| [`6039adc0`](https://github.com/NixOS/nixpkgs/commit/6039adc03a846018674602650e7ef8e1259b22c9) | `` [Backport release-24.11] alexandria: 0.12.0 -> 0.13.1 (#363217) ``                                              |
| [`6af7e4ae`](https://github.com/NixOS/nixpkgs/commit/6af7e4aeff00beb9dc2bd5c3e979f43f0ad63d9f) | `` slack: 4.41.97 -> 4.41.98 ``                                                                                    |
| [`4938994d`](https://github.com/NixOS/nixpkgs/commit/4938994d06b0efc4a20ee01aeb9fdf1cd9ccb24e) | `` mitmproxy: 11.0.1 -> 11.0.2 ``                                                                                  |
| [`4dbea6e2`](https://github.com/NixOS/nixpkgs/commit/4dbea6e2d4bfa443e7d7329ac81532626fc78c8d) | `` [Backport release-24.11] nixos/seafile: fix systemd option capitalization for RandomizedDelaySec (#363366) ``   |
| [`c1ebb001`](https://github.com/NixOS/nixpkgs/commit/c1ebb001a9604a8b427f20810277ff1f7403014a) | `` postfix: 3.9.0 -> 3.9.1 ``                                                                                      |
| [`901bfe3b`](https://github.com/NixOS/nixpkgs/commit/901bfe3b1f428be2624fb8a9c502cfc4ea57ac83) | `` nixos/scx: add new schedulers ``                                                                                |
| [`0cda1c20`](https://github.com/NixOS/nixpkgs/commit/0cda1c20800e95964e23e74dba39147d23365484) | `` scx.full: 1.0.6 -> 1.0.7 ``                                                                                     |
| [`8c99c192`](https://github.com/NixOS/nixpkgs/commit/8c99c1923e1ca5b45c5cf72ee91dd27311ddec84) | `` onedrive: 2.5.2 -> 2.5.3 ``                                                                                     |
| [`eedefe7c`](https://github.com/NixOS/nixpkgs/commit/eedefe7c64874e2b976297a117cf5782cf7160c2) | `` gitlab: 17.5.2 -> 17.6.1 ``                                                                                     |
| [`b26218a0`](https://github.com/NixOS/nixpkgs/commit/b26218a06f3eb6e49121da647b579f751c853a58) | `` linux_xanmod_latest: 6.11.10 -> 6.11.11 ``                                                                      |
| [`233933ef`](https://github.com/NixOS/nixpkgs/commit/233933ef7795167a03506d7d8ae63832810a78c2) | `` python312Packages.parselmouth: fix build ``                                                                     |
| [`514e97d4`](https://github.com/NixOS/nixpkgs/commit/514e97d4835a508d39fc5186ed77381023c8932f) | `` obs-studio: fix lossless audio support ``                                                                       |
| [`d0c2cd3e`](https://github.com/NixOS/nixpkgs/commit/d0c2cd3e5ae52d33a90a141bdc66e78bc4e063e9) | `` wormhole-william: install shell completions ``                                                                  |
| [`3d679090`](https://github.com/NixOS/nixpkgs/commit/3d679090d08600e4a236ffde2a03a2f73339b43e) | `` nixos/wivrn: add server flags option and refactor type check ``                                                 |
| [`6035115f`](https://github.com/NixOS/nixpkgs/commit/6035115f48652fc0c915bae5de1de5ee688f25df) | `` wivrn: 0.19 -> 0.22 ``                                                                                          |
| [`cbfaf563`](https://github.com/NixOS/nixpkgs/commit/cbfaf563277ff6d3c856ed4f8a952ba51cb01b87) | `` diesel-cli: migrate to new darwin SDK pattern ``                                                                |
| [`ee0fac60`](https://github.com/NixOS/nixpkgs/commit/ee0fac603c3d6571ba12b4230d38f049722d8cdb) | `` diesel-cli: 2.2.5 -> 2.2.6 ``                                                                                   |
| [`320df565`](https://github.com/NixOS/nixpkgs/commit/320df56553f1e22ee56722603af2164d63b0c7d2) | `` passepartui: 0.1.4 -> 0.1.5 ``                                                                                  |
| [`aec622a3`](https://github.com/NixOS/nixpkgs/commit/aec622a31ca82fe69bba80d2b7ae37c3f170feb8) | `` trafficserver: 9.2.5 -> 9.2.6 (#355733) ``                                                                      |
| [`056adf60`](https://github.com/NixOS/nixpkgs/commit/056adf60801b32ce91e7a143d12445c120e0f8c6) | `` xmrig-mo: 6.22.1-mo1 -> 6.22.2-mo1 ``                                                                           |
| [`cd008a11`](https://github.com/NixOS/nixpkgs/commit/cd008a1140954e302597e0a9d6c40fa178aacf0e) | `` python312Packages.minio: 7.2.10 -> 7.2.12 ``                                                                    |
| [`d134e5a0`](https://github.com/NixOS/nixpkgs/commit/d134e5a0a408af9fbaacc0c47ffe2199c9c0f3b6) | `` python312Packages.taco: fix build ``                                                                            |
| [`196a0619`](https://github.com/NixOS/nixpkgs/commit/196a06193d97ca03efc5012f2282fbbd3589fa91) | `` taco: nixfmt ``                                                                                                 |
| [`3a017817`](https://github.com/NixOS/nixpkgs/commit/3a01781715cab2dd558732542f1d62ae2796dbf3) | `` python312Packages.logilab-common: fix build ``                                                                  |
| [`f52c4151`](https://github.com/NixOS/nixpkgs/commit/f52c41513cedde4b9ad41cc3437838ed1c692be0) | `` python311Packages.ml-collections: 0.1.1 -> 1.0.0 ``                                                             |
| [`b7d2f8a0`](https://github.com/NixOS/nixpkgs/commit/b7d2f8a018e193513a9796413e46f532f59d84e6) | `` abuild: 3.13.0 -> 3.14.1 ``                                                                                     |
| [`f5251813`](https://github.com/NixOS/nixpkgs/commit/f525181384b256b66fb6ac76ed9f0d6a9c6ebd94) | `` abuild: nixfmt ``                                                                                               |
| [`36306257`](https://github.com/NixOS/nixpkgs/commit/36306257be64ae6c632462b0d711d6518c7fd21c) | `` python312Packages.weaviate-client: 4.9.3 -> 4.9.4 ``                                                            |
| [`3ce6302e`](https://github.com/NixOS/nixpkgs/commit/3ce6302e40a0b6e2e0e0bbff2d93c000de36b541) | `` python312Packages.polyfactory: 2.18.0 -> 2.18.1 ``                                                              |
| [`99abf472`](https://github.com/NixOS/nixpkgs/commit/99abf472d32a06ca6fe950613732f0082eb9efb2) | `` python312Packages.django-rest-registration: fix build ``                                                        |
| [`5c2446b0`](https://github.com/NixOS/nixpkgs/commit/5c2446b03ac9f36f44daba0beceb653ad80a8870) | `` python312Packagesfastnlo-toolkit: fix build ``                                                                  |
| [`77e449e8`](https://github.com/NixOS/nixpkgs/commit/77e449e8b78477cce61292e1f5dce04d528c04d5) | `` fastnlo-toolkit: nixfmt ``                                                                                      |
| [`0136b333`](https://github.com/NixOS/nixpkgs/commit/0136b33388124ef4c6cbf7ee3a0b877db9eef2c8) | `` typora: add launcher ``                                                                                         |
| [`b88c20b2`](https://github.com/NixOS/nixpkgs/commit/b88c20b275ea8595da2ff549258ffbbe6f15e285) | `` typora: fix ``                                                                                                  |
| [`1eaed497`](https://github.com/NixOS/nixpkgs/commit/1eaed497a53b988b07c647b0792d7b4d61daf1fc) | `` [Backport release-24.11] mpris-timer: init at 1.1.1 (#363030) ``                                                |
| [`636583f9`](https://github.com/NixOS/nixpkgs/commit/636583f9c1c8f8f18220a9e1f8421b263adf704e) | `` linuxPackages.nvidiaPackages.latest: 560.35.03 -> 565.77 ``                                                     |
| [`6dd2a3a4`](https://github.com/NixOS/nixpkgs/commit/6dd2a3a48dc51f9c2b2b2ab5e5970e588af35c97) | `` linuxPackages.nvidiaPackages.vulkan_beta: 550.40.80 -> 550.40.81 ``                                             |
| [`1a9db9dc`](https://github.com/NixOS/nixpkgs/commit/1a9db9dccfc2d56422e669066b0ccd1139a9df73) | `` [Backport release-24.11] sops: 3.9.1 -> 3.9.2 (#363011) ``                                                      |
| [`8ef1582a`](https://github.com/NixOS/nixpkgs/commit/8ef1582acaced62ae72827a52f616a01df0806ef) | `` [24.11] qpwgraph: 0.7.8 -> 0.8.0 (#362177) ``                                                                   |
| [`32f1851a`](https://github.com/NixOS/nixpkgs/commit/32f1851a969b374e341e0bd1ae79a409a3922429) | `` audiobookshelf: 2.17.2 -> 2.17.4 ``                                                                             |
| [`1afdc2c8`](https://github.com/NixOS/nixpkgs/commit/1afdc2c89c72b69dcd08605d4c4ae030b5a1c11f) | `` ankama-launcher: 3.12.24 -> 3.12.26 ``                                                                          |
| [`92fd20f5`](https://github.com/NixOS/nixpkgs/commit/92fd20f552c0f1ff4d376fcd2cf00bd3590582cc) | `` [Backport release-24.11] yt-dlp: 2024.12.3 -> 2024.12.6 (#362780) ``                                            |
| [`ee7a132f`](https://github.com/NixOS/nixpkgs/commit/ee7a132fcebffe47c3b6d3f9bc37fba896dd0df8) | `` ungoogled-chromium: 131.0.6778.85-1 -> 131.0.6778.108-1 ``                                                      |
| [`45cf5ede`](https://github.com/NixOS/nixpkgs/commit/45cf5edec0ee164503ef9870659684cbd790ce3c) | `` chromium: support manually specifying the ungoogled patchset rev in update script ``                            |
| [`48cbf1d6`](https://github.com/NixOS/nixpkgs/commit/48cbf1d6df3da3a42a0797e914301a2ccae251ca) | `` shellhub-agent: 0.16.4 -> 0.17.2 ``                                                                             |
| [`67b86c1f`](https://github.com/NixOS/nixpkgs/commit/67b86c1f47f7b4ed85e35a49aaec7b9927af8783) | `` tealdeer: move to pkgs/by-name ``                                                                               |
| [`05097e19`](https://github.com/NixOS/nixpkgs/commit/05097e19ec14b8bf7340e3f6398fa6e0ff63decf) | `` postgresqlPackages.pg_partman: 5.1.0 -> 5.2.1 ``                                                                |
| [`a5053c5a`](https://github.com/NixOS/nixpkgs/commit/a5053c5a3f4df6e7f7e154c0e5292d417edc83e4) | `` mozillavpn: 2.24.1 -> 2.24.3 ``                                                                                 |
| [`098f3677`](https://github.com/NixOS/nixpkgs/commit/098f367726e9a76c47f671f506472a4e201edee7) | `` discord: bump all versions ``                                                                                   |
| [`d7e811df`](https://github.com/NixOS/nixpkgs/commit/d7e811df7f8e0385216931748807ff4489599948) | `` cargo-deadlinks: move to pkgs/by-name ``                                                                        |
| [`4e163b67`](https://github.com/NixOS/nixpkgs/commit/4e163b67e83889bd6eb95fd9625fd76e20a32cf7) | `` nixos/github-runners: remove newam from maintainers ``                                                          |
| [`a87ecf13`](https://github.com/NixOS/nixpkgs/commit/a87ecf13877b92c53c64dfa99b772969e5f534f9) | `` timeshift: sort dependencies alphabetically ``                                                                  |
| [`c6a5a2fe`](https://github.com/NixOS/nixpkgs/commit/c6a5a2fe076e8924e87a745d82d46cecd43a3021) | `` timeshift: format expressions ``                                                                                |
| [`0859b3fd`](https://github.com/NixOS/nixpkgs/commit/0859b3fd696cbf8d34ae5c7a005eb8e963cf7b1b) | `` onedrive: patch for openssl error ``                                                                            |
| [`82ca98b3`](https://github.com/NixOS/nixpkgs/commit/82ca98b3f6c02176a0fd7ad172d3aeac9d10b9fc) | `` Plasticity: Fix EGL ``                                                                                          |
| [`e82d1a7a`](https://github.com/NixOS/nixpkgs/commit/e82d1a7ab513558631350321278588f9f3e8b2f1) | `` opentofu: 1.8.6 -> 1.8.7 ``                                                                                     |
| [`8091872d`](https://github.com/NixOS/nixpkgs/commit/8091872dce5843c3347adcba1b51b5a09ec48e4c) | `` opentofu: apply nixfmt ``                                                                                       |
| [`fe01411b`](https://github.com/NixOS/nixpkgs/commit/fe01411bf46e8af2ac8f06a11a09114a02bf0f83) | `` opentofu: 1.8.5 -> 1.8.6 ``                                                                                     |
| [`8ad4fc1d`](https://github.com/NixOS/nixpkgs/commit/8ad4fc1d96802d4e040be39789a34a59dd1d4391) | `` winetricks: enable darwin support ``                                                                            |
| [`d2fd5599`](https://github.com/NixOS/nixpkgs/commit/d2fd5599207dd6835000701011b3d4cb5d3a8eda) | `` plasma-panel-spacer-extended: init at 1.9.0 ``                                                                  |
| [`f84a623a`](https://github.com/NixOS/nixpkgs/commit/f84a623a3329cb3f3e352dd1653c7a6e5d042c0d) | `` topgrade: 16.0.1 -> 16.0.2 ``                                                                                   |
| [`e634efce`](https://github.com/NixOS/nixpkgs/commit/e634efce4a1d8a70c30c8a3a9622d97547439c00) | `` rtkit: fix reduce logging patch URL (#360182) ``                                                                |
| [`4a88e4a9`](https://github.com/NixOS/nixpkgs/commit/4a88e4a94dcdf0f73a15357cfc80fb89f65a1a81) | `` shogun: disable failing tests ``                                                                                |
| [`7b926ebc`](https://github.com/NixOS/nixpkgs/commit/7b926ebcc6c6b99daa546d89928c3e41f6db2bf5) | `` shogun: modernize ``                                                                                            |
| [`7c3496c5`](https://github.com/NixOS/nixpkgs/commit/7c3496c591661584da17244d29331a3e2cf6f339) | `` python312Packages.hvplot: fix checks on darwin ``                                                               |
| [`c2ddac70`](https://github.com/NixOS/nixpkgs/commit/c2ddac708c567568de37c2e173f10178c4c1bd5f) | `` gnome-extension-manager: fix black screen via upstream patch (#358236) ``                                       |
| [`718a3939`](https://github.com/NixOS/nixpkgs/commit/718a39390ded38e3656c9cd522a6236d7d9b2e77) | `` tree-sitter: update webui fix-paths.patch ``                                                                    |
| [`07044a29`](https://github.com/NixOS/nixpkgs/commit/07044a2911feb45786d364ccd3a75edc7f2cd909) | `` fedifetcher: 7.1.12 -> 7.1.14 ``                                                                                |
| [`6bbc8465`](https://github.com/NixOS/nixpkgs/commit/6bbc84656c6a4b88c2f620a1b252e5430680ed78) | `` python310: 3.10.15 -> 3.10.16 ``                                                                                |
| [`55c9e59c`](https://github.com/NixOS/nixpkgs/commit/55c9e59c5c569a0a4b988bba08cb8dba02e6daed) | `` python39: 3.9.20 -> 3.9.21 ``                                                                                   |
| [`d57b8275`](https://github.com/NixOS/nixpkgs/commit/d57b8275572f1a926e4bf6295c9183c5bd382cfe) | `` lix: only use LTO with GCC ``                                                                                   |
| [`837a4c79`](https://github.com/NixOS/nixpkgs/commit/837a4c79f4f69a9f2944e2abceefe33f82541ee5) | `` nixos/hostapd: remove HT40- from default capabilities ``                                                        |
| [`373e82cb`](https://github.com/NixOS/nixpkgs/commit/373e82cbfa8f7ffd4ab067ec8a7785bdffff2a84) | `` garnet: 1.0.39 -> 1.0.46 ``                                                                                     |
| [`1ae088ab`](https://github.com/NixOS/nixpkgs/commit/1ae088ab3fb4fbe5d4a4c1700cdb91cafaec2ad7) | `` garnet: 1.0.36 -> 1.0.39 ``                                                                                     |
| [`14ae2e9d`](https://github.com/NixOS/nixpkgs/commit/14ae2e9d2396c6346de36edb5ef2012c22878539) | `` time: fix implicit function declaration (#362226) ``                                                            |
| [`41d6ad5b`](https://github.com/NixOS/nixpkgs/commit/41d6ad5b72920ec919af9c08fa7bf5f4c0d8ac9b) | `` pnpm: 9.14.4 -> 9.15.0 ``                                                                                       |
| [`c39483e6`](https://github.com/NixOS/nixpkgs/commit/c39483e6647a500f5f98acc703c32c896d342eaa) | `` amdvlk: 2024.Q4.1.3 -> 2024.Q4.2 ``                                                                             |
| [`ff55b184`](https://github.com/NixOS/nixpkgs/commit/ff55b184e20003bd948d19b560da7156a3505322) | `` amdvlk: 2024.Q3.3 -> 2024.Q4.1 ``                                                                               |
| [`b34d0718`](https://github.com/NixOS/nixpkgs/commit/b34d0718d7335a1c9d279c04bb631f20fb317739) | `` linuxKernel.kernels.linux_zen: 6.12.1-zen1 -> 6.12.2-zen1 ``                                                    |
| [`38460070`](https://github.com/NixOS/nixpkgs/commit/38460070d2ad2e21e359c7a0bf7334738f9fe2f2) | `` linuxKernel.kernels.linux_lqx: 6.12.1-lqx1 -> 6.12.2-lqx3 ``                                                    |
| [`7cc23ab4`](https://github.com/NixOS/nixpkgs/commit/7cc23ab453381fdf3f808198cb7703eb5a3e76d3) | `` palemoon-bin: 33.4.1 -> 33.5.0 ``                                                                               |
| [`4b19b2a8`](https://github.com/NixOS/nixpkgs/commit/4b19b2a897696451a31f0975c28bec27f0acbf51) | `` tagger: fix build with strictDeps ``                                                                            |
| [`5468a7c5`](https://github.com/NixOS/nixpkgs/commit/5468a7c503dc6f1c935a1187b297514c8f0c1bb8) | `` github-runner: fix build with strictDeps ``                                                                     |
| [`ca0d660e`](https://github.com/NixOS/nixpkgs/commit/ca0d660eed9ab66220c9e3b5cf50042da1a49d68) | `` dafny: fix build with strictDeps ``                                                                             |
| [`f8ca47d7`](https://github.com/NixOS/nixpkgs/commit/f8ca47d7e6e1a82edc85db9c925abc8c76b819e1) | `` raycast: 1.87.2 -> 1.87.4 ``                                                                                    |
| [`3855bc48`](https://github.com/NixOS/nixpkgs/commit/3855bc48d3054936320835a1f8f985d13c4a3888) | `` dotnetCorePackages.combinePackages: use wrapper ``                                                              |
| [`fb459fbf`](https://github.com/NixOS/nixpkgs/commit/fb459fbf3f05c696fd674aa5bd62bf6e15a0e166) | `` dotnet: make wrappers usable as DOTNET_ROOT ``                                                                  |
| [`f2217fa7`](https://github.com/NixOS/nixpkgs/commit/f2217fa7c05fc0ceaa3255fb855beb5ccf6421f7) | `` prometheus-knot-exporter: 3.4.2 -> 3.4.3 ``                                                                     |
| [`92ebb4e0`](https://github.com/NixOS/nixpkgs/commit/92ebb4e021c8cdbedf45a9e463162c97d48e1624) | `` python312Packages.libknot: 3.4.2 -> 3.4.3 ``                                                                    |
| [`b5a06be0`](https://github.com/NixOS/nixpkgs/commit/b5a06be0b4383102b3c5bc00039b4424e011b9cb) | `` knot-dns: add .meta.changelog ``                                                                                |
| [`4afc32cd`](https://github.com/NixOS/nixpkgs/commit/4afc32cdb91baf575f9f4e6e4fd54f2ca1b02520) | `` knot-dns: 3.4.2 -> 3.4.3 ``                                                                                     |
| [`8a3654cd`](https://github.com/NixOS/nixpkgs/commit/8a3654cd28ed29957f3a392d5db4720c3257d7b7) | `` witness: 0.6.0 -> 0.7.0 ``                                                                                      |
| [`4f31ba41`](https://github.com/NixOS/nixpkgs/commit/4f31ba41793c460c17651ed58401540b7612008c) | `` redocly: 1.25.9 -> 1.25.11 ``                                                                                   |
| [`dc1da001`](https://github.com/NixOS/nixpkgs/commit/dc1da001242b9817286d585721c425a9d54a7230) | `` python312Packages.sip: 6.8.6 -> 6.9.0 ``                                                                        |
| [`1eac1a44`](https://github.com/NixOS/nixpkgs/commit/1eac1a443209c627f7de07206438885a19c10b95) | `` nixos/github-runner: use bashInteractive instead of bash (#339875) ``                                           |
| [`0e162d8f`](https://github.com/NixOS/nixpkgs/commit/0e162d8f017e46674d31752def1ef66bbb15ea6a) | `` turbo: 2.3.0 -> 2.3.3 ``                                                                                        |
| [`052f57cf`](https://github.com/NixOS/nixpkgs/commit/052f57cf453c3cdabcff69a1b0e3b2f8ed0b90dc) | `` turbo: importCargoLock -> fetchCargoVendor ``                                                                   |
| [`8e6558d4`](https://github.com/NixOS/nixpkgs/commit/8e6558d49964fa996c35c774d45b3d8b97363b35) | `` famistudio: remove `with lib;` ``                                                                               |
| [`221bd1d0`](https://github.com/NixOS/nixpkgs/commit/221bd1d0b90bdc07baf8b6169af05f433e7acc6c) | `` famistudio: .NET 7 -> 8 ``                                                                                      |
| [`cc29c6b7`](https://github.com/NixOS/nixpkgs/commit/cc29c6b74ca50a82273189e3bd66dc4eca78f18b) | `` famistudio: migrate to by-name ``                                                                               |
| [`4cd763a2`](https://github.com/NixOS/nixpkgs/commit/4cd763a2560c71d0322cfc7f393ae781b471e117) | `` famistudio: nixfmt ``                                                                                           |
| [`98990599`](https://github.com/NixOS/nixpkgs/commit/989905995c8f96b038c203f07ab2cb6800991e56) | `` upgrade-assistant: 0.5.820 -> 0.5.829 ``                                                                        |
| [`c967c214`](https://github.com/NixOS/nixpkgs/commit/c967c21403207659fd71ce80425db159862ff37f) | `` pbm: 1.3.2 -> 1.4.3 ``                                                                                          |
| [`1ac8583a`](https://github.com/NixOS/nixpkgs/commit/1ac8583a7a88e84b9099f52362b559569ecbfec2) | `` fable: 4.20.0 -> 4.24.0 ``                                                                                      |
| [`3aae2757`](https://github.com/NixOS/nixpkgs/commit/3aae2757e5764c90527eb1614226d3a626831e7f) | `` csharpier: 0.29.1 -> 0.30.2 ``                                                                                  |
| [`48c86fdd`](https://github.com/NixOS/nixpkgs/commit/48c86fdd87531b068c709fd948eaa4e0405dd62e) | `` fable: add version test ``                                                                                      |
| [`491c90dc`](https://github.com/NixOS/nixpkgs/commit/491c90dcbbe27a025a1c6e625551b668fc22fb65) | `` buildDotnetGlobalTool: add default updateScript ``                                                              |
| [`1dc654bf`](https://github.com/NixOS/nixpkgs/commit/1dc654bf6743cd56ae337384929eff06b79e0152) | `` buildDotnetGlobalTools: add finalAttrs support ``                                                               |
| [`f0c70a5f`](https://github.com/NixOS/nixpkgs/commit/f0c70a5f77de060275cf896ec396e3d9c29dae61) | `` buildDotnetGlobalTool: format with nixfmt ``                                                                    |
| [`b6c5eb8d`](https://github.com/NixOS/nixpkgs/commit/b6c5eb8d602ef35e853df1646a496b5aed6e30d1) | `` python312Packages.comicon: 1.2.0 -> 1.2.1 ``                                                                    |
| [`8eb672c5`](https://github.com/NixOS/nixpkgs/commit/8eb672c5d6054cb26e14d4a27ce234ab11eb8059) | `` nixos-facter: 0.2.0 -> 0.3.0 ``                                                                                 |
| [`430d5cab`](https://github.com/NixOS/nixpkgs/commit/430d5cab6a8dbce08c675c14ad52fe0a7af48b48) | `` hwinfo: split lib from bin output ``                                                                            |
| [`d4459a06`](https://github.com/NixOS/nixpkgs/commit/d4459a064d1ba2287318816c757d6c8c5d959fb9) | `` gnomeExtensions.arcmenu: 55 -> 63 ``                                                                            |
| [`a4a41fc8`](https://github.com/NixOS/nixpkgs/commit/a4a41fc81e89449444a1b60c7cfe0e8d0d036487) | `` rhythmbox: 3.4.7 → 3.4.8 ``                                                                                     |
| [`82f79746`](https://github.com/NixOS/nixpkgs/commit/82f79746275bcd847b97b1fd65c03c420fbd5102) | `` orca: 47.1 → 47.2 ``                                                                                            |
| [`c6c1fe12`](https://github.com/NixOS/nixpkgs/commit/c6c1fe123c1e4536d92d6cc3ff4a42532a406eff) | `` libspelling: 0.4.4 → 0.4.5 ``                                                                                   |
| [`2d46f835`](https://github.com/NixOS/nixpkgs/commit/2d46f835f563fd09f62e1de561933ef3072e0152) | `` gtksourceview5: 5.14.1 → 5.14.2 ``                                                                              |
| [`c224f027`](https://github.com/NixOS/nixpkgs/commit/c224f0274daae61eb9e051a72575d36e5861ab98) | `` gnome-text-editor: 47.1 → 47.2 ``                                                                               |
| [`13722ab2`](https://github.com/NixOS/nixpkgs/commit/13722ab2df47e22bf640f72e9556979dee4531b9) | `` gnome-software: 47.1 → 47.2 ``                                                                                  |
| [`74f55c1a`](https://github.com/NixOS/nixpkgs/commit/74f55c1a78026c8befa4ae38a21bce8208533590) | `` gnome-maps: 47.1 → 47.2 ``                                                                                      |
| [`bff7cc94`](https://github.com/NixOS/nixpkgs/commit/bff7cc94c09882b47633a50acf1d05ac471b2a76) | `` ghex: 46.0 → 46.1 ``                                                                                            |
| [`13af6124`](https://github.com/NixOS/nixpkgs/commit/13af6124f0ee670d6f7b5782830138b443b59aad) | `` file-roller: 44.3 → 44.4 ``                                                                                     |
| [`b2d48159`](https://github.com/NixOS/nixpkgs/commit/b2d4815985e9d29970c030e84330b44aa6ee1ff6) | `` evolution-ews: 3.54.1 → 3.54.2 ``                                                                               |
| [`3dcf5cc4`](https://github.com/NixOS/nixpkgs/commit/3dcf5cc48dcfe10c2b52da1368e6a3f398f2820f) | `` evolution-data-server: 3.54.1 → 3.54.2 ``                                                                       |
| [`8509fad1`](https://github.com/NixOS/nixpkgs/commit/8509fad1ca241d15ab5d0bc9c72c7557c7b7988f) | `` evolution: 3.54.1 → 3.54.2 ``                                                                                   |
| [`76887013`](https://github.com/NixOS/nixpkgs/commit/768870130db92326f0fbe28181778e34ff61ba69) | `` gnome.updateScript: Fetch cache.json from download.gnome.org/sources ``                                         |
| [`3161c72d`](https://github.com/NixOS/nixpkgs/commit/3161c72d6142564351ab81dec6ac208ca53cff51) | `` ocamlPackages.melange: init at 4.0.1-52 + 4.0.0-51 + 4.0.0-414 ``                                               |