### PR TITLE
chore(flake/home-manager): `d963ed33` -> `a8159195`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -355,11 +355,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1738228963,
-        "narHash": "sha256-Ee5hVHM7AWxaq7XJN6xiZztTZX8csdXernjqaTW5r9I=",
+        "lastModified": 1738275749,
+        "narHash": "sha256-PM+cGduJ05EZ+YXulqAwUFjvfKpPmW080mcuN6R1POw=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "d963ed335b890a70ed53eecf14cdb21528eda9b8",
+        "rev": "a8159195bfaef3c64df75d3b1e6a68d49d392be9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                            |
| ----------------------------------------------------------------------------------------------------------- | -------------------------------------------------- |
| [`a8159195`](https://github.com/nix-community/home-manager/commit/a8159195bfaef3c64df75d3b1e6a68d49d392be9) | `` flake-module: fix naming ``                     |
| [`234613d7`](https://github.com/nix-community/home-manager/commit/234613d77c939ff2e2c0f2c476a56d80930e5b8b) | `` neovim: remove with lib ``                      |
| [`86b0f304`](https://github.com/nix-community/home-manager/commit/86b0f3049c3a5f3e8ec13a54a323ed3e2587ed93) | `` hyprland: add null package tests ``             |
| [`fee01c93`](https://github.com/nix-community/home-manager/commit/fee01c9351638a67ec8605a43f2e535c1c66266f) | `` hyprland: fix null package conditions ``        |
| [`e3baf274`](https://github.com/nix-community/home-manager/commit/e3baf274f47678df6289c7482353cb6d38b7be5d) | `` bat: remove with lib ``                         |
| [`c90cd85b`](https://github.com/nix-community/home-manager/commit/c90cd85b04ff3348978b05ba73ffc8e1b74b9fce) | `` kitty: remove with lib ``                       |
| [`2d731a33`](https://github.com/nix-community/home-manager/commit/2d731a33b193209cb88b874e508ea912765f7d99) | `` wezterm: remove with lib ``                     |
| [`20fd9686`](https://github.com/nix-community/home-manager/commit/20fd9686b85dc64657a176466e23d0f3a5e1f760) | `` btop: remove with lib; ``                       |
| [`bf2a029b`](https://github.com/nix-community/home-manager/commit/bf2a029bcde2e223db10a0a3fb9a94dc9e833d75) | `` yazi: add khaneliman maintainer ``              |
| [`d62027e4`](https://github.com/nix-community/home-manager/commit/d62027e44d8ff7adc3306482d3c3b195f21f0004) | `` ripgrep: add khaneliman maintainer ``           |
| [`9cb98f31`](https://github.com/nix-community/home-manager/commit/9cb98f3140c02e59d70262a0d0b8e8275ff3b6be) | `` lazygit: add khaneliman maintainer ``           |
| [`cb985acc`](https://github.com/nix-community/home-manager/commit/cb985acc3ca1cc7d44de0f165b89098f9752f737) | `` git: add khaneliman maintainer ``               |
| [`90b7acd9`](https://github.com/nix-community/home-manager/commit/90b7acd9880ff1809807f5c78af869d4dd5969b5) | `` fzf: add khaneliman maintainer ``               |
| [`a77b2c18`](https://github.com/nix-community/home-manager/commit/a77b2c186a0ab3d50abc547a18842340d8a84d10) | `` fastfetch: add khaneliman maintainer ``         |
| [`5a3f7c6d`](https://github.com/nix-community/home-manager/commit/5a3f7c6d078557ada97938a41adb05c27f52325e) | `` direnv: add khaneliman maintainer ``            |
| [`6a988979`](https://github.com/nix-community/home-manager/commit/6a988979464c3ca13d146ab16bb6996ad86d9b37) | `` nix-index: add khaneliman maintainer ``         |
| [`c72b699e`](https://github.com/nix-community/home-manager/commit/c72b699ec6d16f449a34b980d6d4898f231ada6b) | `` btop: add khaneliman maintainer ``              |
| [`34e28fc6`](https://github.com/nix-community/home-manager/commit/34e28fc6ddeab63f4c9aa1262b24e8bd1197d613) | `` bat: add khaneliman maintainer ``               |
| [`05c64fa7`](https://github.com/nix-community/home-manager/commit/05c64fa76b2dfbf4a3f5fbca916bcc7f434739d7) | `` ghostty: add khaneliman maintainer ``           |
| [`178f8265`](https://github.com/nix-community/home-manager/commit/178f8265cbbe72415dcc3759debebf15f308f0bc) | `` kitty: add khaneliman maintainer ``             |
| [`ebdbb381`](https://github.com/nix-community/home-manager/commit/ebdbb381034f4af008aed45cd3bdf873b1443792) | `` wezterm: add khaneliman maintainer ``           |
| [`06bc3541`](https://github.com/nix-community/home-manager/commit/06bc354189e5a7d94b691779f9cb3ac00bab8bce) | `` neovim: add khaneliman maintainer ``            |
| [`c3031a0e`](https://github.com/nix-community/home-manager/commit/c3031a0e8c988fdf2880c98ce5fbab7ee637e8ad) | `` waybar: add khaneliman maintainer ``            |
| [`9a97ac43`](https://github.com/nix-community/home-manager/commit/9a97ac435e3da2a2abf465a0ddd22ce022418495) | `` swaync: add khaneliman maintainer ``            |
| [`9ee99be0`](https://github.com/nix-community/home-manager/commit/9ee99be0c03f30cf3351917402216d256181c4c1) | `` cliphist: add khaneliman maintainer ``          |
| [`a5e196d6`](https://github.com/nix-community/home-manager/commit/a5e196d61f6e564f7fdeeb4a92cef92e1785d3f5) | `` flake-module: add flake-parts module (#5229) `` |
| [`7a457746`](https://github.com/nix-community/home-manager/commit/7a457746847c9cb3a1e46e5bc86b205fbadf5da8) | `` aerospace: enable option desc fix (#6375) ``    |
| [`c621c26c`](https://github.com/nix-community/home-manager/commit/c621c26c4c1ea6e0a9a01c3ca33ef62da5ee155d) | `` aerospace: cleanup ``                           |