### PR TITLE
chore(flake/stylix): `9015d5d0` -> `5204b085`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -266,6 +266,59 @@
         "type": "github"
       }
     },
+    "git-hooks": {
+      "inputs": {
+        "flake-compat": [
+          "stylix",
+          "flake-compat"
+        ],
+        "gitignore": "gitignore",
+        "nixpkgs": [
+          "stylix",
+          "nixpkgs"
+        ],
+        "nixpkgs-stable": [
+          "stylix",
+          "git-hooks",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1731363552,
+        "narHash": "sha256-vFta1uHnD29VUY4HJOO/D6p6rxyObnf+InnSMT4jlMU=",
+        "owner": "cachix",
+        "repo": "git-hooks.nix",
+        "rev": "cd1af27aa85026ac759d5d3fccf650abe7e1bbf0",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "repo": "git-hooks.nix",
+        "type": "github"
+      }
+    },
+    "gitignore": {
+      "inputs": {
+        "nixpkgs": [
+          "stylix",
+          "git-hooks",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1709087332,
+        "narHash": "sha256-HG2cCnktfHsKV0s4XW83gU3F57gaTljL9KNSuG6bnQs=",
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "rev": "637db329424fd7e46cf4185293b9cc8c88c95394",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "type": "github"
+      }
+    },
     "gnome-shell": {
       "flake": false,
       "locked": {
@@ -312,11 +365,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1735344290,
-        "narHash": "sha256-oJDtWPH1oJT34RJK1FSWjwX4qcGOBRkcNQPD0EbSfNM=",
+        "lastModified": 1733572789,
+        "narHash": "sha256-zjO6m5BqxXIyjrnUziAzk4+T4VleqjstNudSqWcpsHI=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "613691f285dad87694c2ba1c9e6298d04736292d",
+        "rev": "c7ffc9727d115e433fd884a62dc164b587ff651d",
         "type": "github"
       },
       "original": {
@@ -560,6 +613,7 @@
         "base16-vim": "base16-vim",
         "flake-compat": "flake-compat_3",
         "flake-utils": "flake-utils",
+        "git-hooks": "git-hooks",
         "gnome-shell": "gnome-shell",
         "home-manager": "home-manager_2",
         "nixpkgs": [
@@ -571,11 +625,11 @@
         "tinted-tmux": "tinted-tmux"
       },
       "locked": {
-        "lastModified": 1734110444,
-        "narHash": "sha256-fp1iV2JldCSvz+7ODzXYUkQ+H7zyiWw5E0MQ4ILC4vw=",
+        "lastModified": 1736019457,
+        "narHash": "sha256-MWe3RXEV9dov1wFZraWagVAxynPo/VceStIYfNRgqG4=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "9015d5d0d5d100f849129c43d257b827d300b089",
+        "rev": "5204b085385c0bfaa1eb1bb0f8dc81922012128d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                        | Message                                                                           |
| --------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------- |
| [`21c4c4de`](https://github.com/danth/stylix/commit/21c4c4de910c5abe1814d8bb055a2a97dd0b3d91) | `` treewide: add and apply nixfmt pre-commit hook ``                              |
| [`5ed2e219`](https://github.com/danth/stylix/commit/5ed2e21910dbb9de0c701b2ee73f213d0d7084fe) | `` stylix: add ghc developer shell ``                                             |
| [`11d78e25`](https://github.com/danth/stylix/commit/11d78e258cb26069297036fb28eaf9a35ff21bd8) | `` stylix: add hlint pre-commit hook ``                                           |
| [`431752eb`](https://github.com/danth/stylix/commit/431752ebc853abea9f0b9650a9a96483858fd97e) | `` treewide: add and apply stylish-haskell ``                                     |
| [`f55bb0fa`](https://github.com/danth/stylix/commit/f55bb0fa3e2ddb92314204821c00573f74ef9448) | `` ci: prevent the Check workflow from running duplicated checks outputs ``       |
| [`a81bf6ad`](https://github.com/danth/stylix/commit/a81bf6ad5836f9ea4c775e9e111ba090431ffebe) | `` treewide: add and apply yamllint pre-commit hook ``                            |
| [`29c452a5`](https://github.com/danth/stylix/commit/29c452a5c98cb8903d7c8c943ee03111f3bec86c) | `` treewide: add and apply typos pre-commit hook ``                               |
| [`2352bb62`](https://github.com/danth/stylix/commit/2352bb6251fdd11381cd9bde0df28899405de4e9) | `` ci: simplify workflows ``                                                      |
| [`a89ef5c7`](https://github.com/danth/stylix/commit/a89ef5c7f4f1506a44ab088a60391fa888c3b51e) | `` ci: update Ubuntu runner to ubuntu-24.04 ``                                    |
| [`0329852d`](https://github.com/danth/stylix/commit/0329852dcef640b875d9d4fa896e8ec7f28b3e83) | `` ci: lock workflow dependencies to increase reproducibility ``                  |
| [`01be22e7`](https://github.com/danth/stylix/commit/01be22e752738f253ce6138348adab1ca722baef) | `` stylix: add nix-flake-check package ``                                         |
| [`2a39ef0a`](https://github.com/danth/stylix/commit/2a39ef0add9b2eb7308423e107ce12a62ef9805d) | `` stylix: add packages to checks output ``                                       |
| [`e509a398`](https://github.com/danth/stylix/commit/e509a3984f73628f86a832c242adbd2b9c943051) | `` stylix: integrate pre-commit hooks into developer shell ``                     |
| [`e0df5c79`](https://github.com/danth/stylix/commit/e0df5c793b4f50fae5bbdfe3550e2c3bd8964413) | `` ci: consolidate Build and Lint workflows into single Check workflow ``         |
| [`b5179b60`](https://github.com/danth/stylix/commit/b5179b60831440b8459f94a1f2d85a3fd5cfe420) | `` stylix: add deadnix and statix pre-commit hooks ``                             |
| [`f986c4bf`](https://github.com/danth/stylix/commit/f986c4bf4d7ff2918e3b4bd37b19e216e594c1ea) | `` treewide: ignore unused arguments detected by deadnix ``                       |
| [`2f6e9dac`](https://github.com/danth/stylix/commit/2f6e9dac3d1d7d6ec089f627acc1aeca6d35c48b) | `` treewide: leverage direnv to automatically enter developer shell ``            |
| [`64164907`](https://github.com/danth/stylix/commit/641649077245dbb815d01b744739011386a95731) | `` treewide: add developer shell ``                                               |
| [`c4d1ac97`](https://github.com/danth/stylix/commit/c4d1ac97a8d21d9d62f39a42ca097ca2bef26086) | `` ci: fix typo in target branch placeholder ``                                   |
| [`9a950a8a`](https://github.com/danth/stylix/commit/9a950a8a3bb0b9e645dadeed81ebd50fe1182afb) | `` ci: implement automated backports (#664) ``                                    |
| [`e9591b6f`](https://github.com/danth/stylix/commit/e9591b6ff905d8cc9ddce4066a30db7f621a99b6) | `` micro: init (#716) ``                                                          |
| [`85c102be`](https://github.com/danth/stylix/commit/85c102bef03782780d7946778f148a463fb3958a) | `` doc: update copyright year (#715) ``                                           |
| [`295d45cb`](https://github.com/danth/stylix/commit/295d45cb11658c0fb36a2f35fec93d99fde07ec9) | `` doc: update copyright and include contributors (#659) ``                       |
| [`f191bb85`](https://github.com/danth/stylix/commit/f191bb859ed5bc4ce0e14265196368b4ace27f6d) | `` doc: standardize license formatting (#661) ``                                  |
| [`b0c0d8e9`](https://github.com/danth/stylix/commit/b0c0d8e9cd616a05d7e79f2396976fa54ad88832) | `` kde: replace systemd unit with AutostartScript for theme application (#708) `` |
| [`9c767314`](https://github.com/danth/stylix/commit/9c767314840b21f82b6f39da5b1e18628cda1421) | `` fctix5: init (#718) ``                                                         |
| [`9593bd5f`](https://github.com/danth/stylix/commit/9593bd5ff371170ada107b53546466f8b3dca945) | `` doc: document imageScalingMode options (#709) ``                               |
| [`21b1b0c9`](https://github.com/danth/stylix/commit/21b1b0c9f85893276c81381695d57a1f9c1f9615) | `` foot: update desktop file name in testbed (#707) ``                            |
| [`b6476a54`](https://github.com/danth/stylix/commit/b6476a5423e85ca6dbd0c3bc1ebca77612b578f3) | `` zathura: add testbed ``                                                        |
| [`f3463f5f`](https://github.com/danth/stylix/commit/f3463f5f96dc6643568824eb5e78bb19e5f6eff0) | `` wezterm: add testbed ``                                                        |
| [`ac328339`](https://github.com/danth/stylix/commit/ac3283398900b28dc01aadf5c388a5e2429bc954) | `` vesktop: add testbed ``                                                        |
| [`a7182a79`](https://github.com/danth/stylix/commit/a7182a7911e8230a652de4950ac5163cbaf3e980) | `` qutebrowser: add testbed ``                                                    |
| [`e3b9e318`](https://github.com/danth/stylix/commit/e3b9e318c769dfb86cb74373c7d3dd62eaaa39b2) | `` kitty: add testbed ``                                                          |
| [`a3732990`](https://github.com/danth/stylix/commit/a3732990690359a18e4778cb2b7e843c7fc25a9a) | `` gedit: add testbed ``                                                          |
| [`53bd2a60`](https://github.com/danth/stylix/commit/53bd2a6085829a2cc883242623b95ecb00a0c556) | `` foot: add testbed ``                                                           |
| [`e1b98f92`](https://github.com/danth/stylix/commit/e1b98f92b05a78955e5a9f53dc037437345cc44f) | `` emacs: add testbed ``                                                          |
| [`25aa7993`](https://github.com/danth/stylix/commit/25aa79930cc06a0a504ac0242adffcf901785032) | `` chromium: add testbed ``                                                       |
| [`008c94ca`](https://github.com/danth/stylix/commit/008c94caf20373ccd5a1472ad883916a0b138720) | `` alacritty: add testbed ``                                                      |
| [`be80d00f`](https://github.com/danth/stylix/commit/be80d00fb3379d94e9544af56aa4337d6cd9ec78) | `` vscode: add testbed ``                                                         |
| [`123917da`](https://github.com/danth/stylix/commit/123917dabdcf1cc240f8054ee20277cc1adf67b9) | `` firefox: add testbed ``                                                        |
| [`b041bebf`](https://github.com/danth/stylix/commit/b041bebf9fab73aa8836bdae508547c87792eb0d) | `` stylix: add template for application testbeds ``                               |
| [`3a26695d`](https://github.com/danth/stylix/commit/3a26695d93a57af7149b94582d40421520db94cb) | `` gtk: add support for theming Flatpak applications (#693) ``                    |
| [`13037a55`](https://github.com/danth/stylix/commit/13037a55be9ba0075c6b765fde406bb29a4bb081) | `` firefox: leverage Home Manager's mkFirefoxModule pattern (#695) ``             |
| [`c6eecbe5`](https://github.com/danth/stylix/commit/c6eecbe504a4800db10a5556a9c3dc160a5446ed) | `` doc: resolve 'magick convert' deprecation warning (#697) ``                    |
| [`2879ff62`](https://github.com/danth/stylix/commit/2879ff6234346b3299e1dad745bea13d67a16e38) | `` cava: add rainbow theme option (#638) ``                                       |
| [`890582ca`](https://github.com/danth/stylix/commit/890582ca0dc36232a433158526f71d7e83163189) | `` xresources: convert font size to a string ``                                   |
| [`f8617381`](https://github.com/danth/stylix/commit/f8617381ad1876d45211608f89c5d061965126a8) | `` stylix: use floats for font sizes ``                                           |
| [`c35f9279`](https://github.com/danth/stylix/commit/c35f92796d1c3735507029afb698eaf6bc95b47a) | `` vscode: don't round font sizes (#691) ``                                       |
| [`8cdd9f07`](https://github.com/danth/stylix/commit/8cdd9f07259d63635920775740b3a349e62e56ca) | `` treewide: extend stylix.imageScalingMode support ``                            |