### PR TITLE
chore(flake/nixpkgs-stable): `107d5ef0` -> `ae584d90`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -524,11 +524,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1737299813,
-        "narHash": "sha256-Qw2PwmkXDK8sPQ5YQ/y/icbQ+TYgbxfjhgnkNJyT1X8=",
+        "lastModified": 1737404927,
+        "narHash": "sha256-e1WgPJpIYbOuokjgylcsuoEUCB4Jl2rQXa2LUD6XAG8=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "107d5ef05c0b1119749e381451389eded30fb0d5",
+        "rev": "ae584d90cbd0396a422289ee3efb1f1c9d141dc3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                 |
| ---------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------- |
| [`6f3ee2b1`](https://github.com/NixOS/nixpkgs/commit/6f3ee2b132651ff4bb0cc96ac8d18e6675a8974e) | `` gimp: move to openexr_3 ``                                           |
| [`102583ff`](https://github.com/NixOS/nixpkgs/commit/102583ffaab14e36f46eea03ad025a0ffb5cb135) | `` maintainers: update getchoo ``                                       |
| [`8e1bf76e`](https://github.com/NixOS/nixpkgs/commit/8e1bf76e407f76eafaa8d05ca9922f66217e4436) | `` ci/request-reviews: Don't fail when there's too many reviewers ``    |
| [`a2953954`](https://github.com/NixOS/nixpkgs/commit/a29539544cb14bcd888d2beadc0bd8a6cf934929) | `` phpdocumentor: fix vendorHash ``                                     |
| [`29623dc5`](https://github.com/NixOS/nixpkgs/commit/29623dc5c2a33eab9ffdf22daeb35444f2de1d91) | `` ci/eval: support "10.rebuild-${kernel}: 1" labels ``                 |
| [`08fed793`](https://github.com/NixOS/nixpkgs/commit/08fed79347078aeec6a2e0379fdbc4acbdb0b0a7) | `` phpPackages.composer: fix included patch ``                          |
| [`7c3205a7`](https://github.com/NixOS/nixpkgs/commit/7c3205a751da289a5e7b35cc70cf0eee119dac5b) | `` mailmap: add jopejoe1 ``                                             |
| [`5ce49228`](https://github.com/NixOS/nixpkgs/commit/5ce49228b1b1a1e74f10c68dab702b4d1b656255) | `` maintainers: update jopejoe1 ``                                      |
| [`27a67d09`](https://github.com/NixOS/nixpkgs/commit/27a67d09addfa3240eda5c8f5ea266b7a1a9d3e3) | `` television: 0.9.2 -> 0.9.3 ``                                        |
| [`09187059`](https://github.com/NixOS/nixpkgs/commit/09187059b20fd24710f66127a5ae2447c9931ca1) | `` python313Packages.netbox-interface-synchronization: fix build ``     |
| [`84c078d5`](https://github.com/NixOS/nixpkgs/commit/84c078d5f9afbd2cb40019d3e0bac57a30fd04fa) | `` rustc: mark broken for LLVM stdenv ``                                |
| [`e0625f03`](https://github.com/NixOS/nixpkgs/commit/e0625f030a2ac568a3ff6e42dea98841d02e8f0d) | `` ocamlPackages.elpi: use correct version information ``               |
| [`9ccfdd3b`](https://github.com/NixOS/nixpkgs/commit/9ccfdd3b3298b3cd4ebd41ff20f3e50be831b2af) | `` nixos/release-small: add latestKernel test ``                        |
| [`995a3923`](https://github.com/NixOS/nixpkgs/commit/995a3923185db2aeabb8237db07f6620e75e1a13) | `` perf: don't apply dmesg patch on 6.13, remove 6.10 patches ``        |
| [`1b413255`](https://github.com/NixOS/nixpkgs/commit/1b4132554c4fa6ad002803388cd8d9fa81333eba) | `` linux_6_13: init ``                                                  |
| [`1190bfa8`](https://github.com/NixOS/nixpkgs/commit/1190bfa8cde9493a7dbba7a69dda96d692ab58ac) | `` paperwork: fix evaluation warning ``                                 |
| [`112cb776`](https://github.com/NixOS/nixpkgs/commit/112cb77668d4cbbb3153c38975939842e01fa047) | `` nextcloud-notify_push: 0.7.0 -> 1.0.0 ``                             |
| [`0808a8d8`](https://github.com/NixOS/nixpkgs/commit/0808a8d85d048cb665c3a9457c1c3c702cf99b71) | `` {webcord, webcord-vencord}: pin electron_33 ``                       |
| [`679bfc2e`](https://github.com/NixOS/nixpkgs/commit/679bfc2e2f68860be11c4e3e3753d95595f8d582) | `` webcord: add NotAShelf to maintainers ``                             |
| [`4462f59a`](https://github.com/NixOS/nixpkgs/commit/4462f59afbcc214967913e629becf1ef98655cc3) | `` webcord: 4.10.2 -> 4.10.3 ``                                         |
| [`adfdc54c`](https://github.com/NixOS/nixpkgs/commit/adfdc54c18484e55375088a95b26133bc288506f) | `` phpunit: 11.5.2 -> 11.5.3 ``                                         |
| [`3b780d36`](https://github.com/NixOS/nixpkgs/commit/3b780d36c43b5a9a2fcebb07524560f0c4c085f2) | `` {mattermost,mattermostLatest}: fix string escapes ``                 |
| [`f9866285`](https://github.com/NixOS/nixpkgs/commit/f98662855293aff15e589d8db525571dfe1dfa60) | `` mattermostLatest: track 10.x instead of 10.4.x ``                    |
| [`49eccade`](https://github.com/NixOS/nixpkgs/commit/49eccade8f4e3eb8e9edc5e976640390b166137d) | `` mattermost: 9.11.6 -> 9.11.7 ``                                      |
| [`541c64a2`](https://github.com/NixOS/nixpkgs/commit/541c64a2377bbfa4e2b7cdb5536b84e3ea6f3bed) | `` mattermostLatest: 10.3.1 -> 10.4.1 ``                                |
| [`efe22e4b`](https://github.com/NixOS/nixpkgs/commit/efe22e4b838ebca577c67fdd98515ab686d4f46f) | `` mattermostLatest: use 10.4.x branch ``                               |
| [`6410d301`](https://github.com/NixOS/nixpkgs/commit/6410d3018eded03b9e3e86c5a6f31469e570e80e) | `` mattermostLatest: init at 10.3.1 ``                                  |
| [`0f688f9c`](https://github.com/NixOS/nixpkgs/commit/0f688f9c13dafed2b56aeb1cc385d260f86c6357) | `` haskellPackages.ghc-datasize: unbreak ``                             |
| [`f855beac`](https://github.com/NixOS/nixpkgs/commit/f855beac4b1090127e10f4c81657294c44e6ed0a) | `` ungoogled-chromium: 131.0.6778.264-1 -> 132.0.6834.83-1 ``           |
| [`aeb48703`](https://github.com/NixOS/nixpkgs/commit/aeb48703de2fcab24264d49c4c0a0cb289f398f4) | `` python313Packages.webrtc-noise-gain: fix cross builds ``             |
| [`22a92a53`](https://github.com/NixOS/nixpkgs/commit/22a92a53a50a85fb0a84b7ba105d46b3ea9fcfde) | `` arc-browser: 1.77.0-57419 -> 1.78.1-57736 ``                         |
| [`d76dd495`](https://github.com/NixOS/nixpkgs/commit/d76dd495162a7a79d8ff45a063cdfb459c17fd05) | `` arc-browser: 1.74.0-57065 -> 1.77.0-57419 ``                         |
| [`6087042f`](https://github.com/NixOS/nixpkgs/commit/6087042fa0b02c77ed26b9c057f3d93b3e5bd9d6) | `` arc-browser: 1.73.0-56815 -> 1.74.0-57065 ``                         |
| [`91790526`](https://github.com/NixOS/nixpkgs/commit/9179052636a08b365198bd638c80d992ea811c7c) | `` alt-tab-macos: 7.18.1 -> 7.19.1 ``                                   |
| [`1c78a076`](https://github.com/NixOS/nixpkgs/commit/1c78a076b422cfa7d6eb0c272857ead1e1c7bb49) | `` alt-tab-macos: 7.18.0 -> 7.18.1 ``                                   |
| [`33aae7dc`](https://github.com/NixOS/nixpkgs/commit/33aae7dccbb4e5c6ec608559ac7c43ec49b0ec22) | `` alt-tab-macos: 7.14.1 -> 7.18.0 ``                                   |
| [`1e3fa6d4`](https://github.com/NixOS/nixpkgs/commit/1e3fa6d425d72f7ae8f194265d490a9bd7b0f363) | `` alt-tab-macos: 7.12.0 -> 7.14.1 ``                                   |
| [`5959ec3b`](https://github.com/NixOS/nixpkgs/commit/5959ec3b379a31dd19d243b2777ecd96204a6acd) | `` alt-tab-macos: 7.7.0 -> 7.12.0 ``                                    |
| [`d32fd26c`](https://github.com/NixOS/nixpkgs/commit/d32fd26cb25ee01cdc6d5017903de4a7572cdd7f) | `` alt-tab-macos: 7.4.0 -> 7.7.0 ``                                     |
| [`eaea4c2b`](https://github.com/NixOS/nixpkgs/commit/eaea4c2bafa8a077cc029a5b56e2cb4986cc7010) | `` alt-tab-macos: 7.2.0 -> 7.4.0 ``                                     |
| [`2a49a63e`](https://github.com/NixOS/nixpkgs/commit/2a49a63ec84b54fca2864c2c0441660dba48643b) | `` skeditor: 2.8.1 -> 2.8.3; iconConvtools: expand to unix platforms `` |
| [`f7e3a35b`](https://github.com/NixOS/nixpkgs/commit/f7e3a35b683b15094aa4e8fbfceefb41189e6a0a) | `` paperwork: fix installing translations ``                            |
| [`8f01aa16`](https://github.com/NixOS/nixpkgs/commit/8f01aa161f657f9cb9abacbb2d7ddd9e7acf899d) | `` gale: 1.1.4 -> 1.2.2 ``                                              |
| [`7b586216`](https://github.com/NixOS/nixpkgs/commit/7b586216d7b3e8dacf9966c4fa31808f915bf060) | `` gale: fix build ``                                                   |
| [`e1a5445b`](https://github.com/NixOS/nixpkgs/commit/e1a5445b051bf0d2005bc63fec4ebba0e3d12e2b) | `` gale: 0.8.11 -> 1.1.4 ``                                             |
| [`d862cce5`](https://github.com/NixOS/nixpkgs/commit/d862cce5d8bfa5af3b3364a5e67029fb433583df) | `` nixos/postgresql: fix condition for readwritepaths ``                |
| [`951a0a48`](https://github.com/NixOS/nixpkgs/commit/951a0a48f869086f86d507acb050a01dc54f95ac) | `` forgejo-runner: add adamcstephens as maintainer ``                   |
| [`73fe8297`](https://github.com/NixOS/nixpkgs/commit/73fe8297282f83ac3934356c37cabd509f8b6092) | `` forgejo: 9.0.3 -> 10.0.0 ``                                          |
| [`cc6a457c`](https://github.com/NixOS/nixpkgs/commit/cc6a457cb6aceea9aa32cd65ba5653bf234c519f) | `` mastodon: 4.3.2 -> 4.3.3 ``                                          |
| [`0aa26717`](https://github.com/NixOS/nixpkgs/commit/0aa26717ec67d906aefd2eb746cafe81ca2c7364) | `` redict: 7.3.0 -> 7.3.2 ``                                            |
| [`1b69089d`](https://github.com/NixOS/nixpkgs/commit/1b69089de831f07a5ed7c0f14843201db243e5cb) | `` valkey: 8.0.1 -> 8.0.2 ``                                            |
| [`35d559ec`](https://github.com/NixOS/nixpkgs/commit/35d559ecc6393b652cb27226e7f7c22e4394be65) | `` tmuxPlugins.tmux-powerline: init at 3.0.0 ``                         |
| [`49901058`](https://github.com/NixOS/nixpkgs/commit/499010580124c57de316affe9c9fc9e9841bce15) | `` nixos/realmd: init ``                                                |
| [`87aa74cc`](https://github.com/NixOS/nixpkgs/commit/87aa74ccae6f29f8bfc254b83d7139b686668cc6) | `` python312Packages.netbox-topology-views: init at 4.1.0 ``            |
| [`63860d58`](https://github.com/NixOS/nixpkgs/commit/63860d5834492da3e6440624b79ab35eb9c8e356) | `` python312Packages.netbox-plugin-dns: init at 1.1.7 ``                |
| [`8ebd463d`](https://github.com/NixOS/nixpkgs/commit/8ebd463d0c21c13a76700dcbf8520d0d23035ff5) | `` python312Packages.netbox-interface-synchronization: init at 4.1.4 `` |