### PR TITLE
chore(flake/nixpkgs): `bffc22eb` -> `130595eb`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -561,11 +561,11 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1736344531,
-        "narHash": "sha256-8YVQ9ZbSfuUk2bUf2KRj60NRraLPKPS0Q4QFTbc+c2c=",
+        "lastModified": 1736523798,
+        "narHash": "sha256-Xb8mke6UCYjge9kPR9o4P1nVrhk7QBbKv3xQ9cj7h2s=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "bffc22eb12172e6db3c5dde9e3e5628f8e3e7912",
+        "rev": "130595eba61081acde9001f43de3248d8888ac4a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                                           |
| ---------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------- |
| [`f9863a90`](https://github.com/NixOS/nixpkgs/commit/f9863a907258fe2da0fdfd7f434d08df4d909591) | `` gatekeeper: 3.18.1 -> 3.18.2 (#372540) ``                                                                      |
| [`05204b55`](https://github.com/NixOS/nixpkgs/commit/05204b552da55775f7d348ce39e07fd2c8d77a99) | `` heatclient: 4.0.0 -> 4.1.0 ``                                                                                  |
| [`c5940999`](https://github.com/NixOS/nixpkgs/commit/c5940999475c97aaea48b2dad10497eb0ceca60e) | `` ironicclient: 5.9.0 -> 5.10.0 ``                                                                               |
| [`7ef83af8`](https://github.com/NixOS/nixpkgs/commit/7ef83af8e44542433ac8dbd9fea3eed8cb254e02) | `` vimPlugins.gx-nvim: init at 2025-01-07 ``                                                                      |
| [`95811c53`](https://github.com/NixOS/nixpkgs/commit/95811c53e9eca88e301194f67270d2a45ba18256) | `` ddnet: 18.8.2 -> 18.9 ``                                                                                       |
| [`73e18b56`](https://github.com/NixOS/nixpkgs/commit/73e18b5606967ebaa20166dc0529a2fcd8379581) | `` cago-hakari: 0.9.33 -> 0.9.35 ``                                                                               |
| [`480f1aa8`](https://github.com/NixOS/nixpkgs/commit/480f1aa89744a656fcf4672d927c097bf3f39207) | `` gitkraken: 10.5.0 → 10.6.0 ``                                                                                  |
| [`438a8609`](https://github.com/NixOS/nixpkgs/commit/438a86097ab7245b29f5b9a04027ca5ad873aa32) | `` upcloud-cli: init at 3.14.0 ``                                                                                 |
| [`1eeaf5f1`](https://github.com/NixOS/nixpkgs/commit/1eeaf5f198867ebdcdd092c0a58ad8a9c940d3af) | `` libmcfp: 1.3.3 -> 1.3.4 ``                                                                                     |
| [`0561ea4d`](https://github.com/NixOS/nixpkgs/commit/0561ea4d4abc5a4fb394f6505f892bf7c75e6104) | `` slackdump: 3.0.0 -> 3.0.2 ``                                                                                   |
| [`d91fa598`](https://github.com/NixOS/nixpkgs/commit/d91fa5989f591028f9dfd8d16ce54bd18582c887) | `` python313Packages.netutils: 1.10.0 -> 1.12.0 ``                                                                |
| [`dd11ed78`](https://github.com/NixOS/nixpkgs/commit/dd11ed78c3f3d872324376aa0d95a08c37f849f9) | `` pythonPackages.color-operations: 0.1.4 -> 0.1.6 ``                                                             |
| [`c4cfe9bb`](https://github.com/NixOS/nixpkgs/commit/c4cfe9bba53f20887657a667a640b873b7d47685) | `` golds: 0.7.2 -> 0.7.4 ``                                                                                       |
| [`da4d290c`](https://github.com/NixOS/nixpkgs/commit/da4d290cd485c087c878d2ea5e99fb09e20aaa06) | `` tinymist: 0.12.16 -> 0.12.18 ``                                                                                |
| [`aae7c171`](https://github.com/NixOS/nixpkgs/commit/aae7c1714e326414e9909d2c7973ad5c56925409) | `` vorta: cleanup ``                                                                                              |
| [`7a01f145`](https://github.com/NixOS/nixpkgs/commit/7a01f1455a98fe1277a61c297996e1572c5e6c5a) | `` python312Packages.aardwolf: 0.2.8 -> 0.2.11 ``                                                                 |
| [`18ecdf9d`](https://github.com/NixOS/nixpkgs/commit/18ecdf9d33779f9e56fb18ccccd86bfa8980f9cd) | `` ungoogled-chromium: 131.0.6778.204 -> 131.0.6778.264 ``                                                        |
| [`3441c3be`](https://github.com/NixOS/nixpkgs/commit/3441c3be20d3f9c6b64f89b4ef8a94f32acbad25) | `` jwt-cli: migrate to pkgs/by-name ``                                                                            |
| [`e5aac151`](https://github.com/NixOS/nixpkgs/commit/e5aac1511b64086ecbdfb902bf095f7dc0c83d57) | `` magento-cloud: init at 1.46.1 ``                                                                               |
| [`736b92c4`](https://github.com/NixOS/nixpkgs/commit/736b92c465c099d5dd926f8441ade713b266b506) | `` maliit-framework: fix build ``                                                                                 |
| [`4c1d9fa9`](https://github.com/NixOS/nixpkgs/commit/4c1d9fa92bef5b7db613522279faedaf0f64f700) | `` python312Packages.google-cloud-pubsub: 2.27.1 -> 2.27.2 ``                                                     |
| [`4c649a0d`](https://github.com/NixOS/nixpkgs/commit/4c649a0d71deabbab9c0422af76bc9fedf7facb9) | `` python312Packages.chainer: remove ``                                                                           |
| [`4ab8bc31`](https://github.com/NixOS/nixpkgs/commit/4ab8bc3124f2529e7b8edef4b43affbb6b38c635) | `` ggshield: 1.34.0 -> 1.35.0 ``                                                                                  |
| [`6c4ad4bd`](https://github.com/NixOS/nixpkgs/commit/6c4ad4bd6413a24f474b8377310f98a7fcfc9b7d) | `` python313Packages.photutils: update disabled ``                                                                |
| [`b2a69e58`](https://github.com/NixOS/nixpkgs/commit/b2a69e584ce6311dddd3d0feffbcbdca83ac9c83) | `` python313Packages.photutils: 2.0.2 -> 2.1.0 ``                                                                 |
| [`85b68bc5`](https://github.com/NixOS/nixpkgs/commit/85b68bc5b60227be505030059a3aaf2659cc93a2) | `` python313Packages.python-roborock: 2.8.5 -> 2.9.0 ``                                                           |
| [`95d054f4`](https://github.com/NixOS/nixpkgs/commit/95d054f4ac26c3afd0f16769f91ac629b584c6fe) | `` python313Packages.twilio: 9.4.1 -> 9.4.2 ``                                                                    |
| [`f8c4bc25`](https://github.com/NixOS/nixpkgs/commit/f8c4bc25acb28aa7b87f9c4883b62ef20786c835) | `` python313Packages.rns: 0.8.8 -> 0.8.9 ``                                                                       |
| [`1f1841a6`](https://github.com/NixOS/nixpkgs/commit/1f1841a61454a4f1e207f20320260fb89d666dcb) | `` gemmi: 0.6.7 -> 0.7.0 ``                                                                                       |
| [`d018929d`](https://github.com/NixOS/nixpkgs/commit/d018929d2ee0e446aabb4087217de98a14ed7777) | `` python312Packages.mypy-boto3-fms: 1.35.93 -> 1.35.96 ``                                                        |
| [`48811b06`](https://github.com/NixOS/nixpkgs/commit/48811b06b5792a53cd472a0fecea543c6086f0b5) | `` python312Packages.mypy-boto3-compute-optimizer: 1.35.93 -> 1.35.96 ``                                          |
| [`6c1a1acb`](https://github.com/NixOS/nixpkgs/commit/6c1a1acb31cf4957945b96adbd9df36adda7e781) | `` python312Packages.mypy-boto3-codebuild: 1.35.93 -> 1.35.96 ``                                                  |
| [`5311838a`](https://github.com/NixOS/nixpkgs/commit/5311838a0cf1a81c403ac7b3ea3d1e16da93580c) | `` libretro-core-info: 1.19.0 -> 1.20.0 ``                                                                        |
| [`a895f157`](https://github.com/NixOS/nixpkgs/commit/a895f157d3cfc243c628af10fc0c39391684c5a7) | `` python312Packages.rapidfuzz: 3.10.1 -> 3.11.0 ``                                                               |
| [`7710f834`](https://github.com/NixOS/nixpkgs/commit/7710f8346331b2da3bd2faff15daeaf5ad0bfb82) | `` pkgsite: 0-unstable-2024-12-26 -> 0-unstable-2025-01-08 ``                                                     |
| [`346e53ea`](https://github.com/NixOS/nixpkgs/commit/346e53ea6c00d4a4efa801645339f8f880cda371) | `` polarity: latest-unstable-2024-12-20 -> latest-unstable-2025-01-08 ``                                          |
| [`dfb323c3`](https://github.com/NixOS/nixpkgs/commit/dfb323c3f3a4c6dbd671efa236df3df6f59dee2a) | `` mangojuice: 0.7.9 -> 0.8.0 ``                                                                                  |
| [`8607f87d`](https://github.com/NixOS/nixpkgs/commit/8607f87ddd317f24c2f14b90479315943437ecfe) | `` ldeep: 1.0.78 -> 1.0.79 ``                                                                                     |
| [`3982dd5f`](https://github.com/NixOS/nixpkgs/commit/3982dd5fdf62959eb4d2828a488eefd40dc47efc) | `` github-backup: 0.47.0 -> 0.48.0 ``                                                                             |
| [`a62ac179`](https://github.com/NixOS/nixpkgs/commit/a62ac1793ff6faf397ab0d9102435872164506ce) | `` walker: 0.11.16 -> 0.11.19 ``                                                                                  |
| [`fd457e53`](https://github.com/NixOS/nixpkgs/commit/fd457e531541981e13cc42e2531e71d378b9a94f) | `` vimPlugins: add missing dependencies ``                                                                        |
| [`ecbc3c2a`](https://github.com/NixOS/nixpkgs/commit/ecbc3c2a87d8f9850e4fd5f13469e6269be8bec4) | `` stumpwm: 22.11 -> 24.11 ``                                                                                     |
| [`6d10d8ad`](https://github.com/NixOS/nixpkgs/commit/6d10d8adf8453a59c220d9c65fed6ea4a4956911) | `` kubescape: 3.0.22 -> 3.0.23 ``                                                                                 |
| [`e46a62c6`](https://github.com/NixOS/nixpkgs/commit/e46a62c61ac41af2fc5430e87a10f4cacdbdc2b2) | `` fastfetch: 2.33.0 → 2.34.0 ``                                                                                  |
| [`caaf7227`](https://github.com/NixOS/nixpkgs/commit/caaf7227d835d9fa6006f61434f511473520be2e) | `` home-assistant.python.pkgs.pytest-homeassistant-custom-component: 0.13.201 -> 0.13.202 ``                      |
| [`4c488e03`](https://github.com/NixOS/nixpkgs/commit/4c488e035590d1d5af49e2f70b635b0a3ded322e) | `` python313Packages.homeassistant-stubs: 2025.1.1 -> 2025.1.2 ``                                                 |
| [`97c78583`](https://github.com/NixOS/nixpkgs/commit/97c78583923bcd16c0ab451e720b91bcb2cbf507) | `` libsixel: 1.10.3 -> 1.10.5 ``                                                                                  |
| [`83615f05`](https://github.com/NixOS/nixpkgs/commit/83615f056e15158b5cfebe94b82dc365f08837e9) | `` prometheus-nginx-exporter: 1.4.0 -> 1.4.1 ``                                                                   |
| [`c980787b`](https://github.com/NixOS/nixpkgs/commit/c980787b6171ca45f0483cf967c7982b42d6b6e1) | `` geesefs: 0.42.3 -> 0.42.4 ``                                                                                   |
| [`5a51e70e`](https://github.com/NixOS/nixpkgs/commit/5a51e70e7545cc72816eb01c4f840459160cd316) | `` opam: fix opam sandboxing on nixos, cleanup ``                                                                 |
| [`08d3f7b8`](https://github.com/NixOS/nixpkgs/commit/08d3f7b8138cf02231763c7c6105da209e7d96f9) | `` cables: 0.4.4 -> 0.5.0 ``                                                                                      |
| [`4c826d55`](https://github.com/NixOS/nixpkgs/commit/4c826d557bb0670918d88ee3634935cbfd44ff8e) | `` kdePackages.pulseaudio-qt: 1.6.1 -> 1.7.0 ``                                                                   |
| [`35b9acd3`](https://github.com/NixOS/nixpkgs/commit/35b9acd3d4c7b5beb7ac51795aaa0552b313913a) | `` firefoxpwa: remove adamcstephens as maintainer ``                                                              |
| [`aae67958`](https://github.com/NixOS/nixpkgs/commit/aae679589d550ad22eed2b4fc2430d4375ec8c15) | `` firefoxpwa: 2.13.1 -> 2.13.2 ``                                                                                |
| [`9f456058`](https://github.com/NixOS/nixpkgs/commit/9f456058b0dc001e1a49137eb6f47c87e09a5362) | `` vimPlugins: nativeCheckInputs -> checkInputs ``                                                                |
| [`ffacb08c`](https://github.com/NixOS/nixpkgs/commit/ffacb08c63d78e1d62fc206096569ba8995f26c6) | `` opentofu: move the plugin patch from `plugins` to `withPlugins` ``                                             |
| [`ed3bd887`](https://github.com/NixOS/nixpkgs/commit/ed3bd8871ee7ed70cc141e8eaefbc898d95c9e13) | `` vimPlugins.cspell-nvim: init at 2024-11-21 ``                                                                  |
| [`b86b8690`](https://github.com/NixOS/nixpkgs/commit/b86b8690a779818adea5a8cff65f2975a343eff1) | `` home-assistant: 2025.1.1 -> 2025.1.2 ``                                                                        |
| [`28328dfb`](https://github.com/NixOS/nixpkgs/commit/28328dfb02f8a58c9c9abf685febd5d0816bdada) | `` python313Packages.pyflick: 1.1.2 -> 1.1.3 ``                                                                   |
| [`e060d17e`](https://github.com/NixOS/nixpkgs/commit/e060d17e0defe6e059ffcd0278521c9a71d150b7) | `` python312Packages.timm: 1.0.12 -> 1.0.13 ``                                                                    |
| [`f40068d1`](https://github.com/NixOS/nixpkgs/commit/f40068d135bb384a6950c60d0633504bd7b2d5de) | `` adif-multitool: 0.1.15 -> 0.1.18 ``                                                                            |
| [`b67afb20`](https://github.com/NixOS/nixpkgs/commit/b67afb20827eddb70e793fd480d931e7acd9f58a) | `` heroic: use qt6 version of kdialog ``                                                                          |
| [`98c2f369`](https://github.com/NixOS/nixpkgs/commit/98c2f369600b522b506b528bf4e6cc3dc2bef1bc) | `` linux-firmware: 20241210 -> 20250109 ``                                                                        |
| [`fdd340a0`](https://github.com/NixOS/nixpkgs/commit/fdd340a071fbb4c10010fb2f8a15467700de2c31) | `` tideways-daemon: 1.9.28 -> 1.9.30 ``                                                                           |
| [`594dd76c`](https://github.com/NixOS/nixpkgs/commit/594dd76c494e2ea49e3bd7c9e7486a2db365a48b) | `` ocamlPackages.systemd: init at 1.3 (#372037) ``                                                                |
| [`172f95ed`](https://github.com/NixOS/nixpkgs/commit/172f95edf50e00c876b6cceec38ca9f8e526fd45) | `` floorp: 11.21.0 -> 11.22.0 ``                                                                                  |
| [`f45dd40d`](https://github.com/NixOS/nixpkgs/commit/f45dd40da63d088fdd9d832c7924e84bc9b5131f) | `` dart: 3.5.4 -> 3.6.0 ``                                                                                        |
| [`c764201f`](https://github.com/NixOS/nixpkgs/commit/c764201fd0779f82800fa88c2ab55b5ffb62a0a2) | `` ovn: fix missing ovsdb binaries ``                                                                             |
| [`deda9220`](https://github.com/NixOS/nixpkgs/commit/deda9220af5eda8d8a546c437e8992f5d10b3886) | `` python312Packages.mypy-boto3-sagemaker: 1.35.93 -> 1.35.95 ``                                                  |
| [`8df77a2a`](https://github.com/NixOS/nixpkgs/commit/8df77a2ab5b581a6fcb78d0e3266eace4bd3b011) | `` python312Packages.mypy-boto3-route53: 1.35.93 -> 1.35.95 ``                                                    |
| [`21245b84`](https://github.com/NixOS/nixpkgs/commit/21245b84cd17ecbab4b595516f9064f6d3258d04) | `` python312Packages.mypy-boto3-rds: 1.35.93 -> 1.35.95 ``                                                        |
| [`fd385aa8`](https://github.com/NixOS/nixpkgs/commit/fd385aa8f7c44c25dce7f38755789b0450539032) | `` python312Packages.mypy-boto3-imagebuilder: 1.35.93 -> 1.35.94 ``                                               |
| [`7f8cebaa`](https://github.com/NixOS/nixpkgs/commit/7f8cebaa4c6bd3ba9778733ff7e2b9ef897c762d) | `` python312Packages.mypy-boto3-dynamodb: 1.35.93 -> 1.35.94 ``                                                   |
| [`84c59bc1`](https://github.com/NixOS/nixpkgs/commit/84c59bc1cff503a83f692bdf788caa906affdee4) | `` python312Packages.mypy-boto3-cloudhsmv2: 1.35.93 -> 1.35.94 ``                                                 |
| [`05d3e050`](https://github.com/NixOS/nixpkgs/commit/05d3e050f96606d3ffdc2636d9cc7d0c94659f9e) | `` checkov: 3.2.351 -> 3.2.352 ``                                                                                 |
| [`812fc9b0`](https://github.com/NixOS/nixpkgs/commit/812fc9b0217aa4c39efa4ba628bbb54a42a215ec) | `` dart: make update script output in a formatted way ``                                                          |
| [`12509e26`](https://github.com/NixOS/nixpkgs/commit/12509e26d0b629db59a93f5c3034ae9414775b8e) | `` sommelier: Fix update script ``                                                                                |
| [`21b4714a`](https://github.com/NixOS/nixpkgs/commit/21b4714acae2b9ed424683e8efda25a8ce67b05d) | `` dayon: 15.0.0 -> 15.0.1 ``                                                                                     |
| [`c20214d8`](https://github.com/NixOS/nixpkgs/commit/c20214d8fa152997ee8b72ede793940a10dfafbc) | `` linux/hardened/patches/6.6: v6.6.67-hardened1 -> v6.6.69-hardened1 ``                                          |
| [`021011a2`](https://github.com/NixOS/nixpkgs/commit/021011a2f1ca17396974e33d8519a9da5107e4d7) | `` linux/hardened/patches/6.12: v6.12.6-hardened1 -> v6.12.8-hardened1 ``                                         |
| [`54dd511f`](https://github.com/NixOS/nixpkgs/commit/54dd511f6392dadbf1b8228f6f692078bf0f4403) | `` linux/hardened/patches/6.1: v6.1.121-hardened1 -> v6.1.123-hardened1 ``                                        |
| [`9c4551eb`](https://github.com/NixOS/nixpkgs/commit/9c4551eb301cee9927a1d541cffda5e22d82a40a) | `` linux-rt_6_1: 6.1.120-rt46 -> 6.1.120-rt47 ``                                                                  |
| [`abbb2338`](https://github.com/NixOS/nixpkgs/commit/abbb233816f26291b6266d4a9bc5f1ac4d62f2dd) | `` linux-rt_5_4: 5.4.285-rt93 -> 5.4.288-rt94 ``                                                                  |
| [`4d89b531`](https://github.com/NixOS/nixpkgs/commit/4d89b531325971e54b25a40995677d9b95614e4a) | `` linux_5_4: 5.4.288 -> 5.4.289 ``                                                                               |
| [`8ac56230`](https://github.com/NixOS/nixpkgs/commit/8ac5623072c07c7fee26dc829efc745368c8767a) | `` linux_5_10: 5.10.232 -> 5.10.233 ``                                                                            |
| [`79dca86f`](https://github.com/NixOS/nixpkgs/commit/79dca86ffdf185dcf7b1f77aca58e034d8ee84f4) | `` linux_5_15: 5.15.175 -> 5.15.176 ``                                                                            |
| [`7ae9c559`](https://github.com/NixOS/nixpkgs/commit/7ae9c559b677304b0cd178f5cb2438130f46b756) | `` retroarch-assets: 1.19.0-unstable-2024-10-19 -> 1.19.0-unstable-2024-12-31 ``                                  |
| [`c7aed5c6`](https://github.com/NixOS/nixpkgs/commit/c7aed5c6bd007120a218775e0b712c4f38ccd23a) | `` python3.pkgs.liquidctl: 1.13.0 -> 1.14.0 ``                                                                    |
| [`3b1f39b7`](https://github.com/NixOS/nixpkgs/commit/3b1f39b7d1bc111784168abdf320ec140b0f141a) | `` python312Packages.immutabledict: disable flaky test ``                                                         |
| [`33257a9d`](https://github.com/NixOS/nixpkgs/commit/33257a9d7c400cef3ba7f0ee0b9b27ea30c31aae) | `` ci/request-reviews: Fix code owner requests for filenames with spaces ``                                       |
| [`ee1d8d4d`](https://github.com/NixOS/nixpkgs/commit/ee1d8d4d66c4285ee5ed0cc290ee2063c27314f8) | `` opentofu: 1.8.8 -> 1.9.0 ``                                                                                    |
| [`eefcb83b`](https://github.com/NixOS/nixpkgs/commit/eefcb83b7d1eaf7a45266907abe09f5d84b07621) | `` jetbrains.plugins: update ``                                                                                   |
| [`644a1e64`](https://github.com/NixOS/nixpkgs/commit/644a1e642c23664e64e73619eb89499dafe48b86) | `` jetbrains.idea-community-src: 2024.3.1 -> 2024.3.1.1; jetbrains.pycharm-community-src: 2024.3 -> 2024.3.1.1 `` |
| [`6299c4da`](https://github.com/NixOS/nixpkgs/commit/6299c4da50d7138ef1b410814378e77baf78fa30) | `` jetbrains: fix build_maven.py shebang ``                                                                       |
| [`3bd32359`](https://github.com/NixOS/nixpkgs/commit/3bd3235995dffd6b4ab8d7ba5a7f6b4953c50077) | `` pixi: 0.38.0 -> 0.39.5 ``                                                                                      |
| [`7b85adf5`](https://github.com/NixOS/nixpkgs/commit/7b85adf5d6be0ab9a680b371bf9fc2ec0188d85f) | `` qt6.qtmultimedia: add missing dependencies ``                                                                  |
| [`9bf2ff28`](https://github.com/NixOS/nixpkgs/commit/9bf2ff285e1d0a89703a535c7d20640539c62e8d) | `` uv: 0.5.15 -> 0.5.16 ``                                                                                        |
| [`17fa7779`](https://github.com/NixOS/nixpkgs/commit/17fa7779b07a7341adc07c1f00a7ad6d443925c1) | `` kdePackages: Gear 24.12.0 -> 24.12.1 ``                                                                        |
| [`69aceb60`](https://github.com/NixOS/nixpkgs/commit/69aceb6044a3e91f00976939e98d2313979bfb87) | `` python312Packages.beartype: improve ``                                                                         |
| [`f7930aac`](https://github.com/NixOS/nixpkgs/commit/f7930aac32b6e9d3f89b667ad9e32dba0f7fb308) | `` frigate: fix event preview ``                                                                                  |
| [`cd58ef1c`](https://github.com/NixOS/nixpkgs/commit/cd58ef1cba1fd875cd2c17abc08809f147e95048) | `` home-assistant: support wolflink component ``                                                                  |
| [`83d9e485`](https://github.com/NixOS/nixpkgs/commit/83d9e485eec0b2b4673ddeea97490a6d6ce8be5b) | `` python313Packages.wolf-comm: init at 0.0.19 ``                                                                 |
| [`006deac6`](https://github.com/NixOS/nixpkgs/commit/006deac63d1d66e525693c7a58076242c8753c6a) | `` beekeeper-studio: 5.0.6 -> 5.0.9 ``                                                                            |
| [`612ea649`](https://github.com/NixOS/nixpkgs/commit/612ea6490f4fa6e39359b34ff4c080cc16222c8d) | `` dura: fix build ``                                                                                             |
| [`40844464`](https://github.com/NixOS/nixpkgs/commit/40844464bbd01bbec8f50bacd89a4e5c5a5d10b7) | `` python3Packages.python-calamine: 0.2.3 → 0.3.1 ``                                                              |
| [`0eb28221`](https://github.com/NixOS/nixpkgs/commit/0eb282214611ef0d93fe00735fb77a359b2d0502) | `` jetbrains.plugins: update ``                                                                                   |
| [`89caef1f`](https://github.com/NixOS/nixpkgs/commit/89caef1ff41429e49c5eacdf79bdc4b5458429a5) | `` jetbrains: 2024.3 -> 2024.3.3 ``                                                                               |