### PR TITLE
chore(flake/stylix): `55418e8f` -> `b00c9f46`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -576,11 +576,11 @@
         "tinted-zed": "tinted-zed"
       },
       "locked": {
-        "lastModified": 1738025638,
-        "narHash": "sha256-nU3JpvIeEmcDHzQK4OTD1KXSoL/GOff6j9kuSO4X8eM=",
+        "lastModified": 1738278499,
+        "narHash": "sha256-q1SUyXSQ9znHTME53/vPLe+Ga3V1wW3X3gWfa8JsBUM=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "55418e8fc8d4696af619176a22cefcfac56ad2ef",
+        "rev": "b00c9f46ae6c27074d24d2db390f0ac5ebcc329f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                        | Message                                                          |
| --------------------------------------------------------------------------------------------- | ---------------------------------------------------------------- |
| [`b00c9f46`](https://github.com/danth/stylix/commit/b00c9f46ae6c27074d24d2db390f0ac5ebcc329f) | `` nixcord: theme Vencord and Vesktop instead of just Vencord `` |
| [`d9df2b42`](https://github.com/danth/stylix/commit/d9df2b4200ba53a0944c3d2c6d242095e523d3d9) | `` kde: add decorations option and polish code (#772) ``         |