### PR TITLE
chore(flake/nixpkgs-stable): `6a3ae7a5` -> `107d5ef0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -524,11 +524,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1737165118,
-        "narHash": "sha256-s40Kk/OulP3J/1JvC3VT16U4r/Xw6Qdi7SRw3LYkPWs=",
+        "lastModified": 1737299813,
+        "narHash": "sha256-Qw2PwmkXDK8sPQ5YQ/y/icbQ+TYgbxfjhgnkNJyT1X8=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "6a3ae7a5a12fb8cac2d59d7df7cbd95f9b2f0566",
+        "rev": "107d5ef05c0b1119749e381451389eded30fb0d5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                               |
| ---------------------------------------------------------------------------------------------- | --------------------------------------------------------------------- |
| [`9ed87a10`](https://github.com/NixOS/nixpkgs/commit/9ed87a1015ce340bf2439bf95afea4097a97c781) | `` postgresql: add PYTHONPATH via wrapProgram ``                      |
| [`d1f57805`](https://github.com/NixOS/nixpkgs/commit/d1f578059ac7fedbdb4aecd36ea01cb30d4035b4) | `` postgresql: fix build if pythonSupport is enabled ``               |
| [`4367d51c`](https://github.com/NixOS/nixpkgs/commit/4367d51c23e650ffadfe4248f4e5e54ef1eb505c) | `` ci: Interpunction ``                                               |
| [`949185c8`](https://github.com/NixOS/nixpkgs/commit/949185c80eb76c301d236473b9e9a0e748771a7c) | `` ci: Show example nixfmt command prominently ``                     |
| [`9205880a`](https://github.com/NixOS/nixpkgs/commit/9205880adbf6dc92121379be0191d688e34b7c3a) | `` build(deps): bump actions/upload-artifact from 4.5.0 to 4.6.0 ``   |
| [`90fcbad7`](https://github.com/NixOS/nixpkgs/commit/90fcbad7cf81e41206330406a31456cccaea9724) | `` linux_6_1: 6.1.125 -> 6.1.126 ``                                   |
| [`8c44145c`](https://github.com/NixOS/nixpkgs/commit/8c44145cc0b9e9030ee23b2842ff46da38916463) | `` mollysocket: 1.5.5 -> 1.6.0 ``                                     |
| [`067d46b7`](https://github.com/NixOS/nixpkgs/commit/067d46b777a24e52bd74a928c5886cc92e70285e) | `` mollysocket: 1.5.4 -> 1.5.5 ``                                     |
| [`628a8c45`](https://github.com/NixOS/nixpkgs/commit/628a8c45d00e2a0e276b9dbe7afa6e58ba949a93) | `` mollysocket: 1.5.3 -> 1.5.4 ``                                     |
| [`13e196c1`](https://github.com/NixOS/nixpkgs/commit/13e196c137b1dae41c12500a436c8dd4f24ff822) | `` mollysocket: 1.5.2 -> 1.5.3 ``                                     |
| [`36bead22`](https://github.com/NixOS/nixpkgs/commit/36bead22c974fd41b8017a37063791e68833ea4a) | `` nextcloud28Packages: update ``                                     |
| [`9732c012`](https://github.com/NixOS/nixpkgs/commit/9732c0129e3048a9c4bba13330295ccaa476bb47) | `` nextcloudPackages: update ``                                       |
| [`f671ee01`](https://github.com/NixOS/nixpkgs/commit/f671ee01eadea86b16621ef99003065cd8bd59c6) | `` nextcloud28: mark as eol ``                                        |
| [`0aa5675a`](https://github.com/NixOS/nixpkgs/commit/0aa5675affc0a14fb40c5224ffdca9701538c068) | `` victoriametrics: 1.108.1 -> 1.109.0 ``                             |
| [`692e154b`](https://github.com/NixOS/nixpkgs/commit/692e154ba8bed505d012aea6abd5afde9e2202fe) | `` bilibili: 1.16.1-3 -> 1.16.2-2 ``                                  |
| [`e9fb4e47`](https://github.com/NixOS/nixpkgs/commit/e9fb4e47e7b1ae848a9d8983e27165a3ac8c0cd8) | `` nixos/borgbackup: fix typo in example ``                           |
| [`3ad9bb01`](https://github.com/NixOS/nixpkgs/commit/3ad9bb01d10459541658e90096060e0005f73aa9) | `` electron-source.electron_31: remove as it's EOL ``                 |
| [`c3eade0a`](https://github.com/NixOS/nixpkgs/commit/c3eade0afb433431e712cd9869a7d63832158dba) | `` electron_31-bin: mark as insecure because it's EOL ``              |
| [`bd19e43d`](https://github.com/NixOS/nixpkgs/commit/bd19e43d2ec6f7bbcdf8760c7bbbb70192e6c742) | `` electron-chromedriver_31: 31.7.6 -> 31.7.7 ``                      |
| [`6fb54eed`](https://github.com/NixOS/nixpkgs/commit/6fb54eed4c393560335383e3ade0a6b627cda161) | `` electron_31-bin: 31.7.6 -> 31.7.7 ``                               |
| [`4a7d6ef4`](https://github.com/NixOS/nixpkgs/commit/4a7d6ef470e7532e5561dee961ee1688c802d31e) | `` qq: 3.2.15-2024.12.24 -> 3.2.15-2025.1.10 ``                       |
| [`65de7227`](https://github.com/NixOS/nixpkgs/commit/65de7227747b365a9b3dc69e50156df81802b65b) | `` pretix: fix tests after 2025-01-01 ``                              |
| [`91013298`](https://github.com/NixOS/nixpkgs/commit/910132983f52e6ec982096c3234fdee0695eb29f) | `` google-chrome: 131.0.6778.264 -> 132.0.6834.84 ``                  |
| [`a93d85c0`](https://github.com/NixOS/nixpkgs/commit/a93d85c0223150884246930f97ff686be2a75156) | `` ente-auth: 4.2.4 -> 4.2.8 ``                                       |
| [`0b86c9af`](https://github.com/NixOS/nixpkgs/commit/0b86c9aff5be3fdf0947f7f2e6e7794f477b92eb) | `` nextcloud30: 30.0.4 -> 30.0.5 ``                                   |
| [`816e59cf`](https://github.com/NixOS/nixpkgs/commit/816e59cf71ce54f1448e6a6eb6c4a34011c2ae31) | `` nextcloud29: 29.0.10 -> 29.0.11 ``                                 |
| [`5d11bd58`](https://github.com/NixOS/nixpkgs/commit/5d11bd58709003af95eb6558cca900f46af90cf7) | `` raycast: 1.88.4 -> 1.89.0 ``                                       |
| [`cd812146`](https://github.com/NixOS/nixpkgs/commit/cd812146734a6479ad63a3694777f3bc64178825) | `` raycast: 1.88.3 -> 1.88.4 ``                                       |
| [`494b6f8e`](https://github.com/NixOS/nixpkgs/commit/494b6f8e81a2485953ffcb4af548fccdcf928fcc) | `` raycast: add `archBuild`, refactor `passthru.updateScript` ``      |
| [`5a0d5131`](https://github.com/NixOS/nixpkgs/commit/5a0d513116ae47e63f9f9de41d64c975d2f2d90d) | `` zug: add a patch to include algorithm ``                           |
| [`901a9575`](https://github.com/NixOS/nixpkgs/commit/901a9575ffa3e8abceb44b88897c37458dfc8c8e) | `` python314: 3.14.0a3 -> 3.14.0a4 ``                                 |
| [`663c2648`](https://github.com/NixOS/nixpkgs/commit/663c2648d8a8a5d3cdde4fe4d5fa27ed23bc129e) | `` python314: 3.14.0a2 -> 3.14.0a3 ``                                 |
| [`37b2c14c`](https://github.com/NixOS/nixpkgs/commit/37b2c14c25361a9a131ccfae9f1fa0e5ffebe441) | `` linuxPackages.nvidiaPackages.legacy_470: fix 6.6 to 6.12 ``        |
| [`e7426f15`](https://github.com/NixOS/nixpkgs/commit/e7426f1500ef261ba9f01166fab7f4c46ab568d4) | `` linuxPackages.nvidiaPackages.legacy_390: update patches to 6.12 `` |
| [`647355e7`](https://github.com/NixOS/nixpkgs/commit/647355e77e5f5d8ec873984bebfda5540fa3d883) | `` palemoon-bin: 33.5.0 -> 33.5.1 ``                                  |
| [`71657170`](https://github.com/NixOS/nixpkgs/commit/71657170b47c76f802ef0b55e0ca8e8548d5fd5b) | `` lutris: 0.5.17 -> 0.5.18 ``                                        |
| [`ccc35b78`](https://github.com/NixOS/nixpkgs/commit/ccc35b783b2dc8a94fc16b41b0a53642cdedf9cf) | `` python312Packages.napalm-ros: init at 1.2.6 ``                     |
| [`28d8b480`](https://github.com/NixOS/nixpkgs/commit/28d8b480f5d386071bf6dbd45a3978b248fe59e8) | `` httplib: 0.18.3 -> 0.18.4 ``                                       |
| [`ab568664`](https://github.com/NixOS/nixpkgs/commit/ab5686644b7763cd69d4493a2ed33e15c4336cd3) | `` httplib: 0.18.1 -> 0.18.3 ``                                       |
| [`cea8f3c6`](https://github.com/NixOS/nixpkgs/commit/cea8f3c6fe67da81bbc40c832619040c49829501) | `` go_1_22: 1.22.10 -> 1.22.11 ``                                     |
| [`51ad5b2a`](https://github.com/NixOS/nixpkgs/commit/51ad5b2a43111572b11df9d141bbf96dc2667e9e) | `` backport 364050: Update armv5 and armv6 bootstrap tools ``         |