### PR TITLE
chore(flake/zen-browser): `45acccc0` -> `121ee7b8`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -695,11 +695,11 @@
         "nixpkgs": "nixpkgs_4"
       },
       "locked": {
-        "lastModified": 1735712737,
-        "narHash": "sha256-KDVdqZaTsIFnI7sWDTq/ubeNns0aGZ4ttH2qHdZgwds=",
+        "lastModified": 1735744680,
+        "narHash": "sha256-I+rzz+fBailFk0rxmffZ6RTi99A6R73jw6aMN9VEl00=",
         "owner": "0xc000022070",
         "repo": "zen-browser-flake",
-        "rev": "45acccc0bfcedb9a7c1b6eaf0efcc97442b57f0f",
+        "rev": "121ee7b8171037e0a25c9e90a04571052e9f769a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                          | Message                                                          |
| --------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------- |
| [`121ee7b8`](https://github.com/0xc000022070/zen-browser-flake/commit/121ee7b8171037e0a25c9e90a04571052e9f769a) | `` Update Zen Browser twilight @ x86_64 && aarch64 to 1.2-t.6 `` |