### PR TITLE
chore(flake/zen-browser): `f2531327` -> `0c7995b4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -792,11 +792,11 @@
         "nixpkgs": "nixpkgs_4"
       },
       "locked": {
-        "lastModified": 1736482852,
-        "narHash": "sha256-QNFyWJE4SE09cbfD9BYEBLPKl97CFBb6VzzDx6cWp7o=",
+        "lastModified": 1736520301,
+        "narHash": "sha256-yfbnywGJyx1n+xRet1P5T+6gOUVSbR0p9XasU/q7XjY=",
         "owner": "0xc000022070",
         "repo": "zen-browser-flake",
-        "rev": "f2531327702eab4b9f134cf6eb236e0f297e42d3",
+        "rev": "0c7995b493e72c642766fa7668651a5351299eb8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                          | Message                                                   |
| --------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------- |
| [`9fb3b89f`](https://github.com/0xc000022070/zen-browser-flake/commit/9fb3b89f075e136160ff4274fc9d744121b8bd57) | `` Update Zen Browser beta @ x86_64 && aarch64 to 1.6b `` |
| [`b02792c3`](https://github.com/0xc000022070/zen-browser-flake/commit/b02792c3b9d20574485c05f4628e50edd217c2bb) | `` fix: new naming scheme ``                              |