### PR TITLE
chore(flake/spicetify-nix): `47031146` -> `9df915be`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -477,11 +477,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1734409034,
-        "narHash": "sha256-yd3VgQGJiYxWeDaThZFidDpaqIo8XHmK7m04lpl8Dl8=",
+        "lastModified": 1734581787,
+        "narHash": "sha256-hp4sP3gF/LIJRwCv9x3yteSFP1xVK0J6socGrJEd6Hs=",
         "owner": "Gerg-L",
         "repo": "spicetify-nix",
-        "rev": "4703114659cdb75ece88ffa4b62ad837fd7b79a6",
+        "rev": "9df915be725751fccde78f2dfe59025bb1bfbb14",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                    |
| ----------------------------------------------------------------------------------------------------- | -------------------------- |
| [`9df915be`](https://github.com/Gerg-L/spicetify-nix/commit/9df915be725751fccde78f2dfe59025bb1bfbb14) | `` CI update 2024-12-19 `` |
| [`5b15daf1`](https://github.com/Gerg-L/spicetify-nix/commit/5b15daf10de2ce488771e6aabf72a7400b8500fc) | `` CI update 2024-12-18 `` |