### PR TITLE
chore(flake/nix-gaming): `c94feb62` -> `3d29fbfd`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -462,11 +462,11 @@
         "umu": "umu"
       },
       "locked": {
-        "lastModified": 1736127863,
-        "narHash": "sha256-ojmsjlPRzxQp5tAvFRbCXxd94M95bgTgMN7iWIRjlBU=",
+        "lastModified": 1736246920,
+        "narHash": "sha256-jdY1zkAWz3g3KwaKtBIe7wCU00W0DP+fFbJ3BXvmxmk=",
         "owner": "fufexan",
         "repo": "nix-gaming",
-        "rev": "c94feb626623183da1121d9849f1af2de3dca66f",
+        "rev": "3d29fbfd66c3a386a25fa0b86de91f887ea30ea6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                              | Message                                |
| --------------------------------------------------------------------------------------------------- | -------------------------------------- |
| [`3d29fbfd`](https://github.com/fufexan/nix-gaming/commit/3d29fbfd66c3a386a25fa0b86de91f887ea30ea6) | `` wine: use gcc13 for stdenv_32bit `` |