### PR TITLE
chore(flake/zen-browser): `489f8476` -> `25a14343`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -749,11 +749,11 @@
         "nixpkgs": "nixpkgs_4"
       },
       "locked": {
-        "lastModified": 1736045622,
-        "narHash": "sha256-+cIdUGhrVEpn2+ImWDVoA9c4jwsWDQnTQh2eUUdhf3M=",
+        "lastModified": 1736104360,
+        "narHash": "sha256-ggBmv/mUWTt4QIsxBnws6By3zutnQNij7u9RSsGACMA=",
         "owner": "0xc000022070",
         "repo": "zen-browser-flake",
-        "rev": "489f8476303231d437ff7676605733d5acbff236",
+        "rev": "25a143434e2cd793ff75747e94923c34c263d3b6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                          | Message                                                       |
| --------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------- |
| [`25a14343`](https://github.com/0xc000022070/zen-browser-flake/commit/25a143434e2cd793ff75747e94923c34c263d3b6) | `` Update Zen Browser twilight @ x86_64 && aarch64 to 1.6t `` |