### PR TITLE
chore(flake/nixpkgs-stable): `1dab772d` -> `635e887b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -529,11 +529,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1736549401,
-        "narHash": "sha256-ibkQrMHxF/7TqAYcQE+tOnIsSEzXmMegzyBWza6uHKM=",
+        "lastModified": 1736684107,
+        "narHash": "sha256-vH5mXxEvZeoGNkqKoCluhTGfoeXCZ1seYhC2pbMN0sg=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "1dab772dd4a68a7bba5d9460685547ff8e17d899",
+        "rev": "635e887b48521e912a516625eee7df6cf0eba9c1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                 |
| ---------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------- |
| [`14d5e92a`](https://github.com/NixOS/nixpkgs/commit/14d5e92afa12955db43f4890fcca114c7c3a529c) | `` nixos/endlessh-go: fix DNS resolution ``                                             |
| [`c264a10e`](https://github.com/NixOS/nixpkgs/commit/c264a10edc678815617cdd6510b43aeb99065e04) | `` bilibili: 1.16.1-2 -> 1.16.1-3 ``                                                    |
| [`0ad64eb8`](https://github.com/NixOS/nixpkgs/commit/0ad64eb87e650139d9006a1a7d67c9ec8171e8b1) | `` bilibili: 1.16.1-1 -> 1.16.1-2 ``                                                    |
| [`c59736ed`](https://github.com/NixOS/nixpkgs/commit/c59736ed9a27565a49e598893c7d7ea8d906c3ad) | `` bilibili: 1.15.2-2: 1.16.1-1 ``                                                      |
| [`4126a982`](https://github.com/NixOS/nixpkgs/commit/4126a9829ca915454a79a30bbfd273ba38d5e189) | `` niri: avoid flaky tests ``                                                           |
| [`12e35d36`](https://github.com/NixOS/nixpkgs/commit/12e35d36e9144c657c403076f3e36152621b1c8a) | `` niri: 0.1.10.1 -> 25.01 ``                                                           |
| [`0be9e9c5`](https://github.com/NixOS/nixpkgs/commit/0be9e9c5a5f9292a54486d0315ead73d4285dd0e) | `` television: 0.9.1 -> 0.9.2 ``                                                        |
| [`b0192869`](https://github.com/NixOS/nixpkgs/commit/b019286968ca17f404848554233d213b22487e44) | `` nix-fast-build: 1.0.0 -> 1.1.0 ``                                                    |
| [`d67773f9`](https://github.com/NixOS/nixpkgs/commit/d67773f9b13088e53a5f64efbc020ed024c9efe3) | `` greetd.regreet: 0.1.1 -> 0.1.2 ``                                                    |
| [`ee65aa4c`](https://github.com/NixOS/nixpkgs/commit/ee65aa4cad921f5febd6a44856c5c7d59b9b19c3) | `` ente-auth: 4.2.3 -> 4.2.4 ``                                                         |
| [`a84e4fe6`](https://github.com/NixOS/nixpkgs/commit/a84e4fe6c926246e70a075270b9eb91a4ed1b351) | `` openasar: 0-unstable-2024-11-13 -> 0-unstable-2025-01-10 ``                          |
| [`88c94ff0`](https://github.com/NixOS/nixpkgs/commit/88c94ff02ee53479fae765e5fb7973551e77858a) | `` lesspipe: reformat ``                                                                |
| [`7bacef15`](https://github.com/NixOS/nixpkgs/commit/7bacef156ef34c0f556bf870cc59d7ad7e26d7e8) | `` lesspipe: 2.14 -> 2.17 ``                                                            |
| [`107ed2a7`](https://github.com/NixOS/nixpkgs/commit/107ed2a7aded8ce00740c6969646b6c4b420e39a) | `` television: 0.8.6 -> 0.9.1 ``                                                        |
| [`16d92961`](https://github.com/NixOS/nixpkgs/commit/16d929612cea33e9f6cde7c952545f332328a270) | `` pocket-casts: move to pkgs/by-name/ ``                                               |
| [`3369bd79`](https://github.com/NixOS/nixpkgs/commit/3369bd79e297b018859697cbeb9e4969458f7f7e) | `` pocket-casts: update pinned electron version ``                                      |
| [`34fcc8ba`](https://github.com/NixOS/nixpkgs/commit/34fcc8ba257f64be86cbc95a6f7cd5e1e0072276) | `` [24.11] bottles: 51.13 -> 51.15 (#366437) ``                                         |
| [`a5c05e11`](https://github.com/NixOS/nixpkgs/commit/a5c05e11a049cfecd15b46f994354b94d6d1ecfb) | `` phpdocumentor: update and fix hash ``                                                |
| [`b9550f6b`](https://github.com/NixOS/nixpkgs/commit/b9550f6bb8756ed8c9dc1df36e9ac84ab6e86da1) | `` telegram-desktop: 5.10.0 -> 5.10.2 ``                                                |
| [`1124d2ef`](https://github.com/NixOS/nixpkgs/commit/1124d2ef59e2b495b82356b30a46afd43982f6d2) | `` dart.super_native_extensions: add 0.9.0-dev.5 ``                                     |
| [`b9fdfd2a`](https://github.com/NixOS/nixpkgs/commit/b9fdfd2acaab383d58980d25080b56c83a72c690) | `` butterfly: 2.2.2 -> 2.2.3 ``                                                         |
| [`3b9136f7`](https://github.com/NixOS/nixpkgs/commit/3b9136f76a1d57f51166ffd32d2534a382ed6bbd) | `` butterfly: add update script ``                                                      |
| [`4f6cdc40`](https://github.com/NixOS/nixpkgs/commit/4f6cdc4036d8fa38dd9527f738675c259d6b91ee) | `` telegram-desktop: 5.9.0 -> 5.10.0 ``                                                 |
| [`f263ab2a`](https://github.com/NixOS/nixpkgs/commit/f263ab2ad08d84a27ae49e594c55b513ab76ea18) | `` google-chrome: 131.0.6778.204 -> 131.0.6778.264 ``                                   |
| [`6741f337`](https://github.com/NixOS/nixpkgs/commit/6741f33710eb599270b57cdcd858da9b285cf1a9) | `` koboldcpp: 1.81 -> 1.81.1 ``                                                         |
| [`d1bb23c3`](https://github.com/NixOS/nixpkgs/commit/d1bb23c3006bdaaddf59795db59af5f0fcfa9823) | `` prometheus-process-exporter: 0.8.4 -> 0.8.5 ``                                       |
| [`eedefaae`](https://github.com/NixOS/nixpkgs/commit/eedefaae6e30bc778502651ce444395db641b492) | `` haskellPackages.lukko: fix ofd locking on 32bit Linux platforms ``                   |
| [`e1cb0288`](https://github.com/NixOS/nixpkgs/commit/e1cb0288017100a416d956d76014ca439af33d05) | `` workflows: add README ``                                                             |
| [`e2d58714`](https://github.com/NixOS/nixpkgs/commit/e2d58714c7bc22ee5363a60416f310e66665d6a7) | `` workflows: rename baseSha to targetSha ``                                            |
| [`a7642621`](https://github.com/NixOS/nixpkgs/commit/a76426214b99d82401944bf4afc0208b5fa16964) | `` workflows/{editorconfig,nix-parse}: run against release branches ``                  |
| [`9f70c76b`](https://github.com/NixOS/nixpkgs/commit/9f70c76b0b940ced464fbfbaee0db4cc35715687) | `` workflows: make checks work with non-NixOS repos ``                                  |
| [`c2b36c94`](https://github.com/NixOS/nixpkgs/commit/c2b36c94a27a578be57a74bde4d084840eeacd90) | `` workflows/eval: remove non-required "needs: attrs" ``                                |
| [`f4f9df17`](https://github.com/NixOS/nixpkgs/commit/f4f9df1782b928a7d0c69591ffc95e8b6fb5c71c) | `` workflows: basic consistency in formatting workflows ``                              |
| [`40d3bb9d`](https://github.com/NixOS/nixpkgs/commit/40d3bb9d5ec4c0a1ddd556de12fbc0367ce54694) | `` workflows/eval: fix actionlint ``                                                    |
| [`01832460`](https://github.com/NixOS/nixpkgs/commit/01832460695d82c97d2e0b217d77f005297741f8) | `` workflows/check-maintainers-sorted: Use .yml extension for consistency ``            |
| [`7add43e2`](https://github.com/NixOS/nixpkgs/commit/7add43e251333d5422bf699b607acdc06c396959) | `` workflows/check-shell: use job matrix ``                                             |
| [`ae4066f8`](https://github.com/NixOS/nixpkgs/commit/ae4066f8274378b6cfe857632404e76cb4d51c36) | `` workflows/basic-eval: remove ``                                                      |
| [`404fbac1`](https://github.com/NixOS/nixpkgs/commit/404fbac1ea0f045a3269cf9ac02b9afbe8d31d34) | `` ejabberd: 24.10 -> 24.12 ``                                                          |
| [`01dcbced`](https://github.com/NixOS/nixpkgs/commit/01dcbcedda41d592e1c30dc6b82c079c5f20e9d2) | `` ci/request-reviews: Fix code owner requests for filenames with spaces ``             |
| [`aaa48e94`](https://github.com/NixOS/nixpkgs/commit/aaa48e94ff7c2a59761835114b7e627b8d3d578f) | `` build(deps): bump actions/create-github-app-token from 1.11.0 to 1.11.1 (#371397) `` |
| [`a6ea384d`](https://github.com/NixOS/nixpkgs/commit/a6ea384dc002be2b1716d454613ed84f7a4caed8) | `` workflows/eval: add swap to tackle recent borderline OOM ``                          |
| [`c2ab54c6`](https://github.com/NixOS/nixpkgs/commit/c2ab54c6c5ae56d17beacb5e99b63fb439fd4aa7) | `` workflows: lock macOS runner to macos-14 ``                                          |
| [`1a7793d1`](https://github.com/NixOS/nixpkgs/commit/1a7793d1ac9d2c8a5230cffb7a52bbc9149fb0dd) | `` workflows: update Ubuntu runner to ubuntu-24.04 ``                                   |
| [`fae0c7b0`](https://github.com/NixOS/nixpkgs/commit/fae0c7b0ebd60a5c7784dd8f59ed5c939a853797) | `` workflows: lock Ubuntu runner to ubuntu-22.04 ``                                     |
| [`8ccc1cf1`](https://github.com/NixOS/nixpkgs/commit/8ccc1cf1e2f52fb6cf2ba37a978f556d378ffd30) | `` actions/no-channel-pr: re run when base branch is updated ``                         |
| [`4a7117bb`](https://github.com/NixOS/nixpkgs/commit/4a7117bb5af9de97ae6679873b2ec8540aad4284) | `` libplctag: fix build ``                                                              |
| [`8a94d8b1`](https://github.com/NixOS/nixpkgs/commit/8a94d8b112627bc48392658b3aebb5190b7836bf) | `` hentai-at-home: 1.6.3 -> 1.6.4 ``                                                    |
| [`e2edeefa`](https://github.com/NixOS/nixpkgs/commit/e2edeefa8cb89b38ad0e2a7fc22bab8f9be696c3) | `` rustup: Correct patchelf patch's use of create_dir ``                                |
| [`7f8197e8`](https://github.com/NixOS/nixpkgs/commit/7f8197e85a9d7afa7154bf851c3dbe037386afc6) | `` quickgui: fix build error ``                                                         |
| [`1453ffc0`](https://github.com/NixOS/nixpkgs/commit/1453ffc01435d1fae77a9d6619a0df06dd8f53be) | `` _9base: format package.nix ``                                                        |
| [`3a90ec96`](https://github.com/NixOS/nixpkgs/commit/3a90ec96a5cb2506b0e2e08ff29a0228af9ea0ea) | `` _9base: fix build on x86_64-linux ``                                                 |
| [`00384e9f`](https://github.com/NixOS/nixpkgs/commit/00384e9f8d5214a26e0de6da137b8d6d95f9b17c) | `` cie-middleware-linux: 1.5.2 -> 1.5.6 ``                                              |
| [`b81c0b2e`](https://github.com/NixOS/nixpkgs/commit/b81c0b2e71f018123e1756bcb1c9348cc9f82fd6) | `` libsixel: 1.10.3 -> 1.10.5 ``                                                        |
| [`40bf096d`](https://github.com/NixOS/nixpkgs/commit/40bf096dd5504a3094a1fa19f5c4fd47a218d3fc) | `` nautilus: 47.0 → 47.1 ``                                                             |
| [`1ec05e36`](https://github.com/NixOS/nixpkgs/commit/1ec05e369bc72cbf47d65f0be7c5956163ea8265) | `` localsearch: 3.8.1 → 3.8.2 ``                                                        |
| [`62fed29f`](https://github.com/NixOS/nixpkgs/commit/62fed29f1a74be2a939822acaa28600491ab3562) | `` gucharmap: 16.0.1 → 16.0.2 ``                                                        |
| [`c2974389`](https://github.com/NixOS/nixpkgs/commit/c29743898b14c4232382dcd20a4bc91394f860de) | `` gnome-terminal: 3.54.1 → 3.54.2 ``                                                   |
| [`afa9efbe`](https://github.com/NixOS/nixpkgs/commit/afa9efbec48440f3515e1d5f0d14f891658ba755) | `` gnome-contacts: 47.0 → 47.1.1 ``                                                     |
| [`63a2687a`](https://github.com/NixOS/nixpkgs/commit/63a2687a0cea08363253d31c515af5ec47d43f40) | `` gnome-calculator: 47.0 → 47.1 ``                                                     |
| [`3af32653`](https://github.com/NixOS/nixpkgs/commit/3af32653fc9d11c28a25973655c52b6ef7e3f0f4) | `` aisleriot: 3.22.33 → 3.22.34 ``                                                      |
| [`91db0adf`](https://github.com/NixOS/nixpkgs/commit/91db0adfafeab94b81a6b225ad1a3d35e7b376ac) | `` k3s_1_28: mark as vulnerable/insecure due to EOL on 2024-10-28 ``                    |
| [`ba22f018`](https://github.com/NixOS/nixpkgs/commit/ba22f01889d96104ad4fae34a1b149be4280ad43) | `` linphone: symlink sounds ``                                                          |
| [`2db2d504`](https://github.com/NixOS/nixpkgs/commit/2db2d504972c418adfb68a2f4feb9072cf2d4174) | `` hugin: move to openexr_3 ``                                                          |
| [`94afd46e`](https://github.com/NixOS/nixpkgs/commit/94afd46eef42894d7e30ddc1acfe967eb1bfb5a2) | `` lesspipe: 2.11 -> 2.14 ``                                                            |
| [`5291faac`](https://github.com/NixOS/nixpkgs/commit/5291faace6bb96b57f35057094b60cde7762cc93) | `` _7zz: 24.08 -> 24.09 (#360699) ``                                                    |
| [`ba98f0dd`](https://github.com/NixOS/nixpkgs/commit/ba98f0dd990e98d177da3a1ffe6e670a061be7e7) | `` wordpressPackages.plugins.wp-fail2ban-addon-contact-form-7: init at 2.0.0 ``         |
| [`2bf89d38`](https://github.com/NixOS/nixpkgs/commit/2bf89d383cbdc6bba91b34e7ef73e66e2954c1e0) | `` rabbitmq-server: Allow local networking on Darwin ``                                 |
| [`f4618322`](https://github.com/NixOS/nixpkgs/commit/f461832217ace2927e5163a5f7b9a4321e9cc76b) | `` rabbitmq-server: Fix building on Darwin ``                                           |
| [`7da1806a`](https://github.com/NixOS/nixpkgs/commit/7da1806a9751b77fe5bc36c65bae4d45169b6948) | `` vscode: 1.96.0 -> 1.96.2 ``                                                          |
| [`354a9a1e`](https://github.com/NixOS/nixpkgs/commit/354a9a1e55d8d2c8e9a35629037c035be6928cc4) | `` vscode: 1.95.3 -> 1.96.0 ``                                                          |
| [`83a5d911`](https://github.com/NixOS/nixpkgs/commit/83a5d91175de79b3a66d59f2910139da4eb3af28) | `` gnomeExtensions: auto-update ``                                                      |
| [`410510d3`](https://github.com/NixOS/nixpkgs/commit/410510d3f901539e1f6723585d1a5bf3950df416) | `` workflows/eval: add eval summary before requesting reviewers ``                      |
| [`9050e5a9`](https://github.com/NixOS/nixpkgs/commit/9050e5a9d5dc484703b05e624a2be087a1b49cb5) | `` clipcat: 0.19.0 -> 0.20.0 ``                                                         |
| [`1fc14d10`](https://github.com/NixOS/nixpkgs/commit/1fc14d10e860db135027f143daa3028908083f8b) | `` hashes: 1.1.0 -> 1.1.1 ``                                                            |
| [`807a2678`](https://github.com/NixOS/nixpkgs/commit/807a2678d55e6ee51843e5714ccefec63b57d522) | `` authentik: Fix ak script for systemd units ``                                        |
| [`69385dd3`](https://github.com/NixOS/nixpkgs/commit/69385dd3584646c13c0af419a144db557c964e5a) | `` nixos/pykms: suggest dual stack binding ``                                           |
| [`2b67e03a`](https://github.com/NixOS/nixpkgs/commit/2b67e03a80e384df15cafbfe8bd49e0b8b5f8617) | `` nixos/pykms: allow overriding default package ``                                     |
| [`b1b42faf`](https://github.com/NixOS/nixpkgs/commit/b1b42faf44090ca0ea210159a8e16691a311886b) | `` pykms: unstable-2021-01-25 -> 0-unstable-2024-07-06 ``                               |
| [`982e96f5`](https://github.com/NixOS/nixpkgs/commit/982e96f5d0658c953e918ff0c11f944d865826ec) | `` ci/request-reviews: limit to 10 maintainer review requests ``                        |
| [`53d0959f`](https://github.com/NixOS/nixpkgs/commit/53d0959fbc14f624627c5e397815165b8a9ce1a9) | `` ci/request-reviews: request reviewers 1-by-1 ``                                      |
| [`bc3c6a9e`](https://github.com/NixOS/nixpkgs/commit/bc3c6a9edda91328579618e3edd1b3aedae5a221) | `` ci/request-reviews: share code to request reviewers from gh api ``                   |
| [`981355c7`](https://github.com/NixOS/nixpkgs/commit/981355c729d8139e228bbb42a5f6a774df41bbcf) | `` workflows/eval: make "requesting maintainer reviews" separate step ``                |
| [`d82f7fa3`](https://github.com/NixOS/nixpkgs/commit/d82f7fa36dd9415d5966e28f7fa8b57a1cb70a63) | `` ci/request-reviews: use generic wording instead of "code owner" ``                   |
| [`ff1e7882`](https://github.com/NixOS/nixpkgs/commit/ff1e7882382affe0e99bd5c004453066482ffa65) | `` ci/request-reviews: rename code-owner related files ``                               |
| [`6850ea71`](https://github.com/NixOS/nixpkgs/commit/6850ea717888f6dddc1d68186821a4c43a789543) | `` shadps4: add liberodark to maintainers ``                                            |
| [`4307b6a9`](https://github.com/NixOS/nixpkgs/commit/4307b6a925d2daf027ccd97ec153a89b12132642) | `` shadps4: 0.4.0-unstable-2024-12-23 > 0.5.0-unstable-2025-01-02 ``                    |
| [`60363a69`](https://github.com/NixOS/nixpkgs/commit/60363a69f3e93944208c66caadbaae9e0cf19896) | `` shadps4: 0.4.0-unstable-2024-12-08 -> 0.4.0-unstable-2024-12-23 ``                   |
| [`182f1eaf`](https://github.com/NixOS/nixpkgs/commit/182f1eafcb9f1185500860377fa218bbef69de80) | `` tests/shadps4: init ``                                                               |
| [`569599ed`](https://github.com/NixOS/nixpkgs/commit/569599eded48f4899689a220f8a7c5b067928464) | `` shadps4: 0.4.0 -> 0.4.0-unstable-2024-12-08 ``                                       |
| [`47d37679`](https://github.com/NixOS/nixpkgs/commit/47d37679990f7cb63ffc14fc5809fda04a915ba3) | `` nixos/tests/frigate: Add check for unauthenticated API ``                            |
| [`e72a6693`](https://github.com/NixOS/nixpkgs/commit/e72a66935ab8d826c6d357bd4fd27925ab64645e) | `` nixos/frigate: Also listen on port 5000 ``                                           |
| [`58e9df73`](https://github.com/NixOS/nixpkgs/commit/58e9df736319ac1c4ccaf660b65d288ecfed4809) | `` ci/request-reviews: lowercase handles consistently ``                                |
| [`1b7595a9`](https://github.com/NixOS/nixpkgs/commit/1b7595a92291fa854447fb8d049b0d197392f276) | `` ci/request-reviews: Don't request reviews from non-repo-collaborators ``             |
| [`0fb6e88f`](https://github.com/NixOS/nixpkgs/commit/0fb6e88fe33fc8114ad369eb66097ccf40b67365) | `` workflows/eval: Minor cleanup ``                                                     |
| [`b4b6dded`](https://github.com/NixOS/nixpkgs/commit/b4b6ddedf224c9e01c342093b56c87c3e6189d29) | `` workflows/eval: Reuse process-reviewers.sh ``                                        |
| [`d29ca81b`](https://github.com/NixOS/nixpkgs/commit/d29ca81b4fdca14b081cac482b32dc110aedaf7a) | `` ci/request-reviews: split off a more reusable reviewer processing script ``          |
| [`0916ec48`](https://github.com/NixOS/nixpkgs/commit/0916ec48fbbaebabe5274fca2af9444cfaa41226) | `` workflows/eval: Use maintainer GitHub IDs for review requests of changed packages `` |
| [`db45da12`](https://github.com/NixOS/nixpkgs/commit/db45da12a8883b5f39b972e732c3b60635a45a89) | `` workflows/eval: Request reviews from changed package maintainers ``                  |
| [`0d30c0a2`](https://github.com/NixOS/nixpkgs/commit/0d30c0a2e5fbdc2f59d580f5964f112248898098) | `` swift: source darwin-sdk-setup.bash ``                                               |
| [`0ce65f4c`](https://github.com/NixOS/nixpkgs/commit/0ce65f4cb45d79f4ae658d085c683618dba507d9) | `` svg2tikz: mark as broken ``                                                          |
| [`6fe76cd6`](https://github.com/NixOS/nixpkgs/commit/6fe76cd686a5262c445efd26622afa31f5349efe) | `` inkscape: 1.3.2 -> 1.4 ``                                                            |
| [`338f7475`](https://github.com/NixOS/nixpkgs/commit/338f747508197e94a101cce71c13b51cda8747bf) | `` lib2geom: 1.3 → 1.4 ``                                                               |
| [`c4f63e97`](https://github.com/NixOS/nixpkgs/commit/c4f63e973c18b59ad8fef81261e20ccb1deb6690) | `` inkscape: add Luflosi as maintainer ``                                               |
| [`c02be3fc`](https://github.com/NixOS/nixpkgs/commit/c02be3fc277bc457b39901db30659cd5fede7502) | `` inkscape: add x123 as maintainer ``                                                  |
| [`fae0927d`](https://github.com/NixOS/nixpkgs/commit/fae0927d546318a24ff41639c6f273d66b0944e2) | `` inkscape: refactor meta ``                                                           |