### PR TITLE
chore(flake/hyprland-qtutils): `b0214844` -> `534cd1ba`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -426,11 +426,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1736524264,
-        "narHash": "sha256-9m/Ha7hrxtbBl4UylZTYzTT/8a6Sy5DvTmBJrcQ6FwQ=",
+        "lastModified": 1736774415,
+        "narHash": "sha256-pb8v7axHdVKFGhQHEAxIuZP/9REsmlyuDW5eLGIplLc=",
         "owner": "hyprwm",
         "repo": "hyprland-qtutils",
-        "rev": "b0214844d8aaa7b46b5735666b9a9edcbe45cef8",
+        "rev": "534cd1badc46ec9bdd986ab41ad2408bf845961e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                   | Message                                   |
| -------------------------------------------------------------------------------------------------------- | ----------------------------------------- |
| [`534cd1ba`](https://github.com/hyprwm/hyprland-qtutils/commit/534cd1badc46ec9bdd986ab41ad2408bf845961e) | `` README: Add build instructions (#8) `` |