### PR TITLE
chore(flake/nixpkgs-unstable): `3566ab72` -> `d3c42f18`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -391,11 +391,11 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1734119587,
-        "narHash": "sha256-AKU6qqskl0yf2+JdRdD0cfxX4b9x3KKV5RqA6wijmPM=",
+        "lastModified": 1734424634,
+        "narHash": "sha256-cHar1vqHOOyC7f1+tVycPoWTfKIaqkoe1Q6TnKzuti4=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "3566ab7246670a43abd2ffa913cc62dad9cdf7d5",
+        "rev": "d3c42f187194c26d9f0309a8ecc469d6c878ce33",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                             |
| ---------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------- |
| [`77306ff5`](https://github.com/NixOS/nixpkgs/commit/77306ff547b51e819ba617b140bb355e1d719f31) | `` chore(mergify): remove not relevant Tag check (#365804) ``                       |
| [`e5d90d92`](https://github.com/NixOS/nixpkgs/commit/e5d90d92ae07e4843dcc5a4d8195ec29c96d8e4d) | `` python312Packages.llama-index-multi-modal-llms-openai: 0.3.0 -> 0.4.0 ``         |
| [`707ac83f`](https://github.com/NixOS/nixpkgs/commit/707ac83fba79c871a29d08ae572f4e3270aec24d) | `` python312Packages.llama-index-embeddings-openai: 0.3.0 -> 0.3.1 ``               |
| [`74e5cd8f`](https://github.com/NixOS/nixpkgs/commit/74e5cd8f9962c344a93fe4826ccdb9f6aead724d) | `` python312Packages.llama-index-graph-stores-neo4j: 0.4.0 -> 0.4.2 ``              |
| [`7165f219`](https://github.com/NixOS/nixpkgs/commit/7165f2198a78885769090b351dc21a31a431e67f) | `` python312Packages.llama-index-llms-openai-like: 0.3.0 -> 0.3.3 ``                |
| [`35e92667`](https://github.com/NixOS/nixpkgs/commit/35e92667389dd1404561c51fd2ee336afaf41e4c) | `` python312Packages.llama-index-llms-openai: 0.3.2 -> 0.3.10 ``                    |
| [`158a738f`](https://github.com/NixOS/nixpkgs/commit/158a738f138721d5661c22d4543d983aaf030349) | `` python312Packages.llama-index-core: 0.12.4 -> 0.12.5 ``                          |
| [`2bb1689c`](https://github.com/NixOS/nixpkgs/commit/2bb1689c8152ee1c29851e011e12347b1189d112) | `` vimPlugins.blink-cmp-copilot: init at 2024-12-16 ``                              |
| [`d7bed6ff`](https://github.com/NixOS/nixpkgs/commit/d7bed6ff2c454606b6b3a8bb18cdc63f022a47bc) | `` viper4linux-gui,libviperfx,viper4linux,gst_all_1.gst-plugins-viperfx: drop ``    |
| [`aa8a2577`](https://github.com/NixOS/nixpkgs/commit/aa8a2577f1da37310f2c23943014f5d73a71874b) | `` nixos/prometheus: add nvidia-gpu exporter ``                                     |
| [`1ed35a17`](https://github.com/NixOS/nixpkgs/commit/1ed35a17de21c0256f1a09056095fa0eb0694e65) | `` python312Packages.deepdiff: 8.0.1 -> 8.1.1 ``                                    |
| [`25850545`](https://github.com/NixOS/nixpkgs/commit/25850545b759db46567b4b290f7b9e92dabb1763) | `` parca-agent: 0.35.0 -> 0.35.1 ``                                                 |
| [`fc7be674`](https://github.com/NixOS/nixpkgs/commit/fc7be6746c2f660cead91c9d6a55eeb0122fa3b6) | `` bitcomet: 2.11.0 -> 2.12.0 ``                                                    |
| [`28b4ffa2`](https://github.com/NixOS/nixpkgs/commit/28b4ffa230761a1ee2d566ac376b77f5f35efad5) | `` golden-cheetah-bin: 3.6 -> 3.7DEV2410, add darwin (#363290) ``                   |
| [`a2472aa8`](https://github.com/NixOS/nixpkgs/commit/a2472aa8c9e8443966a9876b2a548db62f3687a5) | `` karp: init at 0-unstable-2024-11-20 (#357773) ``                                 |
| [`39a6dd50`](https://github.com/NixOS/nixpkgs/commit/39a6dd50f4b034f4c06f7a777d4a67380e0667f9) | `` yesplaymusic: drop (#364839) ``                                                  |
| [`69e1e8ba`](https://github.com/NixOS/nixpkgs/commit/69e1e8ba04e7d11e17b27b6f4fdd08b30d251076) | `` television: 0.6.2 -> 0.7.1 (#365566) ``                                          |
| [`17c5317d`](https://github.com/NixOS/nixpkgs/commit/17c5317daff3c21f8ec4ad76a87bd97627cf3896) | `` nodePackages.copy-webpack-plugin: drop (#364321) ``                              |
| [`aaa65e08`](https://github.com/NixOS/nixpkgs/commit/aaa65e08c4932e05ede7d78411435088fe971571) | `` python312Packages.hass-client: fix package version ``                            |
| [`c16f43f9`](https://github.com/NixOS/nixpkgs/commit/c16f43f97c059903ac4d07ad5c5e193beeaf1f7b) | `` neovim: add 'autowrapRuntimeDeps' to append (#358587) ``                         |
| [`ccc0c2c6`](https://github.com/NixOS/nixpkgs/commit/ccc0c2c6cbb28bbd81825e084ec9bc69a8b21087) | `` geant4: 11.2.2 -> 11.3.0 (#364998) ``                                            |
| [`2efaa5cb`](https://github.com/NixOS/nixpkgs/commit/2efaa5cbe4399c6a949348d50cb5896dec4e1c25) | `` luarocks-packages-updater: fix keyword argument name (#364834) ``                |
| [`2755c161`](https://github.com/NixOS/nixpkgs/commit/2755c161533638f9b46a941a798ec49afc693825) | `` metasploit: 6.4.39 -> 6.4.40 ``                                                  |
| [`b3a4361a`](https://github.com/NixOS/nixpkgs/commit/b3a4361a94b825a446c335ae893a33d142935cd8) | `` python312Packages.axis: 63 -> 64 ``                                              |
| [`492b9ddc`](https://github.com/NixOS/nixpkgs/commit/492b9ddcce4573089a00ad81ecb8e7572b7fb39d) | `` remind: ignore beta versions in updateScript ``                                  |
| [`6794054b`](https://github.com/NixOS/nixpkgs/commit/6794054b69c929cea5a482e4fd9adf9037194c33) | `` signalbackup-tools: 20241205 -> 20241216 ``                                      |
| [`ae2a2497`](https://github.com/NixOS/nixpkgs/commit/ae2a2497fe5b6b0a4976df6ecab03ffd3933d102) | `` tinymist: 0.12.10 -> 0.12.12 ``                                                  |
| [`29dd2ae3`](https://github.com/NixOS/nixpkgs/commit/29dd2ae34a8a25930d432db82a98e9295861e7a5) | `` monkeysAudio: 10.83 -> 10.85 ``                                                  |
| [`32c4c14a`](https://github.com/NixOS/nixpkgs/commit/32c4c14a88f9fe1ae361e6b7dd95d56827c191f1) | `` intel-gmmlib: 22.5.4 -> 22.5.5 ``                                                |
| [`c90a4afd`](https://github.com/NixOS/nixpkgs/commit/c90a4afdf8542f765988c9b6c37eea32c3056023) | `` prowler: 5.0.0 -> 5.0.1 ``                                                       |
| [`525c37a9`](https://github.com/NixOS/nixpkgs/commit/525c37a96016ba95c5882f1ae19a7f33aae019e0) | `` sequoia-sq: 0.40.0 -> 1.0.0 ``                                                   |
| [`59c5ef55`](https://github.com/NixOS/nixpkgs/commit/59c5ef5569be51fe5c95557fc18027f51ba37b0d) | `` Revert "prefetch-npm-deps: check response status and fail on error (#297863)" `` |
| [`35d9c05d`](https://github.com/NixOS/nixpkgs/commit/35d9c05d4a58828f004f184ec5d905173951342a) | `` python312Packages.twilio: 9.3.8 -> 9.4.1 ``                                      |
| [`6e32c672`](https://github.com/NixOS/nixpkgs/commit/6e32c67255ba50af7c7ef7cee42daf403729d41c) | `` python312Packages.tesla-fleet-api: 0.8.5 -> 0.9.0 ``                             |
| [`a910c32e`](https://github.com/NixOS/nixpkgs/commit/a910c32e142aa5a732151b982f9c9f764c15ab35) | `` python312Packages.pyexploitdb: 0.2.58 -> 0.2.59 ``                               |
| [`c9bd8da9`](https://github.com/NixOS/nixpkgs/commit/c9bd8da9d2bd6738f31fabf70fc027a9bb9a589a) | `` python312Packages.nomadnet: 0.5.5 -> 0.5.6 ``                                    |
| [`b82072b5`](https://github.com/NixOS/nixpkgs/commit/b82072b5527678ff9a7e14a51480028e82f81508) | `` python312Packages.rns: 0.8.7 -> 0.8.8 ``                                         |
| [`49231056`](https://github.com/NixOS/nixpkgs/commit/49231056f93f90709e8496df0d05edb172775b51) | `` responsively-app: init at 1.15.0 ``                                              |
| [`7e69170b`](https://github.com/NixOS/nixpkgs/commit/7e69170b075f84b58ac4c957995df4dec9932ac0) | `` python312Packages.jsonargparse: 4.34.1 -> 4.35.0 ``                              |
| [`f7b32f28`](https://github.com/NixOS/nixpkgs/commit/f7b32f28fba69ec1fac5ea5ae898012396aef09c) | `` python312Packages.ha-mqtt-discoverable: 0.16.0 -> 0.16.2 ``                      |
| [`9fb8d9cb`](https://github.com/NixOS/nixpkgs/commit/9fb8d9cbfcaa79677e33e8e72624197d797db4d2) | `` python312Packages.tencentcloud-sdk-python: 3.0.1281 -> 3.0.1282 ``               |
| [`5d7c1789`](https://github.com/NixOS/nixpkgs/commit/5d7c1789a175011092babad739f654a26abbc0f2) | `` python312Packages.tencentcloud-sdk-python: 3.0.1280 -> 3.0.1281 ``               |
| [`fc639d33`](https://github.com/NixOS/nixpkgs/commit/fc639d33b2b2932de3824486a09166c9b6a365c6) | `` python312Packages.publicsuffixlist: 1.0.2.20241213 -> 1.0.2.20241216 ``          |
| [`8d7fd764`](https://github.com/NixOS/nixpkgs/commit/8d7fd764791514a955a618f222180316ed05c465) | `` typstyle: 0.12.10 -> 0.12.12 ``                                                  |
| [`dea1ccd1`](https://github.com/NixOS/nixpkgs/commit/dea1ccd1f8c1edb36eac7ecd3fabf699edd88464) | `` python312Packages.botocore-stubs: 1.35.80 -> 1.35.81 ``                          |
| [`236f9a22`](https://github.com/NixOS/nixpkgs/commit/236f9a227d860974d0a814cf0c10cbf0248a5750) | `` python312Packages.boto3-stubs: 1.35.80 -> 1.35.81 ``                             |
| [`1dc5f7d6`](https://github.com/NixOS/nixpkgs/commit/1dc5f7d6b69bc3f2ec39b92e4bbe8d78b4cb80d0) | `` hyprprop: init at 0.1-unstable-2024-12-01 ``                                     |
| [`c5217143`](https://github.com/NixOS/nixpkgs/commit/c5217143e8169449328d343497ed2f108bd46794) | `` pylyzer: 0.0.73 -> 0.0.74 ``                                                     |
| [`f9883d97`](https://github.com/NixOS/nixpkgs/commit/f9883d977a91079db35f10c82681535e11bbbf20) | `` python312Packages.pdoc: 15.0.0 -> 15.0.1 ``                                      |
| [`7c06ddfe`](https://github.com/NixOS/nixpkgs/commit/7c06ddfe668f5d75825552f2cfe811f9c1f16b72) | `` python312Packages.craft-cli: 2.10.1 -> 2.12.0 ``                                 |
| [`defc8e70`](https://github.com/NixOS/nixpkgs/commit/defc8e70fe32f004848029945ead7d8cf977a71e) | `` home-assistant-custom-components.moonraker: 1.5.0 -> 1.5.1 ``                    |
| [`d5470c17`](https://github.com/NixOS/nixpkgs/commit/d5470c17e432c2ca1b88fb3b94c6eddbb9b02bac) | `` python312Packages.plotnine: 0.14.3 -> 0.14.4 ``                                  |
| [`2c257615`](https://github.com/NixOS/nixpkgs/commit/2c257615e1a794497182ab993b390376aba88fd9) | `` python312Packages.pystache: 0.6.5 -> 0.6.6 ``                                    |
| [`16b20bf3`](https://github.com/NixOS/nixpkgs/commit/16b20bf3de0d022fcbaa4d14fd482b23f79af6f8) | `` python312Packages.imgw-pib: 1.0.6 -> 1.0.7 ``                                    |
| [`57e44b1a`](https://github.com/NixOS/nixpkgs/commit/57e44b1a6b171ed60705190a9fdaaa0b9c6d2c31) | `` containerlab: 0.60.0 -> 0.60.1 ``                                                |
| [`e2967235`](https://github.com/NixOS/nixpkgs/commit/e29672356238ec2fadf9cc1473eeeffed4272862) | `` nom: 2.6.1 -> 2.6.2 ``                                                           |
| [`df6fb983`](https://github.com/NixOS/nixpkgs/commit/df6fb983d2ffb1bab854bd245e7f47175767d8c7) | `` dune_3: 3.16.1 -> 3.17.0 ``                                                      |
| [`fd44bf73`](https://github.com/NixOS/nixpkgs/commit/fd44bf735bd1a4dd1d20968af58e54d9bdc5984e) | `` wealthfolio: 1.0.21 -> 1.0.22 ``                                                 |
| [`12a27848`](https://github.com/NixOS/nixpkgs/commit/12a27848a1cea2ea636e9e026c6828907ddc3390) | `` nova-password: 0.5.7 -> 0.5.8 ``                                                 |
| [`2d24b2ab`](https://github.com/NixOS/nixpkgs/commit/2d24b2ab86e81b158f1fe8dc1c01f77fd5224475) | `` wealthfolio: add passthru.updateScript ``                                        |
| [`f531cacc`](https://github.com/NixOS/nixpkgs/commit/f531caccd880aa46cbb3277101364055b1b100f9) | `` okteto: 3.2.0 -> 3.2.1 ``                                                        |
| [`a1b67c6c`](https://github.com/NixOS/nixpkgs/commit/a1b67c6cd13c418280c13ffdd7dd90bb5546b492) | `` monsoon: 0.9.2 -> 0.10.0 ``                                                      |
| [`c65684b7`](https://github.com/NixOS/nixpkgs/commit/c65684b73a6c8d8945dc4d87d4bceca5d91b3d9f) | `` litmusctl: 1.12.0 -> 1.13.0 ``                                                   |
| [`b43dc8c2`](https://github.com/NixOS/nixpkgs/commit/b43dc8c2650eb36fbb38cb43826357ac588231c4) | `` infrastructure-agent: 1.58.0 -> 1.58.1 ``                                        |
| [`1bfd4c6a`](https://github.com/NixOS/nixpkgs/commit/1bfd4c6a3da70c2929243ebcd533d57e3d717f7c) | `` frp: 0.61.0 -> 0.61.1 ``                                                         |
| [`866488e4`](https://github.com/NixOS/nixpkgs/commit/866488e445ecdea8d5d75d9197b1f2119dc475c2) | `` geos: fetch source code from GitHub ``                                           |
| [`0164b2b2`](https://github.com/NixOS/nixpkgs/commit/0164b2b29315e69bc22920f06653053d66e595d5) | `` rabbitmq-server: 4.0.4 -> 4.0.5 ``                                               |
| [`6e858969`](https://github.com/NixOS/nixpkgs/commit/6e8589694fd2ef06e132d4811a1053a9b0a73ef4) | `` goreleaser: 2.4.8 -> 2.5.0 ``                                                    |
| [`11f0fc54`](https://github.com/NixOS/nixpkgs/commit/11f0fc5467b0e7b840b698d6ccdf819feba6aa05) | `` arcticons-sans: 0.590 -> 0.591 ``                                                |
| [`53c361bd`](https://github.com/NixOS/nixpkgs/commit/53c361bd7a3f575eac7ade5d3a828e14c7f40382) | `` vulnix: Make henrirosten a maintainer ``                                         |
| [`af44a5af`](https://github.com/NixOS/nixpkgs/commit/af44a5aff062c8fdb4de97f58a45e1c5545110f4) | `` python312Packages.cytoolz: 1.0.0 -> 1.0.1 ``                                     |
| [`35f52c9d`](https://github.com/NixOS/nixpkgs/commit/35f52c9d8a7db48a0817b2fd5747aa10ca2aad55) | `` python312Packages.rocketchat-api: 1.33.0 -> 1.34.0 ``                            |
| [`4df997e5`](https://github.com/NixOS/nixpkgs/commit/4df997e5419590be303724937b1447268a34ea47) | `` wike: 3.0.0 -> 3.1.0 ``                                                          |
| [`8885b3ba`](https://github.com/NixOS/nixpkgs/commit/8885b3ba1756a656171460513cdb5569ad8c5e20) | `` python312Packages.pyquil: 4.14.3 -> 4.15.0 ``                                    |
| [`69a6eed6`](https://github.com/NixOS/nixpkgs/commit/69a6eed6aa516322f597c60d8b78fdd6550c5850) | `` tuba: 0.8.4 -> 0.9.0 ``                                                          |
| [`28a18f2e`](https://github.com/NixOS/nixpkgs/commit/28a18f2e787ac14137b63b17534a7949fe5975b0) | `` python312Packages.treescope: 0.1.6 -> 0.1.7 ``                                   |
| [`d290f478`](https://github.com/NixOS/nixpkgs/commit/d290f478a9965953b697301051163e6150288db1) | `` tageditor: 3.9.3 -> 3.9.4 ``                                                     |
| [`b7c65642`](https://github.com/NixOS/nixpkgs/commit/b7c656421e3627115e6535eef79aeff2aa4cd9e3) | `` python312Packages.pytest-ansible: 24.9.0 -> 24.12.0 ``                           |
| [`ba334d75`](https://github.com/NixOS/nixpkgs/commit/ba334d758a90470d8bc4ceba5be005ea8ce88e03) | `` containerd: 2.0.0 -> 2.0.1 ``                                                    |
| [`bdd90d33`](https://github.com/NixOS/nixpkgs/commit/bdd90d3316686283a4c9f620cb7ab34dd695ad3b) | `` python312Packages.galois: 0.4.2 -> 0.4.3 ``                                      |
| [`60fd99bd`](https://github.com/NixOS/nixpkgs/commit/60fd99bdf82b7d1a70b685b89bda1c2de37e32c1) | `` uiua-unstable: 0.14.0-dev.6 -> 0.14.0-rc.2 ``                                    |
| [`ca965ec6`](https://github.com/NixOS/nixpkgs/commit/ca965ec64f5c4925f9bba3b7e18bc2b41d8dcc56) | `` cryptpad: verify that we've installed the correct versions of OnlyOffice ``      |
| [`0c198f86`](https://github.com/NixOS/nixpkgs/commit/0c198f86eece1657d411c0334b86d2e6b05cd03a) | `` python312Packages.pontos: 24.12.0 -> 24.12.3 ``                                  |
| [`79629762`](https://github.com/NixOS/nixpkgs/commit/79629762357f93bfaa4a0de1f4990989b34b06f8) | `` python312Packages.google-cloud-datastore: 2.20.1 -> 2.20.2 ``                    |
| [`a9a3e341`](https://github.com/NixOS/nixpkgs/commit/a9a3e341c6bc326e5a3de9324c33ba283f7ce242) | `` libftdi1: remove unneeded postFixup ``                                           |
| [`e6ee08f9`](https://github.com/NixOS/nixpkgs/commit/e6ee08f9996f3e9e558a2aed8917e4069f0ed6fe) | `` libftdi1: apply patch for swig 4.3.0 ``                                          |
| [`b046eab6`](https://github.com/NixOS/nixpkgs/commit/b046eab687f7a3fe41b3cba00b783b020a69cd07) | `` rtorrent: fix updateScript args (#364230) ``                                     |
| [`ace2b4c2`](https://github.com/NixOS/nixpkgs/commit/ace2b4c26060a86be0b38268acea8cf54613073f) | `` nixos/firmware: fix compression condition ``                                     |
| [`72768f67`](https://github.com/NixOS/nixpkgs/commit/72768f674f7e0aae458a17714ab802ebfd1a2491) | `` python312Packages.proxmoxer: 2.1.0 -> 2.2.0 ``                                   |
| [`3348c124`](https://github.com/NixOS/nixpkgs/commit/3348c124967b37408156b5f04c280319b68cb6fd) | `` lirc: fix build on ubuntu ``                                                     |
| [`c3478c0c`](https://github.com/NixOS/nixpkgs/commit/c3478c0c316154521dcf25f330812ce0d4611c35) | `` python312Packages.okta: 2.9.8 -> 2.9.9 ``                                        |
| [`a5731428`](https://github.com/NixOS/nixpkgs/commit/a5731428c05158fbe6b475b51a4d708b0b493719) | `` python312Packages.incomfort-client: 0.6.3-1 -> 0.6.4 ``                          |
| [`2c8e6aef`](https://github.com/NixOS/nixpkgs/commit/2c8e6aef5b03d96266356e2a77fed6414452c797) | `` ocamlPackages.melange: disable checks & disable for OCaml 5.0 ``                 |
| [`509652f8`](https://github.com/NixOS/nixpkgs/commit/509652f8dbdcd5abc0f3dd3c205eaf2fbe54f620) | `` matio: refactor ``                                                               |