### PR TITLE
chore(flake/spicetify-nix): `77fb1ae3` -> `3da50a44`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -634,11 +634,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1736482561,
-        "narHash": "sha256-f4hvN4MF26NIYeFA/H1sVW6KU5X9/jy9l95WrMsNUIU=",
+        "lastModified": 1736568948,
+        "narHash": "sha256-nnaMeMQPDg1GLQPBejn4nBtvQKSRVv64IIPZ7XmX5u0=",
         "owner": "Gerg-L",
         "repo": "spicetify-nix",
-        "rev": "77fb1ae39e0f5c60a7d0bd6ce078b9c56e3356cb",
+        "rev": "3da50a44c6c47b3361e56231123797101892c565",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                    |
| ----------------------------------------------------------------------------------------------------- | -------------------------- |
| [`3da50a44`](https://github.com/Gerg-L/spicetify-nix/commit/3da50a44c6c47b3361e56231123797101892c565) | `` CI update 2025-01-11 `` |