### PR TITLE
chore(flake/spicetify-nix): `3da50a44` -> `749a821c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -632,11 +632,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1736568948,
-        "narHash": "sha256-nnaMeMQPDg1GLQPBejn4nBtvQKSRVv64IIPZ7XmX5u0=",
+        "lastModified": 1736655351,
+        "narHash": "sha256-+kAbUaJxCwKAxFvn3WL8dbzxoPaV+WKP4RG0R4JI4rY=",
         "owner": "Gerg-L",
         "repo": "spicetify-nix",
-        "rev": "3da50a44c6c47b3361e56231123797101892c565",
+        "rev": "749a821c86fb61be668d7583761f432f21772306",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                    |
| ----------------------------------------------------------------------------------------------------- | -------------------------- |
| [`749a821c`](https://github.com/Gerg-L/spicetify-nix/commit/749a821c86fb61be668d7583761f432f21772306) | `` CI update 2025-01-12 `` |