### PR TITLE
chore(flake/nixpkgs-stable): `6c909127` -> `4005c3ff`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -434,11 +434,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1734991663,
-        "narHash": "sha256-8T660guvdaOD+2/Cj970bWlQwAyZLKrrbkhYOFcY1YE=",
+        "lastModified": 1735141468,
+        "narHash": "sha256-VIAjBr1qGcEbmhLwQJD6TABppPMggzOvqFsqkDoMsAY=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "6c90912761c43e22b6fb000025ab96dd31c971ff",
+        "rev": "4005c3ff7505313cbc21081776ad0ce5dfd7a3ce",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                           |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------- |
| [`917846b9`](https://github.com/NixOS/nixpkgs/commit/917846b958de6bc2e01700cf6fa038239cecfcd7) | `` nixos/dolibarr: change permissions of conf.php to read only ``                                 |
| [`aa86585e`](https://github.com/NixOS/nixpkgs/commit/aa86585e40f50bb57c76b8a973fd9870fe9aa963) | `` nixos/dolibarr: format ``                                                                      |
| [`f3160e4c`](https://github.com/NixOS/nixpkgs/commit/f3160e4c2f381527bc98cf456bf2446fc480ef42) | `` nixos/plasma6: default to Wayland for SDDM ``                                                  |
| [`b0ed1368`](https://github.com/NixOS/nixpkgs/commit/b0ed1368e1ab38c0598cf024e886ff20f01ad152) | `` prometheus-frr-exporter: init prometheus exporter module ``                                    |
| [`335ee5c9`](https://github.com/NixOS/nixpkgs/commit/335ee5c9d9e90eaaa550ad5de5a128cf3b17f19e) | `` yt-dlp: drop inactive maintainer ``                                                            |
| [`6e7c1523`](https://github.com/NixOS/nixpkgs/commit/6e7c15239fa5f90f584622c53212e2f6bdd019af) | `` yt-dlp: add maintainer donteatoreo ``                                                          |
| [`0fbac75b`](https://github.com/NixOS/nixpkgs/commit/0fbac75b05c4c395fb5714b29e599db0901bedbc) | `` yt-dlp: 2024.12.13 -> 2024.12.23 ``                                                            |
| [`2e61dd14`](https://github.com/NixOS/nixpkgs/commit/2e61dd146bd79067d7260a4f511c99667b8f4f15) | `` fetchgitiles: add tag argument ``                                                              |
| [`2896352b`](https://github.com/NixOS/nixpkgs/commit/2896352b3d17e34476c46551da5fb570c14db8d4) | `` fetchgitlab: add tag argument ``                                                               |
| [`974cb704`](https://github.com/NixOS/nixpkgs/commit/974cb70480b577598015e3f99721cedd1d2d8ca1) | `` fetchgitlab: nixfmt ``                                                                         |
| [`558a7b9c`](https://github.com/NixOS/nixpkgs/commit/558a7b9c7316ecbc7c21cc204b160f3358ea12c3) | `` coq: keep compiling master ``                                                                  |
| [`5a973a71`](https://github.com/NixOS/nixpkgs/commit/5a973a7172d323cb4f56d9cd601e890eddd4c634) | `` prometheus-smartctl-exporter: 0.12.0 -> 0.13.0 ``                                              |
| [`63a5a730`](https://github.com/NixOS/nixpkgs/commit/63a5a7300221be89e5402bca59d076fdf588873b) | `` nixos/firmware: fix compression condition ``                                                   |
| [`4b39b2b3`](https://github.com/NixOS/nixpkgs/commit/4b39b2b37a732a8e6d45281ed1bef1c316894e50) | `` nixos/firmware: make compression configurable ``                                               |
| [`d522a98a`](https://github.com/NixOS/nixpkgs/commit/d522a98a19a2ad4421ce55e3b1eb3e0837fd316c) | `` maintainers: rename pacien -> euxane, update details ``                                        |
| [`87440633`](https://github.com/NixOS/nixpkgs/commit/87440633e2cb268afa3aedb112ff42cdeddcb6cb) | `` kanidm: discern normal build from provisioning build and fix 1_3 patches ``                    |
| [`d1122984`](https://github.com/NixOS/nixpkgs/commit/d11229840293022bcbbfe05c9a37dd0c7de94693) | `` rubyPackages.rails-html-sanitizer: 1.6.0 -> 1.6.1 ``                                           |
| [`883de582`](https://github.com/NixOS/nixpkgs/commit/883de582c740e6fe3f7107c532749cc99f6981a0) | `` arma3-unix-launcher: remove unused dependencies ``                                             |
| [`844b7e4b`](https://github.com/NixOS/nixpkgs/commit/844b7e4bd391ddd66d7de03bf0efe0b749a21404) | `` arma3-unix-launcher: replace curlpp.src with srcOnly curlpp to ensure patches are applied ``   |
| [`d129bcbb`](https://github.com/NixOS/nixpkgs/commit/d129bcbb4252dcd791ac5c22dcf1f1e6d995f9be) | `` python312Packages.conda-libmamba-solver: 24.9.0 -> 24.11.1 ``                                  |
| [`0d6c57ee`](https://github.com/NixOS/nixpkgs/commit/0d6c57eef615d982a6a170b7cabcb0c0df618811) | `` python312Packages.libmambapy: fix build ``                                                     |
| [`a9d1474a`](https://github.com/NixOS/nixpkgs/commit/a9d1474aceef445454be96a42ad92a4da254c523) | `` libmamba: 1.5.8 -> 2.0.4 ``                                                                    |
| [`bfa07d8d`](https://github.com/NixOS/nixpkgs/commit/bfa07d8d4e7c1de07908877ea7a02d8b7c28d44a) | `` rotonda: 0.1.0 -> 0.2.1 ``                                                                     |
| [`438ae8e0`](https://github.com/NixOS/nixpkgs/commit/438ae8e050289d846f9596c9442498aef49090d6) | `` python312Packages.senf: 1.5.0 -> 1.5.0-unstable-2024-11-26 ``                                  |
| [`ddfd20ff`](https://github.com/NixOS/nixpkgs/commit/ddfd20ff710493ea8b678fada53463ef31d799f9) | `` python312Packages.python-youtube: 0.9.6 -> 0.9.7 ``                                            |
| [`49ac7e12`](https://github.com/NixOS/nixpkgs/commit/49ac7e120c5ba700bfcc046edd2313fc84c24522) | `` python312Packages.signify: 0.6.0 -> 0.7.1 ``                                                   |
| [`7a42f235`](https://github.com/NixOS/nixpkgs/commit/7a42f23530e7edad07d63316ffed1355efaf9c19) | `` nym: 2024.13-magura-patched -> 2024.14-crunch-patched ``                                       |
| [`22ceb0e0`](https://github.com/NixOS/nixpkgs/commit/22ceb0e02ff8b84840450eb50171707b4388049b) | `` py-spy: 0.3.14-unstable-2024-02-27 -> 0.4.0 ``                                                 |
| [`cfa1b1fa`](https://github.com/NixOS/nixpkgs/commit/cfa1b1fa48506120dabf1351e6c7c00bf178ee5b) | `` redmine: 5.1.4 -> 5.1.5 ``                                                                     |
| [`bbf225a2`](https://github.com/NixOS/nixpkgs/commit/bbf225a22e74cccdeea548121496d078efff4ae7) | `` quast: 5.0.2 -> 5.3.0 ``                                                                       |
| [`72da18ac`](https://github.com/NixOS/nixpkgs/commit/72da18ac1a4276efbe9a782c2f3139048ebbe874) | `` exegol: 4.3.8 -> 4.3.9 ``                                                                      |
| [`14686e08`](https://github.com/NixOS/nixpkgs/commit/14686e08a472be9784b50a2ca62dd5cf03384d6e) | `` maintainers: add atinba ``                                                                     |
| [`7fad8c80`](https://github.com/NixOS/nixpkgs/commit/7fad8c800363dda8e0814f83ea90822b5dd2f23b) | `` openboard: 1.7.1 -> 1.7.3 ``                                                                   |
| [`55f14ebf`](https://github.com/NixOS/nixpkgs/commit/55f14ebf6ab26c37519a61f6dab67e80e047c3b3) | `` mautrix-signal: 0.7.2 -> 0.7.3 ``                                                              |
| [`559bcd45`](https://github.com/NixOS/nixpkgs/commit/559bcd452ad00a9567dfba41def2aaf0c6c140f8) | `` libsignal-ffi: 0.58.3 -> 0.62.0 ``                                                             |
| [`d1ce5c50`](https://github.com/NixOS/nixpkgs/commit/d1ce5c501eda57fa2d66301b9eab245129b3a253) | `` nixos/tests/systemd-sysusers-password-option-override-ordering: clarify SetCredential check `` |
| [`fe93edd5`](https://github.com/NixOS/nixpkgs/commit/fe93edd5ebc582d9685d953277f19e706f613b92) | `` nixos/modules: remove a few whitespaces from the pw override parts ``                          |
| [`71286bac`](https://github.com/NixOS/nixpkgs/commit/71286bacb11d2cb6f7cb09c8b70ea12a89cd437f) | `` nixos/tests: Add two new tests for password option override ordering ``                        |
| [`7661b3ee`](https://github.com/NixOS/nixpkgs/commit/7661b3eed856d7a351938839fa8e91f97dde2165) | `` nixos/users-groups: Correct and refactor password override documentation ``                    |
| [`786fd88f`](https://github.com/NixOS/nixpkgs/commit/786fd88f833a435bc86e3a209a8aec99f1f073ea) | `` checkip: 0.47.5 -> 0.47.7 ``                                                                   |
| [`1d48b03e`](https://github.com/NixOS/nixpkgs/commit/1d48b03ec67943361362c541bb501ba792c69f85) | `` zulip: expand platforms to all Linux ``                                                        |
| [`9a5bac19`](https://github.com/NixOS/nixpkgs/commit/9a5bac193f610fb2590ae2723e93dab110d6cd94) | `` zulip: build package from source (#279545) ``                                                  |