### PR TITLE
chore(flake/nixpkgs-stable): `3f0a8ac2` -> `1dab772d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -529,11 +529,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1736200483,
-        "narHash": "sha256-JO+lFN2HsCwSLMUWXHeOad6QUxOuwe9UOAF/iSl1J4I=",
+        "lastModified": 1736549401,
+        "narHash": "sha256-ibkQrMHxF/7TqAYcQE+tOnIsSEzXmMegzyBWza6uHKM=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "3f0a8ac25fb674611b98089ca3a5dd6480175751",
+        "rev": "1dab772dd4a68a7bba5d9460685547ff8e17d899",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                                           |
| ---------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------- |
| [`3e160f98`](https://github.com/NixOS/nixpkgs/commit/3e160f9883a3dfdd972b93d5c22a3dacd09ce8e7) | `` phpdocumentor: 3.5.3 -> 3.6.0 ``                                                                               |
| [`cb78d9f4`](https://github.com/NixOS/nixpkgs/commit/cb78d9f4d0bba0a4bef7efe13079c84c37b5ad3f) | `` phpdocumentor: switch to buildComposerProject2 ``                                                              |
| [`5cccb547`](https://github.com/NixOS/nixpkgs/commit/5cccb547aaa5775d8a641899f5dfda45c1203580) | `` phpPackages.php-codesniffer: 3.11.0 -> 3.11.2 ``                                                               |
| [`86034dca`](https://github.com/NixOS/nixpkgs/commit/86034dcaaf1e1b1320b21e2fbe5ac771debb2baf) | `` build-support/php: improve PHP builder ``                                                                      |
| [`b7030323`](https://github.com/NixOS/nixpkgs/commit/b7030323fd923a1678665b73c69bdc13562cbf10) | `` phpPackages.php-cs-fixer: 3.64.0 -> 3.67.0 ``                                                                  |
| [`7f896629`](https://github.com/NixOS/nixpkgs/commit/7f896629cc2a0c482d3f050f04fa7d029a80bfb5) | `` phpPackages.phpstan: 1.11.8 -> 2.1.1 ``                                                                        |
| [`fb0d571f`](https://github.com/NixOS/nixpkgs/commit/fb0d571fa3daa820caf51fdb7ae93b5ac23588d1) | `` phpunit: 11.3.6 -> 11.5.2 ``                                                                                   |
| [`f28d1770`](https://github.com/NixOS/nixpkgs/commit/f28d17708d7aa3496bf8e1bd5607b9b2b3b4a3b7) | `` phpPackages.psalm: 5.25.0 -> 5.26.1 ``                                                                         |
| [`494388cc`](https://github.com/NixOS/nixpkgs/commit/494388ccceff429a8dfa7d074f15bc84f2cac861) | `` mullvad-browser: 14.0.3 -> 14.0.4 ``                                                                           |
| [`174f8bb0`](https://github.com/NixOS/nixpkgs/commit/174f8bb0b81d72c9ae5485d3a7cfbaf7acf76fd6) | `` tor-browser: 14.0.3 -> 14.0.4 ``                                                                               |
| [`121167f7`](https://github.com/NixOS/nixpkgs/commit/121167f7a1faedbaddbdd6e61ea76b2515a694f4) | `` phpdocumentor: minor cleanup ``                                                                                |
| [`291da3a2`](https://github.com/NixOS/nixpkgs/commit/291da3a2a07f767af6fe8f10bd004e23c409bf9a) | `` php84Packages.psysh: 0.12.4 -> 0.12.7 ``                                                                       |
| [`41ae527c`](https://github.com/NixOS/nixpkgs/commit/41ae527cd35d380582f97d886b41942a52d96054) | `` php84Packages.composer: 2.8.1 -> 2.8.4 ``                                                                      |
| [`8e459aa8`](https://github.com/NixOS/nixpkgs/commit/8e459aa83f33e267ccdfb7b10fde37f6b9e82129) | `` signal-desktop(darwin): 7.36.0 -> 7.37.0 ``                                                                    |
| [`773d62a4`](https://github.com/NixOS/nixpkgs/commit/773d62a4b4b807aa91e88bc9b405b9069007a074) | `` signal-desktop: 7.36.0 -> 7.37.0 ``                                                                            |
| [`10c020e3`](https://github.com/NixOS/nixpkgs/commit/10c020e351c38eab0ed5ce7977c9a90fa195f405) | `` rose-pine-gtk-theme: unstable-2022-09-01 -> 2.2.0 ``                                                           |
| [`b595d77d`](https://github.com/NixOS/nixpkgs/commit/b595d77d1e07d9617eb12bfbe3fada47c95b6938) | `` lighttpd: 1.4.76 -> 1.4.77 ``                                                                                  |
| [`494901a3`](https://github.com/NixOS/nixpkgs/commit/494901a33465ccbc7f208568270e605e2f995d95) | `` linux_6_6: 6.6.70 -> 6.6.71 ``                                                                                 |
| [`fd4fc737`](https://github.com/NixOS/nixpkgs/commit/fd4fc737e5732f42f8fbf5d2292d79345213fc26) | `` proxysql: 2.6.0 -> 2.6.6 and fix build ``                                                                      |
| [`e8770112`](https://github.com/NixOS/nixpkgs/commit/e87701120156e4beb7bccc138dd4a1e6732d9b50) | `` ungoogled-chromium: 131.0.6778.204 -> 131.0.6778.264 ``                                                        |
| [`1e23a08b`](https://github.com/NixOS/nixpkgs/commit/1e23a08b8f548e24b1a25fc39dfd364cddd3f95e) | `` arouteserver: disable copyright year test ``                                                                   |
| [`661b1067`](https://github.com/NixOS/nixpkgs/commit/661b1067e1f67319f1204faa33059d178b8b2bdb) | `` gitlab: 17.6.2 -> 17.7.1 ``                                                                                    |
| [`108df6d0`](https://github.com/NixOS/nixpkgs/commit/108df6d0009fca6c199f08d501a702a00872fc15) | `` firefoxpwa: remove adamcstephens as maintainer ``                                                              |
| [`a1de110b`](https://github.com/NixOS/nixpkgs/commit/a1de110b6d9ea2d3b828db7867a74a8331854190) | `` firefoxpwa: 2.13.1 -> 2.13.2 ``                                                                                |
| [`2ab35243`](https://github.com/NixOS/nixpkgs/commit/2ab352432693cb32d043b0258d8119a2fad95274) | `` firefoxpwa: 2.12.5 -> 2.13.1 ``                                                                                |
| [`5d076104`](https://github.com/NixOS/nixpkgs/commit/5d0761048cc523ab9860a99888c0f01c3e3480d5) | `` opam: fix opam sandboxing on nixos, cleanup ``                                                                 |
| [`a6378fe8`](https://github.com/NixOS/nixpkgs/commit/a6378fe8cbeb8325fd66a985febf8729b8ee334b) | `` floorp: 11.21.0 -> 11.22.0 ``                                                                                  |
| [`1effaea5`](https://github.com/NixOS/nixpkgs/commit/1effaea5165d95edbcdd3c93803027947d673bfa) | `` linux-firmware: 20241210 -> 20250109 ``                                                                        |
| [`43f5b08e`](https://github.com/NixOS/nixpkgs/commit/43f5b08e988ed6ef32c25dec13bb8a950b6daedc) | `` jetbrains.plugins: update ``                                                                                   |
| [`0dce3fac`](https://github.com/NixOS/nixpkgs/commit/0dce3faca42127386bb08c7fe533b4f73f2ae4c0) | `` jetbrains.idea-community-src: 2024.3.1 -> 2024.3.1.1; jetbrains.pycharm-community-src: 2024.3 -> 2024.3.1.1 `` |
| [`fa33a481`](https://github.com/NixOS/nixpkgs/commit/fa33a4813c15538465e85dad253ba4269eaac333) | `` jetbrains: fix build_maven.py shebang ``                                                                       |
| [`853b5da0`](https://github.com/NixOS/nixpkgs/commit/853b5da0f65be8b301bf8984e87f9d5b9c4356b5) | `` nixos/pam: fixup refactor ``                                                                                   |
| [`e7198210`](https://github.com/NixOS/nixpkgs/commit/e7198210df545f816fe91e706f347cfc81d6400e) | `` linux/hardened/patches/6.6: v6.6.67-hardened1 -> v6.6.69-hardened1 ``                                          |
| [`16bfbffa`](https://github.com/NixOS/nixpkgs/commit/16bfbffa05e22d022a63bb6bb0612a7186e59548) | `` linux/hardened/patches/6.12: v6.12.6-hardened1 -> v6.12.8-hardened1 ``                                         |
| [`f922f2dd`](https://github.com/NixOS/nixpkgs/commit/f922f2dd9da49e506c14f5a6c132171d7fdd2bd1) | `` linux/hardened/patches/6.1: v6.1.121-hardened1 -> v6.1.123-hardened1 ``                                        |
| [`7b5fb898`](https://github.com/NixOS/nixpkgs/commit/7b5fb8982df51f7af4b6d9493ae41e1a88e6fa19) | `` linux-rt_6_1: 6.1.120-rt46 -> 6.1.120-rt47 ``                                                                  |
| [`f158f670`](https://github.com/NixOS/nixpkgs/commit/f158f6709c9ba751985c63bbaa5a9c7737b067d9) | `` linux-rt_5_4: 5.4.285-rt93 -> 5.4.288-rt94 ``                                                                  |
| [`e0b7c80c`](https://github.com/NixOS/nixpkgs/commit/e0b7c80c9ff214e6d33602938c77c1fb9bcb4100) | `` linux_5_4: 5.4.288 -> 5.4.289 ``                                                                               |
| [`099f8a1a`](https://github.com/NixOS/nixpkgs/commit/099f8a1a16a676070d6f39629a86cd3d120eac75) | `` linux_5_10: 5.10.232 -> 5.10.233 ``                                                                            |
| [`8419e3ef`](https://github.com/NixOS/nixpkgs/commit/8419e3ef1620f00d26f94af7e280cc041cb5af26) | `` linux_5_15: 5.15.175 -> 5.15.176 ``                                                                            |
| [`3af7f16d`](https://github.com/NixOS/nixpkgs/commit/3af7f16d4cf8c4b17cdce5b827eb5e910aa1ea71) | `` linux_6_1: 6.1.123 -> 6.1.124 ``                                                                               |
| [`0312d89a`](https://github.com/NixOS/nixpkgs/commit/0312d89af80554aa763b94d5e176d53066ec6ae5) | `` linux_6_6: 6.6.69 -> 6.6.70 ``                                                                                 |
| [`965a721a`](https://github.com/NixOS/nixpkgs/commit/965a721aaf1240b5f5598f511d6d436ab232dbe1) | `` linux_6_12: 6.12.8 -> 6.12.9 ``                                                                                |
| [`9d301a92`](https://github.com/NixOS/nixpkgs/commit/9d301a92268ac1eaadcec2539f347e56eae579d9) | `` linux_testing: 6.13-rc5 -> 6.13-rc6 ``                                                                         |
| [`57cef550`](https://github.com/NixOS/nixpkgs/commit/57cef5500d8475a1a4f115695976430ff88725b1) | `` jetbrains.plugins: update ``                                                                                   |
| [`51dcad5c`](https://github.com/NixOS/nixpkgs/commit/51dcad5c29a5778bf61fad2abcdc3f961c5d9b6a) | `` jetbrains: 2024.3 -> 2024.3.3 ``                                                                               |
| [`e3a865c3`](https://github.com/NixOS/nixpkgs/commit/e3a865c3a7c79a5a203acba5fb0a85d84cb82be2) | `` vimPlugins.vim-stationeers-ic10: init at 2025-01-08 ``                                                         |
| [`c05e24c0`](https://github.com/NixOS/nixpkgs/commit/c05e24c0570ff9c1de50efb68c0323bd4a78202f) | `` OWNERS: add leona to jetbrains ``                                                                              |
| [`21835e32`](https://github.com/NixOS/nixpkgs/commit/21835e323c4456cafca5239543720140066a5216) | `` snac2: 2.67 -> 2.68 ``                                                                                         |
| [`ee4dd164`](https://github.com/NixOS/nixpkgs/commit/ee4dd1642a57c45801dcf6e7607d70c0fc783ec0) | `` jetbrains.plugins: lint fixes ``                                                                               |
| [`6936d2fd`](https://github.com/NixOS/nixpkgs/commit/6936d2fd8a1d159503aaff2e4e09e26bb7fb78a1) | `` jetbrains.plugins: update ``                                                                                   |
| [`87e5fc4b`](https://github.com/NixOS/nixpkgs/commit/87e5fc4b20449b07ced54aa3a1844d3bcd4713f8) | `` jetbrains.plugins: extend update script for source builds ``                                                   |
| [`05be25ad`](https://github.com/NixOS/nixpkgs/commit/05be25ad874e97bd575b7efeaadfb2cd26d43cdc) | `` vscode-extensions.ms-dotnettools.csharp: 2.39.29 -> 2.55.29 ``                                                 |
| [`b58ffaf4`](https://github.com/NixOS/nixpkgs/commit/b58ffaf430f46d5df136f550e2a36f320c1b50db) | `` vscode-extensions.ms-dotnettools.csdevkit: 1.8.14 -> 1.14.14 ``                                                |
| [`031afec1`](https://github.com/NixOS/nixpkgs/commit/031afec17f6b20685687894203441fde26cfcb05) | `` paperjam: init at 1.2.1 ``                                                                                     |
| [`0d08d0f1`](https://github.com/NixOS/nixpkgs/commit/0d08d0f17cb03bb22897c36d16dd734e12590eb5) | `` jetbrains.{idea,pycharm}-community-src: Update readme.md ``                                                    |
| [`c03ea926`](https://github.com/NixOS/nixpkgs/commit/c03ea9266f9abd0b9fc1c0a29e5b7b4d31709544) | `` jetbrains.idea-community-src: 2024.1 -> 2024.3.1, jetbrains.pycharm-community-src: 2024.1 -> 2024.3 ``         |
| [`e5209c12`](https://github.com/NixOS/nixpkgs/commit/e5209c12161c0a32d7c0de12334697fd9c485c83) | `` kotlin: 2.0.0 -> 2.0.21 ``                                                                                     |
| [`997cd5cc`](https://github.com/NixOS/nixpkgs/commit/997cd5cc65eddc46654720cce650f57e31aff6f4) | `` p7zip: 17.05 -> 17.06 ``                                                                                       |
| [`4edbc7c9`](https://github.com/NixOS/nixpkgs/commit/4edbc7c9b3c03df6403b8b5f1ddf2cb688b45889) | `` Add missing include for libxml2 to gnucobol ``                                                                 |
| [`95d7bbf8`](https://github.com/NixOS/nixpkgs/commit/95d7bbf81e0fcda5a2dfdd60dfabe35ff008996a) | `` haskellPackages.cabal-install: suppress error of missing local index ``                                        |
| [`6910c7a5`](https://github.com/NixOS/nixpkgs/commit/6910c7a54ca1f387649ee4a8004ccaca58661a7e) | `` haskellPackages.nspace: disable tests ``                                                                       |
| [`32b1c06b`](https://github.com/NixOS/nixpkgs/commit/32b1c06b4f231b72ae6d390dec3b9bd484c3245b) | `` mypaint: disable tests ``                                                                                      |
| [`79badca8`](https://github.com/NixOS/nixpkgs/commit/79badca82e8795f66058daefe0c6d9eaf42a73da) | `` mypaint: fetchFromGitHub rev -> tag ``                                                                         |
| [`d71dce69`](https://github.com/NixOS/nixpkgs/commit/d71dce691ba80b2fbfbe446026119788c9929aca) | `` mypaint: remove with lib ``                                                                                    |
| [`b063a3d2`](https://github.com/NixOS/nixpkgs/commit/b063a3d2609568eb8257d83338dc2c5f1fff096a) | `` eartag: 0.6.3 -> 0.6.4 ``                                                                                      |
| [`11e576bc`](https://github.com/NixOS/nixpkgs/commit/11e576bc6534600bf5b49db7e9a71bb28dbf62ab) | `` chromium,chromedriver: 131.0.6778.204 -> 131.0.6778.264 ``                                                     |
| [`29cda693`](https://github.com/NixOS/nixpkgs/commit/29cda6937fde13d65af548de5cdc674bf0e2dfe5) | `` python312Packages.python-telegram-bot: 21.7 -> 21.9 (#368217) ``                                               |
| [`4dbf4eca`](https://github.com/NixOS/nixpkgs/commit/4dbf4eca6ae8b69d71dcb43295c57bbb2542bb7c) | `` linux_xanmod_latest: 6.12.7 -> 6.12.8 ``                                                                       |
| [`4e3c5f49`](https://github.com/NixOS/nixpkgs/commit/4e3c5f49ebff4f5c28e803e47eed8553ab386295) | `` linux_xanmod: 6.6.68 -> 6.6.69 ``                                                                              |
| [`534248a1`](https://github.com/NixOS/nixpkgs/commit/534248a10fd9fa3bf893c6510ae86a512b2ffbc4) | `` ente-auth: 4.2.2 -> 4.2.3 ``                                                                                   |
| [`d4c1d4cd`](https://github.com/NixOS/nixpkgs/commit/d4c1d4cd3e5619cfc8bac2bb28967b3649a466c7) | `` niri: use useFetchCargoVendor instead of vendoring the lock file ``                                            |
| [`681d239a`](https://github.com/NixOS/nixpkgs/commit/681d239afc99f44ad59b1eb5a956827711b03e60) | `` television: 0.8.5 -> 0.8.6 ``                                                                                  |
| [`91d6eafe`](https://github.com/NixOS/nixpkgs/commit/91d6eafe761e330614b54d749ec28bf36b4462b6) | `` curseofwar-sdl: set mainProgram ``                                                                             |
| [`7b52f09b`](https://github.com/NixOS/nixpkgs/commit/7b52f09b0130a9e7ff2e71b45c250d2d8eef4211) | `` envoy: 1.32.0 -> 1.32.3 ``                                                                                     |
| [`61f59a3f`](https://github.com/NixOS/nixpkgs/commit/61f59a3fff3226a713676ad458ac98a7b0f19310) | `` envoy: disable "-Werror" in protobuf ``                                                                        |
| [`2ce2a3da`](https://github.com/NixOS/nixpkgs/commit/2ce2a3da65fb663492a4e1ff78518d5f29db624b) | `` envoy: fix build ``                                                                                            |
| [`fd183212`](https://github.com/NixOS/nixpkgs/commit/fd183212d40bdcf664e4e7e0894ede18d2d88abe) | `` snipe-it: 7.0.13 -> 7.1.15 ``                                                                                  |
| [`4b81ffbd`](https://github.com/NixOS/nixpkgs/commit/4b81ffbd3f0d6d390d9a67a385d8dbc767549cb8) | `` discord: bump all versions (#371793) ``                                                                        |
| [`1b9d3a95`](https://github.com/NixOS/nixpkgs/commit/1b9d3a95882819b37f4761521e55cbf3450e4a3b) | `` discord-development: 0.0.56 -> 0.0.60 ``                                                                       |
| [`dc835030`](https://github.com/NixOS/nixpkgs/commit/dc835030f129be4dda77fa96612bf0a74d10ef91) | `` glpi-agent: fix ip ``                                                                                          |
| [`6f9860ba`](https://github.com/NixOS/nixpkgs/commit/6f9860ba2335a290d1798b8ecd791b54a8917b6b) | `` firefox-esr-128-unwrapped: 128.5.2esr -> 128.6.0esr ``                                                         |
| [`e74ad75c`](https://github.com/NixOS/nixpkgs/commit/e74ad75c111fa5a3dc7c5343ea23665e88c3462d) | `` firefox-bin-unwrapped: 133.0.3 -> 134.0 ``                                                                     |
| [`100457a3`](https://github.com/NixOS/nixpkgs/commit/100457a3aaee297fe9a039a3d7c00f160708c66b) | `` firefox-unwrapped: 133.0.3 -> 134.0 ``                                                                         |
| [`fa4d6cde`](https://github.com/NixOS/nixpkgs/commit/fa4d6cde4fa5b7f12b2d3f32408cd6202d61a45f) | `` buildMozillaMach: use icu74 from version 134.0 ``                                                              |
| [`10f505da`](https://github.com/NixOS/nixpkgs/commit/10f505dae613d2bf1a28b5ab08e91b031a26ed1b) | `` amdvlk: 2024.Q4.2 -> 2024.Q4.3 ``                                                                              |
| [`ff86cf8d`](https://github.com/NixOS/nixpkgs/commit/ff86cf8d3f2c148f70b1a739bf96f506b1848590) | `` amdvlk: use nix-update-script ``                                                                               |
| [`fc05c822`](https://github.com/NixOS/nixpkgs/commit/fc05c82218f04caf4cb57c4895010591030ce2b9) | `` buildMozillaMach: update patch range for Python 3.12.8 compat issue ``                                         |
| [`a96e2287`](https://github.com/NixOS/nixpkgs/commit/a96e2287bf633fa9cd2b8c76089184d0372becd6) | `` buildMozillaMach: patch compat with python 3.12.8/3.13.1 ``                                                    |
| [`b706ecc0`](https://github.com/NixOS/nixpkgs/commit/b706ecc0190b5a9dde55882532200673b68f73a6) | `` koboldcpp: 1.80.3 -> 1.81 ``                                                                                   |
| [`f8f14ebd`](https://github.com/NixOS/nixpkgs/commit/f8f14ebdcd1a1de3f2552f1bc704739ff5714ba9) | `` duplicity: fix darwin build ``                                                                                 |
| [`e608ca17`](https://github.com/NixOS/nixpkgs/commit/e608ca175b007eaac9bfac0d8fd8d0b95e70a924) | `` elan: fix for Lean >= 4.16.0 ``                                                                                |
| [`af48e73f`](https://github.com/NixOS/nixpkgs/commit/af48e73f2f2c5a0b97dbd38d5baec7e3402f2f14) | `` mattermost: build webapp from source ``                                                                        |
| [`b032c048`](https://github.com/NixOS/nixpkgs/commit/b032c0484032044d53b63770fd029339e841f87e) | `` super-slicer: fix build with GCC 14 ``                                                                         |
| [`83042f62`](https://github.com/NixOS/nixpkgs/commit/83042f62032c3c0bb6643a30a386bcd2a65580cb) | `` corretto{11,17,21}: {11.0.24.8.1,17.0.12.7.1,21.0.4.7.1} -> {11.0.25.9.1,17.0.13.11.1,21.0.5.11.1} ``          |
| [`ae59c801`](https://github.com/NixOS/nixpkgs/commit/ae59c8016c09659cae17a85d529401ef55d93bec) | `` python312Packages.opensearch-py: fix build ``                                                                  |
| [`0f54e876`](https://github.com/NixOS/nixpkgs/commit/0f54e8762da96d304d64cd0469bd63ef48a9cca2) | `` mountpoint-s3: 1.12.0 -> 1.13.0 ``                                                                             |
| [`a5184869`](https://github.com/NixOS/nixpkgs/commit/a51848695602d39afbc6a6adb1793cd8f57a0bc6) | `` mountpoint-s3: 1.10.0 -> 1.12.0 ``                                                                             |
| [`899fe7f6`](https://github.com/NixOS/nixpkgs/commit/899fe7f677dc49680ed726926a1c07974bd70ea2) | `` libphidget22: 1.20.20240909 -> 1.21.20241122 ``                                                                |
| [`39417f92`](https://github.com/NixOS/nixpkgs/commit/39417f92546a585c5960f6d28fd672c338b691ee) | `` libphidget22: 0-unstable-2024-04-11 -> 1.20.20240909 ``                                                        |
| [`c51788e7`](https://github.com/NixOS/nixpkgs/commit/c51788e7454d89db0efa34566e46fac63558e6de) | `` qtcreator: 14.0.2 -> 15.0.0 ``                                                                                 |
| [`a8540c71`](https://github.com/NixOS/nixpkgs/commit/a8540c71beb3d0119a0325a53579c4a3a3e1b6d1) | `` pdm: 2.19.3 -> 2.22.1 ``                                                                                       |
| [`c4a5f18a`](https://github.com/NixOS/nixpkgs/commit/c4a5f18a3f1ec3fc9ebfa227fd163ee676dc42fa) | `` labelle: 1.2.3 --> 1.3.2 ``                                                                                    |
| [`0788ee20`](https://github.com/NixOS/nixpkgs/commit/0788ee20d259030b65c14cea14b62cee40ee33b2) | `` python312Packages.httpie: disable failing test ``                                                              |
| [`153f344e`](https://github.com/NixOS/nixpkgs/commit/153f344efc854559e0874661fac3212713904107) | `` python312Packages.calmjs: disable failing test ``                                                              |
| [`1b801c2b`](https://github.com/NixOS/nixpkgs/commit/1b801c2b91ede9ace020606a912c45171b95427b) | `` python312Packages.nox: apply backport for wntrblm/nox#903 ``                                                   |
| [`af8f3f3d`](https://github.com/NixOS/nixpkgs/commit/af8f3f3d975f292463fb1c291a8806ef90794ea9) | `` wezterm: disable tests in x86_64-darwin ``                                                                     |
| [`ec63dce9`](https://github.com/NixOS/nixpkgs/commit/ec63dce91e99609c6de3d25fafa025dd39ccec08) | `` beets: backport updates & other fixes from master ``                                                           |
| [`78157e12`](https://github.com/NixOS/nixpkgs/commit/78157e12c20a4d6be7a60ee8394d69e261030ca4) | `` wezterm: 20240203-110809-5046fc22 -> 0-unstable-2025-01-03 ``                                                  |
| [`fe7eff0b`](https://github.com/NixOS/nixpkgs/commit/fe7eff0b925b09b9e03031b0321486a4e923a649) | `` deepin.dtk6core: 6.0.19 -> 6.0.24 ``                                                                           |
| [`4f89eb9f`](https://github.com/NixOS/nixpkgs/commit/4f89eb9fafa598601a7c66cdd9fd8c85f3dcacc0) | `` deepin.dde-launchpad: 1.0.2 -> 1.0.8 ``                                                                        |
| [`0166e108`](https://github.com/NixOS/nixpkgs/commit/0166e10881f9ed6d6d5a496ef471f4d0ff843448) | `` deepin.dde-shell: 1.0.2 -> 1.0.9 ``                                                                            |
| [`e151c983`](https://github.com/NixOS/nixpkgs/commit/e151c98378c1f44596c900478f36f46c84667ebb) | `` deepin.dde-tray-loader: 1.0.1 -> 1.0.7 ``                                                                      |
| [`cfef7b89`](https://github.com/NixOS/nixpkgs/commit/cfef7b893398f6193925b8663f52ec13445d4319) | `` deepin.treeland-protocols: init at 0.4.5 ``                                                                    |
| [`68216a66`](https://github.com/NixOS/nixpkgs/commit/68216a6692dc8b40d75aebe3d8795f35de0c3f60) | `` deepin.qt6platform-plugins: 6.0.19 -> 6.0.24 ``                                                                |
| [`1a5ae4fc`](https://github.com/NixOS/nixpkgs/commit/1a5ae4fc1b8d46fe63919b362f96ef3f73862e4f) | `` deepin.qt6integration: 6.0.19 -> 6.0.24 ``                                                                     |
| [`d2dd3754`](https://github.com/NixOS/nixpkgs/commit/d2dd37546abe2afbae530bc923efe1ff68cc8916) | `` deepin.dtk6declarative: 6.0.19 -> 6.0.24 ``                                                                    |
| [`a11e629e`](https://github.com/NixOS/nixpkgs/commit/a11e629e34e4f2ef609863497f475aa37b2e6b41) | `` deepin.dtk6widget: 6.0.19 -> 6.0.24 ``                                                                         |
| [`f11d11c1`](https://github.com/NixOS/nixpkgs/commit/f11d11c1848704221da76ad14d9e9e0265213f8c) | `` deepin.dtk6gui: 6.0.19 -> 6.0.24 ``                                                                            |
| [`7d1a4265`](https://github.com/NixOS/nixpkgs/commit/7d1a426532fd425e0d7dc7d17cb0d3f9d6e7cb92) | `` deepin.dde-application-manager: 1.2.15 -> 1.2.19 ``                                                            |
| [`f63fa108`](https://github.com/NixOS/nixpkgs/commit/f63fa108f90b3cf3816f3c3683bcd35003a72b02) | `` deepin.dtk6core: 6.0.19 -> 6.0.24 ``                                                                           |
| [`1a460d26`](https://github.com/NixOS/nixpkgs/commit/1a460d26f1a2392bf94b109bb714c1fa1da3956b) | `` gnomeExtensions.tophat: fix build ``                                                                           |
| [`fbe1c7af`](https://github.com/NixOS/nixpkgs/commit/fbe1c7af2e9dc074e9964dea14f7b2d0c4083770) | `` gnomeExtensions: auto-update ``                                                                                |
| [`a92876db`](https://github.com/NixOS/nixpkgs/commit/a92876db46303d254b03ede0571b74a23317fd8b) | `` river: 0.3.6 -> 0.3.7 ``                                                                                       |
| [`4f7358aa`](https://github.com/NixOS/nixpkgs/commit/4f7358aaf82bd0800ed7a445e52dc8c645e1dfd8) | `` river: fix updateScript ``                                                                                     |
| [`f1f3028f`](https://github.com/NixOS/nixpkgs/commit/f1f3028fd230b3a410c4f25d7a014c0a4f29c85c) | `` nodejs_22: fix build with libuv 1.48.0 ``                                                                      |
| [`0f893f1d`](https://github.com/NixOS/nixpkgs/commit/0f893f1d886ddddebeee4f47b2e6b887f6a3911c) | `` nodejs_23: 23.2.0 -> 23.5.0 (#357699) ``                                                                       |
| [`598874d4`](https://github.com/NixOS/nixpkgs/commit/598874d4e2db5965fbeac1316f35f6fccc853b7a) | `` nodejs_22: 22.11.0 -> 22.12.0 (#361565) ``                                                                     |
| [`20b148aa`](https://github.com/NixOS/nixpkgs/commit/20b148aae78d1f9cabe843665fb9ba7f1cbae021) | `` nodejs_18: fix test-os failure ``                                                                              |
| [`7d52295f`](https://github.com/NixOS/nixpkgs/commit/7d52295f4e70d3055222ccc506f7e37db6a9f3c3) | `` nodejs_{20,22}: fix test-os failure ``                                                                         |
| [`0dbdc3b6`](https://github.com/NixOS/nixpkgs/commit/0dbdc3b6afc0d6976451af3d8868c413015b0bba) | `` nodejs_{20,22,23}: fix flaky test ``                                                                           |
| [`858190e0`](https://github.com/NixOS/nixpkgs/commit/858190e02c09aeb0088957008ba51a347a72b6df) | `` Revert "nodejs_18: fix build with clang 16 mk2" ``                                                             |
| [`81987d9f`](https://github.com/NixOS/nixpkgs/commit/81987d9ff405b694b5378c9ebb053d125832e8c8) | `` nodejs_{18,20}: apply V8 patches for LLVM 19 ``                                                                |
| [`9056aaa2`](https://github.com/NixOS/nixpkgs/commit/9056aaa27ac05aece0d0c8b529fa8cc933576c66) | `` nodejs_{18,20}: fix build with clang 18 on Darwin ``                                                           |
| [`564103c7`](https://github.com/NixOS/nixpkgs/commit/564103c78faf97de89ad65daa6a133082e29c2f5) | `` nodejs_22: 22.10.0 -> 22.11.0 ``                                                                               |
| [`7cc9725b`](https://github.com/NixOS/nixpkgs/commit/7cc9725b0b21b1495353b25750f20e362f3b4050) | `` nodejs: fix build on 32 bit platforms ``                                                                       |
| [`fa0d5a32`](https://github.com/NixOS/nixpkgs/commit/fa0d5a32dcff0a4be785f55dbdbe528234be384e) | `` buildMozillaMach: patch compat with python 3.12.8/3.13.1 ``                                                    |
| [`548259e8`](https://github.com/NixOS/nixpkgs/commit/548259e8103f114e5ffb13f6e78cb6562982ef2a) | `` python312.opentelemetry-instrumentation: fix build ``                                                          |
| [`2a539200`](https://github.com/NixOS/nixpkgs/commit/2a539200bd24b932066eda6c08d64c82754e9349) | `` python312Packages.dulwich: fixup build ``                                                                      |
| [`8d22c736`](https://github.com/NixOS/nixpkgs/commit/8d22c736a9831e2f20337059f8660ee4370f37b9) | `` qt6.qtbase: refresh patch ``                                                                                   |
| [`c16ee71e`](https://github.com/NixOS/nixpkgs/commit/c16ee71e7ca1b9df94d09162f2b2c8eaea58b0ba) | `` python312Packages.argcomplete: add patch to fix downstream issues ``                                           |
| [`7dc58bfe`](https://github.com/NixOS/nixpkgs/commit/7dc58bfe8624bf37c971f624c45e5a8943bbdafa) | `` qt6: don't treat absolute paths without known suffix as library ``                                             |
| [`2ac88195`](https://github.com/NixOS/nixpkgs/commit/2ac88195ca4cf665c0d080c2c0c72ad1521aead5) | `` tree-sitter: 0.24.4 -> 0.24.6 ``                                                                               |
| [`5d1542a1`](https://github.com/NixOS/nixpkgs/commit/5d1542a1ff2c65a20cbc97859460f2500e946a57) | `` koboldcpp: 1.80.1 -> 1.80.3 ``                                                                                 |
| [`9a24caee`](https://github.com/NixOS/nixpkgs/commit/9a24caee96844e8612baa89e494cfa392a894518) | `` koboldcpp: 1.80 -> 1.80.1 ``                                                                                   |
| [`2129cff3`](https://github.com/NixOS/nixpkgs/commit/2129cff35dc6cac55f5464433bb553cdee185d8d) | `` koboldcpp: disable vulkan for darwin ``                                                                        |
| [`362a8548`](https://github.com/NixOS/nixpkgs/commit/362a85482e056646d3e50cfdf7714c68a96ef03d) | `` koboldcpp: add `(darwinMinVersionHook "10.15")` ``                                                             |
| [`e96527ce`](https://github.com/NixOS/nixpkgs/commit/e96527cedc582f1741cbb2aa2bc951401d4d4f02) | `` koboldcpp: 1.79.1 -> 1.80 ``                                                                                   |
| [`e9c1162f`](https://github.com/NixOS/nixpkgs/commit/e9c1162f41ff8c78270d5cff30e098de685dddf9) | `` koboldcpp: drop `openblas` ``                                                                                  |
| [`0f86a47f`](https://github.com/NixOS/nixpkgs/commit/0f86a47f77171f4d3a9cc5d52e20401cf4783856) | `` koboldcpp: remove `gitUpdater` ``                                                                              |
| [`f5e31eaf`](https://github.com/NixOS/nixpkgs/commit/f5e31eaf30dc6ea0a956ccfb590361e69484aae4) | `` koboldcpp: update `cudaArches` example ``                                                                      |
| [`9cc64928`](https://github.com/NixOS/nixpkgs/commit/9cc64928747ff6cddd0a435631fde312bef6705e) | `` python312Packages.jinja2: 3.1.4 -> 3.1.5 ``                                                                    |
| [`0cf9503a`](https://github.com/NixOS/nixpkgs/commit/0cf9503a803b9cbb2a25f8c60e9c90a4e1d6cef4) | `` avahi: apply patch for CVE-2024-52616 ``                                                                       |
| [`ecb8d4a7`](https://github.com/NixOS/nixpkgs/commit/ecb8d4a745ace091a019b745a46cd375da5e3d34) | `` socat: 1.8.0.1 -> 1.8.0.2 ``                                                                                   |