### PR TITLE
chore(flake/nixpkgs): `4005c3ff` -> `d49da4c0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -468,11 +468,11 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1735141468,
-        "narHash": "sha256-VIAjBr1qGcEbmhLwQJD6TABppPMggzOvqFsqkDoMsAY=",
+        "lastModified": 1735264675,
+        "narHash": "sha256-MgdXpeX2GuJbtlBrH9EdsUeWl/yXEubyvxM1G+yO4Ak=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "4005c3ff7505313cbc21081776ad0ce5dfd7a3ce",
+        "rev": "d49da4c08359e3c39c4e27c74ac7ac9b70085966",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                              |
| ---------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------- |
| [`d49da4c0`](https://github.com/NixOS/nixpkgs/commit/d49da4c08359e3c39c4e27c74ac7ac9b70085966) | `` [Backport release-24.11] authenticator: 4.4.0 -> 4.5.0 (#368463) ``                               |
| [`68cfcd6a`](https://github.com/NixOS/nixpkgs/commit/68cfcd6ae2d8f59dbb5e46a7c57c82f4aafd284f) | `` linux/hardened/patches/6.6: v6.6.66-hardened1 -> v6.6.67-hardened1 ``                             |
| [`42c52601`](https://github.com/NixOS/nixpkgs/commit/42c5260162cd49d5ee0a543d2388b9d2b5f25c43) | `` linux/hardened/patches/6.12: v6.12.5-hardened1 -> v6.12.6-hardened1 ``                            |
| [`27729a3a`](https://github.com/NixOS/nixpkgs/commit/27729a3a1e6e056fb929725fcdb9ed48a6ef859a) | `` linux/hardened/patches/6.1: v6.1.120-hardened1 -> v6.1.121-hardened1 ``                           |
| [`3a36f325`](https://github.com/NixOS/nixpkgs/commit/3a36f325383bd4ce4ca6f98f2ee459f89b287fd2) | `` linux/hardened/patches/5.4: v5.4.287-hardened1 -> v5.4.288-hardened1 ``                           |
| [`99e16e6a`](https://github.com/NixOS/nixpkgs/commit/99e16e6aa10077c6027be90aba4dd61de8382e6f) | `` linux/hardened/patches/5.15: v5.15.174-hardened1 -> v5.15.175-hardened1 ``                        |
| [`a7e34b43`](https://github.com/NixOS/nixpkgs/commit/a7e34b430fd3e65a6fee121d0a0e1fb9decb366e) | `` linux/hardened/patches/5.10: v5.10.231-hardened1 -> v5.10.232-hardened1 ``                        |
| [`b85588e9`](https://github.com/NixOS/nixpkgs/commit/b85588e98fff6ae3f10ca1a23c3efc13b71ee037) | `` linux/{common-config,hardened-config}: restore DRM_PANIC_SCREEN_QR_CODE, RUST, SCHED_CLASS_EXT `` |
| [`c4b251f5`](https://github.com/NixOS/nixpkgs/commit/c4b251f5ccbc7640c5d619fb275e71241008f87c) | `` nixos/zfs-replication: add package option ``                                                      |
| [`a393ebcb`](https://github.com/NixOS/nixpkgs/commit/a393ebcbea45dbf502a0a2979d124c574bbd5bd6) | `` nextcloud30Packages: update ``                                                                    |
| [`e6579e24`](https://github.com/NixOS/nixpkgs/commit/e6579e2439aea51131c23e8e14095f49822895b3) | `` nextcloud29Packages: update ``                                                                    |
| [`94b7d3ac`](https://github.com/NixOS/nixpkgs/commit/94b7d3acd3ecb103575e973660b7eced9da9f8f9) | `` nextcloud28Packages: update ``                                                                    |
| [`cdbcbe25`](https://github.com/NixOS/nixpkgs/commit/cdbcbe257df923e45161acc67468773b09a0f9bf) | `` nextcloud-talk-desktop: add desktop item ``                                                       |
| [`1e85e1fb`](https://github.com/NixOS/nixpkgs/commit/1e85e1fb238ed5bb019f73d22dace89f7ad18e02) | `` nixos/nginx: default resolver.ipv6 to networking.enableIPv6 ``                                    |
| [`7ac4af8f`](https://github.com/NixOS/nixpkgs/commit/7ac4af8f9dc76c8c10a81cbb08c2729a3b78b66f) | `` linuxPackages.ipu6-drivers: unstable-2024-10-10 -> unstable-2024-11-19 ``                         |
| [`79a871c1`](https://github.com/NixOS/nixpkgs/commit/79a871c163638117f2baaad10fb8bf94f6abda77) | `` linuxPackages.ipu6-drivers: fix build on Linux >= 6.12 ``                                         |
| [`685cc681`](https://github.com/NixOS/nixpkgs/commit/685cc6817780261ec6f09b8486b26018c727ff20) | `` ankama-launcher: 3.12.27 -> 3.12.28 ``                                                            |
| [`6018445e`](https://github.com/NixOS/nixpkgs/commit/6018445e8615533e9170e562bb83526b85ca19c3) | `` lrcget: add passthru.updateScript ``                                                              |
| [`59afc7e3`](https://github.com/NixOS/nixpkgs/commit/59afc7e31d4d740574f831cafca797651930a65a) | `` lrcget: 0.5.0 -> 0.9.0 ``                                                                         |
| [`0fe707f1`](https://github.com/NixOS/nixpkgs/commit/0fe707f1ae131184ee6459b7ceb67ec306668f3d) | `` ocamlPackages.re: 1.11.0 → 1.12.0 ``                                                              |
| [`855b63a9`](https://github.com/NixOS/nixpkgs/commit/855b63a98dbd36f6dd8992c4c1ccba2a8bb59b10) | `` monado: gate tracing support behind argument ``                                                   |
| [`37aee4f0`](https://github.com/NixOS/nixpkgs/commit/37aee4f04e4344b4b4a540bfc434facf7d4843b7) | `` ruby_3_4: 3.4.0.preview2 -> 3.4.1 ``                                                              |
| [`2ef6cb75`](https://github.com/NixOS/nixpkgs/commit/2ef6cb75ba14df45c688ecb343eadabdb0c88cf2) | `` [Backport release-24.11] keypunch: 4.0 -> 5.0 (#368286) ``                                        |
| [`c9a3fe74`](https://github.com/NixOS/nixpkgs/commit/c9a3fe742a0f7bae31a796750e25f05159610fc3) | `` standardnotes: 3.181.23 -> 3.195.13 ``                                                            |
| [`1dd8f51e`](https://github.com/NixOS/nixpkgs/commit/1dd8f51e62c0ff199e551744ab46fc4fbe6f827a) | `` [Backport release-24.11] slskd: 0.22.0 -> 0.22.1 (#368257) ``                                     |
| [`a2ce4eba`](https://github.com/NixOS/nixpkgs/commit/a2ce4ebab7a8bf4e8cba25f86676de6ba0f45f94) | `` [Backport release-24.11] tuba: 0.9.0 -> 0.9.1 (#368090) ``                                        |
| [`5bacfe77`](https://github.com/NixOS/nixpkgs/commit/5bacfe77ac64c9b31e1d22da1ec0eee5887ecf02) | `` nixos/networkd: add NetLabel & NFTSet options ``                                                  |
| [`50c34566`](https://github.com/NixOS/nixpkgs/commit/50c345663869e0d6eee31e5e796e9e33f1323c56) | `` rabbitmq-server: Fix reported version (#367395) ``                                                |
| [`03c40872`](https://github.com/NixOS/nixpkgs/commit/03c40872343b651bb52c9a9c37d608a5e4718c88) | `` elixir_1_18: init at 1.18.1 ``                                                                    |
| [`195b1525`](https://github.com/NixOS/nixpkgs/commit/195b1525467f246b6fed38a6c1599368484b116c) | `` mongosh: 2.3.3 -> 2.3.7 ``                                                                        |
| [`be7d8239`](https://github.com/NixOS/nixpkgs/commit/be7d82397e5347a63dc85aca27cad70dbb21e37f) | `` agebox: move to buildGoModule ``                                                                  |
| [`e0c2cdb0`](https://github.com/NixOS/nixpkgs/commit/e0c2cdb0640e26a766f0253f1d206305ec04b96a) | `` agebox: 0.7.1 -> 0.7.2 ``                                                                         |
| [`1cf1990c`](https://github.com/NixOS/nixpkgs/commit/1cf1990ce701c9c7315cf3f9262ee9b8602cb9f0) | `` erlang: use nixpkgs zlib, fix darwin ``                                                           |
| [`fc0be3de`](https://github.com/NixOS/nixpkgs/commit/fc0be3dec8dd1598e29bad89516a01280d2e16df) | `` idris2Packages.pack: fix runtime building of Idris2 versions ``                                   |
| [`1ae17bdd`](https://github.com/NixOS/nixpkgs/commit/1ae17bdd4b3934bd34067db67229c5c2ffc48a2a) | `` erlang_27: 27.1.2 -> 27.2 ``                                                                      |
| [`208e9277`](https://github.com/NixOS/nixpkgs/commit/208e927780aadbb363f5a2b36e91659aa9d15047) | `` erlang_26: 26.2.5.4 -> 26.2.5.6 ``                                                                |
| [`55a7725b`](https://github.com/NixOS/nixpkgs/commit/55a7725b07deab9a702d1a39deb8d53674399914) | `` erlang_25: 25.3.2.15 -> 25.3.2.16 ``                                                              |
| [`dc45af7a`](https://github.com/NixOS/nixpkgs/commit/dc45af7adc7b1feea65792d2f92a45c3a0e6501b) | `` erlang: fix updateScript ``                                                                       |
| [`a06ac807`](https://github.com/NixOS/nixpkgs/commit/a06ac807ad63e8974378806016ccda68ec170337) | `` kmon: 1.7.0 -> 1.7.1 ``                                                                           |
| [`c4dad2b2`](https://github.com/NixOS/nixpkgs/commit/c4dad2b2a40be6261d4a117d5ed769c8c0863cbf) | `` nixos/k3s: use same k3s package in multi-node test ``                                             |
| [`b8607ad7`](https://github.com/NixOS/nixpkgs/commit/b8607ad72ac22e2cfe776b4de02e36d349d15a10) | `` microsoft-edge: 131.0.2903.86 -> 131.0.2903.112 ``                                                |
| [`d2fb8e7e`](https://github.com/NixOS/nixpkgs/commit/d2fb8e7ed2c4c8405f5e00f1baf696c7954ccc72) | `` fishPlugins.bang-bang: init at 0-unstable-2023-07-23 ``                                           |
| [`29967fbd`](https://github.com/NixOS/nixpkgs/commit/29967fbd5d939cfc60cf712d3dff79978c5d6909) | `` k3s_1_29: 1.29.11+k3s1 -> 1.29.12+k3s1 ``                                                         |
| [`b2592e94`](https://github.com/NixOS/nixpkgs/commit/b2592e949d0b17c474ec2a6f985655071f437278) | `` k3s_1_30: 1.30.7+k3s1 -> 1.30.8+k3s1 ``                                                           |
| [`c451539f`](https://github.com/NixOS/nixpkgs/commit/c451539f7a07dc05851a2d3919cf4bcf04c78d32) | `` [Backport release-24.11] k3s_1_31: 1.31.2+k3s1 -> 1.31.4+k3s1 ``                                  |
| [`da42e430`](https://github.com/NixOS/nixpkgs/commit/da42e430a945304949cedec03eff2bacce4182e6) | `` nixos/nix-fallback-paths: 2.24.10 -> 2.24.11 ``                                                   |
| [`788f065f`](https://github.com/NixOS/nixpkgs/commit/788f065f63fa180b6d034f8825ed2cf22a2970f7) | `` nixVersions.nix_2_24: 2.24.10 -> 2.24.11 ``                                                       |