### PR TITLE
chore(flake/spicetify-nix): `e1a08224` -> `db77f79d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -632,11 +632,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1736741830,
-        "narHash": "sha256-7cXbJ3t/gvuHTI1uJ8juBK1NmSs4tRSGsb0MtCGo70o=",
+        "lastModified": 1736814410,
+        "narHash": "sha256-7fI+6sEkvF4zHYqCC9hdIZ5/bTZaRmogl81T83z7d9g=",
         "owner": "Gerg-L",
         "repo": "spicetify-nix",
-        "rev": "e1a0822469d975d25de4953860a15662fe5d6595",
+        "rev": "db77f79d4262f9bfb36f7cef216b64dd82383134",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                        |
| ----------------------------------------------------------------------------------------------------- | ------------------------------ |
| [`db77f79d`](https://github.com/Gerg-L/spicetify-nix/commit/db77f79d4262f9bfb36f7cef216b64dd82383134) | `` flake: add darwinModules `` |