### PR TITLE
chore(flake/home-manager): `7b9ece1b` -> `a0428685`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -354,11 +354,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1737669579,
-        "narHash": "sha256-v9WQ3c4ctwPMfdBZMZxpdM9xXev4uChce4BxOpvsu0E=",
+        "lastModified": 1737704314,
+        "narHash": "sha256-zta8jvOQ2wRCZmiwFEnS5iCulWAh8e+fLUlQxrgOBjM=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "7b9ece1bf3c8780cde9b975b28c2d9ccd7e9cdb9",
+        "rev": "a0428685572b134f6594e7d7f5db5e1febbab2d7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                   |
| ----------------------------------------------------------------------------------------------------------- | --------------------------------------------------------- |
| [`a0428685`](https://github.com/nix-community/home-manager/commit/a0428685572b134f6594e7d7f5db5e1febbab2d7) | `` nh: remove PATH assignment in nh-clean systemd unit `` |
| [`a2362a64`](https://github.com/nix-community/home-manager/commit/a2362a64964c406ba3b289a474fbde573f4b7fc9) | `` nh: check osConfig for null before accessing ``        |