### PR TITLE
chore(flake/nixpkgs): `cbd8ec4d` -> `3f0a8ac2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -537,11 +537,11 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1736061677,
-        "narHash": "sha256-DjkQPnkAfd7eB522PwnkGhOMuT9QVCZspDpJJYyOj60=",
+        "lastModified": 1736200483,
+        "narHash": "sha256-JO+lFN2HsCwSLMUWXHeOad6QUxOuwe9UOAF/iSl1J4I=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "cbd8ec4de4469333c82ff40d057350c30e9f7d36",
+        "rev": "3f0a8ac25fb674611b98089ca3a5dd6480175751",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                     |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------- |
| [`3f0a8ac2`](https://github.com/NixOS/nixpkgs/commit/3f0a8ac25fb674611b98089ca3a5dd6480175751) | `` nixos/dhcpcd: fix updating resolv.conf when using systemd-resolved ``                    |
| [`772d5a29`](https://github.com/NixOS/nixpkgs/commit/772d5a297fe8262a6987b985412169f6feaeceb0) | `` nixos/homepage-dashboard: fix stale cache issue ``                                       |
| [`6f17a8c3`](https://github.com/NixOS/nixpkgs/commit/6f17a8c3778e5263640ca9c48ef1e2ab00695330) | `` homepage-dashboard: prefix nixpkgs-specific env var with NIXPKGS_ ``                     |
| [`619747c9`](https://github.com/NixOS/nixpkgs/commit/619747c9b70176baf788ec33808784363a6db89b) | `` shufflecake: 0.4.4 -> 0.5.1 ``                                                           |
| [`ebe67227`](https://github.com/NixOS/nixpkgs/commit/ebe6722742e1a2d81d0e5e6ecab01eab76e8d305) | `` python312Packages.ibm-cloud-sdk-core: 3.21.0 -> 3.22.0 ``                                |
| [`463826fd`](https://github.com/NixOS/nixpkgs/commit/463826fd345ac2a4dd46044ecc322ba764e6a5cd) | `` postgresqlPackages.pg_partman: 5.2.2 -> 5.2.4 ``                                         |
| [`cc6fdab0`](https://github.com/NixOS/nixpkgs/commit/cc6fdab04059919ac95c502cfc21706bcb67cef8) | `` tetragon: 0.1.1 -> 1.2.0 ``                                                              |
| [`dde326c2`](https://github.com/NixOS/nixpkgs/commit/dde326c237b090e342c63a83c35e07dc06fa386e) | `` firefox: extend compile flag "--enable-lto=cross" with parameter "full" ``               |
| [`8354760b`](https://github.com/NixOS/nixpkgs/commit/8354760b479ec9d27a660c11084cbc7d0ea7115a) | `` manaplus: use badPlatforms instead of broken ``                                          |
| [`80936313`](https://github.com/NixOS/nixpkgs/commit/8093631355ad2406aeba001a7e4854fb5910d285) | `` manaplus: don't use sdl-config ``                                                        |
| [`87cbb471`](https://github.com/NixOS/nixpkgs/commit/87cbb4718a4b4db3984e47e15d8f931993045c13) | `` manaplus: move to pkgs/by-name ``                                                        |
| [`e05eeab0`](https://github.com/NixOS/nixpkgs/commit/e05eeab01dd3d24004396c8587afc54f984d95d3) | `` manaplus: build without internalsdlgfx ``                                                |
| [`4b2ee378`](https://github.com/NixOS/nixpkgs/commit/4b2ee3785ed92bf986bb88f90316dcc2e0b0f0df) | `` manaplus: fix build ``                                                                   |
| [`8063eabd`](https://github.com/NixOS/nixpkgs/commit/8063eabdf88b1f85fb4027e560028a8ff0e8c424) | `` consul: 1.20.1 -> 1.20.2 ``                                                              |
| [`0b8505cd`](https://github.com/NixOS/nixpkgs/commit/0b8505cd7a0a59397efa197f4066e7e9968db2d9) | `` mimir: 2.14.2 -> 2.14.3 ``                                                               |
| [`ac277552`](https://github.com/NixOS/nixpkgs/commit/ac277552dcabae0a2ddb0992161b53a956042aaa) | `` nixos/alsa: add rnhmjoj as maintainer ``                                                 |
| [`8fb9c5fb`](https://github.com/NixOS/nixpkgs/commit/8fb9c5fb95e5497f9feb2750c5a13f1a513d40ec) | `` nixos/tests/firefox: use hardware.alsa ``                                                |
| [`4ae218e6`](https://github.com/NixOS/nixpkgs/commit/4ae218e66f2d46d8f95ee46f496f7bf813962f53) | `` nixos/alsa: rebirth from the ashes ``                                                    |
| [`cab779fb`](https://github.com/NixOS/nixpkgs/commit/cab779fbcc35d1b28b262cf88326a57e0a79fcc4) | `` xrizer: init at 0.1 ``                                                                   |
| [`99827283`](https://github.com/NixOS/nixpkgs/commit/99827283b5be29093d1ba92f4fddf777ba38a048) | `` pnpm_9: 9.15.2 -> 9.15.3 ``                                                              |
| [`af76d3d5`](https://github.com/NixOS/nixpkgs/commit/af76d3d5690e51bd2e4248c85f980d4251b5a3ee) | `` nixos/netbird: fix state directory mode ``                                               |
| [`706e9cbf`](https://github.com/NixOS/nixpkgs/commit/706e9cbfd392317485a63f6e1d974ae8b167b2e7) | `` emacs30.pkgs.aio: Fix build ``                                                           |
| [`4d2aa213`](https://github.com/NixOS/nixpkgs/commit/4d2aa213d4b50d63cc11017ef98675f9d70243a2) | `` dotnet: include sdk name in test names ``                                                |
| [`7ba1acfd`](https://github.com/NixOS/nixpkgs/commit/7ba1acfdb593505c98bf7eca63496cd777c0e2af) | `` dotnet: add VB console tests ``                                                          |
| [`98386a71`](https://github.com/NixOS/nixpkgs/commit/98386a71452416ae3da5fe0c7ac0ffe5d5900fd6) | `` dotnet: extend tests to cover F# in addition to C# ``                                    |
| [`f71f6c63`](https://github.com/NixOS/nixpkgs/commit/f71f6c63804a01631ef1c888e15cdcf67079dc39) | `` [Backport release-24.11]: nixos/jupyter: migrate service to jupyter 7 setup (#371199) `` |
| [`85f22ac1`](https://github.com/NixOS/nixpkgs/commit/85f22ac1be498fb295e5e40e8e5c0fd8a1a24d2b) | `` radare2: 5.9.6 -> 5.9.8 ``                                                               |
| [`c0767577`](https://github.com/NixOS/nixpkgs/commit/c0767577ff8adda973a7cb4b7407e2e4fe1244ee) | `` radare2: use system zlib; fix darwin ``                                                  |
| [`16f590bc`](https://github.com/NixOS/nixpkgs/commit/16f590bcd672396abfdbbff4852bad4aab061ea8) | `` halo: 2.20.12 -> 2.20.13 ``                                                              |
| [`94c5466f`](https://github.com/NixOS/nixpkgs/commit/94c5466f863b83f6ac9dc2bb2cb68a81d31d1639) | `` halo: 2.20.11 -> 2.20.12 ``                                                              |
| [`7fcdc500`](https://github.com/NixOS/nixpkgs/commit/7fcdc50035bb9b9f9d3693d0395cb88d9e6dab02) | `` halo: 2.20.10 -> 2.20.11 ``                                                              |
| [`30ba4774`](https://github.com/NixOS/nixpkgs/commit/30ba47745c1523db8bd728d0931430c799a5f5ff) | `` halo: 2.20.5 -> 2.20.10 ``                                                               |
| [`d8994b1f`](https://github.com/NixOS/nixpkgs/commit/d8994b1f4c617dd888d22a81f436dcc2fa005d1d) | `` libmamba: 2.0.4 -> 2.0.5 ``                                                              |
| [`25331821`](https://github.com/NixOS/nixpkgs/commit/253318213d5e2a38b4d3778108388976af00bd81) | `` n98-magerun2: add versionCheckHook ``                                                    |
| [`c4961f9f`](https://github.com/NixOS/nixpkgs/commit/c4961f9f44909eec6a61db5a6afc6a402b43504b) | `` n98-magerun2: use tag ``                                                                 |
| [`f5662dd8`](https://github.com/NixOS/nixpkgs/commit/f5662dd81b8037e0752e0da775b44f0a828553b6) | `` heroic: update pinned electron version ``                                                |
| [`7a55c37b`](https://github.com/NixOS/nixpkgs/commit/7a55c37b659a2b81840a2f82874d82dcd587dd62) | `` lockbook-desktop: init at 0.9.15 ``                                                      |
| [`77219e24`](https://github.com/NixOS/nixpkgs/commit/77219e247b81fb9f7a59db07ed945cc060387e9e) | `` arpack: add option to use macOS Accelerate ``                                            |
| [`4e36292d`](https://github.com/NixOS/nixpkgs/commit/4e36292d14eaa301eac4a05370f8c5f1c4a1df51) | `` arpack: Enable eigenvalue-problems solver based on ICB and eigen ``                      |
| [`91dfc1f6`](https://github.com/NixOS/nixpkgs/commit/91dfc1f6109dd3ea25b31a2661857e93e4314961) | `` arpack: minor cleanups ``                                                                |
| [`c74d7e38`](https://github.com/NixOS/nixpkgs/commit/c74d7e3846ca2819b8f407c833afa1ee56cd21f9) | `` arpack: use openblas on darwin ``                                                        |
| [`c6763b32`](https://github.com/NixOS/nixpkgs/commit/c6763b326d3ff56f78a822d77498db5432b1b8d9) | `` iterm2: 3.5.10 -> 3.5.11 ``                                                              |
| [`b567e666`](https://github.com/NixOS/nixpkgs/commit/b567e666d2761dcec0426cd412bc33dad8b9d92e) | `` iterm2: format ``                                                                        |
| [`7c8f4f9a`](https://github.com/NixOS/nixpkgs/commit/7c8f4f9ad25fd5e69d28ee35cdada840989c594e) | `` iterm2: 3.5.4 -> 3.5.10 ``                                                               |
| [`3cefd48d`](https://github.com/NixOS/nixpkgs/commit/3cefd48d62563859a36eedccf529a161bc6b1c98) | `` Revert "treewide: format all inactive Nix files" for iterm2 ``                           |
| [`570d0e8e`](https://github.com/NixOS/nixpkgs/commit/570d0e8edc0836657716df8855b80f6c01adb5bb) | `` changedetection-io: 0.48.01 -> 0.48.05 ``                                                |
| [`fc4cb700`](https://github.com/NixOS/nixpkgs/commit/fc4cb7000ef5948c743f31383b985795e6d3d196) | `` changedetection-io: format ``                                                            |
| [`b8308e77`](https://github.com/NixOS/nixpkgs/commit/b8308e779bbdc454e040239a33af5e4624014490) | `` changedetection-io: 0.47.06 -> 0.48.01 ``                                                |
| [`6a4e3039`](https://github.com/NixOS/nixpkgs/commit/6a4e3039d2da35e1d47d6d246b1bb1fe29b87682) | `` Revert "treewide: format all inactive Nix files" for changedetection-io ``               |
| [`671dbc59`](https://github.com/NixOS/nixpkgs/commit/671dbc598d0cdf07aa55a936a48fe6bc7cc45264) | `` headscale: backport BaseDomain and ServerURL checks ``                                   |
| [`559951f4`](https://github.com/NixOS/nixpkgs/commit/559951f480b5a3b8a13620291845044ee834e64b) | `` influxdb: fix build with Rust 1.83 ``                                                    |
| [`f5795644`](https://github.com/NixOS/nixpkgs/commit/f57956444c31305cb798f6d49632d3eb95477ebd) | `` influxdb2: fix libflux compile with Rust 1.83 ``                                         |
| [`1eb59c49`](https://github.com/NixOS/nixpkgs/commit/1eb59c49e763a03f6c2c543b4f9f19c4e8f9728a) | `` patool: 2.4.0 -> 3.1.0 ``                                                                |
| [`e86426ff`](https://github.com/NixOS/nixpkgs/commit/e86426ffca34452814e97b9cd5d188363788f8bc) | `` arpack: add top arpack-mpi attribute ``                                                  |
| [`3245e19c`](https://github.com/NixOS/nixpkgs/commit/3245e19ca1dca46d3e9604e1680c94765a69ade9) | `` arpack: add ISO C bindings ``                                                            |