### PR TITLE
chore(flake/zen-browser): `39c4c603` -> `81fb38c5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -698,11 +698,11 @@
         "nixpkgs": "nixpkgs_3"
       },
       "locked": {
-        "lastModified": 1737869730,
-        "narHash": "sha256-4u/VS7fiqAtnEnm2z7DSNzNyM7sUB+nq3aGKcKBwodg=",
+        "lastModified": 1737951684,
+        "narHash": "sha256-Hr9sztSHICvJjTS6P33KInXoPTyB/Uq+fYbY8HIGl6c=",
         "owner": "0xc000022070",
         "repo": "zen-browser-flake",
-        "rev": "39c4c603ee641aed350dce31562ad6dd6f0044d8",
+        "rev": "81fb38c54aa23db4de28b1b9f3d9eb697443abfb",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                          | Message                                                                 |
| --------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------- |
| [`81fb38c5`](https://github.com/0xc000022070/zen-browser-flake/commit/81fb38c54aa23db4de28b1b9f3d9eb697443abfb) | `` Update Zen Browser twilight @ x86_64 && aarch64 to 1.7.2t#d4dd298 `` |
| [`33d9b79f`](https://github.com/0xc000022070/zen-browser-flake/commit/33d9b79f80da8c7dd61446948281c3caa68463fd) | `` Update Zen Browser twilight @ x86_64 && aarch64 to 1.7.2t#405b218 `` |