### PR TITLE
chore(flake/spicetify-nix): `7b022595` -> `e99367ce`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -632,11 +632,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1736828155,
-        "narHash": "sha256-CloX65f6dNJGHPPuwU2ZQkT1TDNKzcG2OqsE9Lpylq4=",
+        "lastModified": 1736914534,
+        "narHash": "sha256-CrgRghA2tCqGbJxpv4Wjk0d16SP1sircAIhVg1qnZ7k=",
         "owner": "Gerg-L",
         "repo": "spicetify-nix",
-        "rev": "7b022595d1d57164008c68bf525f34ca35c9690b",
+        "rev": "e99367ceccbb214c31362c2ee2746cc5473a76e5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                              |
| ----------------------------------------------------------------------------------------------------- | ---------------------------------------------------- |
| [`e99367ce`](https://github.com/Gerg-L/spicetify-nix/commit/e99367ceccbb214c31362c2ee2746cc5473a76e5) | `` CI update 2025-01-15 ``                           |
| [`0645eff7`](https://github.com/Gerg-L/spicetify-nix/commit/0645eff7f0743f37d596e0dee94f29b4194ab793) | `` Update turntable filename in themes.nix (#247) `` |