### PR TITLE
chore(flake/spicetify-nix): `b65b84d6` -> `d42d7a91`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -536,14 +536,15 @@
         "flake-compat": "flake-compat_2",
         "nixpkgs": [
           "nixpkgs"
-        ]
+        ],
+        "systems": "systems"
       },
       "locked": {
-        "lastModified": 1737864911,
-        "narHash": "sha256-yQGyYTEDJreafvnHQvTvCHxmmqy77mrUyzJV1zr3XN0=",
+        "lastModified": 1737974026,
+        "narHash": "sha256-4HpWhnmSYIzLarr8gUwGId92bRPB8U7KTaGck1j8hhI=",
         "owner": "Gerg-L",
         "repo": "spicetify-nix",
-        "rev": "b65b84d6b8e9cd59af6524f05a1972fbe6fecce5",
+        "rev": "d42d7a91019e158931c752e39392b18e923e5229",
         "type": "github"
       },
       "original": {
@@ -567,7 +568,7 @@
         "nixpkgs": [
           "nixpkgs"
         ],
-        "systems": "systems",
+        "systems": "systems_2",
         "tinted-foot": "tinted-foot",
         "tinted-kitty": "tinted-kitty",
         "tinted-tmux": "tinted-tmux",
@@ -588,6 +589,21 @@
       }
     },
     "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "systems_2": {
       "locked": {
         "lastModified": 1681028828,
         "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",


### PR DESCRIPTION
| Commit                                                                                                | Message                         |
| ----------------------------------------------------------------------------------------------------- | ------------------------------- |
| [`d42d7a91`](https://github.com/Gerg-L/spicetify-nix/commit/d42d7a91019e158931c752e39392b18e923e5229) | `` fetcher: fix sources path `` |
| [`c54e245b`](https://github.com/Gerg-L/spicetify-nix/commit/c54e245b9af38b432cb17cc918f3128c44abdf21) | `` CI update 2025-01-27 ``      |
| [`08b2afcc`](https://github.com/Gerg-L/spicetify-nix/commit/08b2afcc47281b4f8bacaf4303165be763f1ff51) | `` update fetcher ``            |
| [`38f2062e`](https://github.com/Gerg-L/spicetify-nix/commit/38f2062e9d3520dd850fe84fc38840d994467443) | `` make flake more sane ``      |