### PR TITLE
chore(flake/home-manager): `e1ae908b` -> `1b4f2a48`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -355,11 +355,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1737968762,
-        "narHash": "sha256-xiPARGKwocaMtv+U/rgi+h2g56CZZEmrcl7ldRaslq8=",
+        "lastModified": 1738145391,
+        "narHash": "sha256-/9mfbWYN9HDQbKa2HdAe2T5e3FfY8e4eqc1FIvAyvLg=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "e1ae908bcc30af792b0bb0a52e53b03d2577255e",
+        "rev": "1b4f2a48168b3d90e11365552d1e7e601a4be6b6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                          |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
| [`1b4f2a48`](https://github.com/nix-community/home-manager/commit/1b4f2a48168b3d90e11365552d1e7e601a4be6b6) | `` zed-editor: add installRemoteServer option `` |
| [`0a64a209`](https://github.com/nix-community/home-manager/commit/0a64a209aa3c0e5ae528b9f25c3c5e9bb735dbb3) | `` flake.lock: Update ``                         |