### PR TITLE
chore(flake/nixpkgs-stable): `39457135` -> `b47fd6fa`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -389,11 +389,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1734323986,
-        "narHash": "sha256-m/lh6hYMIWDYHCAsn81CDAiXoT3gmxXI9J987W5tZrE=",
+        "lastModified": 1734600368,
+        "narHash": "sha256-nbG9TijTMcfr+au7ZVbKpAhMJzzE2nQBYmRvSdXUD8g=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "394571358ce82dff7411395829aa6a3aad45b907",
+        "rev": "b47fd6fa00c6afca88b8ee46cfdb00e104f50bca",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                       |
| ---------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------- |
| [`b47fd6fa`](https://github.com/NixOS/nixpkgs/commit/b47fd6fa00c6afca88b8ee46cfdb00e104f50bca) | `` buildLinux: kernel.configEnv: comply with overrideAttrs ``                 |
| [`5891b0d3`](https://github.com/NixOS/nixpkgs/commit/5891b0d31cdc58af7072cba91029295582cbefcf) | `` slack: move to pkgs/by-name ``                                             |
| [`825d9983`](https://github.com/NixOS/nixpkgs/commit/825d9983eb76028aad2ecc64c9c50e29ac17375a) | `` stalwart-mail.passthru.webadmin: 0.1.19 -> 0.1.20 ``                       |
| [`dc257698`](https://github.com/NixOS/nixpkgs/commit/dc2576985a892fdf5384f40ecaddaac9ca2b019d) | `` slack: 4.41.98 -> 4.41.105 ``                                              |
| [`d6b3c50b`](https://github.com/NixOS/nixpkgs/commit/d6b3c50bcab0154945b849eef8bfb3a43f28bb24) | `` inv-sig-helper: 0-unstable-2024-12-16 -> 0-unstable-2024-12-17 ``          |
| [`1d3e5c1c`](https://github.com/NixOS/nixpkgs/commit/1d3e5c1caee9202986d45e6024da501e318b960d) | `` nitrokey-app2: 2.3.2 -> 2.3.3 ``                                           |
| [`50b0b7bd`](https://github.com/NixOS/nixpkgs/commit/50b0b7bdbafde8a655108bdb0d8972242b573d03) | `` mmctl: 9.11.5 -> 9.11.6 ``                                                 |
| [`a12f09bb`](https://github.com/NixOS/nixpkgs/commit/a12f09bbf1f0faf0a01f47d6fd263410bc005822) | `` kluctl: 2.25.1 -> 2.26.0 ``                                                |
| [`f8ad4ecb`](https://github.com/NixOS/nixpkgs/commit/f8ad4ecbbba3d3eb987b7a450420a6fe4746682a) | `` sportstracker: check for correct JDK ``                                    |
| [`93855111`](https://github.com/NixOS/nixpkgs/commit/93855111efb5d851eb47107ab193e7b847536b44) | `` rage: 0.11.0 -> 0.11.1 ``                                                  |
| [`62081051`](https://github.com/NixOS/nixpkgs/commit/62081051ec3d2bfe0314712946663386beda9bbb) | `` age: 1.2.0 -> 1.2.1 ``                                                     |
| [`ed3063a6`](https://github.com/NixOS/nixpkgs/commit/ed3063a6e83fafab4bd081ca41443b5fdab8d5a2) | `` nixos/nncp: recursively merge configurations ``                            |
| [`721e05ff`](https://github.com/NixOS/nixpkgs/commit/721e05ffb28f4cad00ecde744702f5e2279b539e) | `` nixos/networkd: expose RapidCommit in DHCPv4 network unit section ``       |
| [`2a7a8128`](https://github.com/NixOS/nixpkgs/commit/2a7a8128034b85ca722d4e462a5a7cff1a277bfa) | `` linux/hardened/patches/6.6: v6.6.64-hardened1 -> v6.6.66-hardened1 ``      |
| [`1abbaa4d`](https://github.com/NixOS/nixpkgs/commit/1abbaa4d3de1726c7902f7627117975fad9baf23) | `` linux/hardened/patches/6.12: v6.12.4-hardened1 -> v6.12.5-hardened1 ``     |
| [`acd75c17`](https://github.com/NixOS/nixpkgs/commit/acd75c1780a34bc580929e9b726d14369a0ff614) | `` linux/hardened/patches/6.1: v6.1.119-hardened1 -> v6.1.120-hardened1 ``    |
| [`4e75c608`](https://github.com/NixOS/nixpkgs/commit/4e75c608b874d17a98198dded690acb04455973f) | `` linux/hardened/patches/5.4: v5.4.286-hardened1 -> v5.4.287-hardened1 ``    |
| [`a8589ad6`](https://github.com/NixOS/nixpkgs/commit/a8589ad6cf300c1f1a432d02050220e2a3c02a7b) | `` linux/hardened/patches/5.15: v5.15.173-hardened1 -> v5.15.174-hardened1 `` |
| [`1bc269d0`](https://github.com/NixOS/nixpkgs/commit/1bc269d0692169a5f750691a727a14964257fedd) | `` linux/hardened/patches/5.10: v5.10.230-hardened1 -> v5.10.231-hardened1 `` |
| [`304688e0`](https://github.com/NixOS/nixpkgs/commit/304688e05769b1fb4bfc66e6ae67b48f5a73ce8c) | `` linux_latest-libre: 19675 -> 19683 ``                                      |
| [`8451c87e`](https://github.com/NixOS/nixpkgs/commit/8451c87e7bcc5920be9e6d2439cebd5fd1b7ee9a) | `` linux-rt_6_6: 6.6.63-rt46 -> 6.6.65-rt47 ``                                |
| [`4cab6b34`](https://github.com/NixOS/nixpkgs/commit/4cab6b3485f87bc6ba8f33f546f5bf213b8b1fe0) | `` linux-rt_6_1: 6.1.119-rt45 -> 6.1.120-rt46 ``                              |
| [`b624a8e1`](https://github.com/NixOS/nixpkgs/commit/b624a8e1781ba238ce7064d8c76434c16294821c) | `` linux-rt_5_15: 5.15.170-rt81 -> 5.15.173-rt82 ``                           |
| [`704bbf57`](https://github.com/NixOS/nixpkgs/commit/704bbf57d32c3b95a9ff69b24e18a6069b003496) | `` linux-rt_5_10: 5.10.229-rt121 -> 5.10.231-rt123 ``                         |
| [`c8a23dd8`](https://github.com/NixOS/nixpkgs/commit/c8a23dd8244cac7d8e2e6bdd29884b3cc44f8bb5) | `` linux_testing: 6.13-rc2 -> 6.13-rc3 ``                                     |
| [`6043d805`](https://github.com/NixOS/nixpkgs/commit/6043d805595021a3e88ad732d59825d9ac46640b) | `` qemu: 9.1.1 -> 9.1.2 ``                                                    |
| [`af027b8b`](https://github.com/NixOS/nixpkgs/commit/af027b8b2dc04b8235142922f7cd666aa69ae694) | `` sportstracker: init at 8.0.1 ``                                            |
| [`d1221405`](https://github.com/NixOS/nixpkgs/commit/d12214059d94060f97854411c552c61d3f69f57a) | `` fastnetmon-advanced: 2.0.367 -> 2.0.370 (#365923) ``                       |
| [`37d81500`](https://github.com/NixOS/nixpkgs/commit/37d815006128ad85906961dcd7066384179af12b) | `` vmlinux-to-elf: init at unstable-2024-07-20 ``                             |
| [`7a987c41`](https://github.com/NixOS/nixpkgs/commit/7a987c416ce0a3d64c8daae1726ad75a2da5a977) | `` openmoji-color: 15.0.0 -> 15.1.0 ``                                        |
| [`95ad1532`](https://github.com/NixOS/nixpkgs/commit/95ad1532266b808a97d04aa554b79cf4205a8681) | `` victoriametrics: 1.107.0 -> 1.108.0 ``                                     |
| [`04e3994c`](https://github.com/NixOS/nixpkgs/commit/04e3994c9c07242e03ae9d62ef6e345348637fd0) | `` php84Extensions.swoole: remove broken ``                                   |
| [`f6c5b123`](https://github.com/NixOS/nixpkgs/commit/f6c5b123725632536d69c62d6b82d646a967e856) | `` victoriametrics: 1.105.0 -> 1.107.0 ``                                     |
| [`16cbb03c`](https://github.com/NixOS/nixpkgs/commit/16cbb03c7705238282885e943524c8980983e403) | `` devilutionx: fix incorrect license ``                                      |
| [`a020e40d`](https://github.com/NixOS/nixpkgs/commit/a020e40d8dd6067bf96c5a79496a120b08d7ca4e) | `` linux_xanmod_latest: 6.11.11 -> 6.12.5 ``                                  |
| [`55de8a9e`](https://github.com/NixOS/nixpkgs/commit/55de8a9e5d2108d01e72cb9ffc43770e3cc1ddc0) | `` linux_xanmod: 6.6.63 -> 6.6.66 ``                                          |
| [`7c5d525b`](https://github.com/NixOS/nixpkgs/commit/7c5d525b987f5372820e72298444cd3e4b6a9351) | `` [Backport release-24.11] garnet: 1.0.46 -> 1.0.48 (#365993) ``             |
| [`da8f4ab8`](https://github.com/NixOS/nixpkgs/commit/da8f4ab8e064a447e7698d0281ffe7c7a1fc7460) | `` unison-fsmonitor: switch new darwin SDK pattern ``                         |
| [`0f7fcb94`](https://github.com/NixOS/nixpkgs/commit/0f7fcb940943d8cfd4f15bf8f3e48aacf94594df) | `` unison-fsmonitor: fmt ``                                                   |
| [`11206bed`](https://github.com/NixOS/nixpkgs/commit/11206bede7ac0b934298e17c81180c4075f62a7a) | `` unison-fsmonitor: 0.3.4 -> 0.3.8 ``                                        |
| [`f35209aa`](https://github.com/NixOS/nixpkgs/commit/f35209aa1fb0999f60e436d18e104afc18d9e1b4) | `` dante: 1.4.3 -> 1.4.4 ``                                                   |
| [`d716038b`](https://github.com/NixOS/nixpkgs/commit/d716038b4799a9d198bec4b597184dfc6d0f0cd6) | `` phpPackages.grumphp: 2.9.0 -> 2.10.0 ``                                    |
| [`1ce9311f`](https://github.com/NixOS/nixpkgs/commit/1ce9311f58ee4886cbae5005a826fbf43e4b56ca) | `` phpExtensions.swoole: 5.1.2 -> 6.0.0 ``                                    |
| [`967b230e`](https://github.com/NixOS/nixpkgs/commit/967b230eff4dd0766843a104a69ecdae9b0b6541) | `` nixos/gancio: add gancio to nginx extraGroups only if nginx enabled ``     |
| [`1a06627e`](https://github.com/NixOS/nixpkgs/commit/1a06627e448b3af47923475504f482f2d19b6b3b) | `` [Backport release-24.11] binary: 5.1 -> 5.2 (#365872) ``                   |
| [`afbd2e96`](https://github.com/NixOS/nixpkgs/commit/afbd2e96d657780875fe7e2d56a0656bc9ef388a) | `` [Backport release-24.11] elastic: 0.1.5 -> 0.1.6 (#365863) ``              |
| [`2e9e582f`](https://github.com/NixOS/nixpkgs/commit/2e9e582f93c56602a3c0f187f631cbee3621f51c) | `` [Backport release-24.11] eartag: 0.6.1 -> 0.6.3 (#365840) ``               |
| [`54e01f27`](https://github.com/NixOS/nixpkgs/commit/54e01f27e240d2823efd23972314a4674b78b192) | `` [Backport release-24.11] citations: 0.6.2 -> 0.7.0 (#365836) ``            |
| [`3554b4b0`](https://github.com/NixOS/nixpkgs/commit/3554b4b04cba1cf42ea596043448674695a3f1b5) | `` [Backport release-24.11] textpieces: 4.1.0 -> 4.1.1-1 (#365828) ``         |
| [`e605edd6`](https://github.com/NixOS/nixpkgs/commit/e605edd6c7165d0f1f4018d017e966f3a5ab1c09) | `` stunnel: 5.73 -> 5.74 ``                                                   |
| [`f537f344`](https://github.com/NixOS/nixpkgs/commit/f537f344998b511bbcadc1bd4f8eceed3cc51280) | `` tone: add myself as maintainer ``                                          |
| [`89962c29`](https://github.com/NixOS/nixpkgs/commit/89962c2910fbd1d639dbb65aadb83decba7fe634) | `` tone: update meta.platforms to be correct ``                               |
| [`47d6e752`](https://github.com/NixOS/nixpkgs/commit/47d6e752634079d53bc444a503a9cbf7b73c8870) | `` tone: 0.1.5 -> 0.2.3 ``                                                    |
| [`3bdfedf1`](https://github.com/NixOS/nixpkgs/commit/3bdfedf1249ed1384d21e751f17263b47f338b04) | `` tone: add changelog ``                                                     |
| [`9d1bc00f`](https://github.com/NixOS/nixpkgs/commit/9d1bc00f7f3bf79d7b27e48f48c27242e2c02874) | `` tone: use update script ``                                                 |
| [`aaf64629`](https://github.com/NixOS/nixpkgs/commit/aaf64629a057189dfdfe4da58df99ae10b199a22) | `` tone: use versionCheckHook ``                                              |
| [`67688369`](https://github.com/NixOS/nixpkgs/commit/67688369cc4e29ff1d78e76d6c90a34dd5c77bf5) | `` tone: clean up ``                                                          |
| [`512f7c37`](https://github.com/NixOS/nixpkgs/commit/512f7c377625efa8c059d78c535a63009dd973f9) | `` tone: format ``                                                            |
| [`15aa9de6`](https://github.com/NixOS/nixpkgs/commit/15aa9de6dcbff3d0e12a772ee6e71faefdd78c88) | `` flood: 4.8.2 -> 4.8.5 ``                                                   |
| [`b5325f22`](https://github.com/NixOS/nixpkgs/commit/b5325f2268173e8e6cde2e11b06264244f7b843e) | `` yt-dlp: 2024.12.6 -> 2024.12.13 ``                                         |
| [`0bcab9b5`](https://github.com/NixOS/nixpkgs/commit/0bcab9b5b72188197cfa065093e7fb6423445d44) | `` music-assistant: prevent interactive dependency resolution ``              |
| [`bfcb50f5`](https://github.com/NixOS/nixpkgs/commit/bfcb50f53f6e7f0f43ec5b38c5f59405413a88b2) | `` music-assistant: check dependency versions in provider updater ``          |
| [`23c84397`](https://github.com/NixOS/nixpkgs/commit/23c84397113356e42ba7f3aadf8e8cc52dfa0bed) | `` music-assistant: autoformat provider file ``                               |
| [`ec113036`](https://github.com/NixOS/nixpkgs/commit/ec113036302c4833fc3935b8e721938cea5ebdbf) | `` raycast: 1.87.4 -> 1.88.3 ``                                               |
| [`e40f2c6e`](https://github.com/NixOS/nixpkgs/commit/e40f2c6ed71ccecdc511c4748e3505d087c7f64a) | `` arc-browser: 1.70.0-56062 -> 1.73.0-56815 ``                               |
| [`1025b040`](https://github.com/NixOS/nixpkgs/commit/1025b04070bb4f171a3bad3b400632505053add9) | `` ntpd-rs: migrate to new darwin sdk pattern ``                              |
| [`b6e6ea64`](https://github.com/NixOS/nixpkgs/commit/b6e6ea641eb1d0209de5edb1fe95c946efd22b5a) | `` ntpd-rs: 1.3.1 -> 1.4.0 ``                                                 |
| [`3847586e`](https://github.com/NixOS/nixpkgs/commit/3847586e8e2ba8b0077cdc50fd8a3cc2824f9ca5) | `` skim: update meta.homepage ``                                              |
| [`362d9af0`](https://github.com/NixOS/nixpkgs/commit/362d9af09d6e1dc11d0cd4b51af23dcf0cacd640) | `` skim: 0.15.0 -> 0.15.5 ``                                                  |
| [`16cf8b46`](https://github.com/NixOS/nixpkgs/commit/16cf8b46fb643d32c4b66bf5ff27c1bdf97cb135) | `` inv-sig-helper: 0-unstable-2024-12-10 -> 0-unstable-2024-12-16 ``          |
| [`fe33a060`](https://github.com/NixOS/nixpkgs/commit/fe33a060088c90adcebed780f5f06d2e03f54d8c) | `` pcsc-safenet: 10.8.28 -> 10.8.1050 ``                                      |
| [`dd2e4ceb`](https://github.com/NixOS/nixpkgs/commit/dd2e4ceb31f0cc2883d607651480a6695e3c7db5) | `` ocamlPackages.cppo: 1.6.9 → 1.8.0 ``                                       |
| [`4d1e2e0c`](https://github.com/NixOS/nixpkgs/commit/4d1e2e0cf8a6fffe1b35cbc0ec5222ed61e59aef) | `` stats: 2.11.19 -> 2.11.21 ``                                               |
| [`a62c0ae6`](https://github.com/NixOS/nixpkgs/commit/a62c0ae6102213986f05c913c65f637ab323e0c4) | `` stats: 2.11.18 -> 2.11.19 ``                                               |
| [`3a2ce934`](https://github.com/NixOS/nixpkgs/commit/3a2ce9341fd7ae0e7d34e6bcc8b15d5a3916f757) | `` mpris-timer: 1.5 -> 1.6.2 ``                                               |
| [`bfd6372d`](https://github.com/NixOS/nixpkgs/commit/bfd6372df684d09f50d4eb8be17fbf645a8a0a2b) | `` stats: 2.11.16 -> 2.11.18 ``                                               |
| [`c806340f`](https://github.com/NixOS/nixpkgs/commit/c806340f688e2823269fab9e0dda22fe39d11b7d) | `` [Backport release-24.11] wike: 3.0.0 -> 3.1.0 (#365768) ``                 |
| [`fa544f57`](https://github.com/NixOS/nixpkgs/commit/fa544f579b8a585c66b665ac21ac87a1757add35) | `` [Backport release-24.11] tuba: 0.8.4 -> 0.9.0 (#365767) ``                 |
| [`cf3413d3`](https://github.com/NixOS/nixpkgs/commit/cf3413d3272500bee34cc029221fe9f8758039ed) | `` python312Packages.oddsprout: fix test on darwin ``                         |
| [`9fbf9659`](https://github.com/NixOS/nixpkgs/commit/9fbf9659d6c7c031c629e10e5dcd670157ca4311) | `` python3Packages.nidaqmx: 0.5.7 -> 1.0.2 ``                                 |
| [`46c172b2`](https://github.com/NixOS/nixpkgs/commit/46c172b2edb3ecf8461fdda84df4ff15380fa823) | `` python3Packages.hightime: init at 0.2.2 ``                                 |
| [`fa6d6803`](https://github.com/NixOS/nixpkgs/commit/fa6d680315f876359eaaa22a0b3f73f4f6d3b6da) | `` [Backport release-24.11] television: 0.6.2 -> 0.7.1 (#365733) ``           |
| [`2008731a`](https://github.com/NixOS/nixpkgs/commit/2008731a6a2356fc7625b97bfd8e99efce7c6f01) | `` gnomeExtensions.gsconnect: fix typelibPath substitution ``                 |
| [`d00a1c80`](https://github.com/NixOS/nixpkgs/commit/d00a1c8081095f944295055062be890f75d01571) | `` python312Packages.hass-client: fix package version ``                      |
| [`4e107e80`](https://github.com/NixOS/nixpkgs/commit/4e107e804669aec2ceba11ce96776cad97d4f161) | `` findup: 1.1.1 -> 1.1.2 ``                                                  |
| [`03b200fa`](https://github.com/NixOS/nixpkgs/commit/03b200fa3d4c37475456bacce29e29ed698c247a) | `` [Backport release 24.11] texlivePackages: add homepage (#365151) ``        |
| [`648463fc`](https://github.com/NixOS/nixpkgs/commit/648463fce46c97253ac5a6ad1295fd34975fe31c) | `` zigbee2mqtt: 1.41.0 -> 1.42.0 ``                                           |
| [`49b75be3`](https://github.com/NixOS/nixpkgs/commit/49b75be3b60d6c8914bb24a6eb8cbd39fd8c2345) | `` linux/hardened/patches/6.6: v6.6.63-hardened1 -> v6.6.64-hardened1 ``      |
| [`4017ef8b`](https://github.com/NixOS/nixpkgs/commit/4017ef8baec43a07f2da7491e6e58bfeb1c4df3a) | `` linux/hardened/patches/6.12: init at v6.12.4-hardened1 ``                  |
| [`43862760`](https://github.com/NixOS/nixpkgs/commit/43862760a24d22d6e93350fc6441cb8ae096394c) | `` linux/hardened/patches/6.11: v6.11.10-hardened1 -> v6.11.11-hardened1 ``   |
| [`c663fab0`](https://github.com/NixOS/nixpkgs/commit/c663fab0acb3412ccac8609f3c0690699a1031d6) | `` ipmitool: fix hash ``                                                      |
| [`2c4a7206`](https://github.com/NixOS/nixpkgs/commit/2c4a720683e6399d9d45df28b790d87dd787a139) | `` workflows: Consistently condition on merge commit ``                       |
| [`ab026a7e`](https://github.com/NixOS/nixpkgs/commit/ab026a7e56f4ebded348ff50bdcf9db6b1283548) | `` workflows: Condition all merge-dependent workflows on a merge commit ``    |
| [`499456c6`](https://github.com/NixOS/nixpkgs/commit/499456c639dd68bbc6dba2288e40d3c7376d1185) | `` python312Packages.scapy: 2.6.0 -> 2.6.1 ``                                 |
| [`61d89818`](https://github.com/NixOS/nixpkgs/commit/61d89818cec9c91d5f61558268e52ef8f202408b) | `` fix dhcpcd when ipv6 is disabled ``                                        |
| [`86e4d42b`](https://github.com/NixOS/nixpkgs/commit/86e4d42bb926da9fe782748fd1d9a25084afc428) | `` dune_3: 3.16.1 -> 3.17.0 ``                                                |
| [`49394795`](https://github.com/NixOS/nixpkgs/commit/493947958f49875fa96bc264b26a5cc88c4e67c2) | `` ocamlPackages.melange: disable checks & disable for OCaml 5.0 ``           |
| [`d8cd7d12`](https://github.com/NixOS/nixpkgs/commit/d8cd7d129d2d7d46d2efeb5c0bd200bcc2d5f07b) | `` cplex: fix file permissions ``                                             |
| [`bbd0026f`](https://github.com/NixOS/nixpkgs/commit/bbd0026f29f774de5ab21f045c38b933cc7920de) | `` cplex: fix oplide ``                                                       |
| [`a33fe37e`](https://github.com/NixOS/nixpkgs/commit/a33fe37ea80984ada480c43f8220c39827d406ba) | `` cplex: use makeWrapper instead of wrapProgram ``                           |
| [`019d7541`](https://github.com/NixOS/nixpkgs/commit/019d754134f23da1898f9a9fb097c5c040d57166) | `` cplex: use autoPatchelfHook ``                                             |
| [`1bb23753`](https://github.com/NixOS/nixpkgs/commit/1bb237538f1b98195e75c15c0b7d6bf07f69c687) | `` cplex: put openjdk in nativeBuildInputs ``                                 |
| [`653b1556`](https://github.com/NixOS/nixpkgs/commit/653b155692dc27aeb6b309cca9412389b342d5f0) | `` cplex: install desktop entry ``                                            |
| [`322f9b2c`](https://github.com/NixOS/nixpkgs/commit/322f9b2ca0ce8b5f6a384ceee8e295dc41ec4159) | `` cplex: move doc and license to share, remove uninstall dir ``              |
| [`5ca5ea56`](https://github.com/NixOS/nixpkgs/commit/5ca5ea56d274e3e259dca325ad0fe4db4273d74a) | `` cplex: fix phase hooks ``                                                  |
| [`7f1581a5`](https://github.com/NixOS/nixpkgs/commit/7f1581a574fb5ea9e01176ce0ed47b91297dbbc3) | `` cplex: set meta.mainProgram ``                                             |
| [`5240c257`](https://github.com/NixOS/nixpkgs/commit/5240c257171d7a43d069d8232c5a887eb272d141) | `` prrte: 3.0.7 -> 3.0.8 ``                                                   |
| [`741e00f6`](https://github.com/NixOS/nixpkgs/commit/741e00f66876f4bc9ed66fdc130857e0c4058bd9) | `` wireshark: 4.2.8 -> 4.2.9 ``                                               |
| [`73968cf7`](https://github.com/NixOS/nixpkgs/commit/73968cf7a7045241f2c7d232e8b1dadb36145380) | `` cloud-hypervisor: skip more tests that rely on KVM ``                      |
| [`8d6b113d`](https://github.com/NixOS/nixpkgs/commit/8d6b113d94789cb9b82c98ff0a863719c1d9c054) | `` coolercontrol.*: 1.4.4 -> 1.4.5 ``                                         |
| [`10dde36b`](https://github.com/NixOS/nixpkgs/commit/10dde36bc6303781cbd9eced1d6d7c73a855e613) | `` coolercontrol.*: nixfmt, drop meta-wide "with lib" ``                      |
| [`db193b70`](https://github.com/NixOS/nixpkgs/commit/db193b70c52cc0de2c242c04f0af9642b670d90d) | `` coolercontrol.*: 1.4.0 -> 1.4.4 ``                                         |
| [`5eb803c7`](https://github.com/NixOS/nixpkgs/commit/5eb803c7b22ee6f4ef62cfd9605f2b2c2555502c) | `` qutebrowser: 3.3.1 -> 3.4.0 ``                                             |
| [`1422d4bc`](https://github.com/NixOS/nixpkgs/commit/1422d4bc9d0601c988b4f4d577b3ac95e69a054d) | `` linuxKernels.linux_lqx: fix build by removing SCHED_CLASS_EXT option ``    |
| [`b46e8cd3`](https://github.com/NixOS/nixpkgs/commit/b46e8cd38febb6b9b418f5a558800bb766d64f15) | `` oscavmgr: use fetchCargoVendor ``                                          |
| [`ffae1084`](https://github.com/NixOS/nixpkgs/commit/ffae10842a76b2fe97409329d380ceb3e54faa7a) | `` nfs-ganesha: 6.3 -> 6.4 ``                                                 |
| [`5344ad10`](https://github.com/NixOS/nixpkgs/commit/5344ad1057e2e308d8f01ecdae768e7f0b5d9c36) | `` pmix: 5.0.4 -> 5.0.5 ``                                                    |
| [`91e3552a`](https://github.com/NixOS/nixpkgs/commit/91e3552a6f89f4edfad80a483889b7c6d5d0a8a5) | `` eask-cli: 0.10.1 -> 0.10.2 ``                                              |
| [`08c0c493`](https://github.com/NixOS/nixpkgs/commit/08c0c493b8976996b15fd7016c5a0e82cbcda78e) | `` lirc: fix build on ubuntu ``                                               |
| [`ea82ecb2`](https://github.com/NixOS/nixpkgs/commit/ea82ecb28089583a19be2a9eeca0f1a8f44eacea) | `` coqPackages.coq-elpi: support master ``                                    |
| [`411b89ac`](https://github.com/NixOS/nixpkgs/commit/411b89acd9e49fb699931bc878207fc057c71f84) | `` ocamlPackages.elpi: 2.0.5 -> 2.0.6 ``                                      |
| [`9126ec73`](https://github.com/NixOS/nixpkgs/commit/9126ec73e73121aaeaa8df16c59e94a5702d7b82) | `` davfs2: 1.7.0 -> 1.7.1 ``                                                  |
| [`2a23072c`](https://github.com/NixOS/nixpkgs/commit/2a23072c830fff62d1a5cba6d1bfdba0d5d396f3) | `` [Backport release-24.11] k3s_1_30: 1.30.5+k3s1 -> 1.30.7+k3s1 ``           |
| [`fa5ab19e`](https://github.com/NixOS/nixpkgs/commit/fa5ab19e9f3e79fc9f747110ab33152eda8b4957) | `` python312Packages.pyqt6-webengine: add patch fixing missing include ``     |
| [`a34a4b5f`](https://github.com/NixOS/nixpkgs/commit/a34a4b5f8bae9df3611fd005913184794ca36af0) | `` python312Packages.pyqt6-webengine: 6.7.0 -> 6.8.0 ``                       |
| [`56a3264c`](https://github.com/NixOS/nixpkgs/commit/56a3264cf3720513bfa8804ade4585276a93c179) | `` python312Packages.pyqt6-charts: 6.7.0 -> 6.8.0 ``                          |
| [`27b03901`](https://github.com/NixOS/nixpkgs/commit/27b039017c063614c0b0b3660abdcdcc20fc31af) | `` python312Packages.pyqt6: 6.8.0.dev2410141303 -> 6.8.0 ``                   |
| [`e0744243`](https://github.com/NixOS/nixpkgs/commit/e0744243365712e53a85688b05d2255dbae35bd0) | `` python312Packages.sip: 6.9.0 -> 6.9.1 ``                                   |
| [`a221d5e8`](https://github.com/NixOS/nixpkgs/commit/a221d5e8d7454104881e20c26f1d90467a95b06f) | `` sla2pdf: init at 0.0.1 ``                                                  |