### PR TITLE
chore(flake/nixpkgs): `a0f3e10d` -> `314e12ba`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -392,11 +392,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1733808091,
-        "narHash": "sha256-KWwINTQelKOoQgrXftxoqxmKFZb9pLVfnRvK270nkVk=",
+        "lastModified": 1734083684,
+        "narHash": "sha256-5fNndbndxSx5d+C/D0p/VF32xDiJCJzyOqorOYW4JEo=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "a0f3e10d94359665dba45b71b4227b0aeb851f8e",
+        "rev": "314e12ba369ccdb9b352a4db26ff419f7c49fa84",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                   |
| ---------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------- |
| [`7d9c46c5`](https://github.com/NixOS/nixpkgs/commit/7d9c46c56bd3f2eb6c8e3ae1cda10f88d76878af) | `` hunspellDicts.ko_KR: init at 0.7.94 ``                                                 |
| [`f40eaa41`](https://github.com/NixOS/nixpkgs/commit/f40eaa41bccd269732dcf9ff8a9cb0125df07c38) | `` virtualbox: Fix UI language selection in virtualbox ``                                 |
| [`fc144645`](https://github.com/NixOS/nixpkgs/commit/fc144645c5186e34d41fc4b8bdb2e56f38cfc5da) | `` [Backport release-24.11] cardimpose: init at 0.2.1 (#364775) ``                        |
| [`7809ceec`](https://github.com/NixOS/nixpkgs/commit/7809ceecb62fcefa6b2e607d3f9f80f648332a3e) | `` ocamlPackages.ocplib-simplex: 0.5 → 0.5.1 ``                                           |
| [`198bf24b`](https://github.com/NixOS/nixpkgs/commit/198bf24b143626386d8485d0ea5ee7db8f15cd3a) | `` [Backport release-24.11] sydbox: 3.28.3 -> 3.29.4 (#364530) ``                         |
| [`036d133b`](https://github.com/NixOS/nixpkgs/commit/036d133b02206e91fdca84e02e56ad15fc3fec69) | `` [Backport release-24.11] skim: 0.10.4 -> 0.15.0 (#364598) ``                           |
| [`5cb7453e`](https://github.com/NixOS/nixpkgs/commit/5cb7453e857d5281570c3537a0a635efa4f3588c) | `` [Backport release-24.11] concessio: init at 0.1.9 (#364529) ``                         |
| [`75f58c08`](https://github.com/NixOS/nixpkgs/commit/75f58c08616d21e3c6ef0eee9953e1500104b8ea) | `` forgejo: 9.0.2 -> 9.0.3 ``                                                             |
| [`c2f3de78`](https://github.com/NixOS/nixpkgs/commit/c2f3de78967f2027affc2034546830c839685779) | `` forgejo-lts: 7.0.11 -> 7.0.12 ``                                                       |
| [`8df52f3d`](https://github.com/NixOS/nixpkgs/commit/8df52f3d8b0db7dc0f67e204abd69bc8f1321a41) | `` openslide: expose build system compiler to meson to fix cross build ``                 |
| [`49e6f680`](https://github.com/NixOS/nixpkgs/commit/49e6f6801c9320b1dd35257f229b0e56d21f878b) | `` ungoogled-chromium: 131.0.6778.108-1 -> 131.0.6778.139-1 ``                            |
| [`cfd92cfb`](https://github.com/NixOS/nixpkgs/commit/cfd92cfb7562503d08a47a69972ee02d9f43f743) | `` nixos/doc: document how to allow-list tablespaces ``                                   |
| [`e65d570f`](https://github.com/NixOS/nixpkgs/commit/e65d570f073cbe22a4477023690eb56e37bd35b9) | `` egl-wayland: 1.1.16 -> 1.1.17 ``                                                       |
| [`a5f63a85`](https://github.com/NixOS/nixpkgs/commit/a5f63a851b15b643849460c4cd01b4b3707e8dbd) | `` opentabletdriver: remove `with lib` from meta, remove meta.description from desktop `` |
| [`a0ca5c6b`](https://github.com/NixOS/nixpkgs/commit/a0ca5c6b02f60de30de7e17d62040e02d1ea29b4) | `` opentabletdriver: fix updateScript ``                                                  |
| [`fa0ffc15`](https://github.com/NixOS/nixpkgs/commit/fa0ffc153463044f4bf2d1f82da5a91a1933a030) | `` opentabletdriver: 0.6.4.0 -> 0.6.4.0-unstable-2024-11-25 ``                            |
| [`db130ab1`](https://github.com/NixOS/nixpkgs/commit/db130ab160bd2d492779821edb34f0d54d3a014c) | `` opentabletdriver: replace sed with substituteInPlace ``                                |
| [`cc872dc8`](https://github.com/NixOS/nixpkgs/commit/cc872dc83d2657f9d5c89a50ee97113d66b3f53b) | `` opentabletdriver: format with nixfmt-rfc-style ``                                      |
| [`a7241b94`](https://github.com/NixOS/nixpkgs/commit/a7241b94b4c9d75e8796f626a0358c07cedf409b) | `` opentabletdriver: move to pkgs/by-name ``                                              |
| [`e45fb5c6`](https://github.com/NixOS/nixpkgs/commit/e45fb5c685b2fc77d42690bd571e9a85c495352a) | `` python312Packages.pyslurm: 23.11.0 -> 24.5.0 ``                                        |
| [`72724b10`](https://github.com/NixOS/nixpkgs/commit/72724b107e478cfccb9d3e3a9b36061679f1ccb4) | `` bup: 0.33.4 -> 0.33.5 ``                                                               |
| [`fa388a71`](https://github.com/NixOS/nixpkgs/commit/fa388a71b41aba52bbe280bc2561d35d317c28bb) | `` xmedcon: 0.24.0 -> 0.24.1 ``                                                           |
| [`a1308a68`](https://github.com/NixOS/nixpkgs/commit/a1308a6850cd8793510b92319b779f4f08fda6e1) | `` [Backport release-24.11] rectangle-pro: refactor, 3.0.19 -> 3.0.37 (#364523) ``        |
| [`4c68917b`](https://github.com/NixOS/nixpkgs/commit/4c68917bb3a1f40e34f223647ae61ed053c0f96d) | `` pcloud: fix download link ``                                                           |
| [`5dbd9a89`](https://github.com/NixOS/nixpkgs/commit/5dbd9a899a756b64e8850f9d3eba32aaa30d8084) | `` coqPackages.hierarchy-builder: 1.7.0 -> 1.7.1 (#362647) ``                             |
| [`e75b0cf4`](https://github.com/NixOS/nixpkgs/commit/e75b0cf4056be4ecf096d408a6a5bf8fb31c9472) | `` [Backport release-24.11] gallery-dl: 1.27.7 -> 1.28.1 (#364513) ``                     |
| [`94bc6e08`](https://github.com/NixOS/nixpkgs/commit/94bc6e08f64130ca3e9d55eb5373278d745ed8ee) | `` [Backport release-24.11] clapgrep: init at 1.3.1 (#364493) ``                          |
| [`189349ec`](https://github.com/NixOS/nixpkgs/commit/189349ec9db8abcd559f68e942c651006442f504) | `` [Backport release-24.11] gitlab: 17.6.1 -> 17.6.2 (#364319) ``                         |
| [`2afa70a1`](https://github.com/NixOS/nixpkgs/commit/2afa70a15bdeea839704f4d6383d3d4407f6a6e5) | `` [Backport release-24.11] gitea: 1.22.4 -> 1.22.5 (#364486) ``                          |
| [`c608b391`](https://github.com/NixOS/nixpkgs/commit/c608b39109e97d31a3c90206e287c1d3c5094315) | `` ocamlPackages.elpi: 1.20.0 → 2.0.5 ``                                                  |
| [`ff4cbbad`](https://github.com/NixOS/nixpkgs/commit/ff4cbbad0b13c1aff96439afa449dfbe84d79e8a) | `` nav: init at 1.2.1 ``                                                                  |
| [`6c94f637`](https://github.com/NixOS/nixpkgs/commit/6c94f637f58afc8b577cce8c088d848ca0866b54) | `` maintainers: add Jojo4GH ``                                                            |
| [`c37dcf5d`](https://github.com/NixOS/nixpkgs/commit/c37dcf5d835779dad26ac9b20762ecef029a0a25) | `` maintainers: add David-Kopczynski ``                                                   |
| [`66cfe568`](https://github.com/NixOS/nixpkgs/commit/66cfe5682793051aec4696f0d6e367771566cdc2) | `` [Backport release-24.11] nixos/rtkit: mention pipewire in docstring (#364332) ``       |
| [`8b37852f`](https://github.com/NixOS/nixpkgs/commit/8b37852fb700eade92890cf7f5ea3b86df3e699a) | `` coqPackages.ExtLib: 0.12.2 → 0.13.0 ``                                                 |
| [`2542b275`](https://github.com/NixOS/nixpkgs/commit/2542b275aaab03cfaaced0495d310cfe79ff0bad) | `` zfs_2_1: 2.1.15 -> 2.1.16 ``                                                           |
| [`6e887430`](https://github.com/NixOS/nixpkgs/commit/6e8874307f919d2a0f80e4227bb6f69e60bd9b4f) | `` fetchFromGitHub: expose tag argument ``                                                |
| [`79c6b3b1`](https://github.com/NixOS/nixpkgs/commit/79c6b3b11c1765eb873bb2a48979e479eca5dfe4) | `` zfs_2_2: 2.2.6 -> 2.2.7 ``                                                             |
| [`566f80a4`](https://github.com/NixOS/nixpkgs/commit/566f80a4ba0bc62bf9258daf7f269dd2a63f238f) | `` [Backport release-24.11] television: 0.5.3 -> 0.6.2 (#364358) ``                       |
| [`7946b228`](https://github.com/NixOS/nixpkgs/commit/7946b228aa0edcedeeca2089335fb0372884e905) | `` [Backport release-24.11] lock: 1.3.0 -> 1.3.4 (#364356) ``                             |
| [`549b2c01`](https://github.com/NixOS/nixpkgs/commit/549b2c01ef3f57a7419ee733eb869ac1bb7d6eb8) | `` organicmaps: fix rendering issue ``                                                    |
| [`991a7c5d`](https://github.com/NixOS/nixpkgs/commit/991a7c5df0420dd0e5faffbaa1470923edbb6ee6) | `` xen: 4.19.0-unstable-2024-11-12 -> 4.19.1 ``                                           |
| [`a2e0755b`](https://github.com/NixOS/nixpkgs/commit/a2e0755b39afd75156c1af5b1749edd26d8325b5) | `` xen: make upstreamVersion optional ``                                                  |
| [`c314f117`](https://github.com/NixOS/nixpkgs/commit/c314f117a8d0d7120b281689b0831b651355bbfc) | `` vault-tasks: 0.5.0 -> 0.6.1 ``                                                         |
| [`9c9a7f12`](https://github.com/NixOS/nixpkgs/commit/9c9a7f1265c13b4458733e285f7a3dc08a78cef5) | `` firefox-beta-bin-unwrapped: 133.0b2 -> 134.0b8 ``                                      |
| [`1990f3c3`](https://github.com/NixOS/nixpkgs/commit/1990f3c3907ac856c9c9322d1147e1506ebbbef8) | `` wavebox: 10.129.32-2 -> 10.131.16-2 ``                                                 |
| [`cd3dee03`](https://github.com/NixOS/nixpkgs/commit/cd3dee0358e0b32141cf21a76a79a7c830e1a4d1) | `` cargo-crev: 0.25.11 -> 0.26.2 ``                                                       |
| [`4b720610`](https://github.com/NixOS/nixpkgs/commit/4b720610830eda083ca50926ad23916380733c35) | `` system/activation: mention deps attr in activationScripts example ``                   |
| [`4a63721a`](https://github.com/NixOS/nixpkgs/commit/4a63721abfbb34feb88a1e2ff96627eb3b9a81bb) | `` xen: 4.16 is EOL ``                                                                    |
| [`f8d94a9c`](https://github.com/NixOS/nixpkgs/commit/f8d94a9ce157d06591f5b5dab04fb0a6c867bee3) | `` yandex-music: 5.23.2 -> 5.28.4 ``                                                      |
| [`db61c3c0`](https://github.com/NixOS/nixpkgs/commit/db61c3c0ec4f902bcd97994670b28076ce7dedfe) | `` moneydance: fix GTK crash ``                                                           |
| [`8cda7107`](https://github.com/NixOS/nixpkgs/commit/8cda7107e465449513828a173527dfdbd103e78e) | `` moneydance: apply nixfmt ``                                                            |
| [`52a33c87`](https://github.com/NixOS/nixpkgs/commit/52a33c8771cf8fbb1d0145915084e01d6d92d71e) | `` openvpn3: 23 -> 24 ``                                                                  |
| [`a8aac30f`](https://github.com/NixOS/nixpkgs/commit/a8aac30fee442de6c4604aeaab499ed7399414dc) | `` gdbuspp: 2 -> 3 ``                                                                     |
| [`847f9db5`](https://github.com/NixOS/nixpkgs/commit/847f9db5608ef84e58a02a8d1b7eeb94a505dd3c) | `` maintainers: add second key to progrm_jarvis ``                                        |
| [`927af9a4`](https://github.com/NixOS/nixpkgs/commit/927af9a482db2a8eb35db03ef1e6a9f3d3e278c0) | `` chromium: 131.0.6778.108 -> 131.0.6778.139 ``                                          |
| [`d7d5de31`](https://github.com/NixOS/nixpkgs/commit/d7d5de3199b34f90f0369520aaa5a6d9d5e42ad3) | `` duplicity: 3.0.3.1 -> 3.0.3.2 ``                                                       |
| [`b6f2b0ce`](https://github.com/NixOS/nixpkgs/commit/b6f2b0ce5c09c9f3f7c89d1c19a449f97465e568) | `` duplicity: 3.0.2 -> 3.0.3.1 ``                                                         |
| [`9a07d297`](https://github.com/NixOS/nixpkgs/commit/9a07d297f42b9cfa9597f9c642c3758e9021f69a) | `` wasm-tools: 1.221.0 -> 1.221.2 ``                                                      |
| [`f2fd154b`](https://github.com/NixOS/nixpkgs/commit/f2fd154b46cfcf9daf2d4979225a5c87700b802d) | `` wasm-tools: 1.220.0 -> 1.221.0 ``                                                      |
| [`ba0b4267`](https://github.com/NixOS/nixpkgs/commit/ba0b4267bba9d6054c1e09ba14121c6a540357e2) | `` wasm-tools: 1.219.1 -> 1.220.0 ``                                                      |
| [`95dd1bbf`](https://github.com/NixOS/nixpkgs/commit/95dd1bbf1237f82838130c55b9bfb74608ed62a4) | `` cargo-modules: 0.19.1 -> 0.20.2 ``                                                     |
| [`2e61864c`](https://github.com/NixOS/nixpkgs/commit/2e61864ce169d9a69a961653c8a1acd7494514f2) | `` nixos/librenms: order librenms-setup after network.target ``                           |
| [`ddb80644`](https://github.com/NixOS/nixpkgs/commit/ddb806449d9a9d6e85bfaedbc3db67851225b7c8) | `` batman-adv: 2024.3 -> 2024.4 ``                                                        |
| [`33e11993`](https://github.com/NixOS/nixpkgs/commit/33e11993c13f24ccd843acba2b1ee77d16df0b53) | `` gitlab: increase node heap size limit ``                                               |
| [`4f7f8964`](https://github.com/NixOS/nixpkgs/commit/4f7f8964527e447267a8d0dacc808e855f0744f4) | `` ocamlPackages.tls-eio: init at 1.0.4 ``                                                |
| [`1ed38edc`](https://github.com/NixOS/nixpkgs/commit/1ed38edcc3327f81b34b196a71fd87ac3093eb6b) | `` nixos/ebusd: fix device access ``                                                      |
| [`fe30593a`](https://github.com/NixOS/nixpkgs/commit/fe30593a7128a4bee906888b61a6e487fe3c3e36) | `` ocamlPackages.utop: 2.14.0 → 2.15.0 ``                                                 |
| [`dab4273f`](https://github.com/NixOS/nixpkgs/commit/dab4273f76f05c69f25a98f4115076529cd93961) | `` linux-firmware: 20241110 -> 20241210 ``                                                |
| [`3cfc9ca0`](https://github.com/NixOS/nixpkgs/commit/3cfc9ca05256bb85ee897708cfc825f8fda66b7e) | `` spotdl: 4.2.8 -> 4.2.10 ``                                                             |
| [`7db18b8e`](https://github.com/NixOS/nixpkgs/commit/7db18b8ec24ffb1864e757e163a0d991f6be5648) | `` [Backport release-24.11] scrcpy: 3.0.2 -> 3.1 (#364096) ``                             |
| [`1d444280`](https://github.com/NixOS/nixpkgs/commit/1d444280fdaaf9bde1756b1e6300a222ac3cb253) | `` kanidm: permit hydra to build unmaintained 1.3 release ``                              |
| [`694385bf`](https://github.com/NixOS/nixpkgs/commit/694385bf49100bb59102e2a681cd947e396bc1a1) | `` kanidm: add back 1.3 compatibility ``                                                  |
| [`8be37a49`](https://github.com/NixOS/nixpkgs/commit/8be37a4927734e5c017949847dd8bb7956737b5c) | `` kandim: fix update script and limit to main package ``                                 |
| [`e7c01680`](https://github.com/NixOS/nixpkgs/commit/e7c016803dcc688c752cc2f68eb7bf7267ed9a13) | `` kanidm: support multiple versions, 1.4 and 1.3 ``                                      |
| [`5395b03f`](https://github.com/NixOS/nixpkgs/commit/5395b03f353c4c95c91df67ee305c2330aaf25b6) | `` qtscrcpy: 3.0.0 -> 3.0.1 (#363525) ``                                                  |
| [`d3297722`](https://github.com/NixOS/nixpkgs/commit/d3297722a5abb2c6cd4beafd3ce767de4a166ca1) | `` dotnet: force evaluation of sdk nuget packages ``                                      |
| [`bd101820`](https://github.com/NixOS/nixpkgs/commit/bd101820465e921f23912e76848df1345de47b5f) | `` dotnet/combine-packages: don't inherit meta from cli ``                                |
| [`f5d06d79`](https://github.com/NixOS/nixpkgs/commit/f5d06d7932b2f36bb217d7006f9656df5e788e59) | `` dotnet/wrapper: don't inherit meta from unwrapped ``                                   |
| [`df99c810`](https://github.com/NixOS/nixpkgs/commit/df99c810dcdac631c3326a3e73c03bdd535b4eed) | `` [Backport release-24.11] slskd: 0.21.4 -> 0.22.0 (#364062) ``                          |
| [`b4d91516`](https://github.com/NixOS/nixpkgs/commit/b4d915161034ac05388e8cf0c3b1c2d3aaf5eac6) | `` electron-source.electron_33: 33.0.2 -> 33.3.0 ``                                       |
| [`9331a63f`](https://github.com/NixOS/nixpkgs/commit/9331a63fec6819f3bee931d1ab11e87fabe50967) | `` electron-source.electron_32: 32.2.2 -> 32.2.7 ``                                       |
| [`4b49fa79`](https://github.com/NixOS/nixpkgs/commit/4b49fa793cdbc185d2e872e88d09377d53926cb1) | `` electron-source.electron_31: 31.7.2 -> 31.7.6 ``                                       |
| [`8f073a87`](https://github.com/NixOS/nixpkgs/commit/8f073a87204647b3f2dd9e79b65844100d9dd691) | `` electron-chromedriver_33: 33.0.2 -> 33.3.0 ``                                          |
| [`447b7e35`](https://github.com/NixOS/nixpkgs/commit/447b7e359104bdeb909100ec77b1d9df90734c5f) | `` electron-chromedriver_32: 32.2.2 -> 32.2.7 ``                                          |
| [`d3405005`](https://github.com/NixOS/nixpkgs/commit/d34050058a1cdf806799b9d226d8076c612137b7) | `` electron-chromedriver_31: 31.7.2 -> 31.7.6 ``                                          |
| [`0d72856f`](https://github.com/NixOS/nixpkgs/commit/0d72856fd7dc794779a921e5150cb4eb268fa38c) | `` electron_33-bin: 33.0.2 -> 33.3.0 ``                                                   |
| [`d646a0e4`](https://github.com/NixOS/nixpkgs/commit/d646a0e4d8f0d144c9200b9484cd7d7b1df6535c) | `` electron_32-bin: 32.2.2 -> 32.2.7 ``                                                   |
| [`eddcf598`](https://github.com/NixOS/nixpkgs/commit/eddcf598c0a0e718f23551c5cd37508c5c084afe) | `` electron_31-bin: 31.7.2 -> 31.7.6 ``                                                   |
| [`d663b03c`](https://github.com/NixOS/nixpkgs/commit/d663b03cb609d936702788148826647982dcbab4) | `` linux_latest-libre: 19663 -> 19675 (#359464) ``                                        |
| [`018f8c53`](https://github.com/NixOS/nixpkgs/commit/018f8c53d2a6960af7313e4d4561f9ec57b8628e) | `` .git-blame-ignore-revs: Add treewide reformat pass 1 ``                                |
| [`d9d87c51`](https://github.com/NixOS/nixpkgs/commit/d9d87c51960050e89c79e4025082ed965e770d68) | `` treewide: format all inactive Nix files ``                                             |
| [`8b4dc86f`](https://github.com/NixOS/nixpkgs/commit/8b4dc86f5abf60e2769de0692ae5b486c6a800ff) | `` ocamlPackages.mirage-crypto-rng-eio: init at 1.1.0 ``                                  |
| [`b81321fc`](https://github.com/NixOS/nixpkgs/commit/b81321fcfb1760795e50e2da960a9c12d769e04f) | `` ocamlPackages.mdx: 2.4.1 → 2.5.0 ``                                                    |
| [`d9dbd52b`](https://github.com/NixOS/nixpkgs/commit/d9dbd52b0f560eb26c5ad81c560d24e030d6513a) | `` sonarr: 4.0.10.2544 -> 4.0.11.2680 ``                                                  |
| [`44ce2325`](https://github.com/NixOS/nixpkgs/commit/44ce232544cb3fc6c67c5a64de9d78db044f639d) | `` sonarr: 4.0.9.2244 -> 4.0.10.2544 ``                                                   |
| [`bc536653`](https://github.com/NixOS/nixpkgs/commit/bc5366536ca708498d5ddf07e3fd7b5a14fa8157) | `` opencomposite: 0-unstable-2024-10-28 -> 0-unstable-2024-11-11 ``                       |
| [`72ae55e4`](https://github.com/NixOS/nixpkgs/commit/72ae55e49352fe4c024af6b3409d065e3d41d9f0) | `` [Backport release-24.11] peertube: 6.0.4 -> 6.3.3 (#363680) ``                         |
| [`1296e817`](https://github.com/NixOS/nixpkgs/commit/1296e817011485b641370d1076c1bd7cbe08e456) | `` firefox-esr-128-unwrapped: 128.5.0esr -> 128.5.1esr ``                                 |
| [`b0daf4e3`](https://github.com/NixOS/nixpkgs/commit/b0daf4e3541d4e45472cf0c6efa5e23f01f122c6) | `` firefox-bin-unwrapped: 133.0 -> 133.0.3 ``                                             |
| [`9976cafb`](https://github.com/NixOS/nixpkgs/commit/9976cafb592283d067bfd81482cfe95cd723e006) | `` firefox-unwrapped: 133.0 -> 133.0.3 ``                                                 |
| [`d7a83573`](https://github.com/NixOS/nixpkgs/commit/d7a835738e6b02f94ac0589814632884f279bb2d) | `` jetbrains.plugins: fix adding JAR plugins ``                                           |
| [`092063e1`](https://github.com/NixOS/nixpkgs/commit/092063e155c79c00c39b80c64816d1af854cb4fc) | `` nixos/cupsd: Fix permissions on shared directories ``                                  |
| [`70d961e6`](https://github.com/NixOS/nixpkgs/commit/70d961e65d9ef2c85528b4a6fc749253c62637ed) | `` nixos/printing: fix ShellCheck issues ``                                               |
| [`dddb6322`](https://github.com/NixOS/nixpkgs/commit/dddb6322e1b40511443dce0b6188290e32ea0f2d) | `` python312Packages.python-openstackclient: add requests socks support ``                |
| [`6854fdb0`](https://github.com/NixOS/nixpkgs/commit/6854fdb006f002346dce27b0ae6f4b4dc15dd189) | `` nexusmods-app: fix passthru tests ``                                                   |
| [`44b59915`](https://github.com/NixOS/nixpkgs/commit/44b59915cabf96ec3f3d03cfe7070d87c46d35fd) | `` nextcloud30Packages: update ``                                                         |
| [`b649dbd5`](https://github.com/NixOS/nixpkgs/commit/b649dbd51ebc7d22aac5dac8a7eca69c7880f9b5) | `` nextcloud29Packages: update ``                                                         |
| [`797d4d52`](https://github.com/NixOS/nixpkgs/commit/797d4d5203c833a9f3200f407953ed46f4295f0d) | `` nextcloud28Packages: update ``                                                         |
| [`26e44acf`](https://github.com/NixOS/nixpkgs/commit/26e44acf00492c2c65d7bbbcdd6a6ca3f8bde587) | `` nextcloud29: 29.0.9 -> 29.0.10 ``                                                      |
| [`c83e2b1d`](https://github.com/NixOS/nixpkgs/commit/c83e2b1d73f641c9c09f1afa3b406167554d64a6) | `` [Backport release-24.11] discord: update stable and canary (#363895) ``                |
| [`36b53b6a`](https://github.com/NixOS/nixpkgs/commit/36b53b6ac502fd818fbdd92fde32b308177a6d6c) | `` inv-sig-helper: 0-unstable-2024-09-24 -> 0-unstable-2024-12-10 ``                      |
| [`c80deb22`](https://github.com/NixOS/nixpkgs/commit/c80deb22a7f103f5f420a62f35f4ca7d51f19b16) | `` kryptor: add maintainer gepbird ``                                                     |
| [`558997a9`](https://github.com/NixOS/nixpkgs/commit/558997a97855bf660ac2e00f88987b2b0081982d) | `` kryptor: add version checking ``                                                       |
| [`857f5e64`](https://github.com/NixOS/nixpkgs/commit/857f5e64a4c84b5f0448148e0a5eb0c471170899) | `` kryptor: add update script ``                                                          |
| [`0b21ffed`](https://github.com/NixOS/nixpkgs/commit/0b21ffedda386e8ee039f3ac0b80f5ae153433e4) | `` kryptor: .NET 6 -> 8 ``                                                                |
| [`b920af30`](https://github.com/NixOS/nixpkgs/commit/b920af30de85503109890756b171e750da25bca8) | `` kryptor: refactor ``                                                                   |
| [`716d72c1`](https://github.com/NixOS/nixpkgs/commit/716d72c1368e595c96c2215893c9513cb86037d5) | `` kryptor: nixfmt ``                                                                     |
| [`aee69aa7`](https://github.com/NixOS/nixpkgs/commit/aee69aa73d36d7cc89b00ddf13565f46769b7834) | `` json-schema-for-humans: fix build and update ``                                        |
| [`c5156287`](https://github.com/NixOS/nixpkgs/commit/c5156287d704888daac8d6f46a1e26086b2a36e7) | `` linux_6_6: 6.6.63 -> 6.6.64 ``                                                         |
| [`54bd6476`](https://github.com/NixOS/nixpkgs/commit/54bd647612c47e9ab3252d46eecf5440e11a204f) | `` linux_6_12: 6.12.3 -> 6.12.4 ``                                                        |
| [`8542e972`](https://github.com/NixOS/nixpkgs/commit/8542e9721715eca44d9da5dddc748996935afbb1) | `` linux_testing: 6.13-rc1 -> 6.13-rc2 ``                                                 |
| [`ed95034b`](https://github.com/NixOS/nixpkgs/commit/ed95034b3cd31ac93e1f4c02754076c60c192274) | `` radicle-node: 1.0.0 → 1.1.0 ``                                                         |
| [`3a685649`](https://github.com/NixOS/nixpkgs/commit/3a6856498151a66bf4f952f7ac4b485dee1c083d) | `` [Backport release-24.11] subversion: 1.14.4 -> 1.14.5 (#363850) ``                     |
| [`75472b98`](https://github.com/NixOS/nixpkgs/commit/75472b98166710788496c612a5f9d6e8923c441a) | `` [Backport release-24.11] jenkins: 2.462.3 -> 2.479.2 (#363822) ``                      |
| [`343b3851`](https://github.com/NixOS/nixpkgs/commit/343b3851695e439d5d47cd6bbf09e3b7f02eef51) | `` [Backport release-24.11] nebula: 1.9.4 -> 1.9.5 (#363821) ``                           |
| [`99aa9f88`](https://github.com/NixOS/nixpkgs/commit/99aa9f889a907af8243ecd6200d7540be2c1a6d0) | `` [Backport release-24.11] htmldoc: 1.9.19 -> 1.9.20 (#363800) ``                        |
| [`aa57ca30`](https://github.com/NixOS/nixpkgs/commit/aa57ca305b6eacda953e7064a5f85058cb775cc6) | `` keycloak: 26.0.6 -> 26.0.7 ``                                                          |
| [`4ded1122`](https://github.com/NixOS/nixpkgs/commit/4ded1122b5f86913cd928b1dc3438bbec7566d43) | `` telegram-desktop: 5.8.2 -> 5.9.0 ``                                                    |
| [`e9a63498`](https://github.com/NixOS/nixpkgs/commit/e9a6349896b934d5de3ebca81292376199438592) | `` lunarvim: fix alias neovim is still in node-packages.nix ``                            |
| [`2b87a9b2`](https://github.com/NixOS/nixpkgs/commit/2b87a9b26579000302b0ab44f658ba663778d474) | `` fastly: 10.17.0 -> 10.17.1 ``                                                          |
| [`2a967028`](https://github.com/NixOS/nixpkgs/commit/2a967028475e679030fe986b9072c034ba705028) | `` thunderbird-128-unwrapped: 128.4.3esr -> 128.5.1esr ``                                 |
| [`b9267c05`](https://github.com/NixOS/nixpkgs/commit/b9267c0556cc8134abb82531432735b2668fa843) | `` thunderbird-latest-unwrapped: 132.0.1 -> 133.0 ``                                      |
| [`9ac83bcd`](https://github.com/NixOS/nixpkgs/commit/9ac83bcd08d5b730e0109e57d4c26bc1f98b23b3) | `` nixos/mailman: increase uwsgi buffer size ``                                           |
| [`3de99eb9`](https://github.com/NixOS/nixpkgs/commit/3de99eb96a52183dd238cafee311777afb9eb205) | `` nginxMainline: 1.27.2 -> 1.27.3 ``                                                     |
| [`ec55b0a9`](https://github.com/NixOS/nixpkgs/commit/ec55b0a92be3e63336f5a437d691fd090d8c9672) | `` gnomeExtensions: update collision renames ``                                           |
| [`932fd36c`](https://github.com/NixOS/nixpkgs/commit/932fd36c9e5d39164a2f037a85e97890b02112e9) | `` gnomeExtensions: auto-update ``                                                        |
| [`85592e18`](https://github.com/NixOS/nixpkgs/commit/85592e181b769e908e28984889c8190fd71ffcdb) | `` gnomeExtensions: fault tolerance for update-extensions.py ``                           |
| [`34cdfaeb`](https://github.com/NixOS/nixpkgs/commit/34cdfaeb574f007b4fc02a3a7975d51a9a0d3c99) | `` brave: 1.73.91 -> 1.73.97 ``                                                           |
| [`ed073c3c`](https://github.com/NixOS/nixpkgs/commit/ed073c3cad586a1bf516d8cf89f26033c72147ae) | `` river: 0.3.5 -> 0.3.6 ``                                                               |
| [`bd85aa3d`](https://github.com/NixOS/nixpkgs/commit/bd85aa3daf2a9977dacc94328474985c6ebb22d6) | `` avalanchego: 1.12.0-initial-poc.6 -> 1.12.0 ``                                         |
| [`1d2477c5`](https://github.com/NixOS/nixpkgs/commit/1d2477c5d68d95599fa91e7656a62eea984724dd) | `` chatzone-desktop: 5.2.1 -> 5.2.3 ``                                                    |
| [`98a8a38d`](https://github.com/NixOS/nixpkgs/commit/98a8a38def1625f8fbecf68a35e3795788b576cf) | `` nixos/librenms: add netali to maintainers ``                                           |
| [`4a3dacc5`](https://github.com/NixOS/nixpkgs/commit/4a3dacc509861f8c6e40d95e9769f44967397d93) | `` nixos/librenms: fix links in docs ``                                                   |
| [`fa0a8b55`](https://github.com/NixOS/nixpkgs/commit/fa0a8b5536e0d7d45ac1b21898fe3453dd02d880) | `` nixos/librenms: add enableLocalBilling option ``                                       |
| [`a5fa0a2e`](https://github.com/NixOS/nixpkgs/commit/a5fa0a2eac96fb41b4554ce69434fbfa94e09265) | `` nixos/librenms: add default php_memory_limit and use it in cronjobs ``                 |
| [`4ee290df`](https://github.com/NixOS/nixpkgs/commit/4ee290df6e96c03577dcbc915a677c404179981b) | `` trivy: 0.57.1 -> 0.58.0 ``                                                             |
| [`9c4259ba`](https://github.com/NixOS/nixpkgs/commit/9c4259ba925909ef564497b3fa47c359ba397588) | `` wlink: 0.1.0 -> 0.1.1 ``                                                               |
| [`4146540b`](https://github.com/NixOS/nixpkgs/commit/4146540b55ea85166b5914109622c7416555c6a6) | `` flake-checker: 0.2.0 -> 0.2.1 ``                                                       |
| [`833f5210`](https://github.com/NixOS/nixpkgs/commit/833f521077bda9373691c89d650673fc943359eb) | `` ngtcp2-gnutls: 1.8.0 -> 1.9.1 ``                                                       |
| [`15154570`](https://github.com/NixOS/nixpkgs/commit/15154570fa995ae98664db07c29f3febe3dee9cc) | `` doc/languages-frameworks/python: update references to python 3.12 ``                   |
| [`c725c983`](https://github.com/NixOS/nixpkgs/commit/c725c98341ceb0777bace0d264c5d4e8bbe31e39) | `` doc/languages-frameworks/python: Reword section to make commit rules a bit clearer ``  |
| [`68255b4a`](https://github.com/NixOS/nixpkgs/commit/68255b4a43a8694694e5abca46551b16d79549b6) | `` nixos/qgroundcontrol: Add cfg.package option ``                                        |
| [`0f3c997c`](https://github.com/NixOS/nixpkgs/commit/0f3c997c9bd44e978dc6f113eb3f299348069555) | `` qgroundcontrol: Disable bad message ``                                                 |
| [`61192d3c`](https://github.com/NixOS/nixpkgs/commit/61192d3cf5451e6fe8198e162125d96d172b209f) | `` dotnetCorePackages.patchNupkgs: fix patchelf usage ``                                  |
| [`f89c9d6b`](https://github.com/NixOS/nixpkgs/commit/f89c9d6b4a388bffeb069aa59655d0564c0590dd) | `` istatmenus: init at 7.02.10 ``                                                         |
| [`7d811a7e`](https://github.com/NixOS/nixpkgs/commit/7d811a7ec7a3fcc5918b5804a6ed828b87bd8891) | `` grafana: 11.3.1 -> 11.3.2 ``                                                           |
| [`6286a9d8`](https://github.com/NixOS/nixpkgs/commit/6286a9d86cc7e15c05a7368c283a6309779915da) | `` datadog-integrations-core: moderinize derivation ``                                    |
| [`a6141a01`](https://github.com/NixOS/nixpkgs/commit/a6141a01ab200a829f5fe5bc8a681f8f4c7a11f9) | `` nixos/datadog-agent: migrate deprecated config & set bin option ``                     |
| [`f346ff7d`](https://github.com/NixOS/nixpkgs/commit/f346ff7ddb88abb8157c11f66e5deb60d2605687) | `` datadog-integrations-core: 7.50.2 -> 7.56.2 ``                                         |
| [`ece31d0c`](https://github.com/NixOS/nixpkgs/commit/ece31d0c7c7cb60cbb4e93d9a8b6784e146b77b3) | `` datadog-agent: 7.50.3 -> 7.56.2 ``                                                     |
| [`ae1d1dbf`](https://github.com/NixOS/nixpkgs/commit/ae1d1dbf39804c77bfdbb4416583e7d472bfc29b) | `` datadog-integrations-core: 7.38.0 -> 7.50.2 ``                                         |
| [`9fc5d4ea`](https://github.com/NixOS/nixpkgs/commit/9fc5d4ea9c50c83c75ed9c03e06ea4c49b09645b) | `` docker-compose: 2.30.0 -> 2.30.3 ``                                                    |
| [`86727397`](https://github.com/NixOS/nixpkgs/commit/86727397295a3253636a49a99e712051a80d87ba) | `` linuxPackages_latest.broadcom_sta: add patch to compile on Kernel 6.12 ``              |