### PR TITLE
chore(flake/stylix): `3d887bd0` -> `9015d5d0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -493,11 +493,11 @@
         "tinted-tmux": "tinted-tmux"
       },
       "locked": {
-        "lastModified": 1734025806,
-        "narHash": "sha256-xrpw39YNjsTtUnqdk0nG1WdjJqEGITHdnvlxJwohd9s=",
+        "lastModified": 1734110444,
+        "narHash": "sha256-fp1iV2JldCSvz+7ODzXYUkQ+H7zyiWw5E0MQ4ILC4vw=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "3d887bd0d7fffecae67d4e0088cce9b359d1be97",
+        "rev": "9015d5d0d5d100f849129c43d257b827d300b089",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                        | Message                      |
| --------------------------------------------------------------------------------------------- | ---------------------------- |
| [`9015d5d0`](https://github.com/danth/stylix/commit/9015d5d0d5d100f849129c43d257b827d300b089) | `` librewolf: init (#679) `` |