### PR TITLE
chore(flake/nix-flatpak): `8bdc2540` -> `13be795c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -326,11 +326,11 @@
     },
     "nix-flatpak": {
       "locked": {
-        "lastModified": 1734128415,
-        "narHash": "sha256-HLwdVNxpuTsLlM3tCkpbQU6yCehdgf3kOS1G2SDlkzY=",
+        "lastModified": 1734864618,
+        "narHash": "sha256-8SCTJhDH1fdNGGFhuGStIqbO7vwUKQokgQu6nQlQagY=",
         "owner": "gmodena",
         "repo": "nix-flatpak",
-        "rev": "8bdc2540da516006d07b04019eb57ae0781a04b3",
+        "rev": "13be795cac27df7044a425c0b2de3a42b10ddb18",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                                   |
| ---------------------------------------------------------------------------------------------------- | ----------------------------------------- |
| [`13be795c`](https://github.com/gmodena/nix-flatpak/commit/13be795cac27df7044a425c0b2de3a42b10ddb18) | `` options: add uninstallUnused (#124) `` |