### PR TITLE
chore(flake/home-manager): `613691f2` -> `bd65bc3c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -359,11 +359,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1735344290,
-        "narHash": "sha256-oJDtWPH1oJT34RJK1FSWjwX4qcGOBRkcNQPD0EbSfNM=",
+        "lastModified": 1736373539,
+        "narHash": "sha256-dinzAqCjenWDxuy+MqUQq0I4zUSfaCvN9rzuCmgMZJY=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "613691f285dad87694c2ba1c9e6298d04736292d",
+        "rev": "bd65bc3cde04c16755955630b344bc9e35272c56",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                         |
| ----------------------------------------------------------------------------------------------------------- | ----------------------------------------------- |
| [`bd65bc3c`](https://github.com/nix-community/home-manager/commit/bd65bc3cde04c16755955630b344bc9e35272c56) | `` ghostty: validate configuration on change `` |
| [`d4b03078`](https://github.com/nix-community/home-manager/commit/d4b030780a3486338177dcc9c2bf06f61d69c599) | `` ghostty: fix configuration for bat syntax `` |
| [`e759746b`](https://github.com/nix-community/home-manager/commit/e759746be4bcc8eb62dddd2c694ed71a54dd3be4) | `` ghostty: add module ``                       |
| [`511143d3`](https://github.com/nix-community/home-manager/commit/511143d3fa7bbb5c4323d4e1c5660a03b07a1a58) | `` gpg: fix hash of test (#6200) ``             |
| [`64e7de90`](https://github.com/nix-community/home-manager/commit/64e7de90ee628dc13fa111fe21eceac50f273113) | `` treewide: change pacien to euxane ``         |