### PR TITLE
chore(flake/nixpkgs): `eb62e6aa` -> `5df43628`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -556,11 +556,11 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1736883708,
-        "narHash": "sha256-uQ+NQ0/xYU0N1CnXsa2zghgNaOPxWpMJXSUJJ9W7140=",
+        "lastModified": 1737062831,
+        "narHash": "sha256-Tbk1MZbtV2s5aG+iM99U8FqwxU/YNArMcWAv6clcsBc=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "eb62e6aa39ea67e0b8018ba8ea077efe65807dc8",
+        "rev": "5df43628fdf08d642be8ba5b3625a6c70731c19c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                    |
| ---------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------- |
| [`4f6ebaa6`](https://github.com/NixOS/nixpkgs/commit/4f6ebaa6cd82d54638f5954bafe5ff5312284e34) | `` coqPackages.paco: 4.2.0 → 4.2.2 ``                                      |
| [`6c61e588`](https://github.com/NixOS/nixpkgs/commit/6c61e588d3f638696506a5bb82c1f2748682e860) | `` docs: Fix relative links to packages moved to `/by-name/` ``            |
| [`0dfe3819`](https://github.com/NixOS/nixpkgs/commit/0dfe38199b238ab292c57db5c2c27bb9a7d316d9) | `` dendrite: 0.14.0 -> 0.14.1 ``                                           |
| [`e6cf3e6d`](https://github.com/NixOS/nixpkgs/commit/e6cf3e6db33f131e7caba1c4d5d489c65f2cfcae) | `` trilium-next-desktop: fix Darwin build ``                               |
| [`5744d75b`](https://github.com/NixOS/nixpkgs/commit/5744d75b30d14d8fc75c0bf32267bdd14cad5aea) | `` kdePackages.kirigami-addons: 1.6.0 -> 1.7.0 ``                          |
| [`ab1c313e`](https://github.com/NixOS/nixpkgs/commit/ab1c313e29cfc326250454442d6751e5b74e31bd) | `` telegram-desktop: 5.10.2 → 5.10.3 ``                                    |
| [`dfb1fdf3`](https://github.com/NixOS/nixpkgs/commit/dfb1fdf35f6382b2cc261248d6af44dd4df56e5c) | `` jcli: modernize ``                                                      |
| [`76792578`](https://github.com/NixOS/nixpkgs/commit/76792578741f30411be306105879bcddb0f9db33) | `` coqPackages.stdlib: keep compiling with master ``                       |
| [`a453c04f`](https://github.com/NixOS/nixpkgs/commit/a453c04f594b1a6d62a970024ae4503dd3d874f9) | `` coq: keep compiling master ``                                           |
| [`2599327b`](https://github.com/NixOS/nixpkgs/commit/2599327bc48f151f3c725a4a92902561af98da73) | `` ruff: 0.9.1 -> 0.9.2 ``                                                 |
| [`f1d2f766`](https://github.com/NixOS/nixpkgs/commit/f1d2f766844c65dead454a55ce443dd244061ea1) | `` v2ray-geoip: 202403140037 -> 202501160051 ``                            |
| [`0b0a0bba`](https://github.com/NixOS/nixpkgs/commit/0b0a0bbaf13ea2cc26b9c1c9f558cafcebbd8c2b) | `` cargo: fix install check phase when cross ``                            |
| [`c8ba1d6f`](https://github.com/NixOS/nixpkgs/commit/c8ba1d6fa042515d2f26bdf03fea613c6c7dcca9) | `` raycast: 1.88.4 -> 1.89.0 ``                                            |
| [`0dd7f303`](https://github.com/NixOS/nixpkgs/commit/0dd7f3032e326dfb2f1a3ffbe597ec2ce198efff) | `` jcli: 0.0.46 -> 0.0.47 ``                                               |
| [`d719fb1c`](https://github.com/NixOS/nixpkgs/commit/d719fb1c4cbdd5155d9a91e4c5d925c0da992b1e) | `` orchard: 0.26.2 -> 0.26.3 ``                                            |
| [`ee1fe43d`](https://github.com/NixOS/nixpkgs/commit/ee1fe43d4e473e1f7487eb678c9713b4006edb24) | `` bloop: 2.0.6 -> 2.0.7 ``                                                |
| [`69d90485`](https://github.com/NixOS/nixpkgs/commit/69d90485a54d76090e1ac5b9444d69242cc9d01a) | `` python3Packages.unicodedata2: 15.1.0 -> 16.0.0 ``                       |
| [`bb2d0a6b`](https://github.com/NixOS/nixpkgs/commit/bb2d0a6b4d7c22337c8167f120ddb308d7f6e479) | `` lint-staged: 15.3.0 -> 15.4.0 ``                                        |
| [`7241ef10`](https://github.com/NixOS/nixpkgs/commit/7241ef10ca5e8891cdfc3af8c47e733cf6877b42) | `` kubeseal: 0.27.3 -> 0.28.0 ``                                           |
| [`9818cc03`](https://github.com/NixOS/nixpkgs/commit/9818cc03f77175b86da85192403d8653f68ada88) | `` inputplumber: 0.40.0 -> 0.40.1 ``                                       |
| [`310c5c4d`](https://github.com/NixOS/nixpkgs/commit/310c5c4d3fd457d80365f52c71ac80b9d54a7cc4) | `` bluez: re-disable test on x86_64-unknown-linux-musl ``                  |
| [`16238201`](https://github.com/NixOS/nixpkgs/commit/16238201caa1cb65e68f3dd7bfb0ec1f7152bf9c) | `` wipe: Set platform to Unix ``                                           |
| [`b4b3c73a`](https://github.com/NixOS/nixpkgs/commit/b4b3c73a946d7e20d7afcaba8e08cef87c4c1412) | `` wipe: Switch from sha256 to hash ``                                     |
| [`f292fa21`](https://github.com/NixOS/nixpkgs/commit/f292fa21d79a410a8d75808fd8a033edd11d8dd9) | `` wipe: Do not strip binary during install ``                             |
| [`604fa77e`](https://github.com/NixOS/nixpkgs/commit/604fa77ed8f3b1a94dc4590ad54907498d36019e) | `` pmount: add debian patches; fix gcc-14 build ``                         |
| [`026824ef`](https://github.com/NixOS/nixpkgs/commit/026824ef9b88fb61666c3bae7ae14c4c5a67966e) | `` pay-respects: add bloxx12 to maintainers ``                             |
| [`703c51a6`](https://github.com/NixOS/nixpkgs/commit/703c51a6223cc3dbb2b35e18c7772e278d56fd42) | `` python312Packages.laces: 0.1.1 -> 0.1.2 ``                              |
| [`fb05f9b5`](https://github.com/NixOS/nixpkgs/commit/fb05f9b503e1e7049d655a4cc17ab4ade903929e) | `` pay-respects: 0.4.18 -> 0.6.10 ``                                       |
| [`42574f52`](https://github.com/NixOS/nixpkgs/commit/42574f52056f64257f964be558255e8f3271a03f) | `` fetchFromGitHub: refactor for scope clarity ``                          |
| [`abf3eaf9`](https://github.com/NixOS/nixpkgs/commit/abf3eaf9337a04b5cadd960fa9f9936b43123b76) | `` slimevr-server: update gradle plugin dependencies ``                    |
| [`f26a825e`](https://github.com/NixOS/nixpkgs/commit/f26a825e8bba322f0862e2cd4c6f86d548637e97) | `` keyguard: update gradle plugin dependencies ``                          |
| [`eb43df3e`](https://github.com/NixOS/nixpkgs/commit/eb43df3e281f05d50107e5771a3b1ddc47bb62e6) | `` jadx: update gradle plugin dependencies ``                              |
| [`a3b161e1`](https://github.com/NixOS/nixpkgs/commit/a3b161e1f6aef25df3ae51a5f9eee8fc338fd011) | `` gradle: 8.10.2 -> 8.12 ``                                               |
| [`cd6a44e1`](https://github.com/NixOS/nixpkgs/commit/cd6a44e1b73455c5abe91482e57e10609853c904) | `` gradle: add support for the new file-events library format ``           |
| [`779b6255`](https://github.com/NixOS/nixpkgs/commit/779b6255fd6e477290b9bd3e3956bfe79d60d7a9) | `` gradle: remove unused jdk11 argument ``                                 |
| [`29503f95`](https://github.com/NixOS/nixpkgs/commit/29503f955b8e94ce97824a20192484eb10e6f1ff) | `` gradle: handle updates to .0 versions ``                                |
| [`60820986`](https://github.com/NixOS/nixpkgs/commit/6082098609b0c9ef65939c5e64523043a69a7947) | `` gradle: remove old update script ``                                     |
| [`9ca9394a`](https://github.com/NixOS/nixpkgs/commit/9ca9394a64f76ec0eedb37ba20407a6e78afe23d) | `` gradle: reformat default.nix ``                                         |
| [`a84c233e`](https://github.com/NixOS/nixpkgs/commit/a84c233e15b9ce4af773b9320c63d41735046d0a) | `` arkenfox-userjs: 128.0 -> 133.0 ``                                      |
| [`0e80b9af`](https://github.com/NixOS/nixpkgs/commit/0e80b9af0ff2a3ef3d02e575dd4b6a02eb6abc68) | `` typespec: init at 0.64.0 ``                                             |
| [`b07c183b`](https://github.com/NixOS/nixpkgs/commit/b07c183bf073428060ad6f6abe4f588afc6e3ea0) | `` gqlgen: init at 0.17.63 ``                                              |
| [`6184410b`](https://github.com/NixOS/nixpkgs/commit/6184410b2e9e17103388214e0b3e4371ad559fe9) | `` maintainers: add paukaifler ``                                          |
| [`2ed93509`](https://github.com/NixOS/nixpkgs/commit/2ed93509653648922d2ead0c5cc340f371fa8af5) | `` python312Packages.aw-client: refactor ``                                |
| [`c0a8c8aa`](https://github.com/NixOS/nixpkgs/commit/c0a8c8aaa60c3b5a789bc7f973b051cfe308d703) | `` python312Packages.pyaprilaire: fix description ``                       |
| [`561fe54b`](https://github.com/NixOS/nixpkgs/commit/561fe54b21a3bac080dc4f0efbdfe568c8a4b9ab) | `` eza: 0.20.16 -> 0.20.17 ``                                              |
| [`3e274af9`](https://github.com/NixOS/nixpkgs/commit/3e274af9706ef6a171ce632be2141f4a80901fdf) | `` python313Packages.caio: 0.9.17 -> 0.9.21 ``                             |
| [`021b5ba3`](https://github.com/NixOS/nixpkgs/commit/021b5ba349a808b1ba6a8042e28e1c0e5e829906) | `` libskk: fix cross build ``                                              |
| [`4ea0d443`](https://github.com/NixOS/nixpkgs/commit/4ea0d443c6523416e6e56f69d8d194f28ac3f422) | `` cnspec: 11.36.2 -> 11.37.0 ``                                           |
| [`932ad13d`](https://github.com/NixOS/nixpkgs/commit/932ad13dc32dc23f1beaabf8c1365bb6263e04d5) | `` python313Packages.tencentcloud-sdk-python: 3.0.1303 -> 3.0.1304 ``      |
| [`7ac2597e`](https://github.com/NixOS/nixpkgs/commit/7ac2597ee95e24acc852d8c4cacec97b1d95c9a1) | `` libhangul: fix cross build ``                                           |
| [`b6a35ab9`](https://github.com/NixOS/nixpkgs/commit/b6a35ab9da9a0ea15b83f41a7421a83e0f5a6cd6) | `` ocamlPackages.asn1-combinators: 0.3.1 -> 0.3.2 (#373485) ``             |
| [`56a0ac2c`](https://github.com/NixOS/nixpkgs/commit/56a0ac2c97285d1bfdd9adfaa98867d85b106c49) | `` gradle: Add britter as maintainer ``                                    |
| [`d0da78f9`](https://github.com/NixOS/nixpkgs/commit/d0da78f987a9682cf961b906d1f34ec6cce4734d) | `` maintainers: add britter ``                                             |
| [`4a71f603`](https://github.com/NixOS/nixpkgs/commit/4a71f60381ba80ef62d6a91ee4f2f4b9a1d9e256) | `` uv: 0.5.18 -> 0.5.20 ``                                                 |
| [`94044ee8`](https://github.com/NixOS/nixpkgs/commit/94044ee87fec8d3b62e2ed6385a9caf84718a194) | `` maa-assistant-arknights: 5.10.2 -> 5.12.0-beta-1 ``                     |
| [`1e7ddefc`](https://github.com/NixOS/nixpkgs/commit/1e7ddefce308cdcc8af698e09ff901edac2fa26f) | `` gitleaks: 8.23.0 -> 8.23.1 ``                                           |
| [`0fec5918`](https://github.com/NixOS/nixpkgs/commit/0fec5918ba141bcb4489908257b75fa011d4c08a) | `` python312Packages.pyaprilaire: 0.7.7 -> 0.8.0 ``                        |
| [`bc941151`](https://github.com/NixOS/nixpkgs/commit/bc94115131e42fa2ce1a65fb7c0dd807de92eb0b) | `` python312Packages.aw-client: 0.5.14 -> 0.5.15 ``                        |
| [`376a8b72`](https://github.com/NixOS/nixpkgs/commit/376a8b7230ffa804a09bdd7aafa50ee663014b95) | `` murex: 6.4.1005 -> 6.4.2063 ``                                          |
| [`924758a3`](https://github.com/NixOS/nixpkgs/commit/924758a3f707fa4872d54c795df647ade4bc11f8) | `` yamlscript: 0.1.87 -> 0.1.88 ``                                         |
| [`79371f35`](https://github.com/NixOS/nixpkgs/commit/79371f35ee1a29643d924ded6eeb33dfee025ec1) | `` bitcomet: 2.12.0 -> 2.12.1 ``                                           |
| [`029db9a6`](https://github.com/NixOS/nixpkgs/commit/029db9a62fb522a0f2ac2fb9a04e958956b67f6c) | `` trickest-cli: 1.8.3 -> 1.8.4 ``                                         |
| [`25502586`](https://github.com/NixOS/nixpkgs/commit/255025860db3d1049b29d492d2c07976b54a3598) | `` misconfig-mapper: 1.12.4 -> 1.12.6 ``                                   |
| [`03035691`](https://github.com/NixOS/nixpkgs/commit/03035691fa33365e0882fd9fd507cf65148c8bfd) | `` pinniped: 0.36.0 -> 0.37.0 ``                                           |
| [`6eae496f`](https://github.com/NixOS/nixpkgs/commit/6eae496f0445b7780a4a57941d14f907d8b8f117) | `` cirrus-cli: 0.133.2 -> 0.134.0 ``                                       |
| [`c5a6e156`](https://github.com/NixOS/nixpkgs/commit/c5a6e156e2869946502231a19b3e14217fa454d8) | `` delly: 1.3.2 -> 1.3.3 ``                                                |
| [`5d56a9cd`](https://github.com/NixOS/nixpkgs/commit/5d56a9cd1138cefecb3df60da405c3d915611b73) | `` maltego: 4.8.1 -> 4.9.0 ``                                              |
| [`f7d7be58`](https://github.com/NixOS/nixpkgs/commit/f7d7be581d44657b518e58effc14c9a6dede2b46) | `` kubecfg: 0.35.1 -> 0.35.2 ``                                            |
| [`effda74e`](https://github.com/NixOS/nixpkgs/commit/effda74e948c5782d86cc3b47da5638a87171c81) | `` bundletool: 1.17.2 -> 1.18.0 ``                                         |
| [`e591531c`](https://github.com/NixOS/nixpkgs/commit/e591531c30e4a575c327d173f465b84711995dd9) | `` mapserver: 8.2.2 -> 8.4.0 ``                                            |
| [`7f811073`](https://github.com/NixOS/nixpkgs/commit/7f8110734c6241b97f51abe05a13a2f8f68182af) | `` prometheus-alertmanager: 0.27.0 -> 0.28.0 ``                            |
| [`893bf11b`](https://github.com/NixOS/nixpkgs/commit/893bf11bdfbcaf50b0c52c0614a4065fa8a8c797) | `` vimPlugins.nvzone-typr: init at 2025-01-15 ``                           |
| [`5d4e9568`](https://github.com/NixOS/nixpkgs/commit/5d4e9568bc3d36434f1d7876ea79ae4561b41aa9) | `` vhs: 0.8.0 -> 0.9.0 ``                                                  |
| [`1ea4c422`](https://github.com/NixOS/nixpkgs/commit/1ea4c422d4d1d27c4767055a49d126cc82299bf1) | `` go-containerregistry: 0.20.2 -> 0.20.3 ``                               |
| [`050266d0`](https://github.com/NixOS/nixpkgs/commit/050266d09846ef545e3180a59aff082f71b6fdcf) | `` blis: 1.0 -> 1.1 ``                                                     |
| [`3a120091`](https://github.com/NixOS/nixpkgs/commit/3a1200917f09c44494b411398978b2e2bb12944a) | `` yt-dlp: 2025.1.12 -> 2025.1.15 ``                                       |
| [`cd565f7d`](https://github.com/NixOS/nixpkgs/commit/cd565f7da304e3e4ff159633fcbcbf0e7cb77d98) | `` postgresqlPackages.pgsql-http: 1.6.1 -> 1.6.2 ``                        |
| [`769fe6b8`](https://github.com/NixOS/nixpkgs/commit/769fe6b829bdcad3390a36078c8c2741dd4cf15b) | `` python313Packages.buienradar: add changelog ``                          |
| [`561e1a72`](https://github.com/NixOS/nixpkgs/commit/561e1a72b8d001d6603d2d0583d5bdb2f1139745) | `` python313Packages.svg2tikz: unbreak ``                                  |
| [`0a3babd3`](https://github.com/NixOS/nixpkgs/commit/0a3babd30e2c96b0b35d8cf89a863668599a60c1) | `` home-assistant-custom-components.homematicip_local: 1.78.0 -> 1.78.1 `` |
| [`2b6151b9`](https://github.com/NixOS/nixpkgs/commit/2b6151b9d7e4ca3a436e98b90bda6b869896a8ca) | `` python313Packages.hahomematic: 2025.1.5 -> 2025.1.7 ``                  |
| [`b5212601`](https://github.com/NixOS/nixpkgs/commit/b521260126e73152784363e72841c62bb198082b) | `` webdav: 5.7.1 -> 5.7.2 ``                                               |
| [`507145d1`](https://github.com/NixOS/nixpkgs/commit/507145d1761a397a57df3808b02bce0b5d89aafe) | `` terraform-providers.sysdig: 1.42.0 -> 1.44.0 ``                         |
| [`d2b502d0`](https://github.com/NixOS/nixpkgs/commit/d2b502d03c039376429d3afd5e77926197897d89) | `` astal.cava: unbreak ``                                                  |
| [`2256fa48`](https://github.com/NixOS/nixpkgs/commit/2256fa48115932ef1c1776a22975555659c6af29) | `` lomiri.lomiri-ui-toolkit: Reinstate problematic test marking ``         |
| [`332af29d`](https://github.com/NixOS/nixpkgs/commit/332af29d45d382aedb5b0d285284d224b939a858) | `` python3Packages.gpaw: 24.1.0 -> 25.1.0 ``                               |
| [`9427db47`](https://github.com/NixOS/nixpkgs/commit/9427db47f7c5ba8295660ac4999fae81a870d986) | `` zed-editor: 0.168.3 -> 0.169.2 ``                                       |
| [`e3b93c1f`](https://github.com/NixOS/nixpkgs/commit/e3b93c1fb2f0cb53c074ee56715bff40de94dfeb) | `` notepad-next: migrate to by-name ``                                     |
| [`0371b937`](https://github.com/NixOS/nixpkgs/commit/0371b937995beabb34d1533d87289f8fe37dc9cb) | `` python312Packages.buienradar: 1.0.6 -> 1.0.7 ``                         |
| [`a383bb89`](https://github.com/NixOS/nixpkgs/commit/a383bb892cae86400a0156cbe1ee49b5eb800d4d) | `` notepad-next: modernize ``                                              |
| [`fc43d752`](https://github.com/NixOS/nixpkgs/commit/fc43d7524544386993245844997fe34cf90ef922) | `` nixos/lib/eval-config: fix minor typo ``                                |
| [`1cf5d659`](https://github.com/NixOS/nixpkgs/commit/1cf5d65969e708428f7b7461d90fb82aa1507526) | `` limbo: 0.0.11 -> 0.0.12 ``                                              |
| [`41cf2b03`](https://github.com/NixOS/nixpkgs/commit/41cf2b03a58aa938d47e14c1d87d11bb2fc3558e) | `` gping: move to pkgs/by-name ``                                          |
| [`ddaad969`](https://github.com/NixOS/nixpkgs/commit/ddaad969c764109414bc2e66b7801f3c6d7bc545) | `` gping: add nix update script ``                                         |
| [`8966c27b`](https://github.com/NixOS/nixpkgs/commit/8966c27b2f44b1f3ffa74bf1200cc6585b59d23a) | `` gping: refactor meta ``                                                 |
| [`ddc57775`](https://github.com/NixOS/nixpkgs/commit/ddc57775747e1f6bece9ee16563200c17b4b750f) | `` gping: 1.18.0 -> 1.19.0 ``                                              |
| [`1c169270`](https://github.com/NixOS/nixpkgs/commit/1c169270f7cc40b853b5e2d168483ffc502eae6e) | `` kazumi: 1.5.0 -> 1.5.1 ``                                               |
| [`3d891ad5`](https://github.com/NixOS/nixpkgs/commit/3d891ad5a6bb5e9b3c6a64e787883794720025bb) | `` ktailctl: 0.18.2 -> 0.19.0 ``                                           |
| [`e3ff48d9`](https://github.com/NixOS/nixpkgs/commit/e3ff48d93c2a5783caae14f3d7dfb5c10b35a31f) | `` wlr-layout-ui: 1.6.14 -> 1.6.15 ``                                      |
| [`6a0afb0e`](https://github.com/NixOS/nixpkgs/commit/6a0afb0eb3c4de3d2e4aef73b229f44272455287) | `` maintainers: add skowalak ``                                            |
| [`a7e1062b`](https://github.com/NixOS/nixpkgs/commit/a7e1062b05f8e53e0d79285a6c57aebf9cf7e334) | `` lomiri.lomiri-api: 0.2.1 -> 0.2.2 ``                                    |
| [`062a2ef3`](https://github.com/NixOS/nixpkgs/commit/062a2ef3422adbb2fa32c3ace8b3206d91bfc560) | `` alacritty: add myself as maintainer, drop Mic92 ``                      |
| [`232bc55f`](https://github.com/NixOS/nixpkgs/commit/232bc55fb108c06b4e1fd1250af775a09e5de066) | `` alacritty: 0.14.0 -> 0.15.0 ``                                          |
| [`f2c733a2`](https://github.com/NixOS/nixpkgs/commit/f2c733a28bdd51a91ca6067b19fd40112d9915f3) | `` librest: fix strictDeps build ``                                        |
| [`a858b339`](https://github.com/NixOS/nixpkgs/commit/a858b339e20296199553a1daa86180d350178e8a) | `` gnumeric: fix cross build ``                                            |