### PR TITLE
chore(flake/nixpkgs-stable): `ae584d90` -> `47addd76`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -524,11 +524,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1737404927,
-        "narHash": "sha256-e1WgPJpIYbOuokjgylcsuoEUCB4Jl2rQXa2LUD6XAG8=",
+        "lastModified": 1737569578,
+        "narHash": "sha256-6qY0pk2QmUtBT9Mywdvif0i/CLVgpCjMUn6g9vB+f3M=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "ae584d90cbd0396a422289ee3efb1f1c9d141dc3",
+        "rev": "47addd76727f42d351590c905d9d1905ca895b82",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                              |
| ---------------------------------------------------------------------------------------------- | ---------------------------------------------------- |
| [`2aba840c`](https://github.com/NixOS/nixpkgs/commit/2aba840ce17ccb9b0036f0c6a015127eba346ffa) | `` diebahn: 2.7.1 -> 2.7.2 ``                        |
| [`51ad838b`](https://github.com/NixOS/nixpkgs/commit/51ad838b03a05b1de6f9f2a0fffecee64a9788ee) | `` nodejs_22: 22.12.0 -> 22.13.1 ``                  |
| [`71244e70`](https://github.com/NixOS/nixpkgs/commit/71244e708a636fd539c1816d185b1819fddb65c0) | `` snapcast: 0.29.0 -> 0.30.0 ``                     |
| [`8a277e5e`](https://github.com/NixOS/nixpkgs/commit/8a277e5e34db5ee8045145be2a7f7cb0ddbc3cfd) | `` php83Packages.composer: 2.8.4 -> 2.8.5 ``         |
| [`ba796568`](https://github.com/NixOS/nixpkgs/commit/ba796568628b586b448bf16816beb101c37b0cec) | `` shadow: fix meta.homepage (#375611) ``            |
| [`406f0543`](https://github.com/NixOS/nixpkgs/commit/406f054330a7b7344faeaa9fc8899aae050141d7) | `` osu-lazer-bin: 2025.101.0 -> 2025.118.2 ``        |
| [`272b8159`](https://github.com/NixOS/nixpkgs/commit/272b81592004f024afefcd8065c7cd1a3b6b29aa) | `` osu-lazer: 2025.101.0 -> 2025.118.2 ``            |
| [`dd1123fd`](https://github.com/NixOS/nixpkgs/commit/dd1123fd85b5992a8b234fe6f6aa9d22783b0246) | `` nixos/matrix-appservice-irc: fix signing key ``   |
| [`06454522`](https://github.com/NixOS/nixpkgs/commit/0645452254212aab75c1bafe740bf72f6f7f22c2) | `` firefox-bin-unwnrapped: 134.0.1 -> 134.0.2 ``     |
| [`3192cf69`](https://github.com/NixOS/nixpkgs/commit/3192cf69ce6eddb3f9f4a41700815ad6a7698a32) | `` firefox-unwrapped: 134.0.1 -> 134.0.2 ``          |
| [`6cd77b04`](https://github.com/NixOS/nixpkgs/commit/6cd77b04e58e3b7f7a3c49f56125e2177beaae41) | `` miniflux: 2.2.4 -> 2.2.5 ``                       |
| [`da32b83f`](https://github.com/NixOS/nixpkgs/commit/da32b83f4072047e95b9999dfac80630836e43e7) | `` refinery-cli: update time crate ``                |
| [`16e177c9`](https://github.com/NixOS/nixpkgs/commit/16e177c9712998b83e43157f9debee44a05fc31a) | `` nodejs_23: 23.5.0 -> 23.6.0 ``                    |
| [`eea315cf`](https://github.com/NixOS/nixpkgs/commit/eea315cf7d26ae50d3873d56dcf87e8845a23fc5) | `` google-chrome: Fix QT support ``                  |
| [`5182a40b`](https://github.com/NixOS/nixpkgs/commit/5182a40bb9abd17bf4922811b251d8ecec67680f) | `` signal-desktop(darwin): fix hash ``               |
| [`78e0814a`](https://github.com/NixOS/nixpkgs/commit/78e0814a74fb5bbb77e35c2e8d616bab21552b51) | `` signal-desktop(darwin): 7.37.0 -> 7.38.0 ``       |
| [`9e1a2841`](https://github.com/NixOS/nixpkgs/commit/9e1a2841d4cb35ae21c2383f3b6ef4af0f3a4454) | `` signal-desktop: 7.37.0 -> 7.38.0 ``               |
| [`e3ab7b81`](https://github.com/NixOS/nixpkgs/commit/e3ab7b8116870df5647357dbcf0138b2a3b10e0b) | `` sdl3: init at 3.1.8 ``                            |
| [`5b3b1b78`](https://github.com/NixOS/nixpkgs/commit/5b3b1b785ee29dccff7fca581569acc14b9f1fc8) | `` osu-lazer: 2024.1009.1 -> 2025.101.0 ``           |
| [`fed71387`](https://github.com/NixOS/nixpkgs/commit/fed713870976bc39c52933bef0d0f680c2d4204e) | `` rcu: Fix startup ``                               |
| [`7cf6261e`](https://github.com/NixOS/nixpkgs/commit/7cf6261ebd0c5a338f0354fc4eeeab423036afcc) | `` osu-lazer-bin: 2024.1009.1 -> 2025.101.0 ``       |
| [`d29c3439`](https://github.com/NixOS/nixpkgs/commit/d29c34394cf73d3eb983a370898d819c64e08efa) | `` osu-lazer{,-bin}: add native Wayland option ``    |
| [`dd3a7d5b`](https://github.com/NixOS/nixpkgs/commit/dd3a7d5b7f4fb487526762cb424b3d18eb8a4de1) | `` osu-lazer-bin: stdenv -> stdenvNoCC ``            |
| [`0dd36d97`](https://github.com/NixOS/nixpkgs/commit/0dd36d97b9b77a9b7c83d23b9511c881a824f58f) | `` osu-lazer{,-bin}: add Guanran928 as maintainer `` |