### PR TITLE
chore(flake/nixpkgs-stable): `9c6b49ae` -> `e24b4c09`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -524,11 +524,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1736867362,
-        "narHash": "sha256-i/UJ5I7HoqmFMwZEH6vAvBxOrjjOJNU739lnZnhUln8=",
+        "lastModified": 1736916166,
+        "narHash": "sha256-puPDoVKxkuNmYIGMpMQiK8bEjaACcCksolsG36gdaNQ=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "9c6b49aeac36e2ed73a8c472f1546f6d9cf1addc",
+        "rev": "e24b4c09e963677b1beea49d411cd315a024ad3a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------ |
| [`75907409`](https://github.com/NixOS/nixpkgs/commit/75907409c54bdc8da95fbe4c0ee6ca6b2dabd344) | `` dxvk_2: 2.5 -> 2.5.1 ``                             |
| [`7a7b3dee`](https://github.com/NixOS/nixpkgs/commit/7a7b3dee2776ee7dd332048c9b4b0cab2fa0cedd) | `` firefox-devedition-unwrapped: 133.0b1 -> 135.0b4 `` |
| [`0733d774`](https://github.com/NixOS/nixpkgs/commit/0733d774136d89bca8b1d993d55c3920de8c23f9) | `` recordbox: 0.8.3 -> 0.9.0 ``                        |
| [`095a9718`](https://github.com/NixOS/nixpkgs/commit/095a971855aaf227e178c93a031d09347c3ee3e8) | `` rsync: apply patches for 6 vulnerabilities ``       |
| [`4e137618`](https://github.com/NixOS/nixpkgs/commit/4e137618767e3aa44875847f7d756e2ae3107e4c) | `` opencomposite: fix cross build ``                   |
| [`18c1c000`](https://github.com/NixOS/nixpkgs/commit/18c1c000bf6e7c827dfd7842983abb98fcdd885a) | `` lockbook: 0.9.15 -> 0.9.16 ``                       |
| [`e8d34121`](https://github.com/NixOS/nixpkgs/commit/e8d341210762cbf4de54675194ecf88f953e4e30) | `` lockbook-desktop: 0.9.15 -> 0.9.16 ``               |
| [`1aa8c30d`](https://github.com/NixOS/nixpkgs/commit/1aa8c30db4aefbf51bac97445a04892bb92c9c46) | `` zfs_2_3: init at 2.3.0 ``                           |
| [`a71486cb`](https://github.com/NixOS/nixpkgs/commit/a71486cb8e099f1fd341f8d8c28c6154b9f5e8fe) | `` zfs_unstable: 2.3.0-rc5 -> 2.3.0 ``                 |
| [`8b3fa8fb`](https://github.com/NixOS/nixpkgs/commit/8b3fa8fb1387a8b0d3c6fb15ec2bce80b290b724) | `` zfs_unstable: 2.3.0-rc4 -> 2.3.0-rc5 ``             |
| [`7dbe3def`](https://github.com/NixOS/nixpkgs/commit/7dbe3def26de8662effe946d409a063d53c3af4d) | `` sioyek: fix typo in darwin build steps ``           |
| [`b9aa3f34`](https://github.com/NixOS/nixpkgs/commit/b9aa3f3439f4ecc6b781b6f850bc92cb6c225461) | `` libsearpc: 3.3-20230626 -> 3.3-20241031 ``          |
| [`6c5d1474`](https://github.com/NixOS/nixpkgs/commit/6c5d147426b03915c64eff140bc767a284fa7b39) | `` bird: 2.16 -> 2.16.1 ``                             |
| [`579117cc`](https://github.com/NixOS/nixpkgs/commit/579117cc2c97f0e091126061a71de57456928993) | `` yt-dlp: 2024.12.23 -> 2025.01.12 ``                 |