### PR TITLE
chore(flake/home-manager): `9ce5d0b8` -> `d963ed33`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -355,11 +355,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1738197954,
-        "narHash": "sha256-VYh7+cW3gvgv3zT6xo9pFgIVGlgulZCr+ot/HCUR+/Y=",
+        "lastModified": 1738228963,
+        "narHash": "sha256-Ee5hVHM7AWxaq7XJN6xiZztTZX8csdXernjqaTW5r9I=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "9ce5d0b888a054945121394297ad34173d135547",
+        "rev": "d963ed335b890a70ed53eecf14cdb21528eda9b8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                               |
| ----------------------------------------------------------------------------------------------------------- | ----------------------------------------------------- |
| [`d963ed33`](https://github.com/nix-community/home-manager/commit/d963ed335b890a70ed53eecf14cdb21528eda9b8) | `` linux-wallpaperengine: add module ``               |
| [`41f3dbd7`](https://github.com/nix-community/home-manager/commit/41f3dbd795fd89017232c1a6a90dc9d760334ef8) | `` linux-wallpaperengine: add ckgxrg as maintainer `` |
| [`86a0d627`](https://github.com/nix-community/home-manager/commit/86a0d627cae02e8cc5d29eeb03de97f8c652a4bb) | `` home-manger: fix runtime closure (#5174) ``        |