### PR TITLE
chore(flake/nixpkgs): `314e12ba` -> `39457135`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -407,11 +407,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1734083684,
-        "narHash": "sha256-5fNndbndxSx5d+C/D0p/VF32xDiJCJzyOqorOYW4JEo=",
+        "lastModified": 1734323986,
+        "narHash": "sha256-m/lh6hYMIWDYHCAsn81CDAiXoT3gmxXI9J987W5tZrE=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "314e12ba369ccdb9b352a4db26ff419f7c49fa84",
+        "rev": "394571358ce82dff7411395829aa6a3aad45b907",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                         |
| ---------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------- |
| [`bf673051`](https://github.com/NixOS/nixpkgs/commit/bf6730519ed464be4d4bb9a54eefb8010d29a6e2) | `` python312Packages.wrf-python: mark broken ``                                                 |
| [`384f8480`](https://github.com/NixOS/nixpkgs/commit/384f84805041e87c9a9829e25703bf013a78e5d2) | `` praat: 6.4.23 -> 6.4.25 ``                                                                   |
| [`4067904c`](https://github.com/NixOS/nixpkgs/commit/4067904c231ecc60d2163030579667f64ac9f8b6) | `` praat: 6.4.22 -> 6.4.23 ``                                                                   |
| [`9ca2e304`](https://github.com/NixOS/nixpkgs/commit/9ca2e3046b69a0e541042445c1140f88773bd73e) | `` texlive.tlpdb.nix: escape special characters in short description ``                         |
| [`bd13c947`](https://github.com/NixOS/nixpkgs/commit/bd13c947f92d2e20953af22c3b65fb3cc0225e86) | `` opera: 114.0.5282.102 -> 115.0.5322.77 ``                                                    |
| [`ed084bd0`](https://github.com/NixOS/nixpkgs/commit/ed084bd04c5faff43af2e0f8f83cbd457499fe53) | `` nextcloud-talk-desktop: init at 1.0.0 ``                                                     |
| [`eab87da8`](https://github.com/NixOS/nixpkgs/commit/eab87da8d0cbd3ea90aed1860b6b8ff5c2396e03) | `` postgresqlPackages.pgroonga: 3.2.4 -> 3.2.5 ``                                               |
| [`8a046e8d`](https://github.com/NixOS/nixpkgs/commit/8a046e8d147e5904c9c9fe25b0ae5df1b3c1b447) | `` awsume: propagate setuptools build input ``                                                  |
| [`f471390f`](https://github.com/NixOS/nixpkgs/commit/f471390fa5c559a8620630480899ce877a7f0a62) | `` caido: 0.43.1 -> 0.44.1 ``                                                                   |
| [`ddd460df`](https://github.com/NixOS/nixpkgs/commit/ddd460df41c351c565e6bc8c8b503c9f2727ab45) | `` ecapture: 0.8.10 -> 0.9.0 ``                                                                 |
| [`19cd49ef`](https://github.com/NixOS/nixpkgs/commit/19cd49ef1c9e053fb08930e40eca9f3f1c5cbd3a) | `` stripe-cli: 1.21.10 -> 1.22.0 ``                                                             |
| [`337ca4a9`](https://github.com/NixOS/nixpkgs/commit/337ca4a90582885d2f644a21ae4bb2300e454e3a) | `` postgresqlPackages.pg_partman: 5.2.1 -> 5.2.2 ``                                             |
| [`b2ca7fcf`](https://github.com/NixOS/nixpkgs/commit/b2ca7fcf274cd42ecc072aa7c8444eff9978e839) | `` ecapture: 0.8.9 -> 0.8.10 ``                                                                 |
| [`e4d96ea9`](https://github.com/NixOS/nixpkgs/commit/e4d96ea9abed7b608f498d8b78d71c17cdb0cc5a) | `` postgresqlPackages.pg_net: 0.13.0 -> 0.14.0 ``                                               |
| [`e08e8984`](https://github.com/NixOS/nixpkgs/commit/e08e89841139dbb6f6442b3f42ecea2e9278521b) | `` postgresqlPackages.pg_cron: 1.6.4 -> 1.6.5 ``                                                |
| [`7273024e`](https://github.com/NixOS/nixpkgs/commit/7273024e27996ad21b802d425a9f12d18257d0b0) | `` catppuccin-cursors: 1.0.1 -> 1.0.2 ``                                                        |
| [`c1d305ad`](https://github.com/NixOS/nixpkgs/commit/c1d305ad54aab7b43e447adade75ca66899d5097) | `` google-chrome: 131.0.6778.108/109 -> 131.0.6778.139/140 ``                                   |
| [`5f9f0158`](https://github.com/NixOS/nixpkgs/commit/5f9f0158bf0badaa6c1f5481a70e27f71e28f2ef) | `` oscavmgr: 0.4.2 -> 0.4.3 ``                                                                  |
| [`f7606e65`](https://github.com/NixOS/nixpkgs/commit/f7606e658d7eb29679fe765250ec28ced6824b5f) | `` linux_5_4: 5.4.286 -> 5.4.287 ``                                                             |
| [`00964123`](https://github.com/NixOS/nixpkgs/commit/0096412336c92f7e8041cb1313a3b93f925cd155) | `` linux_5_10: 5.10.230 -> 5.10.231 ``                                                          |
| [`ccd1737c`](https://github.com/NixOS/nixpkgs/commit/ccd1737c052b42b92f93db899964ecefda5ee377) | `` linux_5_15: 5.15.173 -> 5.15.174 ``                                                          |
| [`9c2b08a7`](https://github.com/NixOS/nixpkgs/commit/9c2b08a7179680d71eaf431dee93b8715da9876a) | `` linux_6_1: 6.1.119 -> 6.1.120 ``                                                             |
| [`e4faa305`](https://github.com/NixOS/nixpkgs/commit/e4faa30556ba517b43da65487e6602c345ba3c04) | `` linux_6_6: 6.6.64 -> 6.6.66 ``                                                               |
| [`fa976b29`](https://github.com/NixOS/nixpkgs/commit/fa976b29720f54c3b8161cfa074829b9277cf0f7) | `` linux_6_12: 6.12.4 -> 6.12.5 ``                                                              |
| [`44d744bc`](https://github.com/NixOS/nixpkgs/commit/44d744bc0bff815091908296dcb2550ba6a36e58) | `` phpExtensions.redis: 6.0.2 -> 6.1.0 ``                                                       |
| [`c4d748d5`](https://github.com/NixOS/nixpkgs/commit/c4d748d54aac2428c181dcbfe55895f3e5d26fc3) | `` nixos/librenms: add package option and expose package ``                                     |
| [`2b70f030`](https://github.com/NixOS/nixpkgs/commit/2b70f030069a812c028828dcd8edd12ba2bf4a70) | `` nixos/librenms: use db socket when set ``                                                    |
| [`501356fc`](https://github.com/NixOS/nixpkgs/commit/501356fc14d82fe9e839293c8645080ba1d79085) | `` tests: network: update `nixosTests.networking.scripted.virtual` to match correct behavior `` |
| [`320b4eac`](https://github.com/NixOS/nixpkgs/commit/320b4eac689e231f13263824baec9bfd16e01ca5) | `` network: Fix cycle dependency causing race of netdev and address configuration ``            |
| [`cccc83bc`](https://github.com/NixOS/nixpkgs/commit/cccc83bc9c61e70ecedc69b654f0adbd10551c18) | `` matrix-synapse: 1.121.0 -> 1.121.1 ``                                                        |
| [`6bf96cbe`](https://github.com/NixOS/nixpkgs/commit/6bf96cbe6651a43ede310d432e95ea6ddcd3c73f) | `` matrix-synapse: 1.120.2 -> 1.121.0 ``                                                        |
| [`b663881a`](https://github.com/NixOS/nixpkgs/commit/b663881a0d97be29424020687ad98fd009977ec4) | `` windows.mingw_w64_headers: fix building against msvcrt ``                                    |
| [`588a501b`](https://github.com/NixOS/nixpkgs/commit/588a501bf46073edfb396c2f5c375cc3dc9ccaf8) | `` jetbrains.plugins: update ``                                                                 |
| [`7185da61`](https://github.com/NixOS/nixpkgs/commit/7185da613699de1cba8b13631819b17323ed1d69) | `` jetbrains: 2024.2.1 -> 2024.3.2 ``                                                           |
| [`da92c1a5`](https://github.com/NixOS/nixpkgs/commit/da92c1a5f8c847ba6275edbdb9210f7bdc410bf5) | `` jetbrains.plugins: update ``                                                                 |
| [`770aaca9`](https://github.com/NixOS/nixpkgs/commit/770aaca9e2c6c7ca387d2fa13c62c1560bc499a4) | `` jetbrains: 2024.2.2 -> 2024.3.2 ``                                                           |
| [`6d2b11db`](https://github.com/NixOS/nixpkgs/commit/6d2b11dbd977663ca51ff02946440b95f2c48c79) | `` timetagger: 24.07.1 -> 24.12.1 ``                                                            |
| [`c67f84ab`](https://github.com/NixOS/nixpkgs/commit/c67f84ab06a59bafc210dd4f7fa0440b532d7c07) | `` yggdrasil: 0.5.10 -> 0.5.11 ``                                                               |
| [`837bfa3b`](https://github.com/NixOS/nixpkgs/commit/837bfa3b40b9cc47057a7c05c7038bfb64e97751) | `` deno: 2.1.3 -> 2.1.4 ``                                                                      |
| [`77af51a5`](https://github.com/NixOS/nixpkgs/commit/77af51a58747f63cb1fee85ed09c9c399261369b) | `` organicmaps: 2024.11.12-7 -> 2024.11.27-12 ``                                                |
| [`ce46296e`](https://github.com/NixOS/nixpkgs/commit/ce46296ebc49a8e7526437c68e472b362d6b011c) | `` freetube: 0.22.0 -> 0.22.1 ``                                                                |
| [`2ed91e57`](https://github.com/NixOS/nixpkgs/commit/2ed91e574403ec25a804b749af334da767171aa2) | `` incus: 6.7.0 -> 6.8.0 ``                                                                     |
| [`a72eb69b`](https://github.com/NixOS/nixpkgs/commit/a72eb69bd345b6573adce421dd9f3d127b44e1ee) | `` zfs_unstable: 2.3.0-rc3 -> 2.3.0-rc4 ``                                                      |
| [`6f5a01c5`](https://github.com/NixOS/nixpkgs/commit/6f5a01c5befff9a5f7778fd93a71dbfc52104c44) | `` btcpayserver: 1.13.5 -> 1.13.7 ``                                                            |
| [`3636a2f7`](https://github.com/NixOS/nixpkgs/commit/3636a2f7e0c8b438d77ec70d81f283e1eb6f1edc) | `` nbxplorer: 2.5.7 -> 2.5.16 ``                                                                |
| [`4c77a546`](https://github.com/NixOS/nixpkgs/commit/4c77a546cb95eac53e83a767588837e4b116a090) | `` btcpayserver: move to `pkgs/by-name` ``                                                      |
| [`b33fad7f`](https://github.com/NixOS/nixpkgs/commit/b33fad7f78ae9d95750e169bdc0412bc44b39a22) | `` lockbook: init at 0.9.15 ``                                                                  |
| [`9b9dba03`](https://github.com/NixOS/nixpkgs/commit/9b9dba0395f724c67a5dc88999f8f693cbdcf55a) | `` maintainers: add parth ``                                                                    |
| [`97352f2b`](https://github.com/NixOS/nixpkgs/commit/97352f2b5e3278ec41ee7a0b6f5125470d1d3734) | `` stalwart-mail: 0.10.6 -> 0.10.7 ``                                                           |
| [`0916a8c0`](https://github.com/NixOS/nixpkgs/commit/0916a8c060ff34d21b97fa5db1df6b04af69569f) | `` nifi: 1.28.0 -> 1.28.1 ``                                                                    |
| [`98025726`](https://github.com/NixOS/nixpkgs/commit/98025726282eb9bdda1d06c2f92b7d545b2db38b) | `` buildFHSEnv: void ldconfig warnings ``                                                       |
| [`c2909434`](https://github.com/NixOS/nixpkgs/commit/c2909434c4d3dddd427fcb70d5f036f614c050ca) | `` ps3-disc-dumper: .NET 6 -> .NET 9 ``                                                         |
| [`b11ef1d2`](https://github.com/NixOS/nixpkgs/commit/b11ef1d2d6682412fca3ca5ba19395778eb48f60) | `` ps3-disc-dumper: add maintainer gepbird ``                                                   |
| [`861b31df`](https://github.com/NixOS/nixpkgs/commit/861b31dfb77b8a5d57794567fa814f7dad120db0) | `` ps3-disc-dumper: `fetchFromGitHub` refactor ``                                               |
| [`bf8352fc`](https://github.com/NixOS/nixpkgs/commit/bf8352fc1e05e08ece545026bee5e133aa82212c) | `` ps3-disc-dumper: remove `with lib;`, order `meta` attrs ``                                   |
| [`a4ee0acc`](https://github.com/NixOS/nixpkgs/commit/a4ee0acc35884507228026469a51c38f06aa602a) | `` ps3-disc-dumper: add update script ``                                                        |
| [`1d29f981`](https://github.com/NixOS/nixpkgs/commit/1d29f981dcf263f013b793825f9392046a387e98) | `` ps3-disc-dumper: nixfmt ``                                                                   |
| [`e71909fc`](https://github.com/NixOS/nixpkgs/commit/e71909fc11ca8f59a9bcc8831adec893bbbb8f65) | `` azure-functions-core-tools: 4.0.5455 -> 4.0.6610 ``                                          |
| [`63592a4f`](https://github.com/NixOS/nixpkgs/commit/63592a4f6431d7f5d072a424c2c955046e41d837) | `` treewide: remove uneccessary uses of dotnetCorePackages.combinePackages ``                   |
| [`3effd284`](https://github.com/NixOS/nixpkgs/commit/3effd2848b2b06ea66a9c7cecbbfb6c919b4f834) | `` discord-development: 0.0.53 -> 0.0.54 ``                                                     |
| [`66a28fcd`](https://github.com/NixOS/nixpkgs/commit/66a28fcde3afa12bd24c67028a3db00b4f177bfe) | `` discord-canary: 0.0.538 -> 0.0.541 ``                                                        |
| [`0937b704`](https://github.com/NixOS/nixpkgs/commit/0937b7040e08fb65b16dcde3621032598660893f) | `` discord-development: 0.0.67 -> 0.0.68 ``                                                     |
| [`cf37544d`](https://github.com/NixOS/nixpkgs/commit/cf37544de1cd25ed64902283b71d58f30fa2ca7a) | `` discord-canary: 0.0.650 -> 0.0.653 ``                                                        |
| [`df670e5c`](https://github.com/NixOS/nixpkgs/commit/df670e5caeda6679696858ed6597d7b81e40bc7f) | `` gitea: 1.22.5 -> 1.22.6 ``                                                                   |
| [`4c60685d`](https://github.com/NixOS/nixpkgs/commit/4c60685dfe5a31c2e9a8b3115a3b534b114e5b14) | `` kmon: 1.6.5 -> 1.7.0 ``                                                                      |
| [`e1038237`](https://github.com/NixOS/nixpkgs/commit/e10382375cf25b632800fdef1098144affd6383d) | `` meilisearch: 1.11.1 → 1.11.3 ``                                                              |
| [`1501286b`](https://github.com/NixOS/nixpkgs/commit/1501286bab1330eb6bd135fc18edd6226572cf51) | `` lumafly: use dotnet sdk 9 as sdk 7 has been marked insecure ``                               |
| [`5e7381a7`](https://github.com/NixOS/nixpkgs/commit/5e7381a7bb2ad874e693999f671d4a2d44466f63) | `` build-support: Simplify tmpdir creation with coreutils ``                                    |
| [`19982c2d`](https://github.com/NixOS/nixpkgs/commit/19982c2dab0d7d89260c38b42b31f556a0ca5dac) | `` build-support: fix nix-prefetch-* on macOS ``                                                |
| [`171ac389`](https://github.com/NixOS/nixpkgs/commit/171ac38961f95b3b6a61b093ac6c39f87eaefa70) | `` mongodb-ce: 8.0.3 -> 8.0.4 ``                                                                |
| [`3f6efa87`](https://github.com/NixOS/nixpkgs/commit/3f6efa874915540c4bd971ff7ad7c42efc5f97b5) | `` nextcloud28: 28.0.12 -> 28.0.14 ``                                                           |
| [`163dd400`](https://github.com/NixOS/nixpkgs/commit/163dd4000db3fc7d654dcad71ac768f1d1cb4304) | `` nextcloud30: 30.0.2 -> 30.0.4 ``                                                             |
| [`d9c55412`](https://github.com/NixOS/nixpkgs/commit/d9c55412a221a7f452229d0d50be1c28cb868bed) | `` Add coqPackages.stdlib ``                                                                    |
| [`c1c75b2a`](https://github.com/NixOS/nixpkgs/commit/c1c75b2a945edd766f855eb742ae9cc24584a46a) | `` Rename coq-stdlib into rocq-core ``                                                          |
| [`6c1d0af6`](https://github.com/NixOS/nixpkgs/commit/6c1d0af638ab8615132676b78cc5546ca066238f) | `` vault-ssh-plus: 0.7.5 -> 0.7.6 ``                                                            |
| [`e4194f1a`](https://github.com/NixOS/nixpkgs/commit/e4194f1adcd3f8bae891f9c55cb3df8d69be6c40) | `` flyctl: 0.3.40 -> 0.3.49 ``                                                                  |
| [`ee493425`](https://github.com/NixOS/nixpkgs/commit/ee493425f05a6fd4adc307a4c8c277dc4a903d8a) | `` firefox-bin, thunderbird-bin: tweak updater's formatting ``                                  |
| [`2236c5a8`](https://github.com/NixOS/nixpkgs/commit/2236c5a87abb3c9da567eae115d1b10c92b1cf68) | `` thunderbird-bin: 128.5.0esr -> 128.5.2esr ``                                                 |
| [`d5dc178c`](https://github.com/NixOS/nixpkgs/commit/d5dc178c79ff2173740dab5faca4188efcc076b6) | `` thunderbird: 128.5.1esr -> 128.5.2esr ``                                                     |
| [`1d473445`](https://github.com/NixOS/nixpkgs/commit/1d4734457d8248e2ce8856543152f5bea746661f) | `` systemd-netlogd: 1.4.2 -> 1.4.3 ``                                                           |
| [`b1493bcd`](https://github.com/NixOS/nixpkgs/commit/b1493bcd8dde27400d752bdd4497bb7a94873d86) | `` vpp: 24.06 -> 24.10 ``                                                                       |
| [`1808e076`](https://github.com/NixOS/nixpkgs/commit/1808e076e545a5526118316c02cc8d6bc28d581b) | `` microsoft-edge: 131.0.2903.70 -> 131.0.2903.86 ``                                            |
| [`4d95c21f`](https://github.com/NixOS/nixpkgs/commit/4d95c21f0ff059300266f98fda2c38595e6066b5) | `` nixos/forgejo,forgejo: Add pyrox0 as a maintainer ``                                         |
| [`338f07c3`](https://github.com/NixOS/nixpkgs/commit/338f07c36f168f8040a81820b168a8ad5500c690) | `` nixos/forgejo: fix typo in builtin ssh server conditional ``                                 |
| [`9f1c273c`](https://github.com/NixOS/nixpkgs/commit/9f1c273c013c57cb3a3fbb5de6641f4387131b73) | `` nixos/forgejo: replace `GITEA_` prefix in env with `FORGEJO_` ``                             |
| [`44b5b83f`](https://github.com/NixOS/nixpkgs/commit/44b5b83ff0e3ceb96bd0f78b772f6b62aa95f65e) | `` fsautocomplete: 0.73.2 -> 0.75.0 ``                                                          |
| [`5a154db9`](https://github.com/NixOS/nixpkgs/commit/5a154db96e5b9464b425a6032510e15ecaedc5e7) | `` brave: 1.73.97 -> 1.73.101 ``                                                                |
| [`275eb642`](https://github.com/NixOS/nixpkgs/commit/275eb6426336c3ec70759cb66ed8049601c8e7a7) | `` grafana-agent: 0.43.3 -> 0.43.4 ``                                                           |
| [`e2a918b2`](https://github.com/NixOS/nixpkgs/commit/e2a918b27afac8b7f60075b6c33d3ea3eff517d4) | `` systeroid: 0.4.4 -> 0.4.5 ``                                                                 |
| [`9307f20e`](https://github.com/NixOS/nixpkgs/commit/9307f20e1323a58d023029a3e1a39dfa6ec0b0bd) | `` agate: 3.3.10 -> 3.3.11 ``                                                                   |
| [`1b30a61a`](https://github.com/NixOS/nixpkgs/commit/1b30a61aa9090d38d969ecb3fe40123503464987) | `` terragrunt: 0.69.1 -> 0.69.10 ``                                                             |
| [`b1049b5d`](https://github.com/NixOS/nixpkgs/commit/b1049b5d10a99bcffb13aa7da57bb7f08a4b4bc1) | `` terragrunt: 0.68.7 -> 0.69.1 ``                                                              |
| [`2bb5948a`](https://github.com/NixOS/nixpkgs/commit/2bb5948aa8bf7fcb87db334a37455a2ed053ee9e) | `` python312Packages.mrsqm: fix build ``                                                        |
| [`6c687652`](https://github.com/NixOS/nixpkgs/commit/6c687652a780c807508cee7d8f74eb34d805ff89) | `` just: 1.37.0 -> 1.38.0 ``                                                                    |
| [`9ff3b52c`](https://github.com/NixOS/nixpkgs/commit/9ff3b52c96680725aa8a09b859e326016a349411) | `` just: 1.36.0 -> 1.37.0 ``                                                                    |
| [`cb0c31bf`](https://github.com/NixOS/nixpkgs/commit/cb0c31bfb0d08e15b0b526d3713eeff5d9e1d71a) | `` syft: 1.14.0 -> 1.18.0 ``                                                                    |
| [`7d6dc6b9`](https://github.com/NixOS/nixpkgs/commit/7d6dc6b95b04b7a61828c308228aa460d63f0911) | `` lomiri.telephony-service: Fix NotificationInterface build issue ``                           |
| [`bffdc9fc`](https://github.com/NixOS/nixpkgs/commit/bffdc9fcae090bd5638ec61fac0f3a76e9e635d5) | `` tenere: init at 0.11.2 (#363556) ``                                                          |
| [`92fdd08b`](https://github.com/NixOS/nixpkgs/commit/92fdd08b3c0e4c0760909f62ea34eb954cf1d04e) | `` onedrivegui: add qt wrapping ``                                                              |
| [`45e2fb46`](https://github.com/NixOS/nixpkgs/commit/45e2fb4660cef7d1463ce962339ce46ad959e846) | `` soundsource: 5.7.4 -> 5.7.5 (#363347) ``                                                     |
| [`96c42191`](https://github.com/NixOS/nixpkgs/commit/96c42191419e0f8a3e98a5a514e8ae33d7559b62) | `` jetbrains: rename source-package arg `buildVer` -> `buildNumber` ``                          |
| [`bf3a1e83`](https://github.com/NixOS/nixpkgs/commit/bf3a1e839c8884f8aad4f26ffd1f569b8de37833) | `` jetbrains: fix mismatched versions for source-built packages ``                              |
| [`bcbf11d2`](https://github.com/NixOS/nixpkgs/commit/bcbf11d2b2464cf590c80228dc2c61bbb2e78a1a) | `` python312Packages.graph-tool: 2.79 -> 2.80 ``                                                |
| [`e5f896a1`](https://github.com/NixOS/nixpkgs/commit/e5f896a1886eec475258de5af4e05ddefec4fcb2) | `` python312Packages.graph-tool: 2.78 -> 2.79 ``                                                |
| [`cc70f383`](https://github.com/NixOS/nixpkgs/commit/cc70f38300f4a991fbd6822a6e0b9ba0f50f5e29) | `` simplex-chat-desktop: 6.1.1 -> 6.2.0 ``                                                      |
| [`8b9aceda`](https://github.com/NixOS/nixpkgs/commit/8b9aceda8e8bda7535016ead3f1cec44c4707b32) | `` vaultwarden: 1.32.5 -> 1.32.6 ``                                                             |
| [`036578ad`](https://github.com/NixOS/nixpkgs/commit/036578ad7765bea8207425c0fee791e20cdc5e1e) | `` mobilizon: 4.1.0 -> 5.1.0 ``                                                                 |
| [`20f9a4f8`](https://github.com/NixOS/nixpkgs/commit/20f9a4f8479bbc510d7635877ba502158374651e) | `` quarto: use pandoc 3.5 ``                                                                    |
| [`870faccd`](https://github.com/NixOS/nixpkgs/commit/870faccd6ce052b8b7a6e046320076de85aed2ed) | `` pandoc: add version 3.5 ``                                                                   |
| [`12f27d34`](https://github.com/NixOS/nixpkgs/commit/12f27d343e3966c5425f0490c664e194f5f2ddd7) | `` haskellPackages.pandoc-cli_3_5: fix build ``                                                 |
| [`38104068`](https://github.com/NixOS/nixpkgs/commit/3810406885e4af5e40fe9c458e42c4020f4e1b6f) | `` pkcs11-provider: nixfmt ``                                                                   |
| [`23ef2323`](https://github.com/NixOS/nixpkgs/commit/23ef2323ed58b2bb6ddaa9073e5210b069e9b1e1) | `` pkcs11-provider: 0.5 -> 0.6 ``                                                               |
| [`2523c499`](https://github.com/NixOS/nixpkgs/commit/2523c499cab7c86fafc71997067e112a7acd95a5) | `` moodle: 4.4.3 -> 4.4.4 ``                                                                    |
| [`26c5e364`](https://github.com/NixOS/nixpkgs/commit/26c5e364a63d52536d1e69ef91eb85ed21ecf6b7) | `` buf: 1.47.0 -> 1.47.2 ``                                                                     |
| [`a0cce411`](https://github.com/NixOS/nixpkgs/commit/a0cce4111cef4a99997584464796a7eeab125f60) | `` python312Packages.qbittorrent-api: 2024.10.68 -> 2024.11.70 ``                               |
| [`04ca8352`](https://github.com/NixOS/nixpkgs/commit/04ca8352a92be81c44415050b0db745ddc3ed05a) | `` liblouis: 3.31.0 -> 3.32.0 ``                                                                |
| [`e94bec43`](https://github.com/NixOS/nixpkgs/commit/e94bec4343969575a9246e864ba8e4c6ddb70711) | `` nixos/lib/make-squashfs: set root mode to 0755 ``                                            |
| [`6cece93e`](https://github.com/NixOS/nixpkgs/commit/6cece93e8428234741ac349bac2aeaa1d054102a) | `` python312Packages.pyqt-builder: 1.16.4 -> 1.17.0 ``                                          |
| [`c510e3b5`](https://github.com/NixOS/nixpkgs/commit/c510e3b53b2c17650066c5d2061b17c57d10c97a) | `` llvmPackages_19: 19.1.4 -> 19.1.5 ``                                                         |