### PR TITLE
chore(flake/nix-gaming): `b0358e44` -> `578b00c7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -393,11 +393,11 @@
         "umu": "umu"
       },
       "locked": {
-        "lastModified": 1735472087,
-        "narHash": "sha256-SBpZzWaRdorhn1GquAzbszxKehBKssctN5y2QsA3R9k=",
+        "lastModified": 1735481011,
+        "narHash": "sha256-u5yRymUN2ZuOavCj1HY1Le0Uyyg2azCTtZRLiXfOpo8=",
         "owner": "fufexan",
         "repo": "nix-gaming",
-        "rev": "b0358e442fc51255f1f98495110dd66c8f3e7290",
+        "rev": "578b00c7c0db22464e50d7ae2f492dd9438a284c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                              | Message                              |
| --------------------------------------------------------------------------------------------------- | ------------------------------------ |
| [`578b00c7`](https://github.com/fufexan/nix-gaming/commit/578b00c7c0db22464e50d7ae2f492dd9438a284c) | `` wine: don't override stdenv cc `` |
| [`d4663263`](https://github.com/fufexan/nix-gaming/commit/d4663263fe4389b0e6fa26ba6a03ceacd439a670) | `` wine: use gcc13 for all builds `` |