### PR TITLE
chore(flake/nix-flatpak): `c31b6cbd` -> `78ed84ff`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -373,11 +373,11 @@
     },
     "nix-flatpak": {
       "locked": {
-        "lastModified": 1735500379,
-        "narHash": "sha256-5qmX6YYjYfVYBbsmd2XxbTi7A59YuuN9IwfXU7qFquQ=",
+        "lastModified": 1735913600,
+        "narHash": "sha256-370z+WLVnD7LrN/SvTCZxPl/XPTshS5NS2dHN4iyK6o=",
         "owner": "gmodena",
         "repo": "nix-flatpak",
-        "rev": "c31b6cbd11707fe2c74ad805ef085d59d75116ae",
+        "rev": "78ed84ff81e8d8510926e7165d508bcacef49ff1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                                                          |
| ---------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------- |
| [`78ed84ff`](https://github.com/gmodena/nix-flatpak/commit/78ed84ff81e8d8510926e7165d508bcacef49ff1) | `` installer: warning for manual app removal edge case (#130) `` |