### PR TITLE
chore(flake/nixpkgs-stable): `b47fd6fa` -> `1c6e20d4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -389,11 +389,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1734600368,
-        "narHash": "sha256-nbG9TijTMcfr+au7ZVbKpAhMJzzE2nQBYmRvSdXUD8g=",
+        "lastModified": 1734737257,
+        "narHash": "sha256-GIMyMt1pkkoXdCq9un859bX6YQZ/iYtukb9R5luazLM=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "b47fd6fa00c6afca88b8ee46cfdb00e104f50bca",
+        "rev": "1c6e20d41d6a9c1d737945962160e8571df55daa",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                             |
| ---------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------- |
| [`4066a53e`](https://github.com/NixOS/nixpkgs/commit/4066a53ed9cac57e6bf219b8f9e778be2ae7eb59) | `` nixos/incus: seabios is x86_64 only ``                                           |
| [`5b6548dc`](https://github.com/NixOS/nixpkgs/commit/5b6548dc82fe4bf2c77f7206b9bd5190e16090ca) | `` incus: fix CSM support ``                                                        |
| [`b93a71dc`](https://github.com/NixOS/nixpkgs/commit/b93a71dcc6d73c420356361931e88b8df6d1e4aa) | `` incus: refactor tests ``                                                         |
| [`19470ef0`](https://github.com/NixOS/nixpkgs/commit/19470ef05952e0bf74b9ce3ab8742acc4d9c3c91) | `` [Backport release-24.11] discord: bump all versions (#366343) ``                 |
| [`3e89f767`](https://github.com/NixOS/nixpkgs/commit/3e89f767ddbb86ea782a0a6797d428bd62ced4af) | `` moodle: 4.4.4 -> 4.4.5 ``                                                        |
| [`05b78c70`](https://github.com/NixOS/nixpkgs/commit/05b78c706d12573a8b8f3cab38ad271d0005c59d) | `` tomcat: 11.0.0 -> 11.0.2 ``                                                      |
| [`7faad36f`](https://github.com/NixOS/nixpkgs/commit/7faad36f60844f561fb6c003594b03136a9c4c08) | `` percona-xtrabackup_8_4: 8.4.0-1 -> 8.4.0-2 ``                                    |
| [`39735e66`](https://github.com/NixOS/nixpkgs/commit/39735e66463f17731a7f0a0918fdfaba2dbca708) | `` percona-server_8_4: 8.4.2-2 -> 8.4.3-3 ``                                        |
| [`acc3bd5e`](https://github.com/NixOS/nixpkgs/commit/acc3bd5e6f3e441323b3769c8e98501181a5c8d7) | `` percona-server: add updateScript ``                                              |
| [`80bef76b`](https://github.com/NixOS/nixpkgs/commit/80bef76b79ebc9c20c9bda02693944fa0f12652d) | `` lxcfs: fix cross compilation ``                                                  |
| [`4da2e9a1`](https://github.com/NixOS/nixpkgs/commit/4da2e9a1e4cad6afd6e32f7cb694ded74aa70257) | `` uptime-kuma: 1.23.15 -> 1.23.16 ``                                               |
| [`58949c9a`](https://github.com/NixOS/nixpkgs/commit/58949c9acfce199e3f07fa49acb75fe7206bd202) | `` dotnet: Avoid double escaping of path ``                                         |
| [`2098ce8b`](https://github.com/NixOS/nixpkgs/commit/2098ce8b76546326514945a692825775910a8c55) | `` ungoogled-chromium: 131.0.6778.139-1 -> 131.0.6778.204-1 ``                      |
| [`4b7915ee`](https://github.com/NixOS/nixpkgs/commit/4b7915ee843fa3727f016ef081dabcd0445bd6d8) | `` yggdrasil: 0.5.11 -> 0.5.12 ``                                                   |
| [`09f3e6de`](https://github.com/NixOS/nixpkgs/commit/09f3e6deb26710aa4f11638878d8af9bde56b515) | `` snac2: 2.65 -> 2.66 ``                                                           |
| [`7f0720b2`](https://github.com/NixOS/nixpkgs/commit/7f0720b2ca98d33b85069a53c0b7f31181cfdfad) | `` misskey: 2024.10.0 -> 2024.11.0 ``                                               |
| [`845d4f57`](https://github.com/NixOS/nixpkgs/commit/845d4f57663b1a86dbe9e0a1b176034907cb7d83) | `` chromium,chromedriver: 131.0.6778.139 -> 131.0.6778.204 ``                       |
| [`98c3b4f0`](https://github.com/NixOS/nixpkgs/commit/98c3b4f0ed6ad9d392f06b9d69deb3c2ddf3ff25) | `` chromium: fix cross-"building" of recompressed FODs ``                           |
| [`a0485c90`](https://github.com/NixOS/nixpkgs/commit/a0485c902edc340ad9ff24914ee6d3f5094df5a5) | `` nuget-to-json: fix tools not being added to the lockfile ``                      |
| [`23b51627`](https://github.com/NixOS/nixpkgs/commit/23b51627c56d73a07e4abe4fae26ef1a128b6cfe) | `` addNugetDeps.fetch-deps: remove `set -u` ``                                      |
| [`bc8b499f`](https://github.com/NixOS/nixpkgs/commit/bc8b499ff025f3542f61dccf1893bf9bd390f335) | `` fastddsgen: 4.0.2 -> 4.0.3 ``                                                    |
| [`61f266e5`](https://github.com/NixOS/nixpkgs/commit/61f266e52ae81a4b23430c50929f7d5a633e821c) | `` docs: add buildDotnetModule changes to release notes. ``                         |
| [`9cf669b8`](https://github.com/NixOS/nixpkgs/commit/9cf669b81143caf2cad0664c6610086ae0b84184) | `` treewide: migrate nix-based dotnet lockfiles to JSON ``                          |
| [`f39ee3d3`](https://github.com/NixOS/nixpkgs/commit/f39ee3d36e3598f5d4c1a5fce79734bf87f7965b) | `` update-dotnet-lockfiles: update comment to mention nuget-to-json ``              |
| [`de32a2ce`](https://github.com/NixOS/nixpkgs/commit/de32a2ce1ce8df2b503f2a02c8fe35a05ccd0a20) | `` dotnetCorePackages.mkNugetDeps: support loading JSON lockfiles ``                |
| [`7707d124`](https://github.com/NixOS/nixpkgs/commit/7707d1245f03de215fdea29dd7e6eb60f0baa5a0) | `` buildDotnetModule.fetch-deps: use json lockfiles by default ``                   |
| [`cf30bb1e`](https://github.com/NixOS/nixpkgs/commit/cf30bb1e24c834b6fd405c1483622b76882caf44) | `` addNuGetDeps: support loading JSON lockfiles ``                                  |
| [`9c05a0d1`](https://github.com/NixOS/nixpkgs/commit/9c05a0d1c8136dc79ec3eaac4fb718800acccc7d) | `` nuget-to-nix: refactor on top of nuget-to-json and deprecate ``                  |
| [`8f626eac`](https://github.com/NixOS/nixpkgs/commit/8f626eace5d284936d8fe1520c665ac0debe0b84) | `` nuget-to-json: init ``                                                           |
| [`a32e66c9`](https://github.com/NixOS/nixpkgs/commit/a32e66c9cf975ba6212ce07056ac142cd3934857) | `` vrcadvert: .NET 6 -> .NET 8 ``                                                   |
| [`3788aaf9`](https://github.com/NixOS/nixpkgs/commit/3788aaf9e6a7e03388ec6f4ac37a52ec9cef413c) | `` vrcadvert: refactor ``                                                           |
| [`f874921b`](https://github.com/NixOS/nixpkgs/commit/f874921b586e115edbcb3557a085aa507651ed23) | `` vrcadvert: add update script ``                                                  |
| [`eee3d542`](https://github.com/NixOS/nixpkgs/commit/eee3d542bbd7dbc23094a25d344bc2472e63a593) | `` vrcadvert: add version checking ``                                               |
| [`a034e029`](https://github.com/NixOS/nixpkgs/commit/a034e029ef625ee6c48224e65e1026e57549024f) | `` gnomeExtensions.gsconnect: patch also gsconnect-preferences executable script `` |
| [`263aec75`](https://github.com/NixOS/nixpkgs/commit/263aec753994a54ac1d6afb062313ca78e59c219) | `` nixos/prometheux-exporters/rasdaemon: init ``                                    |
| [`1973decd`](https://github.com/NixOS/nixpkgs/commit/1973decd6dc2e1adb4a2456ff93718b42c17961e) | `` prometheus-rasdaemon-exporter: init at unstable-2023-03-15 ``                    |
| [`5bdd2787`](https://github.com/NixOS/nixpkgs/commit/5bdd27877fa3985912a7cc94791fbcba3633a554) | `` wasmer: 5.0.3 -> 5.0.4 ``                                                        |
| [`2076373f`](https://github.com/NixOS/nixpkgs/commit/2076373f7f964033df919bb9eed3b9abd09ff0d0) | `` wasmer: 5.0.2 -> 5.0.3 (#362987) ``                                              |
| [`a434c39d`](https://github.com/NixOS/nixpkgs/commit/a434c39db886bb74fbd036539e7fc810b327045a) | `` wasmer: 5.0.1 -> 5.0.2 ``                                                        |
| [`1ed95169`](https://github.com/NixOS/nixpkgs/commit/1ed95169f8bccb14d949645246263fc708a7a6fa) | `` asciinema-agg: 1.4.3 -> 1.5.0 ``                                                 |
| [`b51e089d`](https://github.com/NixOS/nixpkgs/commit/b51e089db6b27e8b23c4bd32122e8d75f0dd7ded) | `` asciinema-agg: refactor ``                                                       |
| [`ac13eb1b`](https://github.com/NixOS/nixpkgs/commit/ac13eb1b7a223cf1b82a718b0687b3ad3443727d) | ``  asciinema-agg: migrate to by-name ``                                            |
| [`74adea51`](https://github.com/NixOS/nixpkgs/commit/74adea51a584608f7873d70822db4096d842641a) | `` mediamtx: fix build on non-linux platforms ``                                    |
| [`538c3a5e`](https://github.com/NixOS/nixpkgs/commit/538c3a5e4b878db27deceabbf573050e473686a1) | `` mediamtx: 1.9.3 -> 1.10.0 ``                                                     |
| [`f1b133dd`](https://github.com/NixOS/nixpkgs/commit/f1b133dd30b870ceafcea20cc2aaa8ecdee2e5a7) | `` vencord: 1.10.8 -> 1.10.9 ``                                                     |
| [`0085f21d`](https://github.com/NixOS/nixpkgs/commit/0085f21dee593b7ff407f9d82a1c7da2cda27331) | `` fastcdr: 2.2.5 -> 2.2.6 ``                                                       |
| [`dc1e295a`](https://github.com/NixOS/nixpkgs/commit/dc1e295affd8496ded9b40ae0f4175a930ac0aaf) | `` gitlab-timelogs: 0.4.0 -> 0.5.0 ``                                               |
| [`d23b8aef`](https://github.com/NixOS/nixpkgs/commit/d23b8aefb96be92fadfca71a076b5a0e35014c36) | `` chromium: fix read out of range on aarch64 16k pages builds ``                   |
| [`50b107a4`](https://github.com/NixOS/nixpkgs/commit/50b107a462a664eb460b450fde9dcc72aa88a070) | `` matomo_5: 5.1.2 -> 5.2.0 ``                                                      |
| [`4854ac76`](https://github.com/NixOS/nixpkgs/commit/4854ac767d7900039d1bf6cf446cfa95b6344af1) | `` matomo: mark 4.x as EOL ``                                                       |