### PR TITLE
chore(flake/zen-browser): `cf9f5fdb` -> `6836ed3c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -715,11 +715,11 @@
         "nixpkgs": "nixpkgs_3"
       },
       "locked": {
-        "lastModified": 1738232271,
-        "narHash": "sha256-AeAvRtsZynVS8/FKBc0GsNm91J2zkvCAr3UgqOobc1o=",
+        "lastModified": 1738268302,
+        "narHash": "sha256-nIDWo0hcH0Id4/weABoXbsm3uL3uiRJfR3k97P6741k=",
         "owner": "0xc000022070",
         "repo": "zen-browser-flake",
-        "rev": "cf9f5fdb2755617d234f0dc4d85994f3fd20d9cf",
+        "rev": "6836ed3ca2ac1d0a9244cfbe7f21f34a6bb7e00a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                          | Message                                                                 |
| --------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------- |
| [`6836ed3c`](https://github.com/0xc000022070/zen-browser-flake/commit/6836ed3ca2ac1d0a9244cfbe7f21f34a6bb7e00a) | `` Update Zen Browser beta @ x86_64 && aarch64 to 1.7.3b ``             |
| [`684f9e4b`](https://github.com/0xc000022070/zen-browser-flake/commit/684f9e4ba256457192dccf288dd3831fc84c7d68) | `` Update Zen Browser twilight @ x86_64 && aarch64 to 1.7.2t#5ff6d80 `` |