### PR TITLE
chore(flake/stylix): `51ad2cec` -> `268daf22`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -662,11 +662,11 @@
         "tinted-zed": "tinted-zed"
       },
       "locked": {
-        "lastModified": 1737207873,
-        "narHash": "sha256-XTCuMv753lpm8DvdVf9q2mH3rhlfsKrCUYbaADPC/bA=",
+        "lastModified": 1737416820,
+        "narHash": "sha256-PvOXfVj62pYnl2aq8l/hQkgmo22K1qa6n1JILTm4+ng=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "51ad2cec11e773a949bdbec88bed2524f098f49a",
+        "rev": "268daf22a1f93a00b7efc74c367d6711ca7f18e1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                        | Message                                      |
| --------------------------------------------------------------------------------------------- | -------------------------------------------- |
| [`268daf22`](https://github.com/danth/stylix/commit/268daf22a1f93a00b7efc74c367d6711ca7f18e1) | `` eog: init (#781) ``                       |
| [`6b69fd47`](https://github.com/danth/stylix/commit/6b69fd47fa86a3258b73168524cd196132549162) | `` firefox: support floorp browser (#785) `` |
| [`76b1f6eb`](https://github.com/danth/stylix/commit/76b1f6eb1d401e91571f7691abd6b0a976eb34cd) | `` stylix: add jq to runtimeInputs (#782) `` |