### PR TITLE
chore(flake/zen-browser): `0abfd20d` -> `45acccc0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -695,11 +695,11 @@
         "nixpkgs": "nixpkgs_4"
       },
       "locked": {
-        "lastModified": 1735694112,
-        "narHash": "sha256-X7OYia41wY9W/QZHtzVLmJYex95Lq8GilA/NhQet1oE=",
+        "lastModified": 1735712737,
+        "narHash": "sha256-KDVdqZaTsIFnI7sWDTq/ubeNns0aGZ4ttH2qHdZgwds=",
         "owner": "0xc000022070",
         "repo": "zen-browser-flake",
-        "rev": "0abfd20ddd53b57d15975790a6be7038cc5dff89",
+        "rev": "45acccc0bfcedb9a7c1b6eaf0efcc97442b57f0f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                          | Message                                                          |
| --------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------- |
| [`45acccc0`](https://github.com/0xc000022070/zen-browser-flake/commit/45acccc0bfcedb9a7c1b6eaf0efcc97442b57f0f) | `` Update Zen Browser twilight @ x86_64 && aarch64 to 1.2-t.6 `` |
| [`dc799a46`](https://github.com/0xc000022070/zen-browser-flake/commit/dc799a467ed8f74c94aa30086742151032d4332a) | `` readme: added license section ``                              |