### PR TITLE
chore(flake/nix-flatpak): `13be795c` -> `c31b6cbd`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -373,11 +373,11 @@
     },
     "nix-flatpak": {
       "locked": {
-        "lastModified": 1734864618,
-        "narHash": "sha256-8SCTJhDH1fdNGGFhuGStIqbO7vwUKQokgQu6nQlQagY=",
+        "lastModified": 1735500379,
+        "narHash": "sha256-5qmX6YYjYfVYBbsmd2XxbTi7A59YuuN9IwfXU7qFquQ=",
         "owner": "gmodena",
         "repo": "nix-flatpak",
-        "rev": "13be795cac27df7044a425c0b2de3a42b10ddb18",
+        "rev": "c31b6cbd11707fe2c74ad805ef085d59d75116ae",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                                                                   |
| ---------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------- |
| [`c31b6cbd`](https://github.com/gmodena/nix-flatpak/commit/c31b6cbd11707fe2c74ad805ef085d59d75116ae) | `` restartOnFailure: fix typo. (#129) ``                                  |
| [`885f1293`](https://github.com/gmodena/nix-flatpak/commit/885f12935a83fa0260b4ec7876fddef2156899f7) | `` Enable restart on failure and optionally exponential backoff (#127) `` |