### PR TITLE
chore(flake/zen-browser): `ddbfcd69` -> `6dedec86`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -602,11 +602,11 @@
         "nixpkgs": "nixpkgs_3"
       },
       "locked": {
-        "lastModified": 1733840403,
-        "narHash": "sha256-j5hmZ/Oudzr4/HB383uUvY86PxB4c94+7QRV109kOpE=",
+        "lastModified": 1733972608,
+        "narHash": "sha256-ek7ojwOo/FFfTlTmaYMxK2rNYfnL9I8ACOE8654u6ho=",
         "owner": "0xc000022070",
         "repo": "zen-browser-flake",
-        "rev": "ddbfcd69583724e6d142af98010411ac26c2029d",
+        "rev": "6dedec8619f2fd0da13f45e144bc820b54673222",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                          | Message                                |
| --------------------------------------------------------------------------------------------------------------- | -------------------------------------- |
| [`6dedec86`](https://github.com/0xc000022070/zen-browser-flake/commit/6dedec8619f2fd0da13f45e144bc820b54673222) | `` Update Zen Browser to v1.0.2-b.1 `` |