### PR TITLE
chore(flake/home-manager): `12851ae7` -> `a0046af1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -354,11 +354,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1737075266,
-        "narHash": "sha256-u1gk5I1an975FOAMMdS6oBKnSIsZza5ZKhaeBZAskVo=",
+        "lastModified": 1737120639,
+        "narHash": "sha256-p5e/45V41YD3tMELuiNIoVCa25/w4nhOTm0B9MtdHFI=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "12851ae7467bad8ef422b20806ab4d6d81e12d29",
+        "rev": "a0046af169ce7b1da503974e1b22c48ef4d71887",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                       |
| ----------------------------------------------------------------------------------------------------------- | --------------------------------------------- |
| [`a0046af1`](https://github.com/nix-community/home-manager/commit/a0046af169ce7b1da503974e1b22c48ef4d71887) | `` Translations update from Hosted Weblate `` |