### PR TITLE
chore(flake/zen-browser): `a17923b5` -> `8ec08d6e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -806,11 +806,11 @@
         "nixpkgs": "nixpkgs_4"
       },
       "locked": {
-        "lastModified": 1736824652,
-        "narHash": "sha256-8J56ngRvKVvCxdY3iDtol/9UAJfwCh0k96DnyNchUCA=",
+        "lastModified": 1736911112,
+        "narHash": "sha256-qKUBYa5XgzqZlDCygdQPyJywRmC+ff0bnJ8HhTf6LfE=",
         "owner": "0xc000022070",
         "repo": "zen-browser-flake",
-        "rev": "a17923b5fd758700c67afdaae2a1d3123381f96b",
+        "rev": "8ec08d6e38f065f7f19025f12a462f9f1c33a761",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                          | Message                                                       |
| --------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------- |
| [`8ec08d6e`](https://github.com/0xc000022070/zen-browser-flake/commit/8ec08d6e38f065f7f19025f12a462f9f1c33a761) | `` Update Zen Browser twilight @ x86_64 && aarch64 to 1.7t `` |
| [`c94fd192`](https://github.com/0xc000022070/zen-browser-flake/commit/c94fd192f0cdb8f1882b4a3ce6147275cb03fd3f) | `` Update Zen Browser twilight @ x86_64 && aarch64 to 1.7t `` |