### PR TITLE
chore(flake/spicetify-nix): `e99367ce` -> `cd004cdd`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -632,11 +632,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1736914534,
-        "narHash": "sha256-CrgRghA2tCqGbJxpv4Wjk0d16SP1sircAIhVg1qnZ7k=",
+        "lastModified": 1737000920,
+        "narHash": "sha256-o3dtkMm7M/CPCZ0G3MsK3Mv+KqcJEvP4wYR2iLrpPrs=",
         "owner": "Gerg-L",
         "repo": "spicetify-nix",
-        "rev": "e99367ceccbb214c31362c2ee2746cc5473a76e5",
+        "rev": "cd004cdd2af21f7840a28566cd5e32ca71b73aa7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                    |
| ----------------------------------------------------------------------------------------------------- | -------------------------- |
| [`cd004cdd`](https://github.com/Gerg-L/spicetify-nix/commit/cd004cdd2af21f7840a28566cd5e32ca71b73aa7) | `` CI update 2025-01-16 `` |