### PR TITLE
chore(flake/nixpkgs-stable): `e24b4c09` -> `6a3ae7a5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -524,11 +524,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1736916166,
-        "narHash": "sha256-puPDoVKxkuNmYIGMpMQiK8bEjaACcCksolsG36gdaNQ=",
+        "lastModified": 1737165118,
+        "narHash": "sha256-s40Kk/OulP3J/1JvC3VT16U4r/Xw6Qdi7SRw3LYkPWs=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "e24b4c09e963677b1beea49d411cd315a024ad3a",
+        "rev": "6a3ae7a5a12fb8cac2d59d7df7cbd95f9b2f0566",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                      |
| ---------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------- |
| [`f1581417`](https://github.com/NixOS/nixpkgs/commit/f15814178f8595395c9c7d836c03dc20a91eb59c) | `` home-assistant: regenerate component-packages ``                          |
| [`e1c67ff6`](https://github.com/NixOS/nixpkgs/commit/e1c67ff614a9d03bd9660992d80c922722ea33d0) | `` python313Packages.pyeiscp: init at 0.0.7 ``                               |
| [`1a0f903e`](https://github.com/NixOS/nixpkgs/commit/1a0f903eeac0058f4b4843967f1b1a6f281dc7d1) | `` chromium: unbreak build on aarch64-linux ``                               |
| [`fbb90250`](https://github.com/NixOS/nixpkgs/commit/fbb902507ed8218a1f6bba108c1cc32953acbe50) | `` coq: 8.20.0 -> 8.20.1 (#374488) ``                                        |
| [`3b288e66`](https://github.com/NixOS/nixpkgs/commit/3b288e66049aa5e7485162c6ae6bd6acce715d86) | `` matrix-synapse: 1.121.1 -> 1.122.0 ``                                     |
| [`13b60bbe`](https://github.com/NixOS/nixpkgs/commit/13b60bbe288f7092d1e40cc1ab1c38e7e63534eb) | `` open62541: 1.4.6 -> 1.4.8 ``                                              |
| [`92a58055`](https://github.com/NixOS/nixpkgs/commit/92a580554023141bdb90ef51955e81becf644c3f) | `` nixos/hyperv-guest: remove the now useless videoMode option ``            |
| [`3ef8df2c`](https://github.com/NixOS/nixpkgs/commit/3ef8df2ca4ebb32995d287490dbb2d6db41d46e2) | `` linux/common-config: disable FB_HYPERV when DRM_HYPERV is available ``    |
| [`4fbd2274`](https://github.com/NixOS/nixpkgs/commit/4fbd2274efcf9af69237d73299561975f54ba19a) | `` linux_6_1: 6.1.124 -> 6.1.125 ``                                          |
| [`ee50e7da`](https://github.com/NixOS/nixpkgs/commit/ee50e7da02641c357180ae7185a647dfcb66253e) | `` linux_6_6: 6.6.71 -> 6.6.72 ``                                            |
| [`9f33c0ae`](https://github.com/NixOS/nixpkgs/commit/9f33c0ae1cae01992de27f9b090efcdcea39e174) | `` linux_6_12: 6.12.9 -> 6.12.10 ``                                          |
| [`6a5f95ab`](https://github.com/NixOS/nixpkgs/commit/6a5f95ab8cf0069db55e33137295f3043cb6ae91) | `` linux_testing: 6.13-rc6 -> 6.13-rc7 ``                                    |
| [`879bb033`](https://github.com/NixOS/nixpkgs/commit/879bb03386e058239e91eccb8b2fa057afb4ba9e) | `` mautrix-signal: 0.7.4 -> 0.7.5 ``                                         |
| [`25996e04`](https://github.com/NixOS/nixpkgs/commit/25996e044163b3c888652f7d6cc4291c8ed89492) | `` coqPackages.stdlib: keep compiling with master ``                         |
| [`ecd5d927`](https://github.com/NixOS/nixpkgs/commit/ecd5d9270f97526c97f46005bbf376dad8eae36b) | `` coq: keep compiling master ``                                             |
| [`408da43b`](https://github.com/NixOS/nixpkgs/commit/408da43b34774006502f037e744e8b08106f54c8) | `` discord: bump all versions (#374510) ``                                   |
| [`72c03eef`](https://github.com/NixOS/nixpkgs/commit/72c03eef15e70f2217e63f04a03a1f733880b6e8) | `` lrcget: 0.9.0 -> 0.9.1 ``                                                 |
| [`e90f6ca6`](https://github.com/NixOS/nixpkgs/commit/e90f6ca690439f0ba395e646bf55d85725c29ddb) | `` treewide: fix rev->tag eval breakages ``                                  |
| [`3a91526c`](https://github.com/NixOS/nixpkgs/commit/3a91526c073dc4ec6fb6a4b91c72231ed75f9d01) | `` treewide: migrate fetchgit `rev = "refs/tags/..."` to `tag` ``            |
| [`93991fd0`](https://github.com/NixOS/nixpkgs/commit/93991fd02b0fabd39b5ca55fd6c701a9cf44bd58) | `` dotnet-sdk_9: 9.0.101 -> 9.0.102 ``                                       |
| [`16555759`](https://github.com/NixOS/nixpkgs/commit/165557593273b26d67f70dc591f6dc3ee1ccb533) | `` dotnetCorePackages.dotnet_9.vmr: 9.0.0 -> 9.0.1 ``                        |
| [`adf80613`](https://github.com/NixOS/nixpkgs/commit/adf80613ce2ee6578519f61fbdc9f91eb9d35df1) | `` dotnet-sdk_8: 8.0.404 -> 8.0.405 ``                                       |
| [`ab5f9c42`](https://github.com/NixOS/nixpkgs/commit/ab5f9c428b9f78f6bcd5a88fa60219de4243edfe) | `` dotnetCorePackages.dotnet_8.vmr: 8.0.11 -> 8.0.12 ``                      |
| [`cf937da9`](https://github.com/NixOS/nixpkgs/commit/cf937da98fbbda64cbec764c301dbeab06531ed1) | `` dotnet/update.nix: use relative paths in update script ``                 |
| [`b467b89c`](https://github.com/NixOS/nixpkgs/commit/b467b89c1d841628c79fae6395270f5c2cce5d16) | `` dotnet: deps.nix -> deps.json in VMR packages ``                          |
| [`9d19ff2b`](https://github.com/NixOS/nixpkgs/commit/9d19ff2b073910f0ecdf48b2d528273004dbd5be) | `` dotnet/update.nix: fix error when package is up-to-date ``                |
| [`70096406`](https://github.com/NixOS/nixpkgs/commit/70096406ac5598e5eb89cf9213006f61a23e5cdb) | `` dotnet/update.sh: format output with nixfmt ``                            |
| [`51c7d658`](https://github.com/NixOS/nixpkgs/commit/51c7d65833ddea195c3b461c9441c0c99b148518) | `` dendrite: 0.14.0 -> 0.14.1 ``                                             |
| [`11512be9`](https://github.com/NixOS/nixpkgs/commit/11512be9901a0bbe9ca8f0d8cdd7088ba6ed53aa) | `` ptyxis: 47.5 -> 47.6 ``                                                   |
| [`5ceb97ec`](https://github.com/NixOS/nixpkgs/commit/5ceb97ecbbe1cbb01b1db9b147aabdf6f2fc9f85) | `` trilium-next-desktop: fix Darwin build ``                                 |
| [`6ee16678`](https://github.com/NixOS/nixpkgs/commit/6ee166786107f9b9f4a08114ce42609376559758) | `` prometheus-frr-exporter: fix communication to frr unix socket ``          |
| [`c7b28585`](https://github.com/NixOS/nixpkgs/commit/c7b28585fb64033dcb03e4991bd53c89d393fa75) | `` fetchFromGitHub: refactor for scope clarity ``                            |
| [`0e09a4b9`](https://github.com/NixOS/nixpkgs/commit/0e09a4b9f22ebed8a509cea953e1d4b692f13d62) | `` fetchFromGitHub: use the API tarball endpoint ``                          |
| [`ffbdce35`](https://github.com/NixOS/nixpkgs/commit/ffbdce35b257a43785fb7b333846dc1ce67985c7) | `` gnome-online-accounts: 3.52.2 -> 3.52.3.1 ``                              |
| [`5ccc1bdb`](https://github.com/NixOS/nixpkgs/commit/5ccc1bdb2bd3bdb359ae8138bd2d82298c66855a) | `` eza: 0.20.16 -> 0.20.17 ``                                                |
| [`dfc0fbf1`](https://github.com/NixOS/nixpkgs/commit/dfc0fbf11d15a2fb24b9b7da29d55035ba8fc5d6) | `` yt-dlp: 2025.1.12 -> 2025.1.15 ``                                         |
| [`8e25027f`](https://github.com/NixOS/nixpkgs/commit/8e25027f9900c7837450013bd34aa71ab297cd9f) | `` gradle: add udev to the JNA library path ``                               |
| [`d4098b44`](https://github.com/NixOS/nixpkgs/commit/d4098b44ef8a3444ab21fae72058869d95379b70) | `` devede: 4.17.0 -> 4.19.0 ``                                               |
| [`3234d6be`](https://github.com/NixOS/nixpkgs/commit/3234d6be7727dfae6e769a33db02264e65544b30) | `` chromium: unbreak building M132 by using Rust 1.83 instead of 1.82 ``     |
| [`624012e9`](https://github.com/NixOS/nixpkgs/commit/624012e9aaf0b4b56c7a6105b5c2969b88e95ea3) | `` pingvin-share: 1.7.1 -> 1.8.0 ``                                          |
| [`c8c37f20`](https://github.com/NixOS/nixpkgs/commit/c8c37f20a4a6395ef1c3749fa1de2ccabcb74389) | `` pingvin-share: 1.7.0 -> 1.7.1 ``                                          |
| [`f41d87ba`](https://github.com/NixOS/nixpkgs/commit/f41d87bae8035593fcc2c77430f9e2ca4d83502b) | `` pingvin-share: 1.6.1 -> 1.7.0 ``                                          |
| [`439429d7`](https://github.com/NixOS/nixpkgs/commit/439429d7d6d70ddf055d8b7fb81f713a6875899c) | `` pingvin-share: 1.4.0 -> 1.6.1 ``                                          |
| [`03777e93`](https://github.com/NixOS/nixpkgs/commit/03777e93b55b666b8d9a3719b1b50799f90176e2) | `` pingvin-share: 1.3.0 -> 1.4.0 ``                                          |
| [`7c3932fa`](https://github.com/NixOS/nixpkgs/commit/7c3932fa8b02667d823d807af98d8a2d5137f9ce) | `` pingvin-share: 1.2.4 -> 1.3.0 ``                                          |
| [`e04aaf95`](https://github.com/NixOS/nixpkgs/commit/e04aaf95b0005562b0b4ea09afa5cbd99c2b5f95) | `` pingvin-share: 1.1.3 -> 1.2.4 ``                                          |
| [`952f1d5d`](https://github.com/NixOS/nixpkgs/commit/952f1d5d2e353afeb0fbf7ffc0f9bda5ab2b0d84) | `` {rust,rustPackages}_1_83: init at 1.83.0 ``                               |
| [`ab9de86b`](https://github.com/NixOS/nixpkgs/commit/ab9de86b77e4c0666d0098edcee7227f6716500c) | `` mpris-timer: 2.0.3 -> 2.0.5 ``                                            |
| [`5404fee8`](https://github.com/NixOS/nixpkgs/commit/5404fee829407c1ac045cb8d4366e20beabb7567) | `` showtime: add gst-libav ``                                                |
| [`05bd7b21`](https://github.com/NixOS/nixpkgs/commit/05bd7b216fdf308d14580abf15736fb5e469d627) | `` resources: 1.7.0 -> 1.7.1 (#363218) ``                                    |
| [`a876e006`](https://github.com/NixOS/nixpkgs/commit/a876e0067abe361d91f1ac93a28fd1c74c9991fc) | `` nixosTests.matomo: extend test coverage ``                                |
| [`ddbe88f0`](https://github.com/NixOS/nixpkgs/commit/ddbe88f0ecbfe825ed844b4136cc16666fe9ea9a) | `` nixos/matomo: better check for database being set up ``                   |
| [`2298eada`](https://github.com/NixOS/nixpkgs/commit/2298eada54692b68fad49cd4e23a61cadb4224d8) | `` electrum-ltc: unbreak ``                                                  |
| [`23390d30`](https://github.com/NixOS/nixpkgs/commit/23390d300fd20e61d552732b23ca77ff98a023ff) | `` chromium,chromedriver: 131.0.6778.264 -> 132.0.6834.83 ``                 |
| [`3beccf2f`](https://github.com/NixOS/nixpkgs/commit/3beccf2ffc6f7c36b16def00094bdaf551e12476) | `` amazon-ec2-utils: wrap programs ``                                        |
| [`1336ee57`](https://github.com/NixOS/nixpkgs/commit/1336ee57b3fb5e5f6441bfa2eb3571662cd95760) | `` trilium-next-{desktop,server}: init at 0.90.12 ``                         |
| [`67d2c574`](https://github.com/NixOS/nixpkgs/commit/67d2c574bda491cc27e131bcc971ba42731b7498) | `` nixos/trilium: add adjustable package ``                                  |
| [`a7215fe0`](https://github.com/NixOS/nixpkgs/commit/a7215fe013aecd7a3f06793a7799c3757b00f752) | `` pnpm: pin pnpm to pnpm_9 ``                                               |
| [`fe60b575`](https://github.com/NixOS/nixpkgs/commit/fe60b575c4feafdfc40e030c44601426b812c3a1) | `` keycloak: 26.0.8 -> 26.1.0 ``                                             |
| [`453cdbd8`](https://github.com/NixOS/nixpkgs/commit/453cdbd825883e2bd9dc245d1ebd53f2acd6a426) | `` cargo-tauri: 2.2.1 -> 2.2.2 ``                                            |
| [`91658ec2`](https://github.com/NixOS/nixpkgs/commit/91658ec2d70ca98bf173ec6d96036f74b19fe28d) | `` python313Packages.django_5: 5.1.4 -> 5.1.5 ``                             |
| [`f9390153`](https://github.com/NixOS/nixpkgs/commit/f93901539c5771c266bc4b592dd00a88279aeeb0) | `` matomo_5: 5.2.0 -> 5.2.1 ``                                               |
| [`e0116615`](https://github.com/NixOS/nixpkgs/commit/e011661501fdbf6e98dc4a674ea3decb047393af) | `` pnpm_10: init at 10.0.0 ``                                                |
| [`5e9c6485`](https://github.com/NixOS/nixpkgs/commit/5e9c6485d0bb10f9650c5f90cc685ded9b6f87c6) | `` thunderbird-bin-unwrapped: 128.5.2esr -> 128.6.0esr ``                    |
| [`c917a46b`](https://github.com/NixOS/nixpkgs/commit/c917a46b01944035ffa8c2ce05106ef0f84e4c87) | `` cardimpose: 0.2.1 -> 0.2.1-unstable-2024-12-28 ``                         |
| [`d65dab5d`](https://github.com/NixOS/nixpkgs/commit/d65dab5d4bb4ff2571974c36b71314b7769332c4) | `` pam_u2f: 1.3.0 -> 1.3.1 ``                                                |
| [`a13513d7`](https://github.com/NixOS/nixpkgs/commit/a13513d7c358bd0173f9d43337b52e0ea9a5a091) | `` tests.overriding: restructure and categorise by test targets ``           |
| [`1be59a72`](https://github.com/NixOS/nixpkgs/commit/1be59a7220ed2157800f7b5af1edee581aa852e9) | `` tests.overriding: format with nixfmt-rfc-style ``                         |
| [`9c4430c1`](https://github.com/NixOS/nixpkgs/commit/9c4430c1bf0ec98756902a159f17fc3923bc73ca) | `` dxvk_2: 2.5.1 -> 2.5.2 ``                                                 |
| [`7523f326`](https://github.com/NixOS/nixpkgs/commit/7523f326bedd61e1c41f7410b25c65de99596a5d) | `` keycloak: 26.0.7 -> 26.0.8 ``                                             |
| [`1505bd65`](https://github.com/NixOS/nixpkgs/commit/1505bd65ca9b16cb2768b0706d1061d3d7632093) | `` asterisk: 20.11.0 -> 20.11.1 ``                                           |
| [`9a9f2158`](https://github.com/NixOS/nixpkgs/commit/9a9f215856070edc5bd93758e508f0e9f8a46723) | `` asterisk: 20.9.3 -> 20.11.0 ``                                            |
| [`da62baf2`](https://github.com/NixOS/nixpkgs/commit/da62baf20d77391b9dfb68a109dda63ea96e2554) | `` obs-studio-plugins.obs-transition-table: fix build failure ``             |
| [`9ff2440c`](https://github.com/NixOS/nixpkgs/commit/9ff2440c798d9b9cca20e6d474c83b8ca2a42bad) | `` wslu: 4.1.3 -> 4.1.4 ``                                                   |
| [`07a5482c`](https://github.com/NixOS/nixpkgs/commit/07a5482caca094eeaf6f24964d7e23ccab440535) | `` nixosTests.homepage-dashboard: check declarative settings ``              |
| [`29e3d90f`](https://github.com/NixOS/nixpkgs/commit/29e3d90ff7f995a65233d5e4879e0d37b4664ff1) | `` nixos/libvirtd: Add proper UEFI support ``                                |
| [`b9f7c8d4`](https://github.com/NixOS/nixpkgs/commit/b9f7c8d4f2013cfc7139c3507c39840a986a6520) | `` riffdiff: 3.3.7 -> 3.3.8 ``                                               |
| [`751bf117`](https://github.com/NixOS/nixpkgs/commit/751bf117f20d8e8aff1e0b6f1ce9962668bb2494) | `` python312Packages.netbox-qrcode: init at 0.0.15 (#369931) ``              |
| [`19ae6491`](https://github.com/NixOS/nixpkgs/commit/19ae64918b4e9af6ef6d62707a1ebc991f1796c2) | `` refine: init at 0.4.0 ``                                                  |
| [`69eadb77`](https://github.com/NixOS/nixpkgs/commit/69eadb7788f4e368585ad737156174ca91972b5a) | `` tangara-companion: init at 0.4.3 ``                                       |
| [`618bff4e`](https://github.com/NixOS/nixpkgs/commit/618bff4e7a2434e0703bb5036eda3927b6eddf60) | `` firefox-beta-unwrapped: 133.0b9 -> 135.0b3 ``                             |
| [`b3694b02`](https://github.com/NixOS/nixpkgs/commit/b3694b02d34e0e77365cfe72c5c2131cf1100ebc) | `` perlPackages.ImageMagick: use same version as main imagemagick package `` |
| [`9d9c6262`](https://github.com/NixOS/nixpkgs/commit/9d9c626205220ec0510484c10855d4aed8faa160) | `` qt6.qtwebengine: fix build on darwin ``                                   |
| [`2fd6509a`](https://github.com/NixOS/nixpkgs/commit/2fd6509a25b915b97ae4f5ea0d45256a0766d9d8) | `` qt6.qtwebengine: make the `AppleClang` substitution unconditional ``      |