### PR TITLE
chore(flake/zen-browser): `25a14343` -> `24db8ca6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -749,11 +749,11 @@
         "nixpkgs": "nixpkgs_4"
       },
       "locked": {
-        "lastModified": 1736104360,
-        "narHash": "sha256-ggBmv/mUWTt4QIsxBnws6By3zutnQNij7u9RSsGACMA=",
+        "lastModified": 1736137294,
+        "narHash": "sha256-qnUZVq1WZr1NyqpsPBZwF38whX5xn0OIzlJGKlUeLAQ=",
         "owner": "0xc000022070",
         "repo": "zen-browser-flake",
-        "rev": "25a143434e2cd793ff75747e94923c34c263d3b6",
+        "rev": "24db8ca6fd32116d06662e7676832f0973a7bffc",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                          | Message                                                       |
| --------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------- |
| [`24db8ca6`](https://github.com/0xc000022070/zen-browser-flake/commit/24db8ca6fd32116d06662e7676832f0973a7bffc) | `` Update Zen Browser twilight @ x86_64 && aarch64 to 1.6t `` |
| [`b22d3100`](https://github.com/0xc000022070/zen-browser-flake/commit/b22d31002ba6d9e409fe5d94977a940916b5351f) | `` Update Zen Browser twilight @ x86_64 && aarch64 to 1.6t `` |