### PR TITLE
chore(flake/zen-browser): `33c5f90b` -> `81d35d02`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -801,11 +801,11 @@
         "nixpkgs": "nixpkgs_4"
       },
       "locked": {
-        "lastModified": 1737321278,
-        "narHash": "sha256-A6WeCWhMmpxJt9Q/VoGbEmjEa7gMZCWp+iVcaGX6YB4=",
+        "lastModified": 1737354299,
+        "narHash": "sha256-uzx25R3XdXY1T02dvkIhobr41hH5w5Kb4k4ba6S+yWU=",
         "owner": "0xc000022070",
         "repo": "zen-browser-flake",
-        "rev": "33c5f90bdfa34d1aea183ffca5dc25135507ec8a",
+        "rev": "81d35d02d23c4d83fc83cf63fbbf5831dd4fa8b7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                          | Message                                                               |
| --------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------- |
| [`81d35d02`](https://github.com/0xc000022070/zen-browser-flake/commit/81d35d02d23c4d83fc83cf63fbbf5831dd4fa8b7) | `` Update Zen Browser beta @ x86_64 && aarch64 to 1.7.1b ``           |
| [`015a4132`](https://github.com/0xc000022070/zen-browser-flake/commit/015a413262a4fa0271313e03de1841414a257122) | `` Update Zen Browser twilight @ x86_64 && aarch64 to 1.7t#4a4c8a7 `` |