### PR TITLE
chore(flake/nixpkgs): `9f94733f` -> `3ffbbdba`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -468,11 +468,11 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1735412871,
-        "narHash": "sha256-Qoz0ow6jDGUIBHxduc7Y1cjYFS71tvEGJV5Src/mj98=",
+        "lastModified": 1735531152,
+        "narHash": "sha256-As8I+ebItDKtboWgDXYZSIjGlKeqiLBvjxsQHUmAf1Q=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "9f94733f93e4fe6e82f516efae007096e4ab5a21",
+        "rev": "3ffbbdbac0566a0977da3d2657b89cbcfe9a173b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                |
| ---------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------- |
| [`3ffbbdba`](https://github.com/NixOS/nixpkgs/commit/3ffbbdbac0566a0977da3d2657b89cbcfe9a173b) | `` [Backport release-24.11] gitbutler: 0.12.16 -> 0.14.4 (#368258) ``                  |
| [`49f35744`](https://github.com/NixOS/nixpkgs/commit/49f357445251a44c7e3b0e831d10c3c91f60f927) | `` mono: add mainProgram ``                                                            |
| [`ce5889ef`](https://github.com/NixOS/nixpkgs/commit/ce5889efc25d7f8d863e7e0fc3237fd242314d42) | `` xorg.xorgserver: fix darwin build ``                                                |
| [`4e32c2eb`](https://github.com/NixOS/nixpkgs/commit/4e32c2ebd85a4a91b9a8379bf1f649880685ccd7) | `` libp11: 0.4.12 -> 0.4.13 ``                                                         |
| [`febd21d2`](https://github.com/NixOS/nixpkgs/commit/febd21d23d23c25d1b334051fb4edb74c5ad2f2f) | `` qpwgraph: 0.8.0 -> 0.8.1 ``                                                         |
| [`6a8ed622`](https://github.com/NixOS/nixpkgs/commit/6a8ed622cc8232e2ceb947431d16d07cb6757b82) | `` python312Packages.picos: 2.0 -> 2.5 ``                                              |
| [`6aa52eb6`](https://github.com/NixOS/nixpkgs/commit/6aa52eb6676207e9d02198fde668797ba740af7a) | `` python312Packages.pmdarima: fix build ``                                            |
| [`233d01aa`](https://github.com/NixOS/nixpkgs/commit/233d01aa9b0472358752417b279bc0d44d8ea223) | `` victoriametrics: 1.108.0 -> 1.108.1 ``                                              |
| [`e9e83821`](https://github.com/NixOS/nixpkgs/commit/e9e83821f8c308468091b31e705d3f71e7f5a498) | `` rl-2411: add an entry for the new kmonad module ``                                  |
| [`737f5c97`](https://github.com/NixOS/nixpkgs/commit/737f5c975072c33e7943c475b4970ec0af34769e) | `` duplicati: 2.0.8.1 -> 2.1.0.2 ``                                                    |
| [`0d6bb3a0`](https://github.com/NixOS/nixpkgs/commit/0d6bb3a0bdb52f4f1b1a647d5ce672b0a5be671c) | `` python311Packages.jenkins-job-builder: 6.4.1 -> 6.4.2 ``                            |
| [`6488d4db`](https://github.com/NixOS/nixpkgs/commit/6488d4dbbe8d4add3b28970ed0d1448506ab2968) | `` virtualboxKvm: 20240828 -> 20241220 ``                                              |
| [`1180d09b`](https://github.com/NixOS/nixpkgs/commit/1180d09b2d600ea5a1644bfd0439bf43e23dddb8) | `` homebank: 5.8.5 -> 5.8.6 ``                                                         |
| [`0564d3e4`](https://github.com/NixOS/nixpkgs/commit/0564d3e423914f53559df23510d67c05c5419e92) | `` aw-qt: fix build ``                                                                 |
| [`a89419c3`](https://github.com/NixOS/nixpkgs/commit/a89419c3682dc712609240c3785d01f378667e21) | `` modrinth-app: 0.8.9 -> 0.9.0 ``                                                     |
| [`ba32742c`](https://github.com/NixOS/nixpkgs/commit/ba32742c6d3e5ddb69b8652cd3573c43b6d4204e) | `` modrinth-app: importCargoLock -> fetchCargoVendor ``                                |
| [`4afc5669`](https://github.com/NixOS/nixpkgs/commit/4afc56690a4a6b898b75be57d4d51a7bdc662562) | `` authentik.outposts.proxy: init at 2024.12.1 ``                                      |
| [`bb25413f`](https://github.com/NixOS/nixpkgs/commit/bb25413ff783b11b8ac53312cb2880b67a92f1ef) | `` authentik,authentik.outposts.{ldap,radius}: 2024.6.4 -> 2024.12.1 ``                |
| [`645191b2`](https://github.com/NixOS/nixpkgs/commit/645191b2dffb1d92b6dafd07a0cab745185aa716) | `` python3Packages.python-kadmin-rs: init at 0.5.2 ``                                  |
| [`6d3d248b`](https://github.com/NixOS/nixpkgs/commit/6d3d248bed0736de68ff00ef9b2e5aeb703a52d1) | `` python3Packages.drf-orjson-renderer: init at 1.7.3 ``                               |
| [`f11c6ffd`](https://github.com/NixOS/nixpkgs/commit/f11c6ffd5a66f6639dbbee7918494ff0cdf6b383) | `` python3Packages.scim2-filter-parser: 0.5.0 -> 0.7.0 ``                              |
| [`291332a1`](https://github.com/NixOS/nixpkgs/commit/291332a128ec53d3669ca86c4035bb788e14a4cf) | `` vault-ssh-plus: 0.7.6 -> 0.7.7 ``                                                   |
| [`e98ac0fd`](https://github.com/NixOS/nixpkgs/commit/e98ac0fde62d21293731f7c3481c8681418c4538) | `` wordpressPackages.plugins.wp-fail2ban: init at 5.3.2 ``                             |
| [`02b43c5d`](https://github.com/NixOS/nixpkgs/commit/02b43c5db72ab7757a6156e7c2ecae40080715f7) | `` zabbix64: 6.4.15 -> 6.4.20 ``                                                       |
| [`88876854`](https://github.com/NixOS/nixpkgs/commit/888768547b7725a09fe553b19a0a7c5169ff772a) | `` zabbix60: 6.0.26 -> 6.0.36 ``                                                       |
| [`1768f7c9`](https://github.com/NixOS/nixpkgs/commit/1768f7c90c3aabbd0681db445311555d6e98cbbf) | `` rubyPackages.rexml: 3.3.6 -> 3.3.9 ``                                               |
| [`9ae41519`](https://github.com/NixOS/nixpkgs/commit/9ae41519f9959ac23a28f2623c182cfe034e1a13) | `` tesseract: ensure fixupPhase is run, e.g. ensuring library codesigning on darwin `` |
| [`38511796`](https://github.com/NixOS/nixpkgs/commit/3851179669c002c77377883b3a6965278479277f) | `` xpra: fix xpraWithNvenc build ``                                                    |
| [`d7a56c54`](https://github.com/NixOS/nixpkgs/commit/d7a56c54e9ac6f53b8c4f669ae5623589d1f1727) | `` rsonpath: 0.9.1 -> 0.9.1-unstable-2024-11-15 ``                                     |
| [`2a98baab`](https://github.com/NixOS/nixpkgs/commit/2a98baab8bfc8de9beb215c3113dc1863c698c53) | `` python312Packages.opentelemetry-instrumentation-grpc: fix build ``                  |