### PR TITLE
chore(flake/nixpkgs): `3ffbbdba` -> `edf04b75`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -468,11 +468,11 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1735531152,
-        "narHash": "sha256-As8I+ebItDKtboWgDXYZSIjGlKeqiLBvjxsQHUmAf1Q=",
+        "lastModified": 1735669367,
+        "narHash": "sha256-tfYRbFhMOnYaM4ippqqid3BaLOXoFNdImrfBfCp4zn0=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "3ffbbdbac0566a0977da3d2657b89cbcfe9a173b",
+        "rev": "edf04b75c13c2ac0e54df5ec5c543e300f76f1c9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                     |
| ---------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------- |
| [`b468b0f4`](https://github.com/NixOS/nixpkgs/commit/b468b0f41c2171c62a4f772a95193aea41ef4817) | `` pkgs/xorg: remove xf86-video-intel ``                                    |
| [`9faab2ec`](https://github.com/NixOS/nixpkgs/commit/9faab2ec5a5b5b917fa6b366007068e9cce6eb24) | `` nixos/doc: update the status of Intel Graphics ``                        |
| [`cb3a8932`](https://github.com/NixOS/nixpkgs/commit/cb3a89323ab0ee8f0f49cf40e8046b2150cb3aae) | `` percona-server_8_0: 8.0.39-30 -> 8.0.40-31 ``                            |
| [`bc130b5a`](https://github.com/NixOS/nixpkgs/commit/bc130b5a632d110d76f1584213eab6e029fd7802) | `` [Backport release-24.11] mangojuice: 0.7.8 -> 0.7.9 (#369605) ``         |
| [`a80f2371`](https://github.com/NixOS/nixpkgs/commit/a80f2371d15c238eb35fcb9c0ed5842634df9d93) | `` mobilizon: 5.1.0 -> 5.1.1 ``                                             |
| [`02d3af85`](https://github.com/NixOS/nixpkgs/commit/02d3af852d2e679783256afb3609823a3155f822) | `` opencomposite: 0-unstable-2024-12-20 -> 0-unstable-2024-12-26 ``         |
| [`5198009e`](https://github.com/NixOS/nixpkgs/commit/5198009e5d055485312b6dc1c674e3ba6b01c41d) | `` prometheus-rasdaemon-exporter: fix sqlite connection setup ``            |
| [`3173cdc4`](https://github.com/NixOS/nixpkgs/commit/3173cdc408f535a780a74fa04d569a5de7c32b5a) | `` prometheus-rasdaemon-exporter: normalize metric names ``                 |
| [`366259ff`](https://github.com/NixOS/nixpkgs/commit/366259ff1e56050b1820b40cc4bfc8e35c5f4bd8) | `` python312Packages.qbittorrent-api: 2024.11.70 -> 2024.12.71 ``           |
| [`0f1348fb`](https://github.com/NixOS/nixpkgs/commit/0f1348fb2a3bfbc8360874afea13dffdd4333a8d) | `` sutils: correct license ``                                               |
| [`3f044f4e`](https://github.com/NixOS/nixpkgs/commit/3f044f4ec2bbf17fc350f7199bca3bd1adca637b) | `` nixos/matter-server: allow AF_UNIX sockets for dbus connections ``       |
| [`16be4c71`](https://github.com/NixOS/nixpkgs/commit/16be4c71b3197766690dae658605d588f0fd94a2) | `` dolibarr: 20.0.2 -> 20.0.3 ``                                            |
| [`95508582`](https://github.com/NixOS/nixpkgs/commit/955085826a58a9f1e9a32af96843e311cb025deb) | `` pnpm_9: 9.15.1 -> 9.15.2 ``                                              |
| [`5f23df2c`](https://github.com/NixOS/nixpkgs/commit/5f23df2c3c39b1d451426923e30a53520862250b) | `` nixos/plymouth: Respect plymouth.enable=0 in scripted stage 1 ``         |
| [`3a9e741f`](https://github.com/NixOS/nixpkgs/commit/3a9e741fd7c2f6db36268a82638054a18a3d78aa) | `` snac2: 2.66 -> 2.67 ``                                                   |
| [`d18f6273`](https://github.com/NixOS/nixpkgs/commit/d18f6273a9fa7efc2aea948e3d724be4d868b3ee) | `` intel-compute-runtime-legacy1: init at 24.35.30872.32 ``                 |
| [`245681b6`](https://github.com/NixOS/nixpkgs/commit/245681b622af55a5b66ef209b3315b259550dc3f) | `` rdesktop: fix build ``                                                   |
| [`91c19c89`](https://github.com/NixOS/nixpkgs/commit/91c19c896ff943bf91e53af1650a37651cc1bd2c) | `` sane-frontends: fix gcc14 compilation ``                                 |
| [`cfb79620`](https://github.com/NixOS/nixpkgs/commit/cfb79620d823db0ad620b8c782d939fd525af00d) | `` doc: Add warning for configuration file copy in flake systems ``         |
| [`254df269`](https://github.com/NixOS/nixpkgs/commit/254df26971e567c3d599bd5de9c955387fbd4c77) | `` linux_xanmod_latest: 6.12.6 -> 6.12.7 ``                                 |
| [`70a1309b`](https://github.com/NixOS/nixpkgs/commit/70a1309babb63536e5c183f16e65f401bed64422) | `` linux_xanmod: 6.6.67 -> 6.6.68 ``                                        |
| [`9d28801d`](https://github.com/NixOS/nixpkgs/commit/9d28801d4b943c8cf67630fede3b66947a32abc8) | `` vesktop: fix crashing when settings.json or state.json are read-only ``  |
| [`2fa1d7ea`](https://github.com/NixOS/nixpkgs/commit/2fa1d7ea4f4a39d20e583f78b290e56e7ed49afb) | `` vesktop: 1.5.3 -> 1.5.4 (#362579) ``                                     |
| [`5306340d`](https://github.com/NixOS/nixpkgs/commit/5306340d6b292a07e1be42cb0f68b470b7e8561b) | `` cockpit: iteration from reviews ``                                       |
| [`60f3b4d8`](https://github.com/NixOS/nixpkgs/commit/60f3b4d855f13ea9ae55450ad53d1a8ba66690dd) | `` tests/cockpit: each wait with its own waiter, treat /nonexistent case `` |
| [`bef2bd9e`](https://github.com/NixOS/nixpkgs/commit/bef2bd9e177bfa4d65a8ff71c65a6923e2a08b1b) | `` cockpit: 330 -> 331 ``                                                   |
| [`131bb628`](https://github.com/NixOS/nixpkgs/commit/131bb6285f85bd6dac13217f08a1f4d7510da78a) | `` utpm: init at 0-unstable-2024-12-17 (#353341) ``                         |
| [`703ccc5b`](https://github.com/NixOS/nixpkgs/commit/703ccc5be31c585ccd82a7fc2177ae4165046a06) | `` mautrix-signal: 0.7.3 -> 0.7.4 ``                                        |
| [`f76ed5d0`](https://github.com/NixOS/nixpkgs/commit/f76ed5d00ead1374acca42c457303c4c8b9cd27c) | `` libsignal-ffi: 0.62.0 -> 0.64.1 ``                                       |
| [`e012c5ba`](https://github.com/NixOS/nixpkgs/commit/e012c5bac50da2b82f753944a1b6b0ce6e96554c) | `` cargo-semver-checks: refactor ``                                         |
| [`cf5a6537`](https://github.com/NixOS/nixpkgs/commit/cf5a6537f2e2b725a298421be2bb11777b7e46e9) | `` cargo-semver-checks: 0.34.0 -> 0.38.0 ``                                 |
| [`2fd80b4f`](https://github.com/NixOS/nixpkgs/commit/2fd80b4f9c6facb1faa1539e5439395f58cb7601) | `` zfs-replicate: 3.2.13 -> 4.0.0 ``                                        |
| [`dbb71e26`](https://github.com/NixOS/nixpkgs/commit/dbb71e266a31d152056153a2d2046bc66803137b) | `` nixos/ntpd: fix permissions error when creating drift file ``            |