### PR TITLE
chore(flake/spicetify-nix): `851372d7` -> `b81153ea`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -541,11 +541,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1738020300,
-        "narHash": "sha256-5cP4sRpYb4FARo+fX4/TzZG24BocslMn5+EDlPIV9MY=",
+        "lastModified": 1738062977,
+        "narHash": "sha256-zW1zK0jl5mU27WawATAeFOiALa/NjBnN2KRa+3TU01k=",
         "owner": "Gerg-L",
         "repo": "spicetify-nix",
-        "rev": "851372d7bdf4dfbce82c6378f580b5ae7ea39e9d",
+        "rev": "b81153eab0ef97b43a9bd25707a2ebdf8572ee62",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                 |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------- |
| [`b81153ea`](https://github.com/Gerg-L/spicetify-nix/commit/b81153eab0ef97b43a9bd25707a2ebdf8572ee62) | `` fix typo 'interal' -> 'internal' ``                  |
| [`c833afa1`](https://github.com/Gerg-L/spicetify-nix/commit/c833afa1ccb74ed67f79f402a241617d1af28cb6) | `` Fixed reference to systemPackages in home manager `` |
| [`b69ef740`](https://github.com/Gerg-L/spicetify-nix/commit/b69ef740c45e8fa9d6b8f2c82fa176d358b72545) | `` split modules ``                                     |