### PR TITLE
chore(flake/nixpkgs-stable): `4e96537f` -> `2b4230bf`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -454,11 +454,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1737885640,
-        "narHash": "sha256-GFzPxJzTd1rPIVD4IW+GwJlyGwBDV1Tj5FLYwDQQ9sM=",
+        "lastModified": 1738023785,
+        "narHash": "sha256-BPHmb3fUwdHkonHyHi1+x89eXB3kA1jffIpwPVJIVys=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "4e96537f163fad24ed9eb317798a79afc85b51b7",
+        "rev": "2b4230bf03deb33103947e2528cac2ed516c5c89",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                      |
| ---------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------- |
| [`b2476be3`](https://github.com/NixOS/nixpkgs/commit/b2476be36b098576cdb507c1e0a59b0f9fc1de98) | `` nixos/nix-fallback-paths: 2.24.11 -> 2.24.12 ``                           |
| [`a5ab8291`](https://github.com/NixOS/nixpkgs/commit/a5ab82912f7e1eb415ee83587519215e2bcfa48c) | `` nixVersions.nix_2_24: 2.24.11 -> 2.24.12 ``                               |
| [`f22854b5`](https://github.com/NixOS/nixpkgs/commit/f22854b5b5303291f78569d7caa1021b3be58b05) | `` pnpm_10: 10.0.0 -> 10.1.0 ``                                              |
| [`deb52760`](https://github.com/NixOS/nixpkgs/commit/deb527605411535ccf8ada94387f04c9dded6ff4) | `` Revert "vue-typescript-plugin: init at 2.2.0" ``                          |
| [`65f2dc54`](https://github.com/NixOS/nixpkgs/commit/65f2dc54a7715cdab7fc947ce2105877d81d3fd0) | `` pnpm_10.fetchDeps: fix reproducibility ``                                 |
| [`d5749264`](https://github.com/NixOS/nixpkgs/commit/d57492642c839c301cdf5cb4324df609363dc538) | `` mousai: use fetchCargoVendor ``                                           |
| [`1a2287d9`](https://github.com/NixOS/nixpkgs/commit/1a2287d918f88818ec0bae37a7129ef2cc528296) | `` mousai: 0.7.7 -> 0.7.8 ``                                                 |
| [`540062cf`](https://github.com/NixOS/nixpkgs/commit/540062cfdd1750fee2cb302e2cf0a533b7a5acee) | `` diebahn: use fetchCargoVendor ``                                          |
| [`901b74ef`](https://github.com/NixOS/nixpkgs/commit/901b74ef48c8cbfd4eef518d960e3de84a6ef882) | `` pika-backup: use fetchCargoVendor ``                                      |
| [`ee430dc3`](https://github.com/NixOS/nixpkgs/commit/ee430dc36354adacfae7b1dde4ad407e2c703931) | `` electron-chromedriver_33: 33.3.1 -> 33.3.2 ``                             |
| [`750aadd5`](https://github.com/NixOS/nixpkgs/commit/750aadd5a59cf5946fadfb04e67ee6550b7cc9ef) | `` electron-chromedriver_32: 32.2.8 -> 32.3.0 ``                             |
| [`b0b9bdfe`](https://github.com/NixOS/nixpkgs/commit/b0b9bdfe287630603f27fa09fff57876b551b272) | `` electron-source.electron_33: 33.3.1 -> 33.3.2 ``                          |
| [`cd17e71b`](https://github.com/NixOS/nixpkgs/commit/cd17e71b8b8e2e8a0d4c1f2f948762dad216edb3) | `` electron-source.electron_32: 32.2.8 -> 32.3.0 ``                          |
| [`4a025137`](https://github.com/NixOS/nixpkgs/commit/4a0251370df4d542b8741cfe463ce82b0e48fe43) | `` electron_33-bin: 33.3.1 -> 33.3.2 ``                                      |
| [`0cbd5842`](https://github.com/NixOS/nixpkgs/commit/0cbd58423d416c35c600234b94d334591ac6e7d8) | `` electron_32-bin: 32.2.8 -> 32.3.0 ``                                      |
| [`e5fba755`](https://github.com/NixOS/nixpkgs/commit/e5fba755dae776e5bb358e41edc01e9a02789ffb) | `` jellyfin-web: 10.10.3 -> 10.10.5 ``                                       |
| [`8c430676`](https://github.com/NixOS/nixpkgs/commit/8c4306767fb7adf7c221aadc5e68a86dc1e34203) | `` jellyfin: 10.10.3 -> 10.10.5 ``                                           |
| [`5ebaf120`](https://github.com/NixOS/nixpkgs/commit/5ebaf1201f3bb3e1e67c31eb41072e5a34c6f859) | `` tectonic-unwrapped.src: update hash ``                                    |
| [`381802ac`](https://github.com/NixOS/nixpkgs/commit/381802ac16e25232d1a1cce3b0f01e7df0ee3f1b) | `` vaultwarden-vault: 2024.6.2c -> 2025.1.1 ``                               |
| [`6ad83917`](https://github.com/NixOS/nixpkgs/commit/6ad83917fa451567c5f5d9cdfd7ce5f557cc2a2d) | `` vaultwarden: 1.32.7 -> 1.33.0 ``                                          |
| [`d8510eed`](https://github.com/NixOS/nixpkgs/commit/d8510eedfa975928694a25de954ba3e82ed0a5d0) | `` koboldcpp: 1.81.1 -> 1.82.4 (#374773) ``                                  |
| [`e1c96d9d`](https://github.com/NixOS/nixpkgs/commit/e1c96d9d78011dd9791e0ab4cf8caf9eaadd9053) | `` python312Packages.mlx: 0.18.0 → 0.21.1; unbreak ``                        |
| [`5f59c62b`](https://github.com/NixOS/nixpkgs/commit/5f59c62b2bf3ec45be3896b8cd3d11b7fa917eb8) | `` python312Packages.mlx: add Gabriella439 as maintainer ``                  |
| [`c5ad4602`](https://github.com/NixOS/nixpkgs/commit/c5ad460293402422f48c2c8abf14b9e6e3614f65) | `` openmpi: build against external `prrte` on all platforms ``               |
| [`5727d2bf`](https://github.com/NixOS/nixpkgs/commit/5727d2bfda3db3c303f3f885aa6c1bd0430d7e3b) | `` prrte: enable for darwin ``                                               |
| [`9df6fadd`](https://github.com/NixOS/nixpkgs/commit/9df6fadda1dadcd1a9b009a028274b5e2cffb73d) | `` [Backport release-24.11] protonvpn-cli: Fix crash on startup (#377013) `` |
| [`e2b753f2`](https://github.com/NixOS/nixpkgs/commit/e2b753f21f406f4ae6abc9cd095e6bfbf9ea630f) | `` flyctl: 0.3.61 -> 0.3.68 ``                                               |
| [`debca78b`](https://github.com/NixOS/nixpkgs/commit/debca78b8d4b7f1bac1872600469e78ff487f7bf) | `` vencord: 1.10.9 -> 1.11.2 ``                                              |
| [`b5e6a323`](https://github.com/NixOS/nixpkgs/commit/b5e6a323e260abdc33791bb05092d964a45ea1a0) | `` fastd: 22 -> 23 ``                                                        |
| [`6e3aa748`](https://github.com/NixOS/nixpkgs/commit/6e3aa748f0da40cd76f1666b13d90a2a97de68a9) | `` fastd: add herbetom to maintainers ``                                     |
| [`1025c47c`](https://github.com/NixOS/nixpkgs/commit/1025c47c2d432435c8cd4318f473f955ef8b16de) | `` sops: refactor ``                                                         |
| [`b6bad0e7`](https://github.com/NixOS/nixpkgs/commit/b6bad0e7e0181fc6e14f8b07154ff62ac9dd858c) | `` sops: 3.9.3 -> 3.9.4 ``                                                   |
| [`a00be943`](https://github.com/NixOS/nixpkgs/commit/a00be9434ebfe31c97d6d10346cba8862c5f2a13) | `` sops: 3.9.2 -> 3.9.3 ``                                                   |
| [`555f016c`](https://github.com/NixOS/nixpkgs/commit/555f016cd33b868ca3fc17eb7d0def1eb1ce5eed) | `` nixos/libvirt-guests: add missing dependency on libvirtd.service ``       |
| [`b5ac168d`](https://github.com/NixOS/nixpkgs/commit/b5ac168d0b95e2857429bfc2d7782879d24267bb) | `` lock: 1.3.8 -> 1.3.9 ``                                                   |
| [`79a25a92`](https://github.com/NixOS/nixpkgs/commit/79a25a92f80c87bdee544521caa3d05ef5bfaa8e) | `` nixos/tests/incus: extend check timeouts ``                               |
| [`072414dd`](https://github.com/NixOS/nixpkgs/commit/072414dd74349e25a0f96f6635d1a98b4fabae9d) | `` incus: 6.8.0 -> 6.9.0 ``                                                  |
| [`7915fc23`](https://github.com/NixOS/nixpkgs/commit/7915fc23c62a8d5dcaa75bebaa0bba230d0cbe36) | `` kio-extras, kio-extras-kf5: switch to openexr_3 ``                        |
| [`d887f385`](https://github.com/NixOS/nixpkgs/commit/d887f385ab33ffa48d8edb865214af0a98710a2f) | `` grafana-image-renderer: 3.11.6 -> 3.12.0 ``                               |
| [`1753340a`](https://github.com/NixOS/nixpkgs/commit/1753340a7a9328fee4ab1a954a6f563d0eea75cb) | `` knot-dns: 3.4.3 -> 3.4.4 ``                                               |
| [`bfcfdb71`](https://github.com/NixOS/nixpkgs/commit/bfcfdb71b16dce9879713f284a6497a1c48ad2ba) | `` llvmPackages_19: 19.1.6 -> 19.1.7 ``                                      |
| [`889c8cf3`](https://github.com/NixOS/nixpkgs/commit/889c8cf3d7afc640b5cef6a851071648dc337c66) | `` nixosModules.MooseFS: Improve ``                                          |
| [`9a2f75b7`](https://github.com/NixOS/nixpkgs/commit/9a2f75b73efe5a03ad05f2841c20b4f8a527839c) | `` sunshine: 0.23.1 -> 2025.118.151840 ``                                    |
| [`a2550eef`](https://github.com/NixOS/nixpkgs/commit/a2550eefd649fc4cd2eb2320c589418eb2f28279) | `` sunshine: fix updater package path ``                                     |
| [`1e194e0f`](https://github.com/NixOS/nixpkgs/commit/1e194e0ffc1683f7c8b104bb9595ee5ccd68c419) | `` nixos/tests/sunshine: fix test ``                                         |
| [`3cbdad37`](https://github.com/NixOS/nixpkgs/commit/3cbdad3791dd9d7dd4e3f021b1192538d7ba6b34) | `` sunshine: fix tray icon and menu links ``                                 |
| [`158de107`](https://github.com/NixOS/nixpkgs/commit/158de107632569d4e40cd887ad98783547ce3c4d) | `` sunshine: move to by-name ``                                              |