### PR TITLE
chore(flake/nix-flatpak): `5f4ec93d` -> `b6966d5f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
     },
     "nix-flatpak": {
       "locked": {
-        "lastModified": 1736334301,
-        "narHash": "sha256-370z+WLVnD7LrN/SvTCZxPl/XPTshS5NS2dHN4iyK6o=",
+        "lastModified": 1736952876,
+        "narHash": "sha256-dJXuLP2CBkIG333L+Rb3e1D0oXHYbl0MgmKPGuvFuAI=",
         "owner": "gmodena",
         "repo": "nix-flatpak",
-        "rev": "5f4ec93d432cd5288f6fe20d8842dceb5a065885",
+        "rev": "b6966d5fa96b0fae99a4da0b5bdfbb0a75f5c058",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                                                     |
| ---------------------------------------------------------------------------------------------------- | ----------------------------------------------------------- |
| [`b6966d5f`](https://github.com/gmodena/nix-flatpak/commit/b6966d5fa96b0fae99a4da0b5bdfbb0a75f5c058) | `` nixos: rename execution context param. (#138) ``         |
| [`535af63e`](https://github.com/gmodena/nix-flatpak/commit/535af63e90151689057503baa1513cabe2bdee7b) | `` scheduled updates won't trigger on activation. (#136) `` |