### PR TITLE
chore(flake/nixpkgs): `d49da4c0` -> `9f94733f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -468,11 +468,11 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1735264675,
-        "narHash": "sha256-MgdXpeX2GuJbtlBrH9EdsUeWl/yXEubyvxM1G+yO4Ak=",
+        "lastModified": 1735412871,
+        "narHash": "sha256-Qoz0ow6jDGUIBHxduc7Y1cjYFS71tvEGJV5Src/mj98=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "d49da4c08359e3c39c4e27c74ac7ac9b70085966",
+        "rev": "9f94733f93e4fe6e82f516efae007096e4ab5a21",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                              |
| ---------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------- |
| [`ee7a3359`](https://github.com/NixOS/nixpkgs/commit/ee7a3359b34a9432b86e9ce8d27856d266085a97) | `` virtualbox: 7.0.22 -> 7.1.4 ``                                                                    |
| [`40d09b4f`](https://github.com/NixOS/nixpkgs/commit/40d09b4f3147e89e10edab79748c6e0763e7db63) | `` python312Packages.wandb: fix tests ``                                                             |
| [`1e735656`](https://github.com/NixOS/nixpkgs/commit/1e73565633199130b7860df4b0529cb99734f47f) | `` nixos/tts: fix handling of extraArgs ``                                                           |
| [`c468c026`](https://github.com/NixOS/nixpkgs/commit/c468c0269ad4bba8844e3ce4e6339fa3ae470f1b) | `` tts: 0.20.2 -> 0.25.1 and switch to idiap fork ``                                                 |
| [`293bc58a`](https://github.com/NixOS/nixpkgs/commit/293bc58a61efd96a9d1a8494e18f422f81c93682) | `` python312Packages.trainer: 0.0.36 -> 0.2.0 and switch to idiap fork ``                            |
| [`92b2c49d`](https://github.com/NixOS/nixpkgs/commit/92b2c49d91d088dd95d03e0351ce0121928be6c7) | `` python312Packages.coqpit: 0.0.17 -> 0.1.2 and switch to idiap fork ``                             |
| [`7c9b0f0a`](https://github.com/NixOS/nixpkgs/commit/7c9b0f0a5888b1dea65f9459dabaee5a016b0cb1) | `` python312Packages.triton-bin: fix build ``                                                        |
| [`1604bb50`](https://github.com/NixOS/nixpkgs/commit/1604bb5024f6ff572e11821ceb668596bdc9299c) | `` python312Packages.monotonic-alignment-search: init at 0.1.1 ``                                    |
| [`6468b58b`](https://github.com/NixOS/nixpkgs/commit/6468b58bd3c5446d5e67bd33eb8f711015f6fbec) | `` taschenrechner: 1.4.0 -> 1.5.0 ``                                                                 |
| [`72c678b7`](https://github.com/NixOS/nixpkgs/commit/72c678b748d8bcafcdac856926df994ded2cca2c) | `` nixos/zfs-replication: fix typo ``                                                                |
| [`8a365dcd`](https://github.com/NixOS/nixpkgs/commit/8a365dcde7c5dc40e041d3d4a4a484bf87ffbc62) | `` linux_6_1: 6.1.121 -> 6.1.122 ``                                                                  |
| [`2c296981`](https://github.com/NixOS/nixpkgs/commit/2c296981f0f2b4daab309bda80c95f9929e9d6fe) | `` linux_6_6: 6.6.67 -> 6.6.68 ``                                                                    |
| [`42bec7bd`](https://github.com/NixOS/nixpkgs/commit/42bec7bdfd83de469da3d835eab6783713bf98eb) | `` linux_6_12: 6.12.6 -> 6.12.7 ``                                                                   |
| [`827661a7`](https://github.com/NixOS/nixpkgs/commit/827661a7ebce56ca8f89411ee297e568dd076f64) | `` linux_testing: 6.13-rc3 -> 6.13-rc4 ``                                                            |
| [`ce5b885a`](https://github.com/NixOS/nixpkgs/commit/ce5b885ac8729433d19d3549f618cc508db488dc) | `` linuxPackages.xpadneo: 0.9.6 -> 0.9.7 ``                                                          |
| [`7a62f0f1`](https://github.com/NixOS/nixpkgs/commit/7a62f0f12544c74e3f33c9ec1ca8fc833f6c1879) | `` dotnetCorePackages.dotnet_{8,9}.vmr: switch CDN URL ``                                            |
| [`4b6bf839`](https://github.com/NixOS/nixpkgs/commit/4b6bf839ed98d54a2610aa28a657532fd3a1ec5c) | `` ietf-cli: init at v1.27 ``                                                                        |
| [`3fd30f39`](https://github.com/NixOS/nixpkgs/commit/3fd30f39fab25ecaa1793c0dd9862123d77db624) | `` ente-auth: 4.1.6 -> 4.2.1 ``                                                                      |
| [`3f02dc28`](https://github.com/NixOS/nixpkgs/commit/3f02dc2866b6a8f2f5ecde6a7632bb3aa82b26a3) | `` [Backport release-24.11] nixos/opensmtpd: fix tests, fix sendmail, add sendmail test (#368307) `` |
| [`2db5eb17`](https://github.com/NixOS/nixpkgs/commit/2db5eb179e057fb1aeb0cd423bfbfb1710852f53) | `` virtualboxGuestAdditions: Additional 7.1.4 fixes (#366080) ``                                     |
| [`0f711df1`](https://github.com/NixOS/nixpkgs/commit/0f711df147f61a8a7883862b31efac757281d130) | `` nixos/ddclient: update defaults for usev4/6 ``                                                    |
| [`377e15d6`](https://github.com/NixOS/nixpkgs/commit/377e15d68668f5f54d52e63496fd681b2242ea0e) | `` nixos/ddclient: fix missing iproute2 ``                                                           |
| [`1cb1d893`](https://github.com/NixOS/nixpkgs/commit/1cb1d893a293e30d2b37da87feb931919bdc775a) | `` webkitgtk: 2.46.4 -> 2.46.5 ``                                                                    |