### PR TITLE
chore(flake/spicetify-nix): `8008cc4f` -> `9da99a9e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -475,11 +475,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1734754523,
-        "narHash": "sha256-ywne/i+kIvU6r20dZvib0CprD28aQUYsZKxjAY/hcT8=",
+        "lastModified": 1734840909,
+        "narHash": "sha256-bBMokfGRYs0ofzViAj4MRxjCklnxBZWt4FLok6jo4tA=",
         "owner": "Gerg-L",
         "repo": "spicetify-nix",
-        "rev": "8008cc4f52eb02f503ae6f68c10373c30b8de3dc",
+        "rev": "9da99a9e7598f1b1b2997c508fd21a2ee4a51a94",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                    |
| ----------------------------------------------------------------------------------------------------- | -------------------------- |
| [`9da99a9e`](https://github.com/Gerg-L/spicetify-nix/commit/9da99a9e7598f1b1b2997c508fd21a2ee4a51a94) | `` CI update 2024-12-22 `` |