### PR TITLE
chore(flake/home-manager): `9786661d` -> `bb14224f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -354,11 +354,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1737394973,
-        "narHash": "sha256-EW4oXMfnfA5sNM9Jqm+y98horWVvN66Gu7YIcEpFYZc=",
+        "lastModified": 1737461688,
+        "narHash": "sha256-zQCFe5FcSSGzY3qauAAHZcPt7Ej4WSGo78ShSTCSBvU=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "9786661d57c476021c8a0c3e53bf9fa2b4f3328b",
+        "rev": "bb14224f51ae4caed12a7b26f245d042c8cf8553",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                               |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------- |
| [`bb14224f`](https://github.com/nix-community/home-manager/commit/bb14224f51ae4caed12a7b26f245d042c8cf8553) | `` mu: allow option to set muhome ``  |
| [`0b8df9ee`](https://github.com/nix-community/home-manager/commit/0b8df9eeb66941ef32e5761ecf4cddff91e5c020) | `` lsd: add support for icons.yaml `` |