### PR TITLE
chore(flake/spicetify-nix): `c4e2fb9a` -> `26f2e859`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -539,11 +539,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1735272951,
-        "narHash": "sha256-xGQ4qVMb8XRIpDYq+tNu3db5LzoKyAJFRl3VA0us/+M=",
+        "lastModified": 1735359308,
+        "narHash": "sha256-wxsff5tL6UpQ4gzh+ul4iF1UkVFZTV71AfXM0k8k/zc=",
         "owner": "Gerg-L",
         "repo": "spicetify-nix",
-        "rev": "c4e2fb9a6a46acf1fd842ae33a342e71bd9a2263",
+        "rev": "26f2e859974b87aa946655a058ec7c3e9c94e25d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                    |
| ----------------------------------------------------------------------------------------------------- | -------------------------- |
| [`26f2e859`](https://github.com/Gerg-L/spicetify-nix/commit/26f2e859974b87aa946655a058ec7c3e9c94e25d) | `` CI update 2024-12-28 `` |