### PR TITLE
chore(flake/nix-flatpak): `83cc6a28` -> `d4c75a33`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -391,11 +391,11 @@
     },
     "nix-flatpak": {
       "locked": {
-        "lastModified": 1737806078,
-        "narHash": "sha256-FjgNPBLMCpmwtJT5LiQYkM2lDY+yAmW1ZN1Idx7QeDg=",
+        "lastModified": 1738175805,
+        "narHash": "sha256-fPjaARmK522JLJ7wxFebxG4eE/3HHSmuAA78iAZ+A7g=",
         "owner": "gmodena",
         "repo": "nix-flatpak",
-        "rev": "83cc6a28afc4155fd3fe28274f6b5287f51ed2b6",
+        "rev": "d4c75a33c4a7a16bf87cfd804fb5444a1ec53d49",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                                                 |
| ---------------------------------------------------------------------------------------------------- | ------------------------------------------------------- |
| [`d4c75a33`](https://github.com/gmodena/nix-flatpak/commit/d4c75a33c4a7a16bf87cfd804fb5444a1ec53d49) | `` systemd: fix incorrect unit name for timer (#143) `` |