### PR TITLE
chore(flake/nixpkgs): `d29ab98c` -> `cbd8ec4d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -521,11 +521,11 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1735922141,
-        "narHash": "sha256-vk0xwGZSlvZ/596yxOtsk4gxsIx2VemzdjiU8zhjgWw=",
+        "lastModified": 1736061677,
+        "narHash": "sha256-DjkQPnkAfd7eB522PwnkGhOMuT9QVCZspDpJJYyOj60=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "d29ab98cd4a70a387b8ceea3e930b3340d41ac5a",
+        "rev": "cbd8ec4de4469333c82ff40d057350c30e9f7d36",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                       |
| ---------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------- |
| [`8e55ea23`](https://github.com/NixOS/nixpkgs/commit/8e55ea2332a4cd84c76535371d05f5cbbafa2232) | `` pcmciaUtils: Fix udev rule path ``                                         |
| [`f8c83f45`](https://github.com/NixOS/nixpkgs/commit/f8c83f45ccdcc619c4731cf30fac8e10b6dacdaf) | `` nixos/hardware.pcmcia: Fix passthru.function usage ``                      |
| [`88cfc31a`](https://github.com/NixOS/nixpkgs/commit/88cfc31aeff59d9580aba360677bd229e0ebe3e8) | `` Revert "[Backport release-24.11] atf: 0.21-unstable-2021-09-01 -> 0.22" `` |
| [`1c789a34`](https://github.com/NixOS/nixpkgs/commit/1c789a347a66e013880b5671b34480eb0c0d0b60) | `` linuxPackages_latest.prl-tools: 20.1.2-55742 -> 20.1.3-55743 ``            |
| [`55b430a3`](https://github.com/NixOS/nixpkgs/commit/55b430a3f48173819d6244736657ee0fa964d3b0) | `` dtbloader : improve ``                                                     |
| [`6f5ad5b9`](https://github.com/NixOS/nixpkgs/commit/6f5ad5b983d4df04bc9d93a6a3d8e29a339695cb) | `` google-chrome: 131.0.6778.139 -> 131.0.6778.204 ``                         |
| [`c25dae81`](https://github.com/NixOS/nixpkgs/commit/c25dae8185889e1dce6d5a8f111e24e2a0c8cf8b) | `` legcord: 1.0.5 -> 1.0.6 ``                                                 |
| [`f247dc37`](https://github.com/NixOS/nixpkgs/commit/f247dc37f7b1785aca7599988770da7a3e5e1b52) | `` nixos/prometheus-exporters/fastly: fix secret handling ``                  |
| [`d21375d5`](https://github.com/NixOS/nixpkgs/commit/d21375d561596e0ccd230969ff5627a09d93b175) | `` nextcloudXXPackages.apps.recognize: add meta.description ``                |
| [`42a829dd`](https://github.com/NixOS/nixpkgs/commit/42a829dd4439d5217f04206efe01df1a4ffa2349) | `` nextcloudXXPackages.apps.recognize: use lib.{getExe,getDev}, ``            |
| [`44eff79c`](https://github.com/NixOS/nixpkgs/commit/44eff79cd31cb79134989c7b9f315f391440d035) | `` subtitlecomposer: ffmpeg_6 as dependency ``                                |
| [`d2f9db8b`](https://github.com/NixOS/nixpkgs/commit/d2f9db8be3572587ac5ef25101418e34691fa307) | `` alttpr-opentracker: 1.8.5 -> 1.8.6 ``                                      |
| [`7cc7a3e6`](https://github.com/NixOS/nixpkgs/commit/7cc7a3e6f7dd99fdf1051d9064399d038316d6ab) | `` ilspycmd: simplify hostPlatform checks ``                                  |
| [`8d8fad23`](https://github.com/NixOS/nixpkgs/commit/8d8fad23abd87360b0022d560c96cbd4d50ee78c) | `` formula: simplify postFixup ``                                             |
| [`aa18b9e6`](https://github.com/NixOS/nixpkgs/commit/aa18b9e6a8b462627afc1f102e088a071fbef046) | `` knossosnet: upgrade to .NET 8 ``                                           |
| [`331a6f7e`](https://github.com/NixOS/nixpkgs/commit/331a6f7e856912dc1af7a6cbc62a9743c8fbd633) | `` inklecate: upgrade to .NET 8 ``                                            |
| [`e6792a9f`](https://github.com/NixOS/nixpkgs/commit/e6792a9f49f9ea7307ca5a063d4228bd5a9a7087) | `` ilspycmd: 8.0 -> 9.0-preview3 ``                                           |
| [`b5d2802b`](https://github.com/NixOS/nixpkgs/commit/b5d2802b32fa8eca9af6bb4d0532aaa9d0894899) | `` ilspycmd: format file and switch to finalAttrs ``                          |
| [`f2b7a14d`](https://github.com/NixOS/nixpkgs/commit/f2b7a14d88d7e3957d75eda83e73fe865b606e45) | `` formula: upgrade to .NET 8 ``                                              |
| [`01b2f47e`](https://github.com/NixOS/nixpkgs/commit/01b2f47e2920f7f91c84e13bd0847f3ec44250c7) | `` formula: format file ``                                                    |
| [`7c17d449`](https://github.com/NixOS/nixpkgs/commit/7c17d449c6b0d2ec49fd798452af27de404ed7bd) | `` dafny: upgrade to .NET 8 ``                                                |
| [`deb8bff5`](https://github.com/NixOS/nixpkgs/commit/deb8bff581a58d9b4a45c006bdd02fbd8c795a0a) | `` clr-loader: upgrade to .NET 8 ``                                           |
| [`fb17297d`](https://github.com/NixOS/nixpkgs/commit/fb17297d2e1a48e11d5d245a70ba27bf41240a5d) | `` avalonia-ilspy: upgrade to .NET 8 ``                                       |
| [`70e1c6fd`](https://github.com/NixOS/nixpkgs/commit/70e1c6fde66e99520388608bc8fa6dbf7a73c996) | `` avalonia-ilspy: format file ``                                             |
| [`0c42a711`](https://github.com/NixOS/nixpkgs/commit/0c42a711d12cfc17e04d8b856adf2903c8d70e51) | `` am2rlauncher: upgrade to .NET 8 ``                                         |
| [`6b580e7b`](https://github.com/NixOS/nixpkgs/commit/6b580e7b5bf0ce1d52683e51c43e51205c768454) | `` nixos/oci-containers: option to set the service name of a oci-container `` |
| [`d9452609`](https://github.com/NixOS/nixpkgs/commit/d9452609f4966dda483b85fa0ae2264d4d4e06bb) | `` gitea: drop myself (ma27) from maintainer list ``                          |
| [`a5db6153`](https://github.com/NixOS/nixpkgs/commit/a5db6153d76e2e0074e52d7926d9e547538295d6) | `` sage: backport Darwin sandbox locale fix ``                                |
| [`d5317ca8`](https://github.com/NixOS/nixpkgs/commit/d5317ca800b66ae645e1198d68b944c40fc9427c) | `` dependency-track: pin nodejs_20 for frontend ``                            |
| [`a3bee4eb`](https://github.com/NixOS/nixpkgs/commit/a3bee4ebae94164263b041b1d9609aa0fa5552c6) | `` atf: 0.21-unstable-2021-09-01 -> 0.22 ``                                   |
| [`613063ea`](https://github.com/NixOS/nixpkgs/commit/613063ea7a76fb6bb5af23dff30f05ca6de23368) | `` navidrome: 0.53.3 -> 0.54.3 ``                                             |
| [`0150d321`](https://github.com/NixOS/nixpkgs/commit/0150d321bd09fded3d90bbc7c0a8c1c2da400682) | `` nix-forecast: fix meta.changelog ``                                        |
| [`408458dc`](https://github.com/NixOS/nixpkgs/commit/408458dc18bd1e7a4f3d54346cd1c0616a791d7b) | `` nix-forecast: 0.1.0 -> 0.2.0 ``                                            |
| [`c6b77530`](https://github.com/NixOS/nixpkgs/commit/c6b775300b0f637db3e92c768fa294de18e7765c) | `` nix-forecast: add updateScript ``                                          |
| [`19b9e1a1`](https://github.com/NixOS/nixpkgs/commit/19b9e1a13bfaebe06d82ea14c17c30b22f49907c) | `` broot: 1.44.3 -> 1.44.4 ``                                                 |
| [`4c066f4a`](https://github.com/NixOS/nixpkgs/commit/4c066f4a9b740bcddd58b7b782f4a7b9ceef8963) | `` broot: 1.44.2 -> 1.44.3 ``                                                 |
| [`3f77e199`](https://github.com/NixOS/nixpkgs/commit/3f77e1997600688e4a7f1aa983f550d1e496023f) | `` broot: format ``                                                           |
| [`78803e31`](https://github.com/NixOS/nixpkgs/commit/78803e319510255283c071741a111c68ef261d00) | `` broot: modernize (#362840) ``                                              |
| [`53c4b477`](https://github.com/NixOS/nixpkgs/commit/53c4b47799192cd31b7addf50d64e3e81a2d5789) | `` broot: 1.44.1 -> 1.44.2 ``                                                 |
| [`a49dbd7e`](https://github.com/NixOS/nixpkgs/commit/a49dbd7e2676c0d0ac5c40fda9a46fc5e0e4614a) | `` Revert "treewide: format all inactive Nix files" for broot ``              |
| [`32764e9d`](https://github.com/NixOS/nixpkgs/commit/32764e9d2a1783e0d73b125cd2da38e31627b045) | `` komikku: 1.66.0 -> 1.67.0 ``                                               |
| [`6f29340f`](https://github.com/NixOS/nixpkgs/commit/6f29340f4b9deb13a6196f81f7fcc55c68384b2f) | `` fetchFromGitLab: passthru `rev` based on `tag` ``                          |
| [`882893de`](https://github.com/NixOS/nixpkgs/commit/882893deada777c7d93259c2a1ab02fea36076cc) | `` fetchFromGitHub: passthru `rev` based on `tag` ``                          |
| [`47d60796`](https://github.com/NixOS/nixpkgs/commit/47d60796dc2da619f8d2cd0a509d73636dae1ae1) | `` fetchgit: passthru `tag` ``                                                |
| [`24059844`](https://github.com/NixOS/nixpkgs/commit/24059844111bc3d35de9ddea077c3cd80bb428a9) | `` virtualbox: fix X11 shared clipboard ``                                    |
| [`a35d09ed`](https://github.com/NixOS/nixpkgs/commit/a35d09ed1ec36baa729fb8176483e3cf9bc32e95) | `` element-web: escape JSON string ``                                         |
| [`8ab38ea7`](https://github.com/NixOS/nixpkgs/commit/8ab38ea7327e39ef74d9c5a6a60d79dabec74c21) | `` .github/workflows/ofborg-pending.yml: delete (#370427) ``                  |
| [`9324adf5`](https://github.com/NixOS/nixpkgs/commit/9324adf5f17b0665891d7b383aab2a8c92d4862d) | `` audiobookshelf: 2.17.5 -> 2.17.7 ``                                        |
| [`2f0ae4b3`](https://github.com/NixOS/nixpkgs/commit/2f0ae4b37bcf912c3dd548cda9fcb340fdbe28a4) | `` audiobookshelf: 2.17.4 -> 2.17.5 ``                                        |
| [`52399202`](https://github.com/NixOS/nixpkgs/commit/52399202cf0725908df5a202618c8b5e3a34e81a) | `` dtbloader: init at 1.2.2 ``                                                |
| [`1442a70f`](https://github.com/NixOS/nixpkgs/commit/1442a70fc82e2ac82c4b33a9dfb1259830f650e7) | `` robotframework-tidy: 4.14.0 -> 4.15.0 ``                                   |
| [`b6d156fb`](https://github.com/NixOS/nixpkgs/commit/b6d156fbe5789c2cffc249aeedb34512dd53d7a5) | `` openafs: 1.8.13 → 1.8.13.1 ``                                              |
| [`e663d152`](https://github.com/NixOS/nixpkgs/commit/e663d152315969daf00681fd49f9a03a0b5fe644) | `` regripper: 0-unstable-2024-11-02 -> 0-unstable-2024-12-12 ``               |
| [`1a37f6c9`](https://github.com/NixOS/nixpkgs/commit/1a37f6c914db3a5f6a1246bd8e78c1a1beb0269b) | `` regripper: fix perl libs not in path ``                                    |
| [`9fb557e8`](https://github.com/NixOS/nixpkgs/commit/9fb557e8f749febe479c33b159ae5fefcaee75a8) | `` lock: 1.3.6 -> 1.3.7 ``                                                    |
| [`13dba9f3`](https://github.com/NixOS/nixpkgs/commit/13dba9f32a16a1b728eb9bf9d4b3696a105c1ca6) | `` gdal: switch to openexr_3 ``                                               |
| [`c4acd137`](https://github.com/NixOS/nixpkgs/commit/c4acd137725e6dbb3bcd265c1d6e3c5993214e53) | `` xapian: 1.4.26 -> 1.4.27 ``                                                |
| [`3554cc8b`](https://github.com/NixOS/nixpkgs/commit/3554cc8bc6ec249e572da9dee371532ab9961119) | `` nextcloud30Packages.apps.recognize: s/buildInputs/nativeBuildInputs/ ``    |
| [`2b8e1ae3`](https://github.com/NixOS/nixpkgs/commit/2b8e1ae375fc57f3fb303c73ac978777da57767c) | `` nextcloudXXPackages.apps.recognize: use python3 rather than 311 ``         |
| [`b32bd407`](https://github.com/NixOS/nixpkgs/commit/b32bd407a1ba4f2295be9833e6a60e17feabaa34) | ``  nextcloudXXPackages.apps.recognize: use node from path ``                 |
| [`d9f8ad0b`](https://github.com/NixOS/nixpkgs/commit/d9f8ad0b07a5c5f2f3dc9f14c490f0eb45c8e43e) | `` nextcloud30Packages.apps.recognize: patchPhase -> postPatch ``             |
| [`4558543f`](https://github.com/NixOS/nixpkgs/commit/4558543f8b27f176bf7d2aa29bf8856bb781efbf) | `` nextcloudXXPackages.apps.recognize: suport nextcloud 29 and 28 ``          |
| [`7109bb49`](https://github.com/NixOS/nixpkgs/commit/7109bb4913dcf76df9cafea35c81fdbe3e9e9e1c) | `` nextcloud30Packages.apps.recognize: 8.1.1->8.2.0 ``                        |
| [`670feab6`](https://github.com/NixOS/nixpkgs/commit/670feab6dd1e3e79834c4ebc8e68db0b7cecad90) | `` nextcloud30Packages.apps.recognize: make tensorflow optional ``            |
| [`f9dbb936`](https://github.com/NixOS/nixpkgs/commit/f9dbb9361af8a59849c931e239d721a270a6ccca) | `` nextcloud30Packages.apps.recognize: explain tensorflow version ``          |
| [`77ef61da`](https://github.com/NixOS/nixpkgs/commit/77ef61daa2ebd37185b263a155fcc39d919aeea0) | `` nextcloud30Packages.apps.recognize: simplify tar extractions ``            |
| [`243907e8`](https://github.com/NixOS/nixpkgs/commit/243907e8f3c1b8abd901f71d497c84c749c9f9d4) | `` nextcloud30Packages.apps.recognize: ensure node_binary is replaced ``      |
| [`7b02b2b6`](https://github.com/NixOS/nixpkgs/commit/7b02b2b660b4301cea44d7bf39a7eeddc6a07573) | `` nextcloud: remove useless ... ``                                           |
| [`c5c99e0b`](https://github.com/NixOS/nixpkgs/commit/c5c99e0b7860351315df179b2b3489226cae3b49) | `` nextcloud: add ffmpeg to recognize for recognizing video and audio ``      |
| [`6873d56c`](https://github.com/NixOS/nixpkgs/commit/6873d56cc7c3bb874f46068f03742986c777878c) | `` nextcloud: add recognize app for nextcloud ``                              |
| [`a56d62a7`](https://github.com/NixOS/nixpkgs/commit/a56d62a7f3a34b785354a36098b63553a3f0c0bd) | `` nextcloud: refactor path out of all-packages ``                            |