### PR TITLE
chore(flake/nixpkgs): `edf04b75` -> `d29ab98c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -468,11 +468,11 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1735669367,
-        "narHash": "sha256-tfYRbFhMOnYaM4ippqqid3BaLOXoFNdImrfBfCp4zn0=",
+        "lastModified": 1735922141,
+        "narHash": "sha256-vk0xwGZSlvZ/596yxOtsk4gxsIx2VemzdjiU8zhjgWw=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "edf04b75c13c2ac0e54df5ec5c543e300f76f1c9",
+        "rev": "d29ab98cd4a70a387b8ceea3e930b3340d41ac5a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                                                               |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------- |
| [`865fd677`](https://github.com/NixOS/nixpkgs/commit/865fd6778044f1a6c93f5a97e3e043cfad2c6233) | `` cupsd: Allow major upgrades of gutenprint with cups-genppdupdate. ``                                                               |
| [`0a43e6d9`](https://github.com/NixOS/nixpkgs/commit/0a43e6d90043c4803a24d5c6e20905b19c8a9611) | `` rundeck: init at 5.8.0 ``                                                                                                          |
| [`4e8dde26`](https://github.com/NixOS/nixpkgs/commit/4e8dde267edfe7768a5c994ca9810c46f91d9604) | `` swapspace: refactor ``                                                                                                             |
| [`cda120e6`](https://github.com/NixOS/nixpkgs/commit/cda120e6678eeb240fb896067aeb6a172d738719) | `` nixos/swapspace: add installWrapper option ``                                                                                      |
| [`2e1c2c25`](https://github.com/NixOS/nixpkgs/commit/2e1c2c253f237e0df5c7dc03ced56f77cb7d5da9) | `` deja-dup: Fix missing dep for gdrive ``                                                                                            |
| [`0fbd8db6`](https://github.com/NixOS/nixpkgs/commit/0fbd8db60d99b7a2ed1c120f816762990064a166) | `` resources: show Nvidia GPU info ``                                                                                                 |
| [`3e77619f`](https://github.com/NixOS/nixpkgs/commit/3e77619fae721b7be83691b537f2a9665d4458cc) | `` spotifyd: 0.3.5-unstable-2024-10-21 -> 0.3.5-unstable-2024-12-27 ``                                                                |
| [`dd88d786`](https://github.com/NixOS/nixpkgs/commit/dd88d7868c362349ddcc0dc8b67e0d06023142e7) | `` nixos/kmonad: avoid running an unnecessary bash ``                                                                                 |
| [`cca8a5ca`](https://github.com/NixOS/nixpkgs/commit/cca8a5caa28fb35b31ba33277677c6d86fc23940) | `` nixos/kmonad: remove unnecessary cli flag --input ``                                                                               |
| [`32ee3ce1`](https://github.com/NixOS/nixpkgs/commit/32ee3ce1dcca33f7be4bbf0268cc48e6001195f1) | `` buildGraalvmNativeImage: fix build on darwin-x86_64 ``                                                                             |
| [`f0bd9a72`](https://github.com/NixOS/nixpkgs/commit/f0bd9a727a76d1b2b7be44dfb9a01842cfb7520d) | `` buildGraalvm: fix build on x86_64-darwin ``                                                                                        |
| [`27d2f14c`](https://github.com/NixOS/nixpkgs/commit/27d2f14c9b958a2658f0a5f25a0221ed429ec1a4) | `` mobilizon: fix internal version ``                                                                                                 |
| [`0d10119c`](https://github.com/NixOS/nixpkgs/commit/0d10119c1db89c2af59c02c987188bf4a25c3879) | `` kubernetes: kubelet.extraConfig should be `attrsOf json.type` ``                                                                   |
| [`12497d2a`](https://github.com/NixOS/nixpkgs/commit/12497d2a584540b3c2f78b798387f06798664d54) | `` koreader: fix hash (#370115) ``                                                                                                    |
| [`e03e65af`](https://github.com/NixOS/nixpkgs/commit/e03e65af67bfcec8bcd337b96ffd87d660a3a935) | `` koreader: 2024.04 -> 2024.11 ``                                                                                                    |
| [`27d3b1b1`](https://github.com/NixOS/nixpkgs/commit/27d3b1b1578dab5c31ba1c34abab926987a1a494) | `` nixos/kmonad: create determinate symlinks ``                                                                                       |
| [`d681ac0c`](https://github.com/NixOS/nixpkgs/commit/d681ac0c812afbccdd5a74e8e0c38763ff8747ed) | `` git-delete-merged-branches: 7.4.1 -> 7.4.2 ``                                                                                      |
| [`8bc90746`](https://github.com/NixOS/nixpkgs/commit/8bc90746bd3806acc7952d846bf838db1eaf08f9) | `` bloat: 0-unstable-2024-10-28 -> 0-unstable-2024-12-27 ``                                                                           |
| [`9727fb62`](https://github.com/NixOS/nixpkgs/commit/9727fb62be512da99f3e718a9f2f4237dfe20a42) | `` flyctl: 0.3.53 -> 0.3.56 ``                                                                                                        |
| [`17a78c41`](https://github.com/NixOS/nixpkgs/commit/17a78c4129eb1e93904ae11e4634943e9bc387eb) | `` mplayer: 1.5-unstable-2024-07-03 -> 1.5-unstable-2024-12-21 ``                                                                     |
| [`b5c5c12f`](https://github.com/NixOS/nixpkgs/commit/b5c5c12f75157ee8c1cf8b80f3ba983e62e1bd27) | `` notmuch-mailmover: 0.5.0 -> 0.6.0 ``                                                                                               |
| [`999446c6`](https://github.com/NixOS/nixpkgs/commit/999446c61d91be71159d3a61b541453196fcb563) | `` linux_6_1: 6.1.122 -> 6.1.123 ``                                                                                                   |
| [`c9002bb3`](https://github.com/NixOS/nixpkgs/commit/c9002bb329f3626a13614eaa6172b20082ff3362) | `` linux_6_6: 6.6.68 -> 6.6.69 ``                                                                                                     |
| [`157596f3`](https://github.com/NixOS/nixpkgs/commit/157596f3139da9a5c7c1b6cb8d6849d82010c80b) | `` linux_6_12: 6.12.7 -> 6.12.8 ``                                                                                                    |
| [`50f3b5c2`](https://github.com/NixOS/nixpkgs/commit/50f3b5c294599636bbe128f07caf82275ccaf203) | `` linux_testing: 6.13-rc4 -> 6.13-rc5 ``                                                                                             |
| [`f0a75c85`](https://github.com/NixOS/nixpkgs/commit/f0a75c8509dc020495d95e0ffaa5a1b8d9001bb6) | `` torzu: init at unstable 12.15.24 ``                                                                                                |
| [`6864dc1d`](https://github.com/NixOS/nixpkgs/commit/6864dc1daa1661c91fa72d31c7490abf2a01162a) | `` mesen: init at 2.0.0-unstable-2024-12-25 ``                                                                                        |
| [`b69613fc`](https://github.com/NixOS/nixpkgs/commit/b69613fcb6f97bdb9db0612f61925d4deb06f325) | `` python312Packages.blockdiag: fix missing runtime dependency ``                                                                     |
| [`95a171af`](https://github.com/NixOS/nixpkgs/commit/95a171af367ba1f6743f91f867f5e78df3c1a29e) | `` nixos/zfs-replication: add --verbose to command line arguments ``                                                                  |
| [`8999abb7`](https://github.com/NixOS/nixpkgs/commit/8999abb71e792afb1d8567a209505f13e91aa7ce) | `` nixos/zfs-replication: use expanded arguments for clarity ``                                                                       |
| [`0fc0fa4e`](https://github.com/NixOS/nixpkgs/commit/0fc0fa4ed39b7147d01bda83eb043596a2050302) | `` simplex-chat-desktop: 6.2.1 -> 6.2.3 ``                                                                                            |
| [`43e9cbd5`](https://github.com/NixOS/nixpkgs/commit/43e9cbd5814ebf188116789dde7946af82a35018) | `` ecapture: 0.9.1 -> 0.9.2 ``                                                                                                        |
| [`ba040e28`](https://github.com/NixOS/nixpkgs/commit/ba040e289d1c00ea6440b00f30c25add16c42cc8) | `` python3Packages.loguru: 0.7.2 -> 0.7.3 & cleanups ``                                                                               |
| [`69822178`](https://github.com/NixOS/nixpkgs/commit/69822178635ebe1541003fa23607fa417e09b48b) | `` netbox: 4.1.3 -> 4.1.7 ``                                                                                                          |
| [`1bffbc54`](https://github.com/NixOS/nixpkgs/commit/1bffbc54241af3a67d77ac832cb376fe16f2fd87) | `` ovn: fix missing scripts and wrong paths ``                                                                                        |
| [`058a665d`](https://github.com/NixOS/nixpkgs/commit/058a665d0c4e688b6d14171a110c0601432e5cee) | `` nixos/kmonad: use lib.getExe ``                                                                                                    |
| [`fba9b648`](https://github.com/NixOS/nixpkgs/commit/fba9b6486ec6ca2d6a2b614e604de3a23f07565d) | `` nixos/kmonad: use the official suffix for config file ``                                                                           |
| [`155e085d`](https://github.com/NixOS/nixpkgs/commit/155e085d1f6e35bd09f4dd1852335d3c43f9d2f2) | `` nixos/kmonad: introduce a new helper function mkName ``                                                                            |
| [`22ebf019`](https://github.com/NixOS/nixpkgs/commit/22ebf019dd84d1e2fbf2b8ea5b495a2fcf205b2e) | `` nixos/kmonad: make type of delay more strict ``                                                                                    |
| [`a4054a06`](https://github.com/NixOS/nixpkgs/commit/a4054a06e58a1ab1a2ba92c02eddbc173ffdefe8) | `` nixos/kmonad: simplify config for default keyboard name ``                                                                         |
| [`f5c476c3`](https://github.com/NixOS/nixpkgs/commit/f5c476c368afa9ced801c26f22c5c30ff62ef5f0) | `` nixos/kmonad: improve doc ``                                                                                                       |
| [`b86c19da`](https://github.com/NixOS/nixpkgs/commit/b86c19dad10a3de67e37b70843acd15314bfdf35) | `` nixos/kmonad: add meta.maintainers ``                                                                                              |
| [`0ac68729`](https://github.com/NixOS/nixpkgs/commit/0ac68729e2c9d1c4826a54e6a49b551841886224) | `` nixos/kmonad: add a basic nixos test ``                                                                                            |
| [`ced3bf71`](https://github.com/NixOS/nixpkgs/commit/ced3bf7175b7c527aa5ad0269c2e77f5256927b9) | `` nixos/kmonad: make sure new config is used after nixos-rebuild switch ``                                                           |
| [`48ed4c78`](https://github.com/NixOS/nixpkgs/commit/48ed4c7837bfc59f1ff43f88b6c90255e83d1b43) | `` angie: 1.8.0 -> 1.8.1 ``                                                                                                           |
| [`23b6f487`](https://github.com/NixOS/nixpkgs/commit/23b6f487707670e97cfedadd45f2d20fa98f7d6a) | `` [Backport release-24.11] television: 0.8.1 -> 0.8.5 (#369891) ``                                                                   |
| [`102a12f1`](https://github.com/NixOS/nixpkgs/commit/102a12f1ff8185422f8941137eef6ebbfcdeb451) | `` [Backport release-24.11] skim: 0.15.5 -> 0.15.7 (#369890) ``                                                                       |
| [`4fc70a47`](https://github.com/NixOS/nixpkgs/commit/4fc70a47f2ce01a82c145436626921d2698872eb) | `` release: forbid use of `lib.fileset` in Nixpkgs ``                                                                                 |
| [`800b3b59`](https://github.com/NixOS/nixpkgs/commit/800b3b593bb49eaddef5396720ae7abb6bc80de5) | `` cudaPackages.saxpy: avoid `lib.fileset` ``                                                                                         |
| [`0b746726`](https://github.com/NixOS/nixpkgs/commit/0b746726a005c97ca589be72f1ae2a3d5562e0cb) | `` python312Packages.waitress-django: avoid `lib.fileset` ``                                                                          |
| [`966e96ba`](https://github.com/NixOS/nixpkgs/commit/966e96ba53fe185c4daab5c3d41a7da381830e43) | `` purescm: avoid `lib.fileset` ``                                                                                                    |
| [`60f26471`](https://github.com/NixOS/nixpkgs/commit/60f2647188bb62193ffe0a5ae75d0df5e58dde53) | `` shopify-cli: avoid `lib.fileset` ``                                                                                                |
| [`c2243741`](https://github.com/NixOS/nixpkgs/commit/c2243741c61f83aac4f949bedadf953a7a6ff8cd) | `` yarn2nix-moretea: avoid `lib.fileset` ``                                                                                           |
| [`594f570a`](https://github.com/NixOS/nixpkgs/commit/594f570a13c5e040fe04d28f500a96213b2c8fa3) | `` tests.testers.shellcheck: avoid `lib.fileset` ``                                                                                   |
| [`90d2fb02`](https://github.com/NixOS/nixpkgs/commit/90d2fb02ed8d3a0fa6c01b7828cb295b4a1c93d7) | `` tests.haskell.setBuildTarget: avoid `lib.fileset` ``                                                                               |
| [`12b236d0`](https://github.com/NixOS/nixpkgs/commit/12b236d05cc3ab1612705f97db61ac6573ec8521) | `` tests.haskell.cabalSdist: avoid `lib.fileset` ``                                                                                   |
| [`dd345d60`](https://github.com/NixOS/nixpkgs/commit/dd345d60ef8d0c0e3867d7717a93ae8e87ec58d9) | `` tests.makeBinaryWrapper: avoid `lib.fileset` ``                                                                                    |
| [`981da4b0`](https://github.com/NixOS/nixpkgs/commit/981da4b0e17ec91b7e4249219f4a48f391fc106d) | `` nixos/test-driver: avoid `lib.fileset` ``                                                                                          |
| [`abee2c99`](https://github.com/NixOS/nixpkgs/commit/abee2c992aaced29f4d748216d0f586a5b0f0923) | `` nixpkgs-manual: avoid `lib.fileset` ``                                                                                             |
| [`8f274251`](https://github.com/NixOS/nixpkgs/commit/8f27425189438546449b1d521d8a4e3c3c488c33) | `` aardvark-dns: 1.13.0 -> 1.13.1 ``                                                                                                  |
| [`b0927628`](https://github.com/NixOS/nixpkgs/commit/b092762836cd6ce10f684a4d6df9e803d68136a6) | `` serie: 0.4.0 -> 0.4.1 ``                                                                                                           |
| [`c940a51e`](https://github.com/NixOS/nixpkgs/commit/c940a51eccb0e7cd74f7fd0a973a7770e05568c0) | `` nixos/coturn: restore logging functionality ``                                                                                     |
| [`aeb13111`](https://github.com/NixOS/nixpkgs/commit/aeb13111910d29be65fb2e5ba7081f7d2bd15fc8) | `` tor-browser: fix desktop icon ``                                                                                                   |
| [`db5a0ad7`](https://github.com/NixOS/nixpkgs/commit/db5a0ad7746e5d07aafa4a262ff1bf49858a4a1e) | `` ci: Label 10.rebuild-*-stdenv (#369102) ``                                                                                         |
| [`fddbd3e9`](https://github.com/NixOS/nixpkgs/commit/fddbd3e9800c214f83674791a883716c168a8539) | `` build(deps): bump actions/upload-artifact from 4.4.3 to 4.5.0 ``                                                                   |
| [`fc3d9f32`](https://github.com/NixOS/nixpkgs/commit/fc3d9f32e24ec17ac59b7b8c95c29b40dcec4737) | `` build(deps): bump actions/create-github-app-token from 1.11.0 to 1.11.1 ``                                                         |
| [`bf9c1332`](https://github.com/NixOS/nixpkgs/commit/bf9c1332ee20c5fd5cf3d25aa84f5d6fd738069d) | `` workflows/eval: evaluate all systems to completion on failure ``                                                                   |
| [`bb3bf668`](https://github.com/NixOS/nixpkgs/commit/bb3bf66877abb73fc6e7e32ce2a9097210e6409e) | `` ci/eval/compare: truncate step summary to 1024k ``                                                                                 |
| [`f775bccc`](https://github.com/NixOS/nixpkgs/commit/f775bccc188863af979e653950919d509336de7b) | `` workflows/eval: Catch empty conclusion ``                                                                                          |
| [`7f0d2b1b`](https://github.com/NixOS/nixpkgs/commit/7f0d2b1b45bf72a8c9324e99b1d22941b8d309ab) | `` ci/eval: Avoid noise for failing attribute evals ``                                                                                |
| [`300a4854`](https://github.com/NixOS/nixpkgs/commit/300a4854ca70bc2ca346ea3d82495a80dca1b973) | `` workflows/eval: Improve debuggabilitiy ``                                                                                          |
| [`c1553b51`](https://github.com/NixOS/nixpkgs/commit/c1553b513e6398c5f7c45f4c924ce15f731a50ef) | `` ci/eval: allow precisely choosing which systems to evaluate for (evalSystem -> evalSystems) ``                                     |
| [`e88b48d2`](https://github.com/NixOS/nixpkgs/commit/e88b48d259bc5eba62d06ccafc7b6c6041cb10c9) | `` ci/eval: add rebuildsByPlatform to the comparison result ``                                                                        |
| [`ff9bb621`](https://github.com/NixOS/nixpkgs/commit/ff9bb621de89c49c579099f5e6197fd9549ac20b) | `` ci/eval: fix compare label assignment ``                                                                                           |
| [`3f4f84fd`](https://github.com/NixOS/nixpkgs/commit/3f4f84fdc78dd7ee6a2019bed430fcf0e4d4fdd7) | `` ci/eval: re-implement compare in nix ``                                                                                            |
| [`1388b51a`](https://github.com/NixOS/nixpkgs/commit/1388b51a482ea907675a25cc7ccbc506e6380cae) | `` build(deps): bump korthout/backport-action from 3.0.2 to 3.1.0 ``                                                                  |
| [`887ea689`](https://github.com/NixOS/nixpkgs/commit/887ea689dac5a7bda1b8068576fd5b6234eaae12) | `` workflows/check-nix-format: Improve error message ``                                                                               |
| [`e30b1368`](https://github.com/NixOS/nixpkgs/commit/e30b136818342b548a4614c5100453193d1a8c0e) | `` ci/check-shell: fix `ci/**` path ``                                                                                                |
| [`5191c1a6`](https://github.com/NixOS/nixpkgs/commit/5191c1a687ec79928a1e253badda2814bd75df75) | `` ci/check-shell: only run if `shell.nix` or `./ci/**` is changed ``                                                                 |
| [`f2280139`](https://github.com/NixOS/nixpkgs/commit/f2280139b398447fa6ec53d9ed254508b1d70ea8) | `` add actionlint script ``                                                                                                           |
| [`934a91c9`](https://github.com/NixOS/nixpkgs/commit/934a91c9b741546fa0734a1a9bfa2804eb6e4a19) | `` ci/check-nixf-tidy: replace sed with variable substitution ``                                                                      |
| [`f80ecb0f`](https://github.com/NixOS/nixpkgs/commit/f80ecb0fdd593550a1db3afb7bca9a1a08270b0d) | `` ci/editorconfig-v2: useless use of cat ``                                                                                          |
| [`770295c2`](https://github.com/NixOS/nixpkgs/commit/770295c2290d0b2773c21b593e8c5754e1fb304c) | `` kdePackages: Plasma 6.2.4 -> 6.2.5 ``                                                                                              |
| [`35eac59f`](https://github.com/NixOS/nixpkgs/commit/35eac59ff29387891fa3262ad779316249ea4897) | `` gh-contribs: 0.9.0 -> 0.10.1 ``                                                                                                    |
| [`644fb7ee`](https://github.com/NixOS/nixpkgs/commit/644fb7ee53672a801943b6d465217e69bb0c486e) | `` restic: fixed handling of arguments with spaces in restic wrappers ``                                                              |
| [`8bdf727b`](https://github.com/NixOS/nixpkgs/commit/8bdf727b6a553b890135b9efb9bd4b979af49eb4) | `` keypunch: 5.0 -> 5.1 (#369797) ``                                                                                                  |
| [`715e7659`](https://github.com/NixOS/nixpkgs/commit/715e7659c7fe5a175b62b7dbf49a62d6021ab941) | `` gnome-secrets: 10.3 -> 10.4 (#369598) ``                                                                                           |
| [`91b74971`](https://github.com/NixOS/nixpkgs/commit/91b74971f4c6e2cae06af84ddcf5f31c3a26713e) | `` [Backport release-24.11] television: 0.7.1 -> 0.8.1 (#369683) ``                                                                   |
| [`f7b11968`](https://github.com/NixOS/nixpkgs/commit/f7b11968ea1d19496487f6afaac99c130a87c1ff) | `` ghostty: 1.0.0 -> 1.0.1 (#369782) ``                                                                                               |
| [`85be2504`](https://github.com/NixOS/nixpkgs/commit/85be2504dce9e0e362ea498cb47139e2903b544f) | `` nixos/hydra: fix hydra-compress-logs choking up on quoting when using zstd ``                                                      |
| [`b2765b7b`](https://github.com/NixOS/nixpkgs/commit/b2765b7bbf4eb3af76ff7601ded4bc5035747107) | `` jellyfin-media-player: added paumr as maintainer ``                                                                                |
| [`7bbab8a8`](https://github.com/NixOS/nixpkgs/commit/7bbab8a8c03e4b47b2aad9fc19bae615f8be2d0f) | `` jellyfin-media-player: 1.10.1 -> 1.11.1 ``                                                                                         |
| [`2af597fd`](https://github.com/NixOS/nixpkgs/commit/2af597fd425f51bc0b4e31f26e2748508e05e778) | `` Revert "jellyfin-media-player: 1.10.1 -> 1.11.1" ``                                                                                |
| [`3c71fdef`](https://github.com/NixOS/nixpkgs/commit/3c71fdeffdc030f114da2cdc69960d49c2128fc8) | `` ente-auth: 4.2.1 -> 4.2.2 ``                                                                                                       |
| [`9d5d1bd7`](https://github.com/NixOS/nixpkgs/commit/9d5d1bd7df8baae558a6f16977eaf11af3be14be) | `` helmsman: add sarcasticadmin as maintainer ``                                                                                      |
| [`6286b344`](https://github.com/NixOS/nixpkgs/commit/6286b34405121f57c06959be037577b1d713f319) | `` helmsman: only build helsman subPackage ``                                                                                         |
| [`ccd72d4a`](https://github.com/NixOS/nixpkgs/commit/ccd72d4a30103a37296d0f8c0d3990d32dc736e2) | `` helmsman: nixfmt-rfc-style ``                                                                                                      |
| [`456360c0`](https://github.com/NixOS/nixpkgs/commit/456360c052ba3890e33455335a4507d554b54160) | `` nixos/taskserver: fix test deprecation warning ``                                                                                  |
| [`86b0031b`](https://github.com/NixOS/nixpkgs/commit/86b0031b6b30fa16c9c9294315611595289e1cef) | `` nixos/taskserver: fix systemd shellcheck warning ``                                                                                |
| [`05e7061e`](https://github.com/NixOS/nixpkgs/commit/05e7061e219476883cf36f19ee98424be4ceff43) | `` slackdump: 2.6.0 -> 2.6.1 ``                                                                                                       |
| [`ba60bb9d`](https://github.com/NixOS/nixpkgs/commit/ba60bb9d1f566aa6ac8e1f7c2883169abd8c0ca1) | `` pdfstudio2023: 2023.0.3->2023.0.4 ``                                                                                               |
| [`125f9978`](https://github.com/NixOS/nixpkgs/commit/125f99789e4e16f8de317110cceca4cbbed6128b) | `` pdfstudio: fix hash mismatch ``                                                                                                    |
| [`300eae78`](https://github.com/NixOS/nixpkgs/commit/300eae7855f6748cc53552661f608bcb25a27227) | `` pdfstudio: format ``                                                                                                               |
| [`c9c7df97`](https://github.com/NixOS/nixpkgs/commit/c9c7df9753e8ac7cebb2ef23456b3e2354f892e8) | `` python312Packages.pgpy: fix build ``                                                                                               |
| [`6f337bd8`](https://github.com/NixOS/nixpkgs/commit/6f337bd841ca23aa4e408f62fb9f294ba2018ae7) | `` evdi: 1.14.7 -> 1.14.8 ``                                                                                                          |
| [`19474b59`](https://github.com/NixOS/nixpkgs/commit/19474b5951c8308befb2e6c6084e84f20c97ce1b) | `` brave: 1.73.101 -> 1.73.104 ``                                                                                                     |
| [`180b82bf`](https://github.com/NixOS/nixpkgs/commit/180b82bfc04a4bddba1b2297a947e962ba077e87) | `` wavebox: 10.131.16-2 -> 10.131.18-2 ``                                                                                             |
| [`8a48e0fe`](https://github.com/NixOS/nixpkgs/commit/8a48e0fee7c2101caabccadf2fbe96e1da969f03) | `` qq: 3.2.15-2024.12.10 -> 3.2.15-2024.12.24 ``                                                                                      |
| [`f67d319a`](https://github.com/NixOS/nixpkgs/commit/f67d319ae07a6c6de71582f2436efd624eb38a88) | `` ghostty: remove references to sources correctly ``                                                                                 |
| [`a83dccb3`](https://github.com/NixOS/nixpkgs/commit/a83dccb3f200eb813240124ba7d231f773d582eb) | `` xcb-imdkit: Enforce & fix under strictDeps ``                                                                                      |
| [`f3f53b0f`](https://github.com/NixOS/nixpkgs/commit/f3f53b0f23888d6040b5f725277385cdb2e2a0bd) | `` ghostty: add nixos tests, add build options, fix x11 backend (#368726) ``                                                          |
| [`6d76a591`](https://github.com/NixOS/nixpkgs/commit/6d76a5917015a20b289b0f6c8bec526c08bf07d9) | `` ghostty: init at 1.0.0 (#368404) ``                                                                                                |
| [`79b82c36`](https://github.com/NixOS/nixpkgs/commit/79b82c3638fb7c4b5408e2a599b0618d8f0bd30e) | `` dxvk_1: fix build compatibility with GCC 14 ``                                                                                     |
| [`6802c42c`](https://github.com/NixOS/nixpkgs/commit/6802c42c2e5d776443df7691d61319b400b6fd3b) | `` nixos/mediawiki: change user in maintenance scripts, use maintenance/run.php script, add deleteUserEmail,importDump,run scripts `` |
| [`e7b1d752`](https://github.com/NixOS/nixpkgs/commit/e7b1d752496c4f6fa0644bfd1750d7ecaa46ef2e) | `` [Backport release-24.11] python312Packages.pkginfo: 1.11.1 -> 1.12.0 ``                                                            |
| [`2d759a9c`](https://github.com/NixOS/nixpkgs/commit/2d759a9cdd50002df3373c7a196f98ae13b6a0fb) | `` komikku: 1.65.0 -> 1.66.0 (#367620) ``                                                                                             |
| [`6bb764f4`](https://github.com/NixOS/nixpkgs/commit/6bb764f40d3797e343cc34a36fe9d7b9800830ee) | `` komikku: 1.64.0 -> 1.65.0 (#362524) ``                                                                                             |
| [`8adf4150`](https://github.com/NixOS/nixpkgs/commit/8adf415091928e26cd9bf6a2003e98380769ba9d) | `` komikku: 1.63.0 -> 1.64.0 ``                                                                                                       |
| [`65d01362`](https://github.com/NixOS/nixpkgs/commit/65d01362b42137140da2c1efe0cb6fa5aa2972de) | `` komikku: 1.62.0 -> 1.63.0 ``                                                                                                       |
| [`9bec4f1c`](https://github.com/NixOS/nixpkgs/commit/9bec4f1c52b091d6c2b8bf4c5d589feae9e46f65) | `` nixosTests.containers-restart_networking: ensure eth1 has no ip addresses ``                                                       |
| [`7e1a2f35`](https://github.com/NixOS/nixpkgs/commit/7e1a2f351d57387264c26696c1a24c4a91bbde97) | `` nixos-containers: add networkNamespace option ``                                                                                   |
| [`94dae69d`](https://github.com/NixOS/nixpkgs/commit/94dae69d1f7c245a4de9a865f15e76c690989cd7) | `` angie: 1.7.0 -> 1.8.0 ``                                                                                                           |