### PR TITLE
chore(flake/nixpkgs-unstable): `8f3e1f80` -> `bffc22eb`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -531,11 +531,11 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1736012469,
-        "narHash": "sha256-/qlNWm/IEVVH7GfgAIyP6EsVZI6zjAx1cV5zNyrs+rI=",
+        "lastModified": 1736344531,
+        "narHash": "sha256-8YVQ9ZbSfuUk2bUf2KRj60NRraLPKPS0Q4QFTbc+c2c=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "8f3e1f807051e32d8c95cd12b9b421623850a34d",
+        "rev": "bffc22eb12172e6db3c5dde9e3e5628f8e3e7912",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                      |
| ---------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------- |
| [`d43b3890`](https://github.com/NixOS/nixpkgs/commit/d43b3890c9777f6641f20210ad774cba4cc325a9) | `` vanillatd, vanillara: cleanup (#372053) ``                                                |
| [`0b162c3d`](https://github.com/NixOS/nixpkgs/commit/0b162c3dbc43d663d20b5b3c72f95bb96420aba0) | `` iso-image: fix output filename ``                                                         |
| [`653c1f69`](https://github.com/NixOS/nixpkgs/commit/653c1f69c3737a26fbe314fb9f6adc3f43e136b1) | `` splitcode: add update script; 0.30.0 -> 0.31.2 ``                                         |
| [`ccfeb0ac`](https://github.com/NixOS/nixpkgs/commit/ccfeb0ac5b7d6a0a43f4e2ec955b3c239c63a4aa) | `` pkgs.formats: add documentation entry for CDN ``                                          |
| [`a739cd98`](https://github.com/NixOS/nixpkgs/commit/a739cd98f9646b4e6900f0946ef4379c806c77ef) | `` python3Packages.llm-ollama: Init at 0.8.1 ``                                              |
| [`8d18b516`](https://github.com/NixOS/nixpkgs/commit/8d18b516a2894c929320a6ab1965d6f19a92e920) | `` docs: init lib.stringsWithDeps.textClosureList (#369776) ``                               |
| [`e849b835`](https://github.com/NixOS/nixpkgs/commit/e849b83590284414a0d53f6bc2ab00e91d3845b3) | `` jabref: fix build ``                                                                      |
| [`4fdc071a`](https://github.com/NixOS/nixpkgs/commit/4fdc071afb675d0426fb8a5fad06b43919bfe9df) | `` python313Packages.connexion: 3.1.0 -> 3.2.0 ``                                            |
| [`24888242`](https://github.com/NixOS/nixpkgs/commit/24888242e28f770b16ecc0848e4ee4533c5358c3) | `` monkeysAudio: 10.86 -> 10.87 ``                                                           |
| [`ac8941d7`](https://github.com/NixOS/nixpkgs/commit/ac8941d77fc7945fd5addc021fe9a93f1a27d09c) | `` coqPackages.hierarchy-builder: 1.7.1 -> 1.8.0 ``                                          |
| [`8210f907`](https://github.com/NixOS/nixpkgs/commit/8210f907cbd83961217008e0e998f5015ca6a7f3) | `` coqPackages.mathcomp-analysis: 1.7.0 -> 1.8.0 ``                                          |
| [`a5a738b0`](https://github.com/NixOS/nixpkgs/commit/a5a738b092e790afce747d3135c85f6188506185) | `` coqPackages.mathcomp: 2.2.0 -> 2.3.0 ``                                                   |
| [`42e7bd8b`](https://github.com/NixOS/nixpkgs/commit/42e7bd8b21de130460042004d71276e0f3fa8230) | `` plemoljp-nf: 2.0.0 -> 2.0.2 ``                                                            |
| [`a18ed3da`](https://github.com/NixOS/nixpkgs/commit/a18ed3da8a4d9e13963947633bb2505ab0f083cf) | `` plemoljp: 2.0.0 -> 2.0.2 ``                                                               |
| [`735c842d`](https://github.com/NixOS/nixpkgs/commit/735c842d0868b21caae269f1b82fa217e0c87284) | `` plemoljp-hs: 2.0.0 -> 2.0.2 ``                                                            |
| [`b3ecbffa`](https://github.com/NixOS/nixpkgs/commit/b3ecbffa39c803992f68d0fd80106ba053390c01) | `` pinact: exclude bin/gen-jsonschema ``                                                     |
| [`6f9d611c`](https://github.com/NixOS/nixpkgs/commit/6f9d611c5e5812a41bde71aac76b16a1fe648a4c) | `` python312Packages.recurring-ical-events: 3.3.4 -> 3.4.0 ``                                |
| [`b405106c`](https://github.com/NixOS/nixpkgs/commit/b405106c05feef222571f531243f2ca1c9c06b38) | `` troubadix: relax pontos ``                                                                |
| [`ac61a8b8`](https://github.com/NixOS/nixpkgs/commit/ac61a8b80ae3d1b112fa73b05ee84205825b5890) | `` hugo: 0.140.1 -> 0.140.2 ``                                                               |
| [`c37011b6`](https://github.com/NixOS/nixpkgs/commit/c37011b656b45f030f7c9bbedb38fda1f264e1f4) | `` pianoteq: 8.3.2 -> 8.4.0 ``                                                               |
| [`b8ff5371`](https://github.com/NixOS/nixpkgs/commit/b8ff537154befc43327e6a2fbd0ebe218b89d617) | `` pianoteq: refactor, bump versions ``                                                      |
| [`bc500a9a`](https://github.com/NixOS/nixpkgs/commit/bc500a9a460cf08b50111274cd523f3e61dcdbf4) | `` python313Packages.pygitguardian: 1.18.0 -> 1.19.0 ``                                      |
| [`f9aaf88e`](https://github.com/NixOS/nixpkgs/commit/f9aaf88e7a76bcff7e1b34d468dc5ce3e8572d4d) | `` python313Packages.pontos: 24.12.4 -> 25.1.0 ``                                            |
| [`d536a9d8`](https://github.com/NixOS/nixpkgs/commit/d536a9d842e42f84297600ae7b7e6c429719f9e3) | `` python313Packages.model-checker: 0.6.10 -> 0.7.1 ``                                       |
| [`3b88af65`](https://github.com/NixOS/nixpkgs/commit/3b88af6546cb08db69c1136453f244ae8a34fb89) | `` python313Packages.model-bakery: 1.20.0 -> 1.20.1 ``                                       |
| [`8e1596fa`](https://github.com/NixOS/nixpkgs/commit/8e1596fa39c9d4d98c5cf28ff84508e95ea4ac08) | `` python313Packages.environs: 11.2.1 -> 14.0.0 ``                                           |
| [`8eeed40e`](https://github.com/NixOS/nixpkgs/commit/8eeed40ea2117741147d83062fd204e0f96eb0ba) | `` python313Packages.tesla-fleet-api: 0.9.4 -> 0.9.5 ``                                      |
| [`48a999d8`](https://github.com/NixOS/nixpkgs/commit/48a999d832c903e16273aae6db4d616af27ae5df) | `` python313Packages.tencentcloud-sdk-python: 3.0.1297 -> 3.0.1298 ``                        |
| [`49fd995d`](https://github.com/NixOS/nixpkgs/commit/49fd995d973e48be07df913575e846efc8a1d81b) | `` tandoor-recipes: add changelog to meta ``                                                 |
| [`9febecc7`](https://github.com/NixOS/nixpkgs/commit/9febecc7611d378e326ce34610cb03607de58b6d) | `` flirt: 0.2.1 -> 0.3 ``                                                                    |
| [`e06c6d8a`](https://github.com/NixOS/nixpkgs/commit/e06c6d8a5a4c76785ae4088b10ed3c359e24ef5e) | `` maintainers: add atagen ``                                                                |
| [`9ce4afe6`](https://github.com/NixOS/nixpkgs/commit/9ce4afe6086683ef314e288882745b2f8009d6d8) | `` oterm: 0.6.9 -> 0.7.3 ``                                                                  |
| [`8c977905`](https://github.com/NixOS/nixpkgs/commit/8c977905cbe4b700830955c1ec86c38f0a808c6b) | `` tandoor-recipes: 1.5.25 -> 1.5.27 ``                                                      |
| [`8a071f04`](https://github.com/NixOS/nixpkgs/commit/8a071f043dfe27b2e2a443552fce5da0b438894d) | `` python312Packages.stringzilla: 3.11.1 -> 3.11.3 ``                                        |
| [`a797d904`](https://github.com/NixOS/nixpkgs/commit/a797d904273728ae6b87276fb2ca6c6828515979) | `` cosmic-store: 1.0.0-alpha.2 -> 1.0.0-alpha.4 (#353840) ``                                 |
| [`dfc2a331`](https://github.com/NixOS/nixpkgs/commit/dfc2a331f2acbcecae02739a68b9a33e61a03a9b) | `` maintainer-list: update gpg key and email for pwnwriter (#372027) ``                      |
| [`c11b5dd2`](https://github.com/NixOS/nixpkgs/commit/c11b5dd2b89bc632389b2d8d2fd183780668a888) | `` vimPlugins.blink-cmp: 0.9.3 -> 0.10.0 ``                                                  |
| [`31c64cd7`](https://github.com/NixOS/nixpkgs/commit/31c64cd7668b1f4345ef4f08c74fb283c720067d) | `` vorbisgain: Add patch for incorrect usage of fprintf() ``                                 |
| [`646113a9`](https://github.com/NixOS/nixpkgs/commit/646113a9ddef513933385a64f6124ddaf7338c5d) | `` vorbisgain: Add patch to fix implicit declaration of isatty() ``                          |
| [`47eeefab`](https://github.com/NixOS/nixpkgs/commit/47eeefaba3b8e2cf0973d2460bbe06a5742a9653) | `` vorbisgain: Remove patchPhase ``                                                          |
| [`f0929100`](https://github.com/NixOS/nixpkgs/commit/f092910034bcf933eb36a55c6eaf46fd53a4dbf2) | `` squeekboard: 1.41.0 -> 1.43.1 ``                                                          |
| [`370293c5`](https://github.com/NixOS/nixpkgs/commit/370293c52b56832d71ffd6a107eda62fc715ba93) | `` protoc-gen-connect-go: 1.17.0 -> 1.18.0 ``                                                |
| [`33560265`](https://github.com/NixOS/nixpkgs/commit/3356026546cafaa6f220e6afca51ec38162f483e) | `` .git-blame-ignore-revs: add tmuxPlugins commit ``                                         |
| [`301266db`](https://github.com/NixOS/nixpkgs/commit/301266db991e291c1bc37b5587cfa14b17f4b0d8) | `` xeol: 0.10.1 -> 0.10.2 ``                                                                 |
| [`a28263ed`](https://github.com/NixOS/nixpkgs/commit/a28263ed7b68f46bcb42fded78842c28df9bea95) | `` diffnav: 0.2.8 -> 0.3.0 ``                                                                |
| [`f133faba`](https://github.com/NixOS/nixpkgs/commit/f133fabacac875164baa585911fb796c11b14470) | `` poetryPlugins.poetry-plugin-shell: 1.0.0 -> 1.0.1 ``                                      |
| [`cb657c16`](https://github.com/NixOS/nixpkgs/commit/cb657c1649c07938c5919c4e49d4fa5a8bc1284d) | `` icloudpd: fix build tool versions ``                                                      |
| [`0ea42389`](https://github.com/NixOS/nixpkgs/commit/0ea42389f71a637013edcda2dfc0513a7402b6da) | `` evcc: 0.132.0 -> 0.132.1 ``                                                               |
| [`8b655a16`](https://github.com/NixOS/nixpkgs/commit/8b655a16680372885154eec33a24bc1ef3a36f07) | `` python313Packages.botocore-stubs: 1.35.93 -> 1.35.94 ``                                   |
| [`c89b9515`](https://github.com/NixOS/nixpkgs/commit/c89b9515ec3f512ba73c718e7196130144520769) | `` python313Packages.boto3-stubs: 1.35.93 -> 1.35.94 ``                                      |
| [`a863b8f1`](https://github.com/NixOS/nixpkgs/commit/a863b8f1968ad49f71ae51cb34c8fa3a6d0203cd) | `` nuclei: 3.3.7 -> 3.3.8 ``                                                                 |
| [`c8c0c925`](https://github.com/NixOS/nixpkgs/commit/c8c0c9252e6df67c8e2f83565b2d30d24fc14aa3) | `` zizmor: 1.0.0 -> 1.0.1 ``                                                                 |
| [`6741ae9f`](https://github.com/NixOS/nixpkgs/commit/6741ae9fa743ef33c24143365770f3fb86be16d0) | `` krohnkite: 0.9.8.4 -> 0.9.8.5 ``                                                          |
| [`1fb9feca`](https://github.com/NixOS/nixpkgs/commit/1fb9feca14ef7b260b644a82c8f8303cb2e6891a) | `` actionlint: 1.7.5 -> 1.7.6 ``                                                             |
| [`306ae380`](https://github.com/NixOS/nixpkgs/commit/306ae38084c30b0423331bd1d6e2ea4d76f9e128) | `` python312Packages.aioautomower: 2024.12.0 -> 2025.1.0 ``                                  |
| [`165e372a`](https://github.com/NixOS/nixpkgs/commit/165e372a15c629efd15e4db3b85ca02324b16413) | `` nixos/doh-server: init ``                                                                 |
| [`b3a9b074`](https://github.com/NixOS/nixpkgs/commit/b3a9b074bd7d08a69b44bbb7dbcdad84c703bd20) | `` wsjtz: init at 2.7.0-rc7-1.43 ``                                                          |
| [`8766f12b`](https://github.com/NixOS/nixpkgs/commit/8766f12b3f0cae24ba5ad2067be02a8e4f88ea0d) | `` python312Packages.meilisearch: 0.33.0 -> 0.33.1 ``                                        |
| [`cd2a21a0`](https://github.com/NixOS/nixpkgs/commit/cd2a21a070ed19c8e47310d11b198fd61493ce85) | `` doc/python: update versions ``                                                            |
| [`59725b22`](https://github.com/NixOS/nixpkgs/commit/59725b22ae5b0f7289cbea91a010f6ca12fe15d3) | `` doc: fix pypy39 removal ``                                                                |
| [`59d9636b`](https://github.com/NixOS/nixpkgs/commit/59d9636bdf0829af4becd4c7776fc153a5d3eded) | `` pyfa: add desktop-item ``                                                                 |
| [`26d37cd5`](https://github.com/NixOS/nixpkgs/commit/26d37cd508b012cf6a7f45bdf2efb5f4f31e9314) | `` debootstrap: move to gnupg ``                                                             |
| [`ba0ca0bc`](https://github.com/NixOS/nixpkgs/commit/ba0ca0bc33b25935e718b253fd676d33b1e1f309) | `` minio-warp: add nix-update-script ``                                                      |
| [`9ba6ea13`](https://github.com/NixOS/nixpkgs/commit/9ba6ea13c329333a2a145823a5fded6195dbf2cb) | `` minio-warp: 1.0.7 -> 1.0.8 ``                                                             |
| [`8f65e949`](https://github.com/NixOS/nixpkgs/commit/8f65e949cf49d97e5cb54d4fe0d5165cc550f403) | `` niri: use useFetchCargoVendor instead of vendoring the lock file ``                       |
| [`9cae1828`](https://github.com/NixOS/nixpkgs/commit/9cae18285d96eb8861d679682936926a2e7d3cf2) | `` home-assistant-custom-components.xiaomi_miot: 1.0.7 -> 1.0.8 ``                           |
| [`bf3495ea`](https://github.com/NixOS/nixpkgs/commit/bf3495ea8a6c6614b27274e0d67d512ef8fc07e7) | `` curseofwar-sdl: set mainProgram ``                                                        |
| [`3e01e22b`](https://github.com/NixOS/nixpkgs/commit/3e01e22b135d25b152af0bb56117301f0b3ab730) | `` pretalx: fix eval ``                                                                      |
| [`efdf4a86`](https://github.com/NixOS/nixpkgs/commit/efdf4a86702f6032ed2db2e01db13eeb1372b40a) | `` nwg-panel: 0.9.58 -> 0.9.59 ``                                                            |
| [`7c94ade5`](https://github.com/NixOS/nixpkgs/commit/7c94ade5df7052bdef805bc30b9d86d420347b05) | `` python313Packages.whispers: adjust inputs ``                                              |
| [`9d5dd054`](https://github.com/NixOS/nixpkgs/commit/9d5dd054329f2cf56b88d242248c66d391a64ab3) | `` python312Packages.jellyfish: 1.0.4 -> 1.1.2 ``                                            |
| [`4193ef17`](https://github.com/NixOS/nixpkgs/commit/4193ef177a52e30f87ab97273cb7160921d2f5ea) | `` discord: bump all versions (#371793) ``                                                   |
| [`64282cb0`](https://github.com/NixOS/nixpkgs/commit/64282cb0118ac9a899777e6514f95687e9ccad4b) | `` python312Packages.ruff: cosmetic change ``                                                |
| [`b33f06bc`](https://github.com/NixOS/nixpkgs/commit/b33f06bcc948229ce9a49d942c3c56e9baf5602a) | `` hyprls: 0.3.0 -> 0.4.1 ``                                                                 |
| [`67e33c07`](https://github.com/NixOS/nixpkgs/commit/67e33c074065a9eedc9135032098a471c7fce665) | `` maintainers/scripts: remove with lib from meta ``                                         |
| [`c7ade740`](https://github.com/NixOS/nixpkgs/commit/c7ade74095791cb632683e81640044460f24eb0d) | `` ente-auth: 4.2.2 -> 4.2.3 ``                                                              |
| [`3fcaaee3`](https://github.com/NixOS/nixpkgs/commit/3fcaaee36bf6487f10deee312e314ccbd9155e1c) | `` virtnbdbackup: init at 2.18 ``                                                            |
| [`3f4fd566`](https://github.com/NixOS/nixpkgs/commit/3f4fd5664aeba5c58fc346c9634ae3dae826cea8) | `` jitsi-meet-electron: fix build ``                                                         |
| [`2b3db55d`](https://github.com/NixOS/nixpkgs/commit/2b3db55d5a6e201d4a71a806fd146105bec6b3d9) | `` os-agent: init at 1.6.0 ``                                                                |
| [`cd464e47`](https://github.com/NixOS/nixpkgs/commit/cd464e4736d8be4c328273eb02a4997c951e59b5) | `` phase-cli: init at 1.18.6 ``                                                              |
| [`80b772f2`](https://github.com/NixOS/nixpkgs/commit/80b772f24775babde12243e1afef3501d7e20045) | `` python312Packages.spacy: unpin numpy ``                                                   |
| [`0cba26e6`](https://github.com/NixOS/nixpkgs/commit/0cba26e6364b519f2e3a6adde9d73b08ff965e1e) | `` python312Packages.wandb: skip failing tests ``                                            |
| [`9c4fe1b2`](https://github.com/NixOS/nixpkgs/commit/9c4fe1b2b55af665f7577f702e2f933f7ffb6f1e) | `` glpi-agent: fix ip ``                                                                     |
| [`40397fbf`](https://github.com/NixOS/nixpkgs/commit/40397fbf15f502b36aa1e57d193fda0b55a30e07) | `` poetryPlugins.poetry-plugin-up: mark broken ``                                            |
| [`005781a4`](https://github.com/NixOS/nixpkgs/commit/005781a4eb834e35711d556e007a1256da2144a9) | `` ticker: 4.7.1 -> 4.8.0 ``                                                                 |
| [`d57a6c19`](https://github.com/NixOS/nixpkgs/commit/d57a6c192e9e35055e8d8c7977bae75f5ba67d1c) | `` freebsd.init: set mainProgram (#371715) ``                                                |
| [`f89d9311`](https://github.com/NixOS/nixpkgs/commit/f89d9311e1c208a93628d39729f1db085c581e18) | `` home-assistant.python.pkgs.pytest-homeassistant-custom-component: 0.13.200 -> 0.13.201 `` |
| [`6235631c`](https://github.com/NixOS/nixpkgs/commit/6235631cdae822fe46369ae06ca47dafc80217ef) | `` python313Packages.homeassistant-stubs: 2025.1.0 -> 2025.1.1 ``                            |
| [`2cecb793`](https://github.com/NixOS/nixpkgs/commit/2cecb7931519c09eb4051c93b7c1ef904f152839) | `` envoy: 1.32.0 -> 1.32.3 ``                                                                |
| [`fac1a241`](https://github.com/NixOS/nixpkgs/commit/fac1a2418174958623a885e1571a1b27ac6fb19c) | `` home-assistant: 2025.1.0 -> 2025.1.1 ``                                                   |
| [`68eab267`](https://github.com/NixOS/nixpkgs/commit/68eab267d2e9f0291e06f1f34db8e11abacf49f7) | `` ucspi-tcp: use debian's 0.88-11 patch set ``                                              |
| [`1fecf7b8`](https://github.com/NixOS/nixpkgs/commit/1fecf7b8c15a211a26a1b203bfa172a2f658229b) | `` python313Packages.zha: 0.0.44 -> 0.0.45 ``                                                |