### PR TITLE
chore(flake/home-manager): `1b4f2a48` -> `9ce5d0b8`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -355,11 +355,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1738145391,
-        "narHash": "sha256-/9mfbWYN9HDQbKa2HdAe2T5e3FfY8e4eqc1FIvAyvLg=",
+        "lastModified": 1738197954,
+        "narHash": "sha256-VYh7+cW3gvgv3zT6xo9pFgIVGlgulZCr+ot/HCUR+/Y=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "1b4f2a48168b3d90e11365552d1e7e601a4be6b6",
+        "rev": "9ce5d0b888a054945121394297ad34173d135547",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                                                                    |
| ----------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------- |
| [`9ce5d0b8`](https://github.com/nix-community/home-manager/commit/9ce5d0b888a054945121394297ad34173d135547) | `` xdg-autostart: add module (#5251) ``                                                                    |
| [`7636b248`](https://github.com/nix-community/home-manager/commit/7636b248675e00d887ec0e6932c316d87f36dbf3) | `` hyprland: make package nullable (#5742) ``                                                              |
| [`ba3338ab`](https://github.com/nix-community/home-manager/commit/ba3338ab990e4348a4e57fc4fdac758524cf7029) | `` waybar: allow setting layer to overlay (#5729) ``                                                       |
| [`697ba131`](https://github.com/nix-community/home-manager/commit/697ba1319fdc58c94dc94cd7908df554dc48d970) | `` waybar: allow setting systemd.target to null (#6241) ``                                                 |
| [`6fbbfb92`](https://github.com/nix-community/home-manager/commit/6fbbfb92409bf999fd80b78c7f7bc145d2d36f39) | `` Revert "thunderbird: add native host support (#6292)" (#6371) ``                                        |
| [`79eff1f6`](https://github.com/nix-community/home-manager/commit/79eff1f6b95c059ed0f9dfae9fd16689c1dda5ca) | `` zsh: added HIST_SAVE_NO_DUPS and HIST_FIND_NO_DUPS options to zsh for history configuration. (#6227) `` |
| [`6aa38ffd`](https://github.com/nix-community/home-manager/commit/6aa38ffdf77fb4250f5d832fd5a09eb99226fba7) | `` atuin: set socket path for darwin (#6248) ``                                                            |
| [`608b26d1`](https://github.com/nix-community/home-manager/commit/608b26d16ee69384580b1b14ac947d81d0240beb) | `` thunderbird: add native host support (#6292) ``                                                         |
| [`d5e5c0d0`](https://github.com/nix-community/home-manager/commit/d5e5c0d051d8d4f293d8c7550c167597427e058b) | `` aerospace: add module (#6279) ``                                                                        |
| [`d71828a7`](https://github.com/nix-community/home-manager/commit/d71828a7dd0dc53cf3994e8737c84b4180cc6dfa) | `` ghostty: allow darwin users to manager their config (#6300) ``                                          |
| [`c4650fb9`](https://github.com/nix-community/home-manager/commit/c4650fb9c0c4c8f7e1a43e6d72378246a4b50f3b) | `` cliphist: support multiple systemdTargets properly (#5669) ``                                           |
| [`5dc1c2e4`](https://github.com/nix-community/home-manager/commit/5dc1c2e40410f7dabef3ba8bf4fdb3145eae3ceb) | `` hyprland: add xdg.portal configuration (#5707) ``                                                       |
| [`0ee8bfdd`](https://github.com/nix-community/home-manager/commit/0ee8bfdd04de611a93cf57dda01686b613cc587d) | `` firefox: add preConfig ``                                                                               |
| [`bd530df4`](https://github.com/nix-community/home-manager/commit/bd530df4e284310fee0fada3562de908009e1236) | `` firefox: avoid unnecessarily overriding package ``                                                      |
| [`82455a84`](https://github.com/nix-community/home-manager/commit/82455a84e32af01c66e326e5a188795f324975a1) | `` nushell: allow multi-word aliases ``                                                                    |
| [`709aaab1`](https://github.com/nix-community/home-manager/commit/709aaab1a5c35a8d1f1e7546efa226e09f3316fb) | `` nushell: set env in config.nu file ``                                                                   |
| [`46c83c07`](https://github.com/nix-community/home-manager/commit/46c83c07b9a97a8f7633dd162dd9a3bbe511195b) | `` nushell: add settings option ``                                                                         |
| [`a1df6c4c`](https://github.com/nix-community/home-manager/commit/a1df6c4c76a839661207105daa519e3de3b5fe15) | `` nushell: slight refactor ``                                                                             |