### PR TITLE
chore(flake/zen-browser): `cea051b6` -> `c4421ea0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -484,11 +484,11 @@
     },
     "nixpkgs_4": {
       "locked": {
-        "lastModified": 1734649271,
-        "narHash": "sha256-4EVBRhOjMDuGtMaofAIqzJbg4Ql7Ai0PSeuVZTHjyKQ=",
+        "lastModified": 1735471104,
+        "narHash": "sha256-0q9NGQySwDQc7RhAV2ukfnu7Gxa5/ybJ2ANT8DQrQrs=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "d70bd19e0a38ad4790d3913bf08fcbfc9eeca507",
+        "rev": "88195a94f390381c6afcdaa933c2f6ff93959cb4",
         "type": "github"
       },
       "original": {
@@ -695,11 +695,11 @@
         "nixpkgs": "nixpkgs_4"
       },
       "locked": {
-        "lastModified": 1735092772,
-        "narHash": "sha256-u9uEmMRE3RR8hwZto4USSDvee7X2FEYeWcSSLf4Jjrs=",
+        "lastModified": 1735618544,
+        "narHash": "sha256-X38ZBR8UZjSN/HD2MQ3c46kvGN9xi6s0BQHTKMx1WZM=",
         "owner": "0xc000022070",
         "repo": "zen-browser-flake",
-        "rev": "cea051b6f908304f4af6484b14a532c729f0cc34",
+        "rev": "c4421ea028db11bb86e4005bfbd84d46b36fbb72",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                          | Message                                                           |
| --------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------- |
| [`c4421ea0`](https://github.com/0xc000022070/zen-browser-flake/commit/c4421ea028db11bb86e4005bfbd84d46b36fbb72) | `` chore(flake): comments about download url have been removed `` |
| [`dc24ea98`](https://github.com/0xc000022070/zen-browser-flake/commit/dc24ea98102d0d67ae24b07692c9f427a380ec97) | `` feat: each browser variant has its own .desktop file ``        |
| [`98d839eb`](https://github.com/0xc000022070/zen-browser-flake/commit/98d839ebd0c9245cd40abd3e0289d999ea445037) | `` fix: beta hash will update correctly now by CI script ``       |
| [`f680b806`](https://github.com/0xc000022070/zen-browser-flake/commit/f680b806124cf7e7f82c5dfe6e1965100c222e01) | `` feat: disabled browser auto-updates via policies.json ``       |
| [`78606d5b`](https://github.com/0xc000022070/zen-browser-flake/commit/78606d5bd01a410c0e222e3464352fdc645654e9) | `` readme: updated integration section ``                         |
| [`89aae015`](https://github.com/0xc000022070/zen-browser-flake/commit/89aae015138fb16fe775b972e051ae38af6a013b) | `` ci: only beta version will be automatically updated for now `` |
| [`16bfb48f`](https://github.com/0xc000022070/zen-browser-flake/commit/16bfb48f0ea55cf796bee25de7bdbe43e7efaed9) | `` feat: zen browser beta and twilight versions ``                |