### PR TITLE
chore(flake/stylix): `e594886e` -> `7c1c3259`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -574,11 +574,11 @@
         "tinted-zed": "tinted-zed"
       },
       "locked": {
-        "lastModified": 1737657729,
-        "narHash": "sha256-TIDR1zKoP2uaqRot/LnarugfAC9U7geycjbJqA1naVM=",
+        "lastModified": 1737833281,
+        "narHash": "sha256-+hCZqNMvcjGinYinsITX+kJvqkEqcWheaNX5WGGcRow=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "e594886eb0951a0a0c28ffa333a9df6fb13857a1",
+        "rev": "7c1c3259283f2da9c3d15c9096e7b8864f82bd4c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                        | Message                                                                      |
| --------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------- |
| [`7c1c3259`](https://github.com/danth/stylix/commit/7c1c3259283f2da9c3d15c9096e7b8864f82bd4c) | `` ci: remove Magic Nix Cache (#745) ``                                      |
| [`5e8be752`](https://github.com/danth/stylix/commit/5e8be7521e8f7cc927c92f24f8753e64ec050cdf) | `` treewide: simplify and standardize message convention (#796) ``           |
| [`58b54b66`](https://github.com/danth/stylix/commit/58b54b664b7c67929cd0b5e6221cecbed3eab233) | `` doc: elaborate pre-commit hook usage in development environment (#793) `` |