### PR TITLE
chore(flake/home-manager): `edb8b00e` -> `8264bfe3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -290,11 +290,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1734893686,
-        "narHash": "sha256-JUEZn9MmpLGsW4J3luSX+R4BhcThccYpYg5AuKW7zG0=",
+        "lastModified": 1734944412,
+        "narHash": "sha256-36QfCAl8V6nMIRUCgiC79VriJPUXXkHuR8zQA1vAtSU=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "edb8b00e4d17b2116b60eca50f38ac68f12b9ab4",
+        "rev": "8264bfe3a064d704c57df91e34b795b6ac7bad9e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------------ |
| [`8264bfe3`](https://github.com/nix-community/home-manager/commit/8264bfe3a064d704c57df91e34b795b6ac7bad9e) | `` mu: add integration tests ``                        |
| [`7349b015`](https://github.com/nix-community/home-manager/commit/7349b01505d18cd60ba0e573e78c234b742056ef) | `` mu: reinitialize when personal addresses change ``  |
| [`8bea1a20`](https://github.com/nix-community/home-manager/commit/8bea1a2005c64a8c9c430d0dddb6b2e5db5f6f12) | `` nixgl: forward override calls to wrapped package `` |