### PR TITLE
chore(flake/zen-browser): `3afebe6b` -> `188c54c4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -801,11 +801,11 @@
         "nixpkgs": "nixpkgs_4"
       },
       "locked": {
-        "lastModified": 1737083951,
-        "narHash": "sha256-0cgLd+0B2gH59lVmvbJ8x0PYt3eHbS14WiY1C+8EeAk=",
+        "lastModified": 1737177311,
+        "narHash": "sha256-MuwxPJgJIrQhnl5KHY+5mIK2udvGCyksgNreGcYcQi4=",
         "owner": "0xc000022070",
         "repo": "zen-browser-flake",
-        "rev": "3afebe6b6eb7ffa3c0c86794d36c82a5a76b6e1b",
+        "rev": "188c54c427edb7e3fab1ba9dabdcd88804cac4b1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                          | Message                                                       |
| --------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------- |
| [`188c54c4`](https://github.com/0xc000022070/zen-browser-flake/commit/188c54c427edb7e3fab1ba9dabdcd88804cac4b1) | `` Update Zen Browser twilight @ x86_64 && aarch64 to 1.7t `` |
| [`ea4cc928`](https://github.com/0xc000022070/zen-browser-flake/commit/ea4cc9280db1370808dec8ba93c47785c8d392da) | `` Update Zen Browser twilight @ x86_64 && aarch64 to 1.7t `` |