### PR TITLE
chore(flake/spicetify-nix): `ffff5a33` -> `52c3363e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -539,11 +539,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1735445831,
-        "narHash": "sha256-XfC/uQO77JXC4DSOYUjRI7f46xF7Pz2Ipo4z0fYAzdo=",
+        "lastModified": 1735532154,
+        "narHash": "sha256-b+Yz6cOqcDmWYt8BIifTrY1n8q5zTJEHuEh/16nhS7k=",
         "owner": "Gerg-L",
         "repo": "spicetify-nix",
-        "rev": "ffff5a333a9dea5f3fba352239c5f445b0788083",
+        "rev": "52c3363e4a6896c263657491e8177ee8b63af3b4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                    |
| ----------------------------------------------------------------------------------------------------- | -------------------------- |
| [`52c3363e`](https://github.com/Gerg-L/spicetify-nix/commit/52c3363e4a6896c263657491e8177ee8b63af3b4) | `` CI update 2024-12-30 `` |