### PR TITLE
chore(flake/spicetify-nix): `26f2e859` -> `ffff5a33`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -539,11 +539,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1735359308,
-        "narHash": "sha256-wxsff5tL6UpQ4gzh+ul4iF1UkVFZTV71AfXM0k8k/zc=",
+        "lastModified": 1735445831,
+        "narHash": "sha256-XfC/uQO77JXC4DSOYUjRI7f46xF7Pz2Ipo4z0fYAzdo=",
         "owner": "Gerg-L",
         "repo": "spicetify-nix",
-        "rev": "26f2e859974b87aa946655a058ec7c3e9c94e25d",
+        "rev": "ffff5a333a9dea5f3fba352239c5f445b0788083",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                    |
| ----------------------------------------------------------------------------------------------------- | -------------------------- |
| [`ffff5a33`](https://github.com/Gerg-L/spicetify-nix/commit/ffff5a333a9dea5f3fba352239c5f445b0788083) | `` CI update 2024-12-29 `` |