### PR TITLE
chore(flake/stylix): `f4626fbf` -> `743ad1da`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -642,11 +642,11 @@
         "tinted-tmux": "tinted-tmux"
       },
       "locked": {
-        "lastModified": 1736276220,
-        "narHash": "sha256-plIQVeq7E6VZtgxqpI+QS6vln/NYdUifAzfZfgeqRt8=",
+        "lastModified": 1736300250,
+        "narHash": "sha256-xyEutjs7pWQ7cLqfdTnhvWWeJ136wu6Jlxz5ez4htHE=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "f4626fbf4f0f804e2568e5428d9bbf76f3ddd907",
+        "rev": "743ad1da11fec9711f46c2fcf46e7142da0594cd",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                        | Message                                                             |
| --------------------------------------------------------------------------------------------- | ------------------------------------------------------------------- |
| [`743ad1da`](https://github.com/danth/stylix/commit/743ad1da11fec9711f46c2fcf46e7142da0594cd) | `` ci: update Ubuntu runner to ubuntu-24.04 in Backport workflow `` |
| [`046916b4`](https://github.com/danth/stylix/commit/046916b453aed18ea2c4c48279924fd6c32afb3c) | `` ci: lock Ubuntu runner to ubuntu-22.04 in Backport workflow ``   |
| [`d22e88aa`](https://github.com/danth/stylix/commit/d22e88aa2a16e4fdd506766c07e5e38d604a84ef) | `` treewide: remove redundant empty line in testbeds (#760) ``      |