### PR TITLE
chore(flake/stylix): `7c1c3259` -> `d6951d0b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -574,11 +574,11 @@
         "tinted-zed": "tinted-zed"
       },
       "locked": {
-        "lastModified": 1737833281,
-        "narHash": "sha256-+hCZqNMvcjGinYinsITX+kJvqkEqcWheaNX5WGGcRow=",
+        "lastModified": 1737861120,
+        "narHash": "sha256-V/GWU1BQwbxyZif9RBvwn10S1KX+86uPkkI41KQEcQQ=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "7c1c3259283f2da9c3d15c9096e7b8864f82bd4c",
+        "rev": "d6951d0b2ffe74e4779a180e9b6a0e17627756e1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                        | Message                                                   |
| --------------------------------------------------------------------------------------------- | --------------------------------------------------------- |
| [`d6951d0b`](https://github.com/danth/stylix/commit/d6951d0b2ffe74e4779a180e9b6a0e17627756e1) | `` vesktop: change theme location on nix-darwin (#784) `` |