### PR TITLE
chore(flake/zen-browser): `113bba61` -> `3c6e47b3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -698,11 +698,11 @@
         "nixpkgs": "nixpkgs_3"
       },
       "locked": {
-        "lastModified": 1737767621,
-        "narHash": "sha256-1HAG9VIWsScSmIRKb1OvQv7YQVCAtNm9ckITAEcmpps=",
+        "lastModified": 1737782128,
+        "narHash": "sha256-jGnAm7ielzT/LFN34WpJY42Gued3TMOi/z8A4zQoL3Q=",
         "owner": "0xc000022070",
         "repo": "zen-browser-flake",
-        "rev": "113bba61ed2267ce436b6825cd6d5fe67dff767c",
+        "rev": "3c6e47b39a34f6bb0be2bb52e79168970e91f32a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                          | Message                                                                 |
| --------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------- |
| [`3c6e47b3`](https://github.com/0xc000022070/zen-browser-flake/commit/3c6e47b39a34f6bb0be2bb52e79168970e91f32a) | `` Update Zen Browser twilight @ x86_64 && aarch64 to 1.7.2t#c0eeab9 `` |