### PR TITLE
chore(flake/zen-browser): `48a7f03c` -> `32f3692c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -806,11 +806,11 @@
         "nixpkgs": "nixpkgs_4"
       },
       "locked": {
-        "lastModified": 1736565714,
-        "narHash": "sha256-/OyRMWPzV7027/Zvi5Kwb7D8UM0mhRLqPkC0WRHre2I=",
+        "lastModified": 1736655632,
+        "narHash": "sha256-TeA6G+BUWhOi2ZnewAEfwbsY/ku1H1sdNKfwjvH0wzM=",
         "owner": "0xc000022070",
         "repo": "zen-browser-flake",
-        "rev": "48a7f03cdc23ca81c668d0f09ea4ab2278f61162",
+        "rev": "32f3692cc4d6a1d1cb8943be7d2e712a63c4b374",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                          | Message                                                       |
| --------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------- |
| [`32f3692c`](https://github.com/0xc000022070/zen-browser-flake/commit/32f3692cc4d6a1d1cb8943be7d2e712a63c4b374) | `` Update Zen Browser twilight @ x86_64 && aarch64 to 1.7t `` |