### PR TITLE
chore(flake/nixpkgs-stable): `035f8c08` -> `4e96537f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -453,11 +453,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1737672001,
-        "narHash": "sha256-YnHJJ19wqmibLQdUeq9xzE6CjrMA568KN/lFPuSVs4I=",
+        "lastModified": 1737885640,
+        "narHash": "sha256-GFzPxJzTd1rPIVD4IW+GwJlyGwBDV1Tj5FLYwDQQ9sM=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "035f8c0853c2977b24ffc4d0a42c74f00b182cd8",
+        "rev": "4e96537f163fad24ed9eb317798a79afc85b51b7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                        |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------ |
| [`9a9e7a1a`](https://github.com/NixOS/nixpkgs/commit/9a9e7a1adb21fde707c81b6fa4d0a20806b87b7f) | `` python3Packages.waitress: disable tests on x86_64-darwin ``                 |
| [`745bf877`](https://github.com/NixOS/nixpkgs/commit/745bf8777c1e5e373602252f0ac025abb591af08) | `` cargo-tauri: 2.2.2 -> 2.2.3 ``                                              |
| [`b6962ef0`](https://github.com/NixOS/nixpkgs/commit/b6962ef08390cc64fb3f7767447160237372c6a1) | `` garnet: 1.0.50 -> 1.0.53 ``                                                 |
| [`3abfd8a4`](https://github.com/NixOS/nixpkgs/commit/3abfd8a40863a63ee9f6d0382c5dc4e9cc315c6b) | `` komikku: 1.67.0 -> 1.68.0 ``                                                |
| [`e97b29a9`](https://github.com/NixOS/nixpkgs/commit/e97b29a90a41b3137af0d7193ed34e04e7d65f1b) | `` television: 0.9.3 -> 0.9.4 ``                                               |
| [`b7199d53`](https://github.com/NixOS/nixpkgs/commit/b7199d5380567a78467362ead79dee572e0b263b) | `` lockbook: 0.9.16 -> 0.9.17 ``                                               |
| [`f51be2c7`](https://github.com/NixOS/nixpkgs/commit/f51be2c7d814e2bb12169034cfadb6049cf7c053) | `` lockbook-desktop: 0.9.16 -> 0.9.17 ``                                       |
| [`18cd1b94`](https://github.com/NixOS/nixpkgs/commit/18cd1b9484ae394b3ce08bcbeab50895011f517c) | `` python312Packages.wandb: skip failing tests ``                              |
| [`1b47bfcd`](https://github.com/NixOS/nixpkgs/commit/1b47bfcdc7ce0895c8f4fb22100e6a7e7928af42) | `` telegram-desktop: 5.10.4 -> 5.10.5 ``                                       |
| [`bec79b79`](https://github.com/NixOS/nixpkgs/commit/bec79b7983816caab60e9c58720e92239f570fa2) | `` telegram-desktop: 5.10.3 -> 5.10.4 ``                                       |
| [`b12c9564`](https://github.com/NixOS/nixpkgs/commit/b12c956425ec8547e30e082d2edb9515f733684d) | `` nixos/incus: add lxc hook path to service env ``                            |
| [`e7abcd1e`](https://github.com/NixOS/nixpkgs/commit/e7abcd1e9edc899bc7b5824a8985a607a4b99241) | `` nixos/tests/incus: fix subtest names and add reboot check ``                |
| [`ec8dae0f`](https://github.com/NixOS/nixpkgs/commit/ec8dae0f02a23bc523fc8d99586ccd79eb17710b) | `` incus: support per-instance lxcfs ``                                        |
| [`dd7891d8`](https://github.com/NixOS/nixpkgs/commit/dd7891d809a28d04658a3ddf31f5eff05bdbd3ce) | `` incus: fix instance shutdown when softDaemonRestart enabled ``              |
| [`57f581f4`](https://github.com/NixOS/nixpkgs/commit/57f581f4c97ff5f52985bfb0d892bc2b95082aaf) | `` telegram-desktop: 5.10.2 → 5.10.3 ``                                        |
| [`ce23bc25`](https://github.com/NixOS/nixpkgs/commit/ce23bc25e9ec9395b54c035f64c2966ea1d83f04) | `` osu-lazer-bin: 2025.118.2 -> 2025.118.3 ``                                  |
| [`3dd5f551`](https://github.com/NixOS/nixpkgs/commit/3dd5f551ceb49a7574a211ac5270fde3f433d8bc) | `` osu-lazer: 2025.118.2 -> 2025.118.3 ``                                      |
| [`2acdb161`](https://github.com/NixOS/nixpkgs/commit/2acdb16155bc808228aaa11e687199d06a34f56b) | `` Revert "linux_latest: pin to 6.12, out of tree modules are broken" ``       |
| [`ac774d45`](https://github.com/NixOS/nixpkgs/commit/ac774d45d578dde25f90748bdb6b137d02a810a0) | `` treewide: kernel.makeFlags -> kernel.moduleMakeFlags ``                     |
| [`860447c0`](https://github.com/NixOS/nixpkgs/commit/860447c06123afc4867934b0c1956cdf20877e45) | `` linuxManualConfig: expose moduleMakeFlags for out-of-tree module builds ``  |
| [`3b1c33ca`](https://github.com/NixOS/nixpkgs/commit/3b1c33ca7aec11a22a45a9a567fd322f52957b23) | `` openasar: 0-unstable-2025-01-10 -> 0-unstable-2025-01-20 ``                 |
| [`4e5627e0`](https://github.com/NixOS/nixpkgs/commit/4e5627e01c11e7d8917f86d27d56755d96f288cc) | `` python3Packages.uvloop: avoid test_dns (on darwin) ``                       |
| [`cdc9e88f`](https://github.com/NixOS/nixpkgs/commit/cdc9e88f7014d9178021c891eea1ac373c19614b) | `` mmctl: 9.11.7 -> 9.11.8 ``                                                  |
| [`c1ced57f`](https://github.com/NixOS/nixpkgs/commit/c1ced57f975d3ce3bedbeb216972b02cbd6dc8b6) | `` python312Packages.sqids: 0.5.0 -> 0.5.1 ``                                  |
| [`07e1494e`](https://github.com/NixOS/nixpkgs/commit/07e1494ef68b505111843bcd343a1085cb3d1115) | `` nitrokey: 0.2.3 -> 0.2.4 ``                                                 |
| [`8c5773d5`](https://github.com/NixOS/nixpkgs/commit/8c5773d5d936d0a5f0e35c442aeb1c5007f3fc87) | `` discord-canary: 0.0.569 -> 0.0.574 ``                                       |
| [`f796540e`](https://github.com/NixOS/nixpkgs/commit/f796540ef04d130c0adc77de80d627840d74f3b5) | `` discord-ptb: 0.0.126 -> 0.0.127 ``                                          |
| [`27086e20`](https://github.com/NixOS/nixpkgs/commit/27086e200b7c91b95fa3df69fa41e89bab6ce583) | `` discord: 0.0.80 -> 0.0.81 ``                                                |
| [`433b1067`](https://github.com/NixOS/nixpkgs/commit/433b10672dc51f184f37d43edaa9f936c958bf14) | `` pkgsCross.x86_64-darwin.discord-development: 0.0.76 -> 0.0.78 ``            |
| [`15fde4b9`](https://github.com/NixOS/nixpkgs/commit/15fde4b930091f801479fb5a8e809cbdf8c8d446) | `` pkgsCross.x86_64-darwin.discord-canary: 0.0.681 -> 0.0.686 ``               |
| [`8d59ab68`](https://github.com/NixOS/nixpkgs/commit/8d59ab68cbd2d24403b1dc59250c47611f49a72b) | `` pkgsCross.x86_64-darwin.discord-ptb: 0.0.156 -> 0.0.157 ``                  |
| [`7f9042f6`](https://github.com/NixOS/nixpkgs/commit/7f9042f69b676212b40508e60584d86e0762705a) | `` pkgsCross.x86_64-darwin.discord: 0.0.332 -> 0.0.333 ``                      |
| [`c0462cdd`](https://github.com/NixOS/nixpkgs/commit/c0462cdd1c6e2e8764f07cd193289f1be75b7108) | `` epson-escpr2: 1.2.24 -> 1.2.25 ``                                           |
| [`604ddbbf`](https://github.com/NixOS/nixpkgs/commit/604ddbbf44e8f62bb5cb6a3cc9a68a320068470e) | `` epson-escpr2: 1.2.21 -> 1.2.24 ``                                           |
| [`32a1a3f3`](https://github.com/NixOS/nixpkgs/commit/32a1a3f3cd6ce39ea84da24593f4fb9e8af5672a) | `` epson-escpr2: fix gcc14 compilation ``                                      |
| [`553ba07b`](https://github.com/NixOS/nixpkgs/commit/553ba07baabca62d751f3acf3b7c575f82c76ecf) | `` vcard: fix disabled specification ``                                        |
| [`3c162269`](https://github.com/NixOS/nixpkgs/commit/3c1622695f655313bb3d4168a809f929308173c6) | `` qrcp: 0.11.3 -> 0.11.4 ``                                                   |
| [`f45adabf`](https://github.com/NixOS/nixpkgs/commit/f45adabf4edd3ac3064d1d6ce15430c10eba7490) | `` julia_111: 1.11.2 -> 1.11.3 ``                                              |
| [`a11e47bf`](https://github.com/NixOS/nixpkgs/commit/a11e47bf184bdc57f072f0d9df864d366fddb400) | `` julia_111-bin: 1.11.2 -> 1.11.3 ``                                          |
| [`b481d5c7`](https://github.com/NixOS/nixpkgs/commit/b481d5c7bd770a27881150b88558ddfcd40ad767) | `` steampipe: 1.0.1 -> 1.0.2 ``                                                |
| [`c5530726`](https://github.com/NixOS/nixpkgs/commit/c553072625f4739d7c1dae187fdb2d771e2c7d54) | `` steampipe: 1.0.0 -> 1.0.1 ``                                                |
| [`af7d7954`](https://github.com/NixOS/nixpkgs/commit/af7d79541ee77bda4922fd84e781e97dd25ac204) | `` mopidy-spotify: 5.0.0a2 -> 5.0.0a3 ``                                       |
| [`9264d6ca`](https://github.com/NixOS/nixpkgs/commit/9264d6caa5e5ee5bbd55472ae85f20308bc1214c) | `` mopidy: backport spotify access token auth ``                               |
| [`69ccc951`](https://github.com/NixOS/nixpkgs/commit/69ccc951cf0222dd1f00e3fc0327675fd0b6eb8c) | `` apacheHttpdPackages.php: 8.3.15 -> 8.3.16 ``                                |
| [`2cabe6e9`](https://github.com/NixOS/nixpkgs/commit/2cabe6e92237f4758254e3c8ac27dc24f8530c75) | `` quartus-prime-lite: add missing runtime dependency xorg.libXscrnSaver ``    |
| [`4b1b0268`](https://github.com/NixOS/nixpkgs/commit/4b1b02682f2f43a7d99a810c0fc95d1b399f712f) | `` skim: 0.15.7 -> 0.16.0 ``                                                   |
| [`5039e705`](https://github.com/NixOS/nixpkgs/commit/5039e7058c997df0fade996a801fa318bdcaf863) | `` strace: 6.12 -> 6.13 ``                                                     |
| [`90a94678`](https://github.com/NixOS/nixpkgs/commit/90a94678de2ca053866aec14033161b5e1bfa64a) | `` ci/eval: restore `501+` label ``                                            |
| [`3eaaa431`](https://github.com/NixOS/nixpkgs/commit/3eaaa4319eb5af8aa8cdcb3bdb696fd0ff0a7e41) | `` gancio: add generic updateScript and update to 1.21.0 (#360430) ``          |
| [`34c2c46d`](https://github.com/NixOS/nixpkgs/commit/34c2c46d14dceceb43971b0e9410a6789db91e89) | `` mpris-timer: 2.0.5 -> 2.1.1 ``                                              |
| [`63d66b29`](https://github.com/NixOS/nixpkgs/commit/63d66b2958823be0a86c71cf8892fbf40acce5a5) | `` matomo-beta: 5.2.1 -> 5.2.2 ``                                              |
| [`6476b952`](https://github.com/NixOS/nixpkgs/commit/6476b9525fd8e68a6d9d788e3f4e90d1e4c683f3) | `` matomo_5: 5.2.1 -> 5.2.2 ``                                                 |
| [`391a7739`](https://github.com/NixOS/nixpkgs/commit/391a77390e0f2acf0ef48db8cd7e83eef1c51a65) | `` goattracker: 2.76 -> 2.77 ``                                                |
| [`aaef62dc`](https://github.com/NixOS/nixpkgs/commit/aaef62dcc086c1469b2a1a4b584d2eeec51897fd) | `` linux/hardened/patches/6.6: v6.6.69-hardened1 -> v6.6.73-hardened1 ``       |
| [`16f5ac7c`](https://github.com/NixOS/nixpkgs/commit/16f5ac7ce229b0dfefe36f6df70debd19e63182a) | `` linux/hardened/patches/6.12: v6.12.8-hardened1 -> v6.12.10-hardened1 ``     |
| [`dfe79378`](https://github.com/NixOS/nixpkgs/commit/dfe79378e50ee39a3c9870702a04963adeced608) | `` linux/hardened/patches/6.1: v6.1.123-hardened1 -> v6.1.126-hardened1 ``     |
| [`37e6eb09`](https://github.com/NixOS/nixpkgs/commit/37e6eb099b2080002f91369991000100a370ff83) | `` linux/hardened/patches/5.4: v5.4.288-hardened1 -> v5.4.289-hardened1 ``     |
| [`207b5909`](https://github.com/NixOS/nixpkgs/commit/207b59096dfbf71f45ae382d0c41248a23240531) | `` linux/hardened/patches/5.15: v5.15.175-hardened1 -> v5.15.176-hardened1 ``  |
| [`b187cb93`](https://github.com/NixOS/nixpkgs/commit/b187cb9381dba448ff4a1fc7f9811d1a200dccdd) | `` linux/hardened/patches/5.10: v5.10.232-hardened1 -> v5.10.233-hardened1 ``  |
| [`c5ab6bd8`](https://github.com/NixOS/nixpkgs/commit/c5ab6bd84bb6dfa675f609366ce36e12841346ae) | `` vscode-extensions.ms-dotnettools.csdevkit: 1.14.14 -> 1.15.34 ``            |
| [`62edaad3`](https://github.com/NixOS/nixpkgs/commit/62edaad343ef3466e71332bb5dfc5df89f9a48dd) | `` ungoogled-chromium: 132.0.6834.83-1 -> 132.0.6834.110-1 ``                  |
| [`2f5d90ee`](https://github.com/NixOS/nixpkgs/commit/2f5d90eeef9c0c96a84483ee403fda787363ce30) | `` chromium,chromedriver: 132.0.6834.83 -> 132.0.6834.110 ``                   |
| [`efdda142`](https://github.com/NixOS/nixpkgs/commit/efdda14244a26f6b20d542692cc655401d9d5448) | `` meshcentral: 1.1.35 -> 1.1.38 ``                                            |
| [`d8f649d4`](https://github.com/NixOS/nixpkgs/commit/d8f649d40e1383fa824857c85863d2a026d39404) | `` eza: 0.20.17 -> 0.20.18 ``                                                  |
| [`b6378371`](https://github.com/NixOS/nixpkgs/commit/b6378371650c3783ae6609b95c32e4f1f34d3df8) | `` vue-typescript-plugin: init at 2.2.0 ``                                     |
| [`6fb61496`](https://github.com/NixOS/nixpkgs/commit/6fb6149698d5e6a99561682705d8dd5a5d2538aa) | `` vigra: unstable-2022-01-11 -> 1.12.1 ``                                     |
| [`61e1e472`](https://github.com/NixOS/nixpkgs/commit/61e1e472700241628b47617a7879860334156c57) | `` python3.pkgs.w3lib: fix build with python 3.9 and 3.10 ``                   |
| [`38b97cae`](https://github.com/NixOS/nixpkgs/commit/38b97cae7e837c37c331a00214cc2598edbca7c1) | `` linuxKernel.kernels.linux_lqx: 6.12.2 -> 6.12.10 ``                         |
| [`9a3b0671`](https://github.com/NixOS/nixpkgs/commit/9a3b0671ae01a051c97e87f07922a893670affb8) | `` linuxKernel.kernels.linux_zen: 6.12.2 -> 6.12.10 ``                         |
| [`e32c9a69`](https://github.com/NixOS/nixpkgs/commit/e32c9a692e130f1adcc97ec63710d3718bbfe04d) | `` linuxKernel.kernels.linux_zen: fix update script ``                         |
| [`747171b9`](https://github.com/NixOS/nixpkgs/commit/747171b9fbb00bfc3fa2c4ec2a4c5820c55c01f4) | `` openjpeg: apply patches for CVE-2024-56826 ``                               |
| [`7b0d7bd2`](https://github.com/NixOS/nixpkgs/commit/7b0d7bd27d90ac02ac6cfd7bf8436e2f393e42a8) | `` redis: 7.2.6 -> 7.2.7 ``                                                    |
| [`84ce9af4`](https://github.com/NixOS/nixpkgs/commit/84ce9af4d2081b946e729228fdf39629a9fc87f3) | `` git: 2.47.1 -> 2.47.2 ``                                                    |
| [`7ad65336`](https://github.com/NixOS/nixpkgs/commit/7ad65336c3ffd9e320c5f6fccbf740ba29e87a0a) | `` go_1_23: 1.23.4 -> 1.23.5 ``                                                |
| [`99241537`](https://github.com/NixOS/nixpkgs/commit/99241537efce8da8ccaeb1a0815ea9fddd4a63dc) | `` curl: apply eventfd free patch (#373692) ``                                 |
| [`7415730c`](https://github.com/NixOS/nixpkgs/commit/7415730cfc8e54882dc26c0af4484291e29a2b80) | `` rsync: 3.3.0 -> 3.4.1 ``                                                    |
| [`37153b32`](https://github.com/NixOS/nixpkgs/commit/37153b32d0f988fd1d0a497130dbd6780b5aeb64) | `` python313Packages.django_4: 4.2.17 -> 4.2.18 ``                             |
| [`63e6f2f8`](https://github.com/NixOS/nixpkgs/commit/63e6f2f8d280bc568e9a39c17cc5696cc72ef74f) | `` gtk4: 4.16.3 → 4.16.7 ``                                                    |
| [`5efb6574`](https://github.com/NixOS/nixpkgs/commit/5efb65741634a1129fc7d319d271ab255df6de0e) | `` sysprof: 47.0 → 47.2 ``                                                     |
| [`414218b5`](https://github.com/NixOS/nixpkgs/commit/414218b5b20bd3fb5cbaea27ed6942b72a187cc4) | `` buildGoModule: fix GO_NO_VENDOR_CHECKS for v1.23+ ``                        |
| [`79442c07`](https://github.com/NixOS/nixpkgs/commit/79442c07658dbeb603f6fa33522c89d0a5d007e1) | `` rustPlatform.importCargoLock: support lockfile v4 escaping ``               |
| [`5fdc6830`](https://github.com/NixOS/nixpkgs/commit/5fdc683082e81727a7ecec0d5d7683bde46c3add) | `` rustPlatform.fetchCargoVendor: support lockfile v4 escaping ``              |
| [`ec6d3309`](https://github.com/NixOS/nixpkgs/commit/ec6d3309e07829703188f67277332f3d1364d2d2) | `` qt6.qtwayland: backport fix for qtwayland compositor ``                     |
| [`956dd6cd`](https://github.com/NixOS/nixpkgs/commit/956dd6cd9a115eac6bbc694421589738577072b8) | `` Reapply "[Backport release-24.11] atf: 0.21-unstable-2021-09-01 -> 0.22" `` |
| [`3e46711a`](https://github.com/NixOS/nixpkgs/commit/3e46711af10a5fcb17c7205069b8cb9976a2ff7a) | `` hwdata: 0.389 -> 0.390 ``                                                   |
| [`c9ac79b7`](https://github.com/NixOS/nixpkgs/commit/c9ac79b71454cd7c1b592d9f7814aadb394f18a3) | `` hwdata: 0.388 -> 0.389 ``                                                   |