### PR TITLE
chore(flake/nixpkgs-stable): `1807c2b9` -> `6c909127`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -434,11 +434,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1734875076,
-        "narHash": "sha256-Pzyb+YNG5u3zP79zoi8HXYMs15Q5dfjDgwCdUI5B0nY=",
+        "lastModified": 1734991663,
+        "narHash": "sha256-8T660guvdaOD+2/Cj970bWlQwAyZLKrrbkhYOFcY1YE=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "1807c2b91223227ad5599d7067a61665c52d1295",
+        "rev": "6c90912761c43e22b6fb000025ab96dd31c971ff",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                   |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------- |
| [`833a3e28`](https://github.com/NixOS/nixpkgs/commit/833a3e285ef95f880929f7fdab21a6db8ca3b5a9) | `` signal-desktop(aarch64-linux): 7.34.0 -> 7.36.0 ``                     |
| [`3e437a67`](https://github.com/NixOS/nixpkgs/commit/3e437a67975cb21d711acdce9dfa60b34984ada0) | `` signal-desktop(darwin): 7.35.0 -> 7.36.0 ``                            |
| [`55f422fb`](https://github.com/NixOS/nixpkgs/commit/55f422fb432c3126ba0725098db808b958042b5f) | `` signal-desktop: 7.35.0 -> 7.36.0 ``                                    |
| [`401b0376`](https://github.com/NixOS/nixpkgs/commit/401b03765e81c4640018b7f9fc43d92ba8c1e90f) | `` flyctl: 0.3.49 -> 0.3.53 ``                                            |
| [`990882e0`](https://github.com/NixOS/nixpkgs/commit/990882e09c8f9f4e42c658f11de935caf33b3328) | `` ecapture: 0.9.0 -> 0.9.1 ``                                            |
| [`69e7a925`](https://github.com/NixOS/nixpkgs/commit/69e7a9257dc7817034dfac521ead98b9a6f78403) | `` scx.full: remove aarch64-linux from badPlatforms ``                    |
| [`383bce33`](https://github.com/NixOS/nixpkgs/commit/383bce330ff68b5e20b6adf72aa6d1bd2f8f0e77) | `` scx.full: 1.0.7 -> 1.0.8 ``                                            |
| [`295d030c`](https://github.com/NixOS/nixpkgs/commit/295d030c8682857470377d28745461f77839af3b) | `` linux_xanmod_latest: 6.12.5 -> 6.12.6 ``                               |
| [`5542d54b`](https://github.com/NixOS/nixpkgs/commit/5542d54bf88ecb7c26eb423f050dd661e8bd9f91) | `` linux_xanmod: 6.6.66 -> 6.6.67 ``                                      |
| [`ec47e4f3`](https://github.com/NixOS/nixpkgs/commit/ec47e4f39e27d8f10c3d59cbceb805c7bb0de73b) | `` switchaudio-osx: init at 1.2.2 ``                                      |
| [`29384ea0`](https://github.com/NixOS/nixpkgs/commit/29384ea02b0f09a6d1048cb9bb8c69ba12551ae7) | `` [Backport release-24.11] lock: 1.3.4 -> 1.3.6 (#367547) ``             |
| [`eb7d7286`](https://github.com/NixOS/nixpkgs/commit/eb7d7286a03795fafb4d51aab2239a1dcf8fe58a) | `` emacs30: add a patch to fix upstream bug 67916 ``                      |
| [`d28f9301`](https://github.com/NixOS/nixpkgs/commit/d28f9301c35e66751872254b8029f31fa9e0da20) | `` [Backport release-24.11] hadolint-sarif: 0.6.6 -> 0.7.0 (#367513) ``   |
| [`10eb6dc2`](https://github.com/NixOS/nixpkgs/commit/10eb6dc272d71ec7881412a2ff99befcfd669cf1) | `` [Backport release-24.11] clippy-sarif: 0.6.6 -> 0.7.0 (#367515) ``     |
| [`2725f399`](https://github.com/NixOS/nixpkgs/commit/2725f399f2f366e61c6d96590749331b5722d06c) | `` [Backport release-24.11] sarif-fmt: 0.6.6 -> 0.7.0 (#367516) ``        |
| [`e020e190`](https://github.com/NixOS/nixpkgs/commit/e020e1909f1c79fe807f4126d74551088d2a96b5) | `` nixos/tests/incus: fix multi-system support ``                         |
| [`8013a974`](https://github.com/NixOS/nixpkgs/commit/8013a974fdd2193cb2312786f6ae6ff757c2c04d) | `` incus-lts: 6.0.2 -> 6.0.3 ``                                           |
| [`9b054a23`](https://github.com/NixOS/nixpkgs/commit/9b054a236c04a33af8e0db40e29b4defbb2331f3) | `` [Backport release-24.11] shellcheck-sarif: 0.6.6 -> 0.7.0 (#367514) `` |
| [`98393674`](https://github.com/NixOS/nixpkgs/commit/98393674d35986dbb66ed2c10d0ff77878b0a799) | `` [Backport release-24.11] cartridges: 2.10.1 -> 2.11 (#367518) ``       |
| [`d4f29341`](https://github.com/NixOS/nixpkgs/commit/d4f29341959dd7909f64678238abb0bb49673edd) | `` [Backport release-24.11] mangojuice: fix GTK4 paths (#367517) ``       |
| [`01b7b296`](https://github.com/NixOS/nixpkgs/commit/01b7b296e43e6c96602761b0d39c7c6be4bce122) | `` dotnet/update.sh: fix error when output path contains spaces ``        |
| [`0b6f5e64`](https://github.com/NixOS/nixpkgs/commit/0b6f5e64a7ee7c83382114d525ea1639b23c9e60) | `` lxc: 6.0.2 -> 6.0.3 ``                                                 |
| [`f2ef08c0`](https://github.com/NixOS/nixpkgs/commit/f2ef08c0777437ab34abd30797e81d756bff3f8f) | `` vikunja: 0.24.5 -> 0.24.6 ``                                           |
| [`a4dcfced`](https://github.com/NixOS/nixpkgs/commit/a4dcfced29c84f5cfcbdde9650080c4ee649001e) | `` firefox-esr-128-unwrapped: 128.5.1esr -> 128.5.2esr ``                 |
| [`98348ca7`](https://github.com/NixOS/nixpkgs/commit/98348ca74dcb7e54d8ffca8606f1f16903ad8c04) | `` lib: add defaultTo ``                                                  |
| [`a2b899cf`](https://github.com/NixOS/nixpkgs/commit/a2b899cfb24c676fed44b637c5c52b2429156732) | `` dafny: add basic test for auto-updates ``                              |
| [`0f1c7c4b`](https://github.com/NixOS/nixpkgs/commit/0f1c7c4bfdae38e8f7dd5f7f0f6617a70ada213f) | `` emacs30: 30.0.92 -> 30.0.93 ``                                         |
| [`29e87d72`](https://github.com/NixOS/nixpkgs/commit/29e87d724917e61dd5a27695dd313d66ae06091b) | `` bup: 0.33.5 -> 0.33.6 ``                                               |
| [`4470299b`](https://github.com/NixOS/nixpkgs/commit/4470299ba4c83d590e49383700c7c5d9a6bdaf4a) | `` brltty: 6.6 -> 6.7 ``                                                  |
| [`5b88e373`](https://github.com/NixOS/nixpkgs/commit/5b88e3735061e40d081d1ef08f14f50ab41decab) | `` pnpm: 9.15.0 -> 9.15.1 ``                                              |
| [`1a0f4620`](https://github.com/NixOS/nixpkgs/commit/1a0f46204e83cdb42b071209282b1b3a1664dde0) | `` dpdk: 23.11 -> 23.11.3 ``                                              |
| [`72c0faa5`](https://github.com/NixOS/nixpkgs/commit/72c0faa512e6c528be01c627ae872d240e7b6ac7) | `` llvmPackages_19: 19.1.5 -> 19.1.6 ``                                   |