### PR TITLE
chore(flake/zen-browser): `b275d71b` -> `4a48a5c0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -695,11 +695,11 @@
         "nixpkgs": "nixpkgs_4"
       },
       "locked": {
-        "lastModified": 1735849099,
-        "narHash": "sha256-nYykv3COeYunqlha9Co+8CCigM2GtdtS7vw9xuhoO7Q=",
+        "lastModified": 1735881391,
+        "narHash": "sha256-T9N1q8YWn9MnIqUpm0+p/kAqktfSoeKfyOTZiXQoNPU=",
         "owner": "0xc000022070",
         "repo": "zen-browser-flake",
-        "rev": "b275d71ba83928121235a4e7968b9be55986fdc6",
+        "rev": "4a48a5c007863df58d1586f96010a6d4bde99f69",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                          | Message                                                          |
| --------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------- |
| [`4a48a5c0`](https://github.com/0xc000022070/zen-browser-flake/commit/4a48a5c007863df58d1586f96010a6d4bde99f69) | `` Update Zen Browser twilight @ x86_64 && aarch64 to 1.2-t.6 `` |