### PR TITLE
chore(flake/home-manager): `bb14224f` -> `4481a16d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -354,11 +354,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1737461688,
-        "narHash": "sha256-zQCFe5FcSSGzY3qauAAHZcPt7Ej4WSGo78ShSTCSBvU=",
+        "lastModified": 1737480538,
+        "narHash": "sha256-rk/cmrvq3In0TegW9qaAxw+5YpJhRWt2p74/6JStrw0=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "bb14224f51ae4caed12a7b26f245d042c8cf8553",
+        "rev": "4481a16d1ac5bff4a77c608cefe08c9b9efe840d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                              |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------ |
| [`4481a16d`](https://github.com/nix-community/home-manager/commit/4481a16d1ac5bff4a77c608cefe08c9b9efe840d) | `` yazi: improve fish integration `` |
| [`96dee79b`](https://github.com/nix-community/home-manager/commit/96dee79b178d295b716052feca3ee46abc085abe) | `` lsd: remove with lib; ``          |