### PR TITLE
chore(flake/zen-browser): `6dedec86` -> `b2a4aeaa`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -602,11 +602,11 @@
         "nixpkgs": "nixpkgs_3"
       },
       "locked": {
-        "lastModified": 1733972608,
-        "narHash": "sha256-ek7ojwOo/FFfTlTmaYMxK2rNYfnL9I8ACOE8654u6ho=",
+        "lastModified": 1734038753,
+        "narHash": "sha256-v2NetNrFvObcTx5Gw0MV9leJQr0KfCLtbpC4gZaq+Tc=",
         "owner": "0xc000022070",
         "repo": "zen-browser-flake",
-        "rev": "6dedec8619f2fd0da13f45e144bc820b54673222",
+        "rev": "b2a4aeaad1cdb4a0d8901313d6388a8b4bf2c59d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                          | Message                                               |
| --------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------- |
| [`002ffff1`](https://github.com/0xc000022070/zen-browser-flake/commit/002ffff13523589d983a493e55ce89df8520e898) | `` fix(desktop): update StartupWMClass to zen-beta `` |