### PR TITLE
chore(flake/nix-gaming): `4845fe94` -> `cbe40678`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -411,11 +411,11 @@
         "umu": "umu"
       },
       "locked": {
-        "lastModified": 1737855374,
-        "narHash": "sha256-RRGX2C+c+GaR3YMiYm6l/Tp5N/KZtYpiTplUrBwH/og=",
+        "lastModified": 1738395007,
+        "narHash": "sha256-FRztpttPJBnvMD44NeUnkhOYMFd3jblx8baRlTU4RvU=",
         "owner": "fufexan",
         "repo": "nix-gaming",
-        "rev": "4845fe94cda365c7550d9fd1ef899d45df0bc18a",
+        "rev": "cbe40678ac1b1cd345b169b6b8edbceeb43462b0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                              | Message                                            |
| --------------------------------------------------------------------------------------------------- | -------------------------------------------------- |
| [`cbe40678`](https://github.com/fufexan/nix-gaming/commit/cbe40678ac1b1cd345b169b6b8edbceeb43462b0) | `` CI: remove deprecated magic-nix-cache-action `` |
| [`72f40069`](https://github.com/fufexan/nix-gaming/commit/72f40069bf60d3430e9cbd56d52df1529509694d) | `` Update packages ``                              |