### PR TITLE
chore(flake/zen-browser): `8ec08d6e` -> `96be5663`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -806,11 +806,11 @@
         "nixpkgs": "nixpkgs_4"
       },
       "locked": {
-        "lastModified": 1736911112,
-        "narHash": "sha256-qKUBYa5XgzqZlDCygdQPyJywRmC+ff0bnJ8HhTf6LfE=",
+        "lastModified": 1736997529,
+        "narHash": "sha256-eyZXz3aphVJ8mMZ5KivtnYS+5vhNxVjWGlBJM0DMqlE=",
         "owner": "0xc000022070",
         "repo": "zen-browser-flake",
-        "rev": "8ec08d6e38f065f7f19025f12a462f9f1c33a761",
+        "rev": "96be5663cc2ef52e8815c90f7abf3363be3950c2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                          | Message                                                       |
| --------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------- |
| [`96be5663`](https://github.com/0xc000022070/zen-browser-flake/commit/96be5663cc2ef52e8815c90f7abf3363be3950c2) | `` Update Zen Browser twilight @ x86_64 && aarch64 to 1.7t `` |
| [`10dff9a2`](https://github.com/0xc000022070/zen-browser-flake/commit/10dff9a2f38005b186241ef23d872b9bbb48ffa3) | `` Update Zen Browser beta @ x86_64 && aarch64 to 1.7b ``     |
| [`356ea5bb`](https://github.com/0xc000022070/zen-browser-flake/commit/356ea5bbc8558e653fb00ccd14e4aff527ca9323) | `` Update Zen Browser twilight @ x86_64 && aarch64 to 1.7t `` |