### PR TITLE
chore(flake/home-manager): `97d7946b` -> `f8ef4541`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -354,11 +354,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1737221749,
-        "narHash": "sha256-igllW0yG+UbetvhT11jnt9RppSHXYgMykYhZJeqfHs0=",
+        "lastModified": 1737299337,
+        "narHash": "sha256-0NBrY2A7buujKmeCbieopOMSbLxTu8TFcTLqAbTnQDw=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "97d7946b5e107dd03cc82f21165251d4e0159655",
+        "rev": "f8ef4541bb8a54a8b52f19b52912119e689529b3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                                                     |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------- |
| [`f8ef4541`](https://github.com/nix-community/home-manager/commit/f8ef4541bb8a54a8b52f19b52912119e689529b3) | `` nixpkgs: lib.isFunction replaces builtins.isFunction in check for overlayType (#6338) `` |