### PR TITLE
chore(flake/zen-browser): `121ee7b8` -> `4cbef43b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -695,11 +695,11 @@
         "nixpkgs": "nixpkgs_4"
       },
       "locked": {
-        "lastModified": 1735744680,
-        "narHash": "sha256-I+rzz+fBailFk0rxmffZ6RTi99A6R73jw6aMN9VEl00=",
+        "lastModified": 1735791650,
+        "narHash": "sha256-2t6v5LcNyJOEMshCqEuCq70WPhJLtCoItbk5K8fqf5A=",
         "owner": "0xc000022070",
         "repo": "zen-browser-flake",
-        "rev": "121ee7b8171037e0a25c9e90a04571052e9f769a",
+        "rev": "4cbef43b946c0e620fd283b74d505408a28a00d1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                          | Message                                                                                           |
| --------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------- |
| [`4cbef43b`](https://github.com/0xc000022070/zen-browser-flake/commit/4cbef43b946c0e620fd283b74d505408a28a00d1) | `` Update Zen Browser twilight @ x86_64 && aarch64 to 1.2-t.6 ``                                  |
| [`04058273`](https://github.com/0xc000022070/zen-browser-flake/commit/04058273f2f8c359a9495cf176f707d8c3e5c85f) | `` fix(desktop-files): app icon names have their variant names attached to them when installed `` |
| [`c3b4304d`](https://github.com/0xc000022070/zen-browser-flake/commit/c3b4304d73308aebc1a33a6aecf0bb98fcb751e1) | `` fix(desktop-files): ensuring correct zen instance is used in Exec entries ``                   |