### PR TITLE
chore(flake/zen-browser): `162825fc` -> `c3ea41c7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -801,11 +801,11 @@
         "nixpkgs": "nixpkgs_4"
       },
       "locked": {
-        "lastModified": 1737540985,
-        "narHash": "sha256-sNRzX/wjH/zB0+EItUT6b+mY58/lPKTe/flKR9RpB3E=",
+        "lastModified": 1737573247,
+        "narHash": "sha256-qYr17CTrtmudrwcDXBZjgZM6E8elQ8O7SfMhmZj7x00=",
         "owner": "0xc000022070",
         "repo": "zen-browser-flake",
-        "rev": "162825fcd767f2c019014f409545f6db1c055c85",
+        "rev": "c3ea41c78e72866919a46116a5231c4e92062327",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                          | Message                                                                 |
| --------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------- |
| [`c3ea41c7`](https://github.com/0xc000022070/zen-browser-flake/commit/c3ea41c78e72866919a46116a5231c4e92062327) | `` Update Zen Browser beta @ x86_64 && aarch64 to 1.7.2b ``             |
| [`c4dd05c7`](https://github.com/0xc000022070/zen-browser-flake/commit/c4dd05c794af046f04da58a426fa74d326694246) | `` Update Zen Browser twilight @ x86_64 && aarch64 to 1.7.2t#c9f9766 `` |