### PR TITLE
chore(flake/nix-flatpak): `b6966d5f` -> `83cc6a28`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -390,11 +390,11 @@
     },
     "nix-flatpak": {
       "locked": {
-        "lastModified": 1736952876,
-        "narHash": "sha256-dJXuLP2CBkIG333L+Rb3e1D0oXHYbl0MgmKPGuvFuAI=",
+        "lastModified": 1737806078,
+        "narHash": "sha256-FjgNPBLMCpmwtJT5LiQYkM2lDY+yAmW1ZN1Idx7QeDg=",
         "owner": "gmodena",
         "repo": "nix-flatpak",
-        "rev": "b6966d5fa96b0fae99a4da0b5bdfbb0a75f5c058",
+        "rev": "83cc6a28afc4155fd3fe28274f6b5287f51ed2b6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                                                           |
| ---------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------- |
| [`83cc6a28`](https://github.com/gmodena/nix-flatpak/commit/83cc6a28afc4155fd3fe28274f6b5287f51ed2b6) | `` flatpak: remove network side effects (#141) ``                 |
| [`286616bf`](https://github.com/gmodena/nix-flatpak/commit/286616bfb149ada13d51325db4d86a5b65aab469) | `` README: add nix highlighting for overlays code block (#140) `` |