### PR TITLE
chore(flake/nixpkgs-stable): `2b4230bf` -> `59e618d9`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -454,11 +454,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1738023785,
-        "narHash": "sha256-BPHmb3fUwdHkonHyHi1+x89eXB3kA1jffIpwPVJIVys=",
+        "lastModified": 1738163270,
+        "narHash": "sha256-B/7Y1v4y+msFFBW1JAdFjNvVthvNdJKiN6EGRPnqfno=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "2b4230bf03deb33103947e2528cac2ed516c5c89",
+        "rev": "59e618d90c065f55ae48446f307e8c09565d5ab0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                          |
| ---------------------------------------------------------------------------------------------- | ---------------------------------------------------------------- |
| [`593601e3`](https://github.com/NixOS/nixpkgs/commit/593601e373c39044db0a013247895767e762652b) | `` cargo-tauri: 2.2.3 -> 2.2.7 ``                                |
| [`f263d3b4`](https://github.com/NixOS/nixpkgs/commit/f263d3b4e70b7925bfd7775d73f6e115831793e9) | `` refine: 0.4.0 -> 0.4.2 ``                                     |
| [`4d1d8f62`](https://github.com/NixOS/nixpkgs/commit/4d1d8f6272035a99fed982abdecc349d48c50baa) | `` cpupower: add `which` to nativeBuildInputs ``                 |
| [`4b1f224b`](https://github.com/NixOS/nixpkgs/commit/4b1f224bfa8afd559f45059252a62ea540e2d2bb) | `` stegseek: mark broken on darwin, only test on x86_64-linux `` |
| [`f17dcb74`](https://github.com/NixOS/nixpkgs/commit/f17dcb74dbfe8fff902d0bf0034720498e58ce2b) | `` libmcrypt: fix build with gcc14 ``                            |
| [`40d691e4`](https://github.com/NixOS/nixpkgs/commit/40d691e47d6b0fd2639215a0810321fa2bc42570) | `` detect-it-easy: add aarch64-linux ``                          |
| [`a6fb7237`](https://github.com/NixOS/nixpkgs/commit/a6fb7237cd4b325a8a75e0eab9e43caa94fcd3f1) | `` element-{desktop,web}: 1.11.89 -> 1.11.91 ``                  |
| [`544f4295`](https://github.com/NixOS/nixpkgs/commit/544f42955162d3a417b22b61026bd768a35a4ee2) | `` team-list: create Hyprland team (#377573) ``                  |
| [`75ab63cf`](https://github.com/NixOS/nixpkgs/commit/75ab63cf72c71045ae66081d9929c804a1fd2a57) | `` microsoft-edge: 131.0.2903.112 -> 132.0.2957.127 ``           |
| [`fc844b1d`](https://github.com/NixOS/nixpkgs/commit/fc844b1da7c8e3dd1381addca2076cb22f85a0fe) | `` bitwarden-desktop: 2024.12.1 -> 2025.1.1 ``                   |
| [`5c255f40`](https://github.com/NixOS/nixpkgs/commit/5c255f4025ec39c8e78086a715ee2a6e3cbf0310) | `` bitwarden-desktop: 2024.12.0 -> 2024.12.1 ``                  |
| [`53798cb0`](https://github.com/NixOS/nixpkgs/commit/53798cb041520b465227a8e983cd82988e68a35e) | `` bitwarden-desktop: 2024.11.1 -> 2024.12.0 ``                  |
| [`428641fe`](https://github.com/NixOS/nixpkgs/commit/428641fea961b054bc6b1fdb76eaeb7abb3488c3) | `` matrix-hookshot: 5.4.1 -> 5.4.2 ``                            |
| [`a462b913`](https://github.com/NixOS/nixpkgs/commit/a462b91317444c6f316ec28c4b18626c19c4a2a8) | `` linux_5_15: 5.15.176 -> 5.15.177 ``                           |
| [`a1b3f123`](https://github.com/NixOS/nixpkgs/commit/a1b3f123bbb9efa469b5c1fb220ae7532db7e10c) | `` linux_6_1: 6.1.126 -> 6.1.127 ``                              |
| [`9622d0be`](https://github.com/NixOS/nixpkgs/commit/9622d0be41fdeff428d8de3bc506ef6f72e82e00) | `` linux_6_6: 6.6.72 -> 6.6.74 ``                                |
| [`d32a17e4`](https://github.com/NixOS/nixpkgs/commit/d32a17e4d7da478c3b0a5dd058bf79ef5e59b79a) | `` linux_6_12: 6.12.10 -> 6.12.11 ``                             |
| [`a911ce45`](https://github.com/NixOS/nixpkgs/commit/a911ce455bb66ef718b30332e117c0f695b6edbd) | `` cockpit: extend test case to not use default port ``          |
| [`bd7d63f9`](https://github.com/NixOS/nixpkgs/commit/bd7d63f90ab4e903b1fb807d2267256e8958fce5) | `` cockpit: fix listen port (#371245) ``                         |