### PR TITLE
chore(flake/spicetify-nix): `c0db9c52` -> `0227d83d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -539,11 +539,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1735827474,
-        "narHash": "sha256-s8fDRn99iDIf5olFuIXlw6BDUjdBj4sk9uqPWD4pDdU=",
+        "lastModified": 1735877772,
+        "narHash": "sha256-6OT4xYCwZTJ9qK28NNM98ibFZinwrJK/sRlg+dDqdJs=",
         "owner": "Gerg-L",
         "repo": "spicetify-nix",
-        "rev": "c0db9c52e158f3b3dedb08e77f3c87aecac3d2c3",
+        "rev": "0227d83d2eb29189b8ed8d180e2442ada633dd0d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                                              |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------ |
| [`0227d83d`](https://github.com/Gerg-L/spicetify-nix/commit/0227d83d2eb29189b8ed8d180e2442ada633dd0d) | `` CI update 2025-01-03 ``                                                           |
| [`ed0abe68`](https://github.com/Gerg-L/spicetify-nix/commit/ed0abe68bbf8351d89230a537f4870d815092a62) | `` extensions: add starRatings ``                                                    |
| [`c1d7197a`](https://github.com/Gerg-L/spicetify-nix/commit/c1d7197aa59053e665d1023fd295b6022f2302ea) | `` use callPackage from _module.args.pkgs instead of self.<system>.legacyPackages `` |