### PR TITLE
chore(flake/nixpkgs-stable): `1c6e20d4` -> `1807c2b9`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -389,11 +389,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1734737257,
-        "narHash": "sha256-GIMyMt1pkkoXdCq9un859bX6YQZ/iYtukb9R5luazLM=",
+        "lastModified": 1734875076,
+        "narHash": "sha256-Pzyb+YNG5u3zP79zoi8HXYMs15Q5dfjDgwCdUI5B0nY=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "1c6e20d41d6a9c1d737945962160e8571df55daa",
+        "rev": "1807c2b91223227ad5599d7067a61665c52d1295",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                         |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------- |
| [`a1b8c11a`](https://github.com/NixOS/nixpkgs/commit/a1b8c11a0f4ce1999816baee61bfeea18d980df0) | `` wluma: 4.4.0 → 4.5.1 ``                                                      |
| [`7b40eb89`](https://github.com/NixOS/nixpkgs/commit/7b40eb8929c086f14299178d711e31b7c792bdf6) | `` Apppapersway: 1.001 -> 1.004 ``                                              |
| [`564d9d41`](https://github.com/NixOS/nixpkgs/commit/564d9d41c2f2a13ae7f974d879ae16d70deba817) | `` pack: 0.36.0 -> 0.36.1 ``                                                    |
| [`ca6d6831`](https://github.com/NixOS/nixpkgs/commit/ca6d683116ce2dfbe4899af675401060b1f233c2) | `` pack: 0.35.1 -> 0.36.0 ``                                                    |
| [`22708ada`](https://github.com/NixOS/nixpkgs/commit/22708adacc60e258dfdbba72406ede231df1962d) | `` bilibili: 1.14.0-2 -> 1.15.2-2 ``                                            |
| [`a0784ddf`](https://github.com/NixOS/nixpkgs/commit/a0784ddf3220de9193d487235387660b69eb3894) | `` lxcfs: 6.0.2 -> 6.0.3 ``                                                     |
| [`79c20921`](https://github.com/NixOS/nixpkgs/commit/79c209219516998773b7bb8bde6eaf69eb3234cb) | `` simplex-chat-desktop: 6.2.0 -> 6.2.1 ``                                      |
| [`8c2a6163`](https://github.com/NixOS/nixpkgs/commit/8c2a6163f86e0d7072dd97729ebaff7dd7845403) | `` skypeforlinux: 8.133.0.202 -> 8.134.0.202 ``                                 |
| [`f709397f`](https://github.com/NixOS/nixpkgs/commit/f709397f3624f863ce2d8a557eec4fbd8a4da3d0) | `` wofi-pass: 24.0.2 -> 24.1.0 ``                                               |
| [`a18a9d04`](https://github.com/NixOS/nixpkgs/commit/a18a9d04d059f2b5e8dd277c2a72155d0395c82d) | `` singularity: 4.2.1 -> 4.2.2 ``                                               |
| [`1efcf623`](https://github.com/NixOS/nixpkgs/commit/1efcf6239dfdbf62bc2431df3ad763d675183b1d) | `` miniflux: 2.2.3 -> 2.2.4 ``                                                  |
| [`3e125554`](https://github.com/NixOS/nixpkgs/commit/3e1255541bca84bf170c1bbded0da6b0b3a275ba) | `` kanidm: 1.4.4 -> 1.4.5 ``                                                    |
| [`f707fa1b`](https://github.com/NixOS/nixpkgs/commit/f707fa1b2bd93418784bb0f1cf340e0239f40715) | `` php83: 8.3.14 -> 8.3.15 ``                                                   |
| [`45fb6bdc`](https://github.com/NixOS/nixpkgs/commit/45fb6bdc55f4489cc26a0b45ba296ed7d68bc244) | `` mautrix-whatsapp: 0.11.1 -> 0.11.2 ``                                        |
| [`e0dd5422`](https://github.com/NixOS/nixpkgs/commit/e0dd5422969c96b48f75eef2df3aa36f122762e9) | `` chiaki-ng: 1.9.2 -> 1.9.3 ``                                                 |
| [`621261ae`](https://github.com/NixOS/nixpkgs/commit/621261ae9f2287d24b3490abb13871695680b7e4) | `` chiaki-ng: 1.9.1 -> 1.9.2 ``                                                 |
| [`5e3f6c6c`](https://github.com/NixOS/nixpkgs/commit/5e3f6c6c69832f5e5ac8002f2fa6c60c666c9c13) | `` opencomposite: 0-unstable-2024-11-11 -> 0-unstable-2024-12-20 ``             |
| [`d6683ad3`](https://github.com/NixOS/nixpkgs/commit/d6683ad3540379820f1dc456db50b804bb76f819) | `` librewolf-bin: 131.0.2-1 -> 133.0.3-1 ``                                     |
| [`3e53960c`](https://github.com/NixOS/nixpkgs/commit/3e53960c839b89cb7758ee3466209adbe0f9136c) | `` librewolf-bin: add dwrege as maintainer ``                                   |
| [`e99e84c2`](https://github.com/NixOS/nixpkgs/commit/e99e84c210cdb7a4655b9abd1046d2118d82857a) | `` glab: use nix-update-script ``                                               |
| [`27c9c9fa`](https://github.com/NixOS/nixpkgs/commit/27c9c9faef6ba02d1160451115b45b2e59b1bd9b) | `` glab: 1.50.0 -> 1.51.0 ``                                                    |
| [`0bb4018b`](https://github.com/NixOS/nixpkgs/commit/0bb4018b85c5e44a3e92b8179b1653ab7f9f3b52) | `` glab: 1.49.0 -> 1.50.0 ``                                                    |
| [`ed343441`](https://github.com/NixOS/nixpkgs/commit/ed343441a04f34a7a0cda7a955f50497b3fc0154) | `` glab: 1.48.0 -> 1.49.0 ``                                                    |
| [`bc0d8940`](https://github.com/NixOS/nixpkgs/commit/bc0d89405209c63abd77e8e24d74460978306f07) | `` gh-gei: 1.9.0 -> 1.11.0 ``                                                   |
| [`6acd4c3c`](https://github.com/NixOS/nixpkgs/commit/6acd4c3c706dd80e0242f058d7bf619e53e13e09) | `` php82: 8.2.26 -> 8.2.27 ``                                                   |
| [`937021a9`](https://github.com/NixOS/nixpkgs/commit/937021a960fdb6b695a8044babd7aea351ca0cc6) | `` php84: 8.4.1 -> 8.4.2 ``                                                     |
| [`a1b69751`](https://github.com/NixOS/nixpkgs/commit/a1b69751f618474a697cb3e6592fa07d5864c12a) | `` wasm-tools: 1.221.2 -> 1.222.0 ``                                            |
| [`d7edec5c`](https://github.com/NixOS/nixpkgs/commit/d7edec5cdedc1f56e110da702cc05c482404adfb) | `` process-compose: 1.40.1 -> 1.46.0 ``                                         |
| [`9ecd11e1`](https://github.com/NixOS/nixpkgs/commit/9ecd11e16f188a888e49e67f1d0e1eb812ca393c) | `` python312Packages.debianbts: fix build ``                                    |
| [`14f3a068`](https://github.com/NixOS/nixpkgs/commit/14f3a068b534524792d71860b5b3d14634c32a63) | `` python312Packages.pallets-sphinx-themes: 2.1.3 -> 2.3.0 ``                   |
| [`ee2c91fe`](https://github.com/NixOS/nixpkgs/commit/ee2c91fe8ee81502f3424dddcd720252f43a52c1) | `` python312Packages.pycatch22: fix build ``                                    |
| [`ad0d463b`](https://github.com/NixOS/nixpkgs/commit/ad0d463b7bc44b8fe5b27cc33d4690c8157af7a0) | `` shaka-packager: 3.4.0 -> 3.4.1 ``                                            |
| [`2181aa25`](https://github.com/NixOS/nixpkgs/commit/2181aa2588e989783232739efd0525c9603f3c84) | `` gh-gei: 1.8.0 -> 1.9.0 ``                                                    |
| [`ed27df72`](https://github.com/NixOS/nixpkgs/commit/ed27df72c517332971a49d702da6a3168ff470b3) | `` mullvad: 2024.7 -> 2024.8 ``                                                 |
| [`77c7739a`](https://github.com/NixOS/nixpkgs/commit/77c7739a8116f9af6474a54a224ec4b55b41de76) | `` mullvad-vpn: 2024.6 -> 2024.8 ``                                             |
| [`03b0d0ea`](https://github.com/NixOS/nixpkgs/commit/03b0d0eacbbd135920efb004fe1e9af0d8f95aa4) | `` firecracker: 1.9.0 -> 1.9.1, build from source ``                            |
| [`76d3c36a`](https://github.com/NixOS/nixpkgs/commit/76d3c36aef04b842fb459ac04af297db11f1ef4a) | `` [Backport release-24.11] raider: 3.0.1 -> 3.0.2 (#367044) ``                 |
| [`f2c9a96d`](https://github.com/NixOS/nixpkgs/commit/f2c9a96d998c76aafc10302c41dfaa6e2fa69c16) | `` dolibarr: add GaetanLepage as maintainer ``                                  |
| [`e1656b9e`](https://github.com/NixOS/nixpkgs/commit/e1656b9e46b832a76af6cb6cee6fb486b577d756) | `` dolibarr: 20.0.0 -> 20.0.2 ``                                                |
| [`cc3e99d7`](https://github.com/NixOS/nixpkgs/commit/cc3e99d7bc88bfa561ac553da642eb2512f576cc) | `` [Backport release-24.11] alda: 2.2.3 -> 2.3.1 (#367017) ``                   |
| [`d38b1bc9`](https://github.com/NixOS/nixpkgs/commit/d38b1bc9ef4bf6ca6726e0681895e1c3e8215a49) | `` [Backport release-24.11] python312Packages.nimfa: fix build (#367015) ``     |
| [`d0de4680`](https://github.com/NixOS/nixpkgs/commit/d0de46802f51bcd8688e6876dd9c3d95c25f5bfa) | `` python312Packages.globus-sdk: 3.48.0 -> 3.49.0 ``                            |
| [`c7f7afbe`](https://github.com/NixOS/nixpkgs/commit/c7f7afbe65ac6bacabc63f466b1da86855558478) | `` livepeer: 0.8.0 -> 0.8.1 ``                                                  |
| [`bbbbe0dd`](https://github.com/NixOS/nixpkgs/commit/bbbbe0ddbed663ad093eddf0b557a4b9a12fee5f) | `` kubetui: 1.5.3 -> 1.5.4 ``                                                   |
| [`2f618880`](https://github.com/NixOS/nixpkgs/commit/2f618880104a1a50fa6f236de0765c22f6461b0e) | `` qq: 3.2.13-2024.11.12 -> 3.2.15-2024.12.10 ``                                |
| [`4a8e3e80`](https://github.com/NixOS/nixpkgs/commit/4a8e3e80c5cf48197f49ff0418ecbaa87c77fbdd) | `` element-desktop: remove darwin frameworks, already part ``                   |
| [`f49a12ef`](https://github.com/NixOS/nixpkgs/commit/f49a12ef33ba9095f7902d55f148794845d30b77) | `` element-web: add back conf override option ``                                |
| [`60dfff3c`](https://github.com/NixOS/nixpkgs/commit/60dfff3c6ff1695a94799c860067bc79cad49585) | `` element-web: format with `nixfmt-rfc-style` ``                               |
| [`642de4ff`](https://github.com/NixOS/nixpkgs/commit/642de4ffcb5df3b7a7793872c9199b5195a9bf38) | `` element-{web,desktop}: move to pkgs/by-name, ``                              |
| [`7d0e02a8`](https://github.com/NixOS/nixpkgs/commit/7d0e02a880e723411acae09a060ae06ed65c5fa4) | `` element-desktop: 1.11.87 -> 1.11.89 ``                                       |
| [`f03135b2`](https://github.com/NixOS/nixpkgs/commit/f03135b20255873a64355eb5ee9434fb373872ba) | `` perlPackages.MailDKIM: add missing CryptX dependency (#366744) ``            |
| [`8f43aca1`](https://github.com/NixOS/nixpkgs/commit/8f43aca1dbf2b7d0e8331b0021b2dc2349b605c2) | `` forgejo-lts: Fix invalid string escape ``                                    |
| [`3570ec50`](https://github.com/NixOS/nixpkgs/commit/3570ec5001c69af90c90e533f4bc614620226352) | `` treewide: Fix invalid string escapes ``                                      |
| [`46d69923`](https://github.com/NixOS/nixpkgs/commit/46d69923d7a2819f0e48d2160919f515675c78a2) | `` vscode-js-debug: Fix invalid string escape ``                                |
| [`bea6e796`](https://github.com/NixOS/nixpkgs/commit/bea6e7961e0436fbd126e35157c078569780b698) | `` pkcs11-provider: Fix invalid string escape ``                                |
| [`9f7521fa`](https://github.com/NixOS/nixpkgs/commit/9f7521faeb5d7b3e65aae29bd8c23c871f8a6538) | `` duplicity: Fix invalid string escape ``                                      |
| [`097b2bfd`](https://github.com/NixOS/nixpkgs/commit/097b2bfdc16341a9f94a7e6d1ae0c194830b8da8) | `` av1an-unwrapped: Fix invalid string escape ``                                |
| [`82ca9a76`](https://github.com/NixOS/nixpkgs/commit/82ca9a7679367e892a216d1c5e96633649de838a) | `` uuu: Fix invalid string escape ``                                            |
| [`672a41f6`](https://github.com/NixOS/nixpkgs/commit/672a41f64a89c90f3b538d99d24b5a6f52e066c2) | `` teams: Fix invalid string escape ``                                          |
| [`4b2ea4b7`](https://github.com/NixOS/nixpkgs/commit/4b2ea4b725fcce6d9d69a6e56ef7b22e41fe5c7f) | `` turbo-unwrapped: Fix invalid string escape ``                                |
| [`8489512e`](https://github.com/NixOS/nixpkgs/commit/8489512e322ca5ebfd6b9b9ebcc9996429c5954d) | `` mattermost: Fix invalid string escape ``                                     |
| [`fd450440`](https://github.com/NixOS/nixpkgs/commit/fd450440f5146b382ef839003c2ea01717dc8757) | `` circt: Fix invalid string escape ``                                          |
| [`e53e0a06`](https://github.com/NixOS/nixpkgs/commit/e53e0a067db123bf7a90d20754c00c278dc3e2f0) | `` awscli2: Fix invalid string escape ``                                        |
| [`09f708dc`](https://github.com/NixOS/nixpkgs/commit/09f708dccc78aee336f000e869cdd40c7db75bbf) | `` renode-unstable: Fix invalid string escape ``                                |
| [`3555ffec`](https://github.com/NixOS/nixpkgs/commit/3555ffec143a24373af5c9cc4c44fd4a4f9cb458) | `` klee: Fix invalid string escape ``                                           |
| [`2cada570`](https://github.com/NixOS/nixpkgs/commit/2cada57042795da09da5994e85c0bd47ec755575) | `` vaultwarden: 1.32.6 -> 1.32.7 ``                                             |
| [`ab66bf32`](https://github.com/NixOS/nixpkgs/commit/ab66bf323cf56b42ef106bb8641725d64297b3c2) | `` tomcat10: 10.1.33 -> 10.1.34 ``                                              |
| [`06bade6c`](https://github.com/NixOS/nixpkgs/commit/06bade6cb56aab0f2f7eb5ed41cdf181e9f79877) | `` tomcat10: 10.1.30 -> 10.1.33 ``                                              |
| [`ab13e8b8`](https://github.com/NixOS/nixpkgs/commit/ab13e8b8f800fd477e00f5bf8a7c8b60f0a5392d) | `` tomcat9: 9.0.97 -> 9.0.98 ``                                                 |
| [`83aa801c`](https://github.com/NixOS/nixpkgs/commit/83aa801c87ffecf05e698f899953d5e071812c84) | `` tomcat9: 9.0.95 -> 9.0.97 ``                                                 |
| [`3a009655`](https://github.com/NixOS/nixpkgs/commit/3a0096551c7293d0922c12ea5155b0044e2111d1) | `` nixos/firefly-iii: Improved cache clearing ``                                |
| [`2902189a`](https://github.com/NixOS/nixpkgs/commit/2902189a439b26d70965f5aaa18c287918165821) | `` firefly-iii: 6.1.24 -> 6.1.25 ``                                             |
| [`5a5665ad`](https://github.com/NixOS/nixpkgs/commit/5a5665ad539ef6a75b9e5c850439651e633c84cb) | `` coqPackages.compcert: 3.14 → 3.15 ``                                         |
| [`4672d4c9`](https://github.com/NixOS/nixpkgs/commit/4672d4c94c9c1ca3337e9512456320316b1fad65) | `` nixos/networkmanager: add nm-file-secret-agent options ``                    |
| [`d781bfda`](https://github.com/NixOS/nixpkgs/commit/d781bfdabf07e8fc5d188025bae2a2dfdb96d975) | `` nm-file-secret-agent: init at v1.0.0 ``                                      |
| [`ab917731`](https://github.com/NixOS/nixpkgs/commit/ab91773122ddc8a83e9ba6e35f06be45e65e2ed3) | `` maintainers: add lilioid ``                                                  |
| [`1f409a4a`](https://github.com/NixOS/nixpkgs/commit/1f409a4a81bcb0ee4549f37e04925774b6fa7a24) | ``  glpi-agent: init at 1.11 ``                                                 |
| [`aa2c1d15`](https://github.com/NixOS/nixpkgs/commit/aa2c1d15cf4631318289bf5c1ec4fe1394e4e22e) | `` linux_5_4: 5.4.287 -> 5.4.288 ``                                             |
| [`6335ea40`](https://github.com/NixOS/nixpkgs/commit/6335ea405a8b3b71c1a891e5c84b82d21569fefe) | `` linux_5_10: 5.10.231 -> 5.10.232 ``                                          |
| [`f38fd0d9`](https://github.com/NixOS/nixpkgs/commit/f38fd0d9d6e6f642b0d6b7b286c487b38f49eb1b) | `` linux_5_15: 5.15.174 -> 5.15.175 ``                                          |
| [`f128beab`](https://github.com/NixOS/nixpkgs/commit/f128beab38b8c3f3c6bfa7f05e8ecc080682d1cc) | `` linux_6_1: 6.1.120 -> 6.1.121 ``                                             |
| [`bc5c819a`](https://github.com/NixOS/nixpkgs/commit/bc5c819a4fd85b05aaf33142f5d309e16638b6f5) | `` linux_6_6: 6.6.66 -> 6.6.67 ``                                               |
| [`12fc1cc6`](https://github.com/NixOS/nixpkgs/commit/12fc1cc6118333518b0a8262b5e359f6cea971b5) | `` linux_6_12: 6.12.5 -> 6.12.6 ``                                              |
| [`a6062bc4`](https://github.com/NixOS/nixpkgs/commit/a6062bc4dc91ec65094ed2d9998b4c7ffcf99190) | `` tt-rss: Add gileri as maintainer ``                                          |
| [`d62d43af`](https://github.com/NixOS/nixpkgs/commit/d62d43afe5737f5c5a618121687088eac9b29c21) | `` tt-rss: Add updateDaemon.commandFlags parameter ``                           |
| [`3f79fcb2`](https://github.com/NixOS/nixpkgs/commit/3f79fcb285edb889ab4ccf370318c5e0bd1d8076) | `` tt-rss: unstable-2023-04-13 -> 0-unstable-2024-11-04 ``                      |
| [`e60361f2`](https://github.com/NixOS/nixpkgs/commit/e60361f2cf0f11ebc2ec6ba5c99841462ea567a4) | `` tt-rss: Add updateScript ``                                                  |
| [`e94acb0e`](https://github.com/NixOS/nixpkgs/commit/e94acb0e5e9c4eadfcd7be23d9c99c9fa5bc50b8) | `` tt-rss: Add simple test ``                                                   |
| [`5953add4`](https://github.com/NixOS/nixpkgs/commit/5953add467c171a590dcdab69323522eb0c3dd39) | `` ente-auth: disable updates ``                                                |
| [`2beb6782`](https://github.com/NixOS/nixpkgs/commit/2beb67827c2e1f3c2d17d81a097f78de16a1bd9b) | `` opencascade-occt: fix compilation on darwin (#365409) ``                     |
| [`c0077488`](https://github.com/NixOS/nixpkgs/commit/c00774886a7ba91447356c4e11fa90c78010eaf2) | `` home-assistant-custom-components.philips_airpurifier_coap: init at 0.28.0 `` |
| [`b1c34f2a`](https://github.com/NixOS/nixpkgs/commit/b1c34f2af4969754c56b5e5b045017cb836fd034) | `` python3Packages.aioairctrl: init at 0.2.5 ``                                 |
| [`a9c7b47f`](https://github.com/NixOS/nixpkgs/commit/a9c7b47f04303b27ebde1be7e564d6b574400e0f) | `` Revert "gnome-weather: remove absolute path in desktop entry" ``             |
| [`64268ff0`](https://github.com/NixOS/nixpkgs/commit/64268ff01835c6ee4dca747a4660b8be20fdc934) | `` networkmanager-vpnc: 1.2.8 → 1.4.0 ``                                        |
| [`72bfc8c7`](https://github.com/NixOS/nixpkgs/commit/72bfc8c7b4e8b7575497adca8868476cf7526ca6) | `` gnome-extensions-cli: 0.10.3 -> 0.10.4 ``                                    |
| [`c83c8939`](https://github.com/NixOS/nixpkgs/commit/c83c893982f9eb54156cd4fc6466f5e00ad4c128) | `` mutter: 47.1 → 47.3 ``                                                       |
| [`3da1fbe6`](https://github.com/NixOS/nixpkgs/commit/3da1fbe6d55f202f89927b88426d0bb52f55d5da) | `` loupe: 47.1 → 47.2 ``                                                        |
| [`76bba56b`](https://github.com/NixOS/nixpkgs/commit/76bba56baa955093d06cfbe4e558324eccc3b49d) | `` localsearch: 3.8.0 → 3.8.1 ``                                                |
| [`3fce0fb3`](https://github.com/NixOS/nixpkgs/commit/3fce0fb32727a474df376f72573e2f7fdde78924) | `` gtranslator: 47.0 → 47.1 ``                                                  |
| [`d83efe00`](https://github.com/NixOS/nixpkgs/commit/d83efe000f6f919571bdbb4aebf039e76d88f7d2) | `` gnome-user-docs: 47.0 → 47.2 ``                                              |
| [`743ca3de`](https://github.com/NixOS/nixpkgs/commit/743ca3de9cc369c816120eb44255a4f3d91c98f4) | `` gnome-user-share: 47.0 → 47.2 ``                                             |
| [`3243105a`](https://github.com/NixOS/nixpkgs/commit/3243105a1effca7be4f32159a541046599f471c8) | `` gnome-shell-extensions: 47.1 → 47.2 ``                                       |
| [`8f8792e2`](https://github.com/NixOS/nixpkgs/commit/8f8792e2e011e9177e657f7a017c8fb0a8328f53) | `` gnome-shell: 47.1 → 47.2 ``                                                  |
| [`62de4768`](https://github.com/NixOS/nixpkgs/commit/62de47683c2722de017a202d1466e1c16ebeefc2) | `` gnome-settings-daemon: 47.1 → 47.2 ``                                        |
| [`7fdf8a69`](https://github.com/NixOS/nixpkgs/commit/7fdf8a69a27dd8b0c6928bb1aa4c0f2d157cc67c) | `` gnome-remote-desktop: 47.1 → 47.2 ``                                         |
| [`3898e1fa`](https://github.com/NixOS/nixpkgs/commit/3898e1fa0ac8530e2e5162441776ef04a8fc8846) | `` gnome-music: 47.0 → 47.1 ``                                                  |
| [`f2267ede`](https://github.com/NixOS/nixpkgs/commit/f2267edec5ccd9144fd2b9fcd121f122309bb9f7) | `` gnome-online-accounts: 3.52.1 → 3.52.2 ``                                    |
| [`b15e4012`](https://github.com/NixOS/nixpkgs/commit/b15e4012707a7371a25cf554bd03a47e8392d5e0) | `` gnome-initial-setup: 47.1 → 47.2 ``                                          |
| [`a531bc0c`](https://github.com/NixOS/nixpkgs/commit/a531bc0c7cd3773c92acd6ee779f95a8c78119d9) | `` gnome-control-center: 47.1.1 → 47.2 ``                                       |
| [`aa628dff`](https://github.com/NixOS/nixpkgs/commit/aa628dff5e563ec8a396fbfb5de439b68c62b8c2) | `` gnome-secrets: 9.6 -> 10.3 ``                                                |
| [`d6c48650`](https://github.com/NixOS/nixpkgs/commit/d6c4865096eb150e22549c1d4890f83a01e53ed7) | `` gnome-online-accounts-gtk: 3.50.4 -> 3.50.5 ``                               |
| [`bc8ce34f`](https://github.com/NixOS/nixpkgs/commit/bc8ce34f27082e7c6dae70800bca54d465d925e9) | `` gnome-network-displays: 0.93.0 -> 0.94.0 ``                                  |
| [`413ca19c`](https://github.com/NixOS/nixpkgs/commit/413ca19c62a2deca5a99a2d23f5a2b76d73c132e) | `` Revert "gnome-maps: remove absolute path in desktop entry" ``                |
| [`6478cd89`](https://github.com/NixOS/nixpkgs/commit/6478cd89f6b45c1bf5edfbaa8b42d959de1cb1f4) | `` vte: 0.78.1 -> 0.78.2 ``                                                     |
| [`93a2d7f7`](https://github.com/NixOS/nixpkgs/commit/93a2d7f7366481fe7f3e65f10766c8c62074cb69) | `` gnome-maps: fix cross compilation ``                                         |
| [`64815b30`](https://github.com/NixOS/nixpkgs/commit/64815b30a05a837acac5d2b26a1d6fc699784d4e) | `` gjs: assign meta.mainProgram ``                                              |
| [`5f5c9ab1`](https://github.com/NixOS/nixpkgs/commit/5f5c9ab1690f4e58a63f74926e5b3217693143d1) | `` gnome-extensions-cli: 0.10.2 -> 0.10.3 ``                                    |
| [`40df1589`](https://github.com/NixOS/nixpkgs/commit/40df1589ca224ad7354d711057321d790f2111ff) | `` gnome-control-center: remove absolute path in desktop entry ``               |
| [`21fa2ab0`](https://github.com/NixOS/nixpkgs/commit/21fa2ab07693b43bf4d12a6d22eff67847b6df9f) | `` gnome-panel: remove absolute path in desktop entry ``                        |
| [`c0583efb`](https://github.com/NixOS/nixpkgs/commit/c0583efbe2037ab10381b10a042417b3f6fe29cc) | `` gnome-maps: remove absolute path in desktop entry ``                         |
| [`8cbff0d2`](https://github.com/NixOS/nixpkgs/commit/8cbff0d24cc04f7ad7e24c144e353e3c43ad5eff) | `` gnome-weather: remove absolute path in desktop entry ``                      |
| [`3a034642`](https://github.com/NixOS/nixpkgs/commit/3a0346427382230c21b5b7c21b4d25fc4718056e) | `` gnome: check for package exclusions by name for default program modules ``   |
| [`ecfd0946`](https://github.com/NixOS/nixpkgs/commit/ecfd094659df807fa856c111f0b2e09d7929fad9) | `` ente-auth: 4.0.2 -> 4.1.6 ``                                                 |
| [`7e69d995`](https://github.com/NixOS/nixpkgs/commit/7e69d9956f8ff62da378bb96c3b233446410262a) | `` ente-auth: install icon to pixmaps instead of generating multiple sizes ``   |
| [`f8a4a60d`](https://github.com/NixOS/nixpkgs/commit/f8a4a60d6e0300825408f96ffb74c4c4d04b363c) | `` ente-auth: use postPatch instead of overriding patchPhase ``                 |
| [`56990045`](https://github.com/NixOS/nixpkgs/commit/56990045157c4c6ad3c859d7d59f5e5f6e12a468) | `` [Backport release-24.11] k3s_1_29: 1.29.10+k3s1 -> 1.29.11+k3s1 ``           |
| [`50c5b26b`](https://github.com/NixOS/nixpkgs/commit/50c5b26b073caf82ce154c5bbae6307b45cfb437) | `` parmmg: init at 1.4.0-unstable-2024-04-22 ``                                 |
| [`2ad28bcf`](https://github.com/NixOS/nixpkgs/commit/2ad28bcff3a83e750e9bd9faf40403f3a5b21738) | `` mmg: init at 5.7.3-unstable-2024-05-31 ``                                    |
| [`a6c748fb`](https://github.com/NixOS/nixpkgs/commit/a6c748fb7c8182e029b6b6175ea866c7480d6ebb) | `` material-maker: init at 1.3 ``                                               |
| [`1934a4d3`](https://github.com/NixOS/nixpkgs/commit/1934a4d39ed8c8742989ce7c16dae6b727b03fcc) | `` ttaenc: init at 3.4.1 ``                                                     |
| [`d1b58d0d`](https://github.com/NixOS/nixpkgs/commit/d1b58d0d9264d6de88e3c09857229c924af5e3b4) | `` maintainers: update natsukagami ``                                           |
| [`6a4c2a71`](https://github.com/NixOS/nixpkgs/commit/6a4c2a71b6869b227390bd0225d09d801fb608cb) | `` immich: 1.122.3 -> 1.123.0 ``                                                |
| [`6faadf83`](https://github.com/NixOS/nixpkgs/commit/6faadf83a1b556d744a21af4d04df82d69000792) | `` immich: update geodata ``                                                    |
| [`b638404a`](https://github.com/NixOS/nixpkgs/commit/b638404aaa384d20d66d279347737685e5f0abaa) | `` immich: 1.122.2 -> 1.122.3 ``                                                |
| [`d07eb617`](https://github.com/NixOS/nixpkgs/commit/d07eb617f6789131f794d337e7df5d0db130bffe) | `` immich: reduce closure size ``                                               |
| [`66326a8c`](https://github.com/NixOS/nixpkgs/commit/66326a8cfd02501692ffac63c853a7cc5fc5f7e6) | `` llvmPackages_git: 20.0.0-git-2024-10-07 -> 20.0.0-git-2024-11-25 ``          |
| [`ce22625a`](https://github.com/NixOS/nixpkgs/commit/ce22625a2de7bc58705ce1ca0f00b8bf96684bee) | `` ovn: fix missing ovs-lib ``                                                  |
| [`c02b72d6`](https://github.com/NixOS/nixpkgs/commit/c02b72d619a518837e059581b454452bfdbb03ff) | `` arion: 0.2.1.0 -> 0.2.2.0 ``                                                 |
| [`6ab1b73d`](https://github.com/NixOS/nixpkgs/commit/6ab1b73ddad6d7fdcd220b7941a95d7cf5c98b1d) | `` k9s: 0.32.6 -> 0.32.7 ``                                                     |
| [`1bbabaf8`](https://github.com/NixOS/nixpkgs/commit/1bbabaf8e88530df7f63176a714e5d940786f065) | `` k9s: 0.32.5 -> 0.32.6 ``                                                     |
| [`a16362fe`](https://github.com/NixOS/nixpkgs/commit/a16362fe1d441c5e773ff7a17ec8c518c404649e) | `` duti: add maintainer n-hass ``                                               |
| [`5375a973`](https://github.com/NixOS/nixpkgs/commit/5375a973c86e5c5f7625f776663d5ee9d2c543b4) | `` duti: update to new darwin SDK pattern ``                                    |