### PR TITLE
chore(flake/zen-browser): `c4421ea0` -> `0abfd20d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -695,11 +695,11 @@
         "nixpkgs": "nixpkgs_4"
       },
       "locked": {
-        "lastModified": 1735618544,
-        "narHash": "sha256-X38ZBR8UZjSN/HD2MQ3c46kvGN9xi6s0BQHTKMx1WZM=",
+        "lastModified": 1735694112,
+        "narHash": "sha256-X7OYia41wY9W/QZHtzVLmJYex95Lq8GilA/NhQet1oE=",
         "owner": "0xc000022070",
         "repo": "zen-browser-flake",
-        "rev": "c4421ea028db11bb86e4005bfbd84d46b36fbb72",
+        "rev": "0abfd20ddd53b57d15975790a6be7038cc5dff89",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                          | Message                                                                                                    |
| --------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------- |
| [`0abfd20d`](https://github.com/0xc000022070/zen-browser-flake/commit/0abfd20ddd53b57d15975790a6be7038cc5dff89) | `` chore: moved LICENSE to .github directory ``                                                            |
| [`de3806d9`](https://github.com/0xc000022070/zen-browser-flake/commit/de3806d97eb69815ae9868524bf41da8b639e7da) | `` readme: updated disclaimers ``                                                                          |
| [`644676bb`](https://github.com/0xc000022070/zen-browser-flake/commit/644676bbe02104447da5f51c6f08b059c6dc0a89) | `` fix: twilight's .desktop filename compatible with the freedesktop dbus specification for messages ``    |
| [`48344ab8`](https://github.com/0xc000022070/zen-browser-flake/commit/48344ab82c7f2620863a49b3e86911d7b481b176) | `` feat: exposing desktop file name via derivation metadata ``                                             |
| [`5206a8fc`](https://github.com/0xc000022070/zen-browser-flake/commit/5206a8fc340180afed3f5eb0b601dfb82de16494) | `` feat: added package metadata ``                                                                         |
| [`b5e7bd3d`](https://github.com/0xc000022070/zen-browser-flake/commit/b5e7bd3defc733771f8aad0532c39d567f8f2aed) | `` Update Zen Browser beta @ x86_64 && aarch64 to 1.0.2-b.5 and twilight @ x86_64 && aarch64 to 1.2-t.6 `` |
| [`38ae3378`](https://github.com/0xc000022070/zen-browser-flake/commit/38ae337815d55097e6e38213861bcdffd12dce64) | `` debug: all SHA1s are empty in sources.json file ``                                                      |
| [`5a6f4b32`](https://github.com/0xc000022070/zen-browser-flake/commit/5a6f4b324fb1c5c682ac7d409023abd99fec76dc) | `` chore: removed name entry from sources.json file ``                                                     |
| [`9730693e`](https://github.com/0xc000022070/zen-browser-flake/commit/9730693e926faa9980995040c2c649c893074ead) | `` ci(update): updated log when local source appears outdated ``                                           |
| [`49095384`](https://github.com/0xc000022070/zen-browser-flake/commit/49095384686f36b0e9c986d7755f86645133069e) | `` Update Zen Browser twilight @ x86_64 && aarch64 to 1.2-t.6 ``                                           |
| [`2426938e`](https://github.com/0xc000022070/zen-browser-flake/commit/2426938e9abc079e4733fca7e7951973414a46e8) | `` debug(sources.json): twilight's SHA1s are an empty string ``                                            |
| [`1e252e0e`](https://github.com/0xc000022070/zen-browser-flake/commit/1e252e0e5ff78db53ef4fccdc8bff2540c34c5af) | `` ci(update): extracting twilight semver from release name ``                                             |
| [`92c1e51d`](https://github.com/0xc000022070/zen-browser-flake/commit/92c1e51d80641441c1457ef4be640841a857e9bb) | `` feat: twilight has a different name in .desktop file ``                                                 |
| [`d8ff58d6`](https://github.com/0xc000022070/zen-browser-flake/commit/d8ff58d6fd32282d2afd6b35991ae156bf33c743) | `` Update Zen Browser beta @ x86_64 && aarch64 to 1.0.2-b.5 and twilight @ x86_64 && aarch64 to latest ``  |
| [`d5e8cb9b`](https://github.com/0xc000022070/zen-browser-flake/commit/d5e8cb9b90191aef77ef6b2733481474369e1fd0) | `` debug(sources.json): updated every sha1 hash ``                                                         |
| [`6af8216a`](https://github.com/0xc000022070/zen-browser-flake/commit/6af8216a80e6ce8a790e6f2ba26b77cba4e7f2c3) | `` ci(update): using nix store prefetch with --unpack option ``                                            |
| [`3aca3001`](https://github.com/0xc000022070/zen-browser-flake/commit/3aca3001ed41ba1076990563e1a580405b6b11e3) | `` readme: updated section about features ``                                                               |
| [`b5e941a7`](https://github.com/0xc000022070/zen-browser-flake/commit/b5e941a70abd5e4dc565fb53ea9bb14378ef384e) | `` Update Zen Browser beta @ x86_64 to 1.0.2-b.5 and twilight @ x86_64 to latest ``                        |
| [`b47cc043`](https://github.com/0xc000022070/zen-browser-flake/commit/b47cc0439e35e85561177c32a024be998091b524) | `` debug(sources.json): updated some hashes ``                                                             |
| [`1894eec5`](https://github.com/0xc000022070/zen-browser-flake/commit/1894eec539ca6ff03ed878552747894328303be0) | `` feat(flake): support for aarch64-linux ``                                                               |
| [`3d26db3a`](https://github.com/0xc000022070/zen-browser-flake/commit/3d26db3a166d5607220b46aeb2c7deadd0b17e0f) | `` ci: script to update everything can produce good commit messages ``                                     |
| [`07a074f2`](https://github.com/0xc000022070/zen-browser-flake/commit/07a074f2f791475e7fbdfceb4152e1fba3ed33df) | `` ci: partial integration with new script to fetch new versions ``                                        |
| [`49b0ac38`](https://github.com/0xc000022070/zen-browser-flake/commit/49b0ac38c4484122a304d6003b7046102a93ace4) | `` fix(flake): function to mkZen package accepts extra arguments ``                                        |
| [`f7f3e0aa`](https://github.com/0xc000022070/zen-browser-flake/commit/f7f3e0aa62c465828447a84c2ade59590fd45264) | `` feat: support for aarch64 architecture ``                                                               |
| [`974934b7`](https://github.com/0xc000022070/zen-browser-flake/commit/974934b72233695d95fc5708cff728f20d851dd1) | `` feat: new script to automatically update beta and twilight versions ``                                  |
| [`5ca7b0ed`](https://github.com/0xc000022070/zen-browser-flake/commit/5ca7b0ed795814a7748cfd197de18619c57d8470) | `` feat: using using json file to store package metadata ``                                                |
| [`4bf04b10`](https://github.com/0xc000022070/zen-browser-flake/commit/4bf04b101b72878f48762a91048609e5e38e4d26) | `` readme: added sections about features and installation ``                                               |
| [`3987362a`](https://github.com/0xc000022070/zen-browser-flake/commit/3987362ab8c936d1f2f9a62cc7a26f2fb49cbb53) | `` feat: exposing binary alias depending on the chosen version ``                                          |
| [`1381f1e8`](https://github.com/0xc000022070/zen-browser-flake/commit/1381f1e8babbf0cca4dff25c250abcbd42a430d8) | `` Update flake.nix to correct twilight sha256 ``                                                          |