### PR TITLE
chore(flake/stylix): `079feceb` -> `963e77a3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -569,11 +569,11 @@
         "tinted-tmux": "tinted-tmux"
       },
       "locked": {
-        "lastModified": 1735151068,
-        "narHash": "sha256-sJ1/y4aXAZ22trJjY+nH/bJ+pydaDKf3wZtafM+Yjcs=",
+        "lastModified": 1735253599,
+        "narHash": "sha256-aKLAUkdeMH2N5gMDNiOC7KghRNy1necLtLa9+zUcj1g=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "079fecebad5f616561726359c89cedd811c8a722",
+        "rev": "963e77a3a4fc2be670d5a9a6cbeb249b8a43808a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                        | Message                                                        |
| --------------------------------------------------------------------------------------------- | -------------------------------------------------------------- |
| [`963e77a3`](https://github.com/danth/stylix/commit/963e77a3a4fc2be670d5a9a6cbeb249b8a43808a) | `` gtk: add support for theming Flatpak applications (#693) `` |