### PR TITLE
chore(flake/zen-browser): `21695ffb` -> `cea051b6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -692,11 +692,11 @@
         "nixpkgs": "nixpkgs_4"
       },
       "locked": {
-        "lastModified": 1735042792,
-        "narHash": "sha256-L2kY/1dSrqFd+slZkp3M5jXEpwb+/6Vl3dCX/G3tf0s=",
+        "lastModified": 1735092772,
+        "narHash": "sha256-u9uEmMRE3RR8hwZto4USSDvee7X2FEYeWcSSLf4Jjrs=",
         "owner": "0xc000022070",
         "repo": "zen-browser-flake",
-        "rev": "21695ffb62a6b535b074753841eb2263b392ba80",
+        "rev": "cea051b6f908304f4af6484b14a532c729f0cc34",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                          | Message                                                                      |
| --------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------- |
| [`cea051b6`](https://github.com/0xc000022070/zen-browser-flake/commit/cea051b6f908304f4af6484b14a532c729f0cc34) | `` Update Zen Browser to v1.0.2-b.5 ``                                       |
| [`a375eff6`](https://github.com/0xc000022070/zen-browser-flake/commit/a375eff6d3ce617cdf35a3766661047195f9de46) | `` fix: exposing package via `packages.${system}.default` in flake output `` |