### PR TITLE
chore(flake/nixpkgs-stable): `635e887b` -> `9c6b49ae`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -529,11 +529,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1736684107,
-        "narHash": "sha256-vH5mXxEvZeoGNkqKoCluhTGfoeXCZ1seYhC2pbMN0sg=",
+        "lastModified": 1736867362,
+        "narHash": "sha256-i/UJ5I7HoqmFMwZEH6vAvBxOrjjOJNU739lnZnhUln8=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "635e887b48521e912a516625eee7df6cf0eba9c1",
+        "rev": "9c6b49aeac36e2ed73a8c472f1546f6d9cf1addc",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                     |
| ---------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------- |
| [`2c170899`](https://github.com/NixOS/nixpkgs/commit/2c17089904cd1c6b0b0a358507c27343b26dcdf4) | `` archiver: tag with knownVulnerabilities for CVE-2024-0406 ``             |
| [`b2612e4f`](https://github.com/NixOS/nixpkgs/commit/b2612e4f20f13b21692d3398ae2ce90a68767c99) | `` [backport release-24.11] gerrit: 3.10.3 -> 3.10.4 ``                     |
| [`b4e1783a`](https://github.com/NixOS/nixpkgs/commit/b4e1783a48795353f8683c7e6e0a1f176e7e2cde) | `` appium-inspector: init at 2024.12.1 ``                                   |
| [`db5faafe`](https://github.com/NixOS/nixpkgs/commit/db5faafe1787b5faecf80fe563e78783f7beae58) | `` sogo: update libwbxml in activesync patch ``                             |
| [`fc2f7598`](https://github.com/NixOS/nixpkgs/commit/fc2f7598920456a27360942a32200afac2933463) | `` frigate: fix event preview ``                                            |
| [`ae8b7796`](https://github.com/NixOS/nixpkgs/commit/ae8b779613cd8dbc3ea1ac277d2efb27a6f7ffc3) | `` flyctl: 0.3.56 -> 0.3.61 ``                                              |
| [`e136fef1`](https://github.com/NixOS/nixpkgs/commit/e136fef1cfe3e07ad74471bfaaba8af3f8911779) | `` firefox-bin-unwrapped: 134.0 -> 134.0.1 ``                               |
| [`d2512176`](https://github.com/NixOS/nixpkgs/commit/d2512176718b7c73bd21926af051bf332e9805bc) | `` firefox-unwrapped: 134.0 -> 134.0.1 ``                                   |
| [`4320f18e`](https://github.com/NixOS/nixpkgs/commit/4320f18e815a15d5d5b5a48edb03b2eddd8b0705) | `` lib.dropEnd: init ``                                                     |
| [`fa9b53bb`](https://github.com/NixOS/nixpkgs/commit/fa9b53bb6a166bb86620efd9bcba930040e4c6ae) | `` lib/tests/misc: Test lib.drop ``                                         |
| [`3dca86b9`](https://github.com/NixOS/nixpkgs/commit/3dca86b9e5aa8a359c35d2144c83aae11b8ff63a) | `` workflows/codeowners-v2: only run if github.repository_owner is NixOS `` |
| [`ef33040e`](https://github.com/NixOS/nixpkgs/commit/ef33040eac0dbe4b756504d72360c684c52f1a5d) | `` nixpkgs-review: 3.0.0 -> 3.0.1 ``                                        |
| [`8defbfa0`](https://github.com/NixOS/nixpkgs/commit/8defbfa014800c0872e6a343f700395087f01e73) | `` nixpkgs-review: 2.12.0 -> 3.0.0 ``                                       |
| [`333eb491`](https://github.com/NixOS/nixpkgs/commit/333eb491009b33fd040872eb7f5935ccfd2a9bb5) | `` roslyn-ls: 4.13.0-3.24577.4 -> 4.13.0-3.25051.1 ``                       |
| [`155c78d8`](https://github.com/NixOS/nixpkgs/commit/155c78d8bbf24c98d7278293c0dd3c153ae356fe) | `` nixos/home-assistant: allow amshan to access serial ports ``             |
| [`71385a0e`](https://github.com/NixOS/nixpkgs/commit/71385a0e1d99f387e64c58bb8e56f4f08bbb27b5) | `` home-assistant-custom-components.amshan: init at 2024.12.0 ``            |
| [`e6d95acc`](https://github.com/NixOS/nixpkgs/commit/e6d95accb28ec3e659fd5336e54937ac410c24db) | `` python3Packages.amshan: init at 2.1.1 ``                                 |
| [`6243b832`](https://github.com/NixOS/nixpkgs/commit/6243b832a0c64821bb4c279b430e94fe8dafcd74) | `` lock: 1.3.7 -> 1.3.8 ``                                                  |
| [`f7eaf406`](https://github.com/NixOS/nixpkgs/commit/f7eaf406ffff5352d8d98cdfc60c83e09475d75d) | `` impl: 1.3.0 -> 1.4.0 ``                                                  |
| [`bf9f5625`](https://github.com/NixOS/nixpkgs/commit/bf9f5625f557af9fa1134e5dfc12fc71f77e14f5) | `` prismlauncher: 9.1 -> 9.2 ``                                             |
| [`a473760e`](https://github.com/NixOS/nixpkgs/commit/a473760efb938055d1f820ec1e5b79a79ff26bcb) | `` nixos/wyoming-faster-whisper: remove ProcSubset protection ``            |
| [`c7298a0e`](https://github.com/NixOS/nixpkgs/commit/c7298a0e656818099beb331ccef09af1078b05de) | `` mattermost: allow overriding the webapp easily ``                        |
| [`500c1969`](https://github.com/NixOS/nixpkgs/commit/500c19690b0f3c1cd918d1ea9620ffb093f590dc) | `` ocamlPackages.uring: disable tests ``                                    |
| [`f393c53f`](https://github.com/NixOS/nixpkgs/commit/f393c53f7b4e81742e734793b8593519681588df) | `` librewolf: 133.0.3-1 -> 134.0-1 ``                                       |
| [`2c5ffaba`](https://github.com/NixOS/nixpkgs/commit/2c5ffaba59684e38cd158900749278d003be31bb) | `` librewolf-unwrapped: 133.0-1 -> 133.0.3-1 ``                             |
| [`7d45d1be`](https://github.com/NixOS/nixpkgs/commit/7d45d1bed50524b0a733947186675869ad6018b3) | `` curtail: 1.11.1 -> 1.12.0 ``                                             |
| [`b470475b`](https://github.com/NixOS/nixpkgs/commit/b470475bf7ad4cef81a84740c0960b095c1fc318) | `` curtail: 1.11.0 -> 1.11.1 ``                                             |
| [`2718560a`](https://github.com/NixOS/nixpkgs/commit/2718560a669c7204ed5690d0edb957926621fa81) | `` cargo-tauri: update hash for hook test ``                                |
| [`e3185df7`](https://github.com/NixOS/nixpkgs/commit/e3185df793b72b4d516228b77c899e82b7b6d8af) | `` cargo-tauri: 2.2.0 -> 2.2.1 ``                                           |
| [`ac2b7be1`](https://github.com/NixOS/nixpkgs/commit/ac2b7be151d778f61c0e27ab99f151841f977abb) | `` cargo-tauri: 2.1.1 -> 2.2.0 ``                                           |
| [`c3ec9dc4`](https://github.com/NixOS/nixpkgs/commit/c3ec9dc494576d5d1dde153035116563dfcfe84f) | `` cargo-tauri: importCargoLock -> fetchCargoVendor ``                      |
| [`2b09c23c`](https://github.com/NixOS/nixpkgs/commit/2b09c23c0614dcd942db03119e82d44d064b2426) | `` [24.11] zammad: apply fix for ZAA-2024-05 ``                             |
| [`79f9ac9f`](https://github.com/NixOS/nixpkgs/commit/79f9ac9f5674c78cd57022da54281ed1b2c56f6c) | `` python312Packages.datalad: 1.1.4 -> 1.1.5 ``                             |
| [`6a7343c9`](https://github.com/NixOS/nixpkgs/commit/6a7343c9750db0d32abe8004df41cdc6b9e6193f) | `` datalad: fix changed hash from upstream ``                               |
| [`cbb74b5e`](https://github.com/NixOS/nixpkgs/commit/cbb74b5ed14440c9adcfd08c9112ba680e926947) | `` eza: 0.20.11 -> 0.20.16 ``                                               |
| [`8c370e16`](https://github.com/NixOS/nixpkgs/commit/8c370e1694572cad781470ab006f2d4271fa3a47) | `` librewolf-bin: 133.0.3-1 -> 134.0-1 ``                                   |
| [`76b1e1fc`](https://github.com/NixOS/nixpkgs/commit/76b1e1fc842b386c7131df15c59643187b2e1f23) | `` Revert "[Backport release-24.11] nixos/alsa: rebirth from the ashes" ``  |
| [`e3e3fd63`](https://github.com/NixOS/nixpkgs/commit/e3e3fd635fee5d353c76ed1a38dec42034d6943a) | `` linuxPackages.system76: 1.0.16 -> 1.0.17 ``                              |
| [`4c4ac333`](https://github.com/NixOS/nixpkgs/commit/4c4ac3332eba43dc9b250cf45f4399636bdff0fa) | `` linuxPackages_latest.prl-tools: 20.1.3-55743 -> 20.2.0-55872 ``          |
| [`0e075588`](https://github.com/NixOS/nixpkgs/commit/0e07558818c34afebb6e5293c1e115dd1be19668) | `` linuxPackages_latest.prl-tools: skip git commit in update.sh ``          |
| [`83fceeaa`](https://github.com/NixOS/nixpkgs/commit/83fceeaab3fa2e30ef0a96c229b273febbe1e596) | `` patchy: init at 1.2.7 ``                                                 |
| [`d06be2e5`](https://github.com/NixOS/nixpkgs/commit/d06be2e526b0d2d0675f88209e5d803c0c3859e2) | `` dendrite: 0.13.8 -> 0.14.0 ``                                            |
| [`7c4869c4`](https://github.com/NixOS/nixpkgs/commit/7c4869c47090dd7f9f1bdfb49a22aea026996815) | `` qtox: 1.17.6 -> 1.18.0, switch to TokTok fork ``                         |
| [`c59a435e`](https://github.com/NixOS/nixpkgs/commit/c59a435e3b59f364a30a5684bb88207094df25ff) | `` python312Packages.datalad: refactor ``                                   |
| [`9b883bc3`](https://github.com/NixOS/nixpkgs/commit/9b883bc36715b278b3e01b737099bcf112b3bf5c) | `` python312Packages.datalad: 1.1.3 -> 1.1.4 ``                             |
| [`c5aff0a1`](https://github.com/NixOS/nixpkgs/commit/c5aff0a10f728ca7b47bbc2fe207247eb97a02e7) | `` garnet: 1.0.48 -> 1.0.50 ``                                              |
| [`3fa17106`](https://github.com/NixOS/nixpkgs/commit/3fa1710643ed42b323e98fc5464bc1c13b299b77) | `` mangojuice: 0.7.9 -> 0.8.0 ``                                            |
| [`24fd4c0b`](https://github.com/NixOS/nixpkgs/commit/24fd4c0bacce8a51edb9d82aba9c4bfc4d2dd126) | `` mpris-timer: 1.6.2 -> 2.0.3 ``                                           |
| [`80a8e64e`](https://github.com/NixOS/nixpkgs/commit/80a8e64e7f175dfff9377569b8c1022c8982babe) | `` electron-source: copy node_headers.tar to new 'header' output ``         |
| [`c22e55de`](https://github.com/NixOS/nixpkgs/commit/c22e55de7f639cc3ff1c400650fbf5c8093b27d7) | `` electron-chromedriver_33: 33.3.0 -> 33.3.1 ``                            |
| [`f2dc9909`](https://github.com/NixOS/nixpkgs/commit/f2dc9909639689821f93c48beb3393bca049f08e) | `` electron-chromedriver_32: 32.2.7 -> 32.2.8 ``                            |
| [`e304d096`](https://github.com/NixOS/nixpkgs/commit/e304d0961e84f9e2a838fa5ec1d21e40818e383e) | `` electron-source.electron_33: 33.3.0 -> 33.3.1 ``                         |
| [`5819d43c`](https://github.com/NixOS/nixpkgs/commit/5819d43c6df48cdd82ebe0b237acce8ad1582f82) | `` electron-source.electron_32: 32.2.7 -> 32.2.8 ``                         |
| [`6b43dac0`](https://github.com/NixOS/nixpkgs/commit/6b43dac0a26743afa8c46971268142383ae302ef) | `` electron_33-bin: 33.3.0 -> 33.3.1 ``                                     |
| [`a415dc33`](https://github.com/NixOS/nixpkgs/commit/a415dc336b2df027570079653fd5be97f16af775) | `` electron_32-bin: 32.2.7 -> 32.2.8 ``                                     |
| [`f6ea57fd`](https://github.com/NixOS/nixpkgs/commit/f6ea57fd16bec4e473dbbdabb8a017204b072706) | `` treewide: Fix incorrect string indentations ``                           |
| [`772006e8`](https://github.com/NixOS/nixpkgs/commit/772006e8c05d0c216574f3bb1d2d4c42ca7f492a) | `` treewide: Fix incorrect string escapes ``                                |
| [`c0cd1a19`](https://github.com/NixOS/nixpkgs/commit/c0cd1a19ba680cca16f94cf07246c234f5994147) | `` thunderbird-128-unwrapped: 128.5.2esr -> 128.6.0esr ``                   |