### PR TITLE
chore(flake/nixpkgs-stable): `47addd76` -> `035f8c08`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -453,11 +453,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1737569578,
-        "narHash": "sha256-6qY0pk2QmUtBT9Mywdvif0i/CLVgpCjMUn6g9vB+f3M=",
+        "lastModified": 1737672001,
+        "narHash": "sha256-YnHJJ19wqmibLQdUeq9xzE6CjrMA568KN/lFPuSVs4I=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "47addd76727f42d351590c905d9d1905ca895b82",
+        "rev": "035f8c0853c2977b24ffc4d0a42c74f00b182cd8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                               |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------- |
| [`5c21ab47`](https://github.com/NixOS/nixpkgs/commit/5c21ab47441e2cd2efbfdac29c020f5ab0190636) | `` ovn: 24.09.1 -> 24.09.2 ``                                                         |
| [`c1b1d405`](https://github.com/NixOS/nixpkgs/commit/c1b1d405873fb8faff039e279bca710a00fc9710) | `` julia_111: 1.11.1 -> 1.11.2 ``                                                     |
| [`53e2916c`](https://github.com/NixOS/nixpkgs/commit/53e2916ced9ed61064bd081bb47d528b0f6fe353) | `` julia_111-bin: 1.11.1 -> 1.11.2 ``                                                 |
| [`9e1eb348`](https://github.com/NixOS/nixpkgs/commit/9e1eb348c92ed157a4d72dfcf1b8ce86814cf381) | `` google-chrome: 132.0.6834.83 -> 132.0.6834.110 ``                                  |
| [`ad932449`](https://github.com/NixOS/nixpkgs/commit/ad93244947aafeb7942fc7b8be032a0eda085258) | `` vscode-extensions.ms-dotnettools.csharp: 2.55.29 -> 2.61.28 (#376090) ``           |
| [`f09e71bc`](https://github.com/NixOS/nixpkgs/commit/f09e71bc0e805065a7c33d5d1ebf82d8c61aadea) | `` coqPackages.mathcomp: adapt to https://github.com/math-comp/math-comp/pull/1329 `` |
| [`7082cef0`](https://github.com/NixOS/nixpkgs/commit/7082cef01790eeb2ed1dfd53bcfc21ea82bd2630) | `` php84: 8.4.2 -> 8.4.3 ``                                                           |
| [`07afafcf`](https://github.com/NixOS/nixpkgs/commit/07afafcfd05a5d2ddc240551b2aa397162311f27) | `` linux_latest: pin to 6.12, out of tree modules are broken ``                       |
| [`46d9ddb1`](https://github.com/NixOS/nixpkgs/commit/46d9ddb16c2a35a878e5b9d89a35bf7f7b63e53e) | `` brave: 1.73.104 -> 1.74.48 ``                                                      |
| [`db07246f`](https://github.com/NixOS/nixpkgs/commit/db07246fd19d123d08629d1b8d084138a49794a7) | `` veracrypt: 1.26.15 -> 1.26.18 ``                                                   |
| [`27d81461`](https://github.com/NixOS/nixpkgs/commit/27d81461db43ccd7fcc081ceada8dc75b7d6f7de) | `` freebsd.ports: fetchzip -> fetchgit ``                                             |
| [`c68df130`](https://github.com/NixOS/nixpkgs/commit/c68df13059e309f3d438e7f19bd9556686031c2b) | `` python3Packages.netbox-floorplan-plugin: init at 0.6.0 ``                          |
| [`9e822f89`](https://github.com/NixOS/nixpkgs/commit/9e822f898d2ac745272688855e5f7fa336b949a7) | `` maintainers: add cobalt ``                                                         |
| [`c888df50`](https://github.com/NixOS/nixpkgs/commit/c888df5018f52dd2ae3f29fda9c767e231cb1ebd) | `` sdl3: add vulkan-headers/loader to dlopenPropagatedBuildInputs ``                  |
| [`6d089e9f`](https://github.com/NixOS/nixpkgs/commit/6d089e9fa55093fb23d22c57997ab865cbf0d979) | `` sdl3: 3.1.8 -> 3.2.0 ``                                                            |
| [`7074647e`](https://github.com/NixOS/nixpkgs/commit/7074647e3c1df9a3fb4224fba4c80c43126a9906) | `` gradle: do not include udev on Mac (#374559) ``                                    |
| [`6c77bb3c`](https://github.com/NixOS/nixpkgs/commit/6c77bb3cf7e96e4c0657286ba46b7510a127f992) | `` awsume: substitute path to awsume-autocomplete bin ``                              |
| [`8a64436c`](https://github.com/NixOS/nixpkgs/commit/8a64436c30780fd886ab867a1475b6abfacee398) | `` awsume: install correct Zsh autocompletion ``                                      |
| [`321d672a`](https://github.com/NixOS/nixpkgs/commit/321d672a68ff57fcd139e81db8f72e0171f71255) | `` cobang: 0.14.1 -> 0.15.0 ``                                                        |
| [`980586c7`](https://github.com/NixOS/nixpkgs/commit/980586c7ef7f813f85c0ecf2c7c8eae8c96b6de5) | `` python312Packages.netbox-napalm-plugin: init at 0.3.1 ``                           |
| [`12766410`](https://github.com/NixOS/nixpkgs/commit/12766410676230dd660592590632b8ccda68a33f) | `` tone: 0.2.3 -> 0.2.4 ``                                                            |