### PR TITLE
chore(flake/hyprland-qtutils): `c77109d7` -> `6997fe38`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -386,11 +386,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1734906472,
-        "narHash": "sha256-pWPRv/GA/X/iAwoE6gMNUqn/ZeJX1IeLPRpZI0tTPK0=",
+        "lastModified": 1736114838,
+        "narHash": "sha256-FxbuGQExtN37ToWYnGmO6weOYN6WPHN/RAqbr7gNPek=",
         "owner": "hyprwm",
         "repo": "hyprland-qtutils",
-        "rev": "c77109d7e1ddbcdb87cafd32ce411f76328ae152",
+        "rev": "6997fe382dcf396704227d2b98ffdd5066da6959",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                   | Message                                   |
| -------------------------------------------------------------------------------------------------------- | ----------------------------------------- |
| [`6997fe38`](https://github.com/hyprwm/hyprland-qtutils/commit/6997fe382dcf396704227d2b98ffdd5066da6959) | `` version: bump to 0.1.2 ``              |
| [`8fcc4436`](https://github.com/hyprwm/hyprland-qtutils/commit/8fcc44363078cfe0686ab88055bf125e353122a8) | `` update-screen: add a support button `` |