### PR TITLE
chore(flake/nix-flatpak): `11eb05ac` -> `5f4ec93d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -442,11 +442,11 @@
     },
     "nix-flatpak": {
       "locked": {
-        "lastModified": 1736280283,
-        "narHash": "sha256-YEXPRM6CmjQer/eBtgU9hFUwGq3l62SLkt2G8+fcX5w=",
+        "lastModified": 1736334301,
+        "narHash": "sha256-370z+WLVnD7LrN/SvTCZxPl/XPTshS5NS2dHN4iyK6o=",
         "owner": "gmodena",
         "repo": "nix-flatpak",
-        "rev": "11eb05ac5d54db808158ab6c189206cdfdcde8a6",
+        "rev": "5f4ec93d432cd5288f6fe20d8842dceb5a065885",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                                                                     |
| ---------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------- |
| [`5f4ec93d`](https://github.com/gmodena/nix-flatpak/commit/5f4ec93d432cd5288f6fe20d8842dceb5a065885) | `` Revert "installer: minimize side effects on activation (#132)" (#134) `` |