### PR TITLE
chore(flake/nix-gaming): `95f1cc7e` -> `b0358e44`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -393,11 +393,11 @@
         "umu": "umu"
       },
       "locked": {
-        "lastModified": 1735090720,
-        "narHash": "sha256-Abx/6obaYLgFio8g06pcmMaRPwjKo/bOn1P+gsDMVg0=",
+        "lastModified": 1735472087,
+        "narHash": "sha256-SBpZzWaRdorhn1GquAzbszxKehBKssctN5y2QsA3R9k=",
         "owner": "fufexan",
         "repo": "nix-gaming",
-        "rev": "95f1cc7ebe63b5a5af6c2d206ffd422739c5959e",
+        "rev": "b0358e442fc51255f1f98495110dd66c8f3e7290",
         "type": "github"
       },
       "original": {
@@ -452,11 +452,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1734435836,
-        "narHash": "sha256-kMBQ5PRiFLagltK0sH+08aiNt3zGERC2297iB6vrvlU=",
+        "lastModified": 1735268880,
+        "narHash": "sha256-7QEFnKkzD13SPxs+UFR5bUFN2fRw+GlL0am72ZjNre4=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "4989a246d7a390a859852baddb1013f825435cee",
+        "rev": "7cc0bff31a3a705d3ac4fdceb030a17239412210",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                              | Message                          |
| --------------------------------------------------------------------------------------------------- | -------------------------------- |
| [`b0358e44`](https://github.com/fufexan/nix-gaming/commit/b0358e442fc51255f1f98495110dd66c8f3e7290) | `` wine-tkg: build with gcc13 `` |
| [`a24aac1a`](https://github.com/fufexan/nix-gaming/commit/a24aac1a429c630cf31173fa7eb5bddc5a62c8b7) | `` Update flake ``               |