### PR TITLE
chore(flake/zen-browser): `24db8ca6` -> `c96c6a1e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -766,11 +766,11 @@
         "nixpkgs": "nixpkgs_4"
       },
       "locked": {
-        "lastModified": 1736137294,
-        "narHash": "sha256-qnUZVq1WZr1NyqpsPBZwF38whX5xn0OIzlJGKlUeLAQ=",
+        "lastModified": 1736267677,
+        "narHash": "sha256-7FH/gFShKOzf46yKqA4VWAaWxuyHBRnXOdaffbTxVo4=",
         "owner": "0xc000022070",
         "repo": "zen-browser-flake",
-        "rev": "24db8ca6fd32116d06662e7676832f0973a7bffc",
+        "rev": "c96c6a1ebf1bea782f9528dc316d986a6087ebc0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                          | Message                                                       |
| --------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------- |
| [`c96c6a1e`](https://github.com/0xc000022070/zen-browser-flake/commit/c96c6a1ebf1bea782f9528dc316d986a6087ebc0) | `` Update Zen Browser twilight @ x86_64 && aarch64 to 1.6t `` |
| [`d1bb2a67`](https://github.com/0xc000022070/zen-browser-flake/commit/d1bb2a67c6bb4960390aa00112269e7243cfaa11) | `` Update Zen Browser twilight @ x86_64 && aarch64 to 1.6t `` |