### PR TITLE
chore(flake/zen-browser): `555d5d39` -> `cf9f5fdb`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -715,11 +715,11 @@
         "nixpkgs": "nixpkgs_3"
       },
       "locked": {
-        "lastModified": 1738038026,
-        "narHash": "sha256-9Lm/QBT9ImIwtA6XzlHXsz/U5SN2+G3MIvjZQSxXYyc=",
+        "lastModified": 1738232271,
+        "narHash": "sha256-AeAvRtsZynVS8/FKBc0GsNm91J2zkvCAr3UgqOobc1o=",
         "owner": "0xc000022070",
         "repo": "zen-browser-flake",
-        "rev": "555d5d3951f8bfae7a421928ec6402765980538c",
+        "rev": "cf9f5fdb2755617d234f0dc4d85994f3fd20d9cf",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                          | Message                                                                 |
| --------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------- |
| [`cf9f5fdb`](https://github.com/0xc000022070/zen-browser-flake/commit/cf9f5fdb2755617d234f0dc4d85994f3fd20d9cf) | `` Update Zen Browser twilight @ x86_64 && aarch64 to 1.7.2t#3413399 `` |
| [`2bcfa194`](https://github.com/0xc000022070/zen-browser-flake/commit/2bcfa194195a3b7f7e6e120f763f69fbdcd76359) | `` Update Zen Browser twilight @ x86_64 && aarch64 to 1.7.2t#93ab8ba `` |