### PR TITLE
chore(flake/zen-browser): `6836ed3c` -> `a82cff5b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -715,11 +715,11 @@
         "nixpkgs": "nixpkgs_3"
       },
       "locked": {
-        "lastModified": 1738268302,
-        "narHash": "sha256-nIDWo0hcH0Id4/weABoXbsm3uL3uiRJfR3k97P6741k=",
+        "lastModified": 1738304685,
+        "narHash": "sha256-9/33VmuaWVVLjdkiKI/mhzfvyf3FwAQUCMLrjDxgpSg=",
         "owner": "0xc000022070",
         "repo": "zen-browser-flake",
-        "rev": "6836ed3ca2ac1d0a9244cfbe7f21f34a6bb7e00a",
+        "rev": "a82cff5bc15ff8aa1aa6d0bf44e1f377b16e564b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                          | Message                                                                 |
| --------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------- |
| [`a82cff5b`](https://github.com/0xc000022070/zen-browser-flake/commit/a82cff5bc15ff8aa1aa6d0bf44e1f377b16e564b) | `` Update Zen Browser beta @ x86_64 && aarch64 to 1.7.4b ``             |
| [`ea22af42`](https://github.com/0xc000022070/zen-browser-flake/commit/ea22af42c027630ee852dd90a459d71bf78f9247) | `` Update Zen Browser twilight @ x86_64 && aarch64 to 1.7.4t#5259fa7 `` |