### PR TITLE
chore(flake/nixpkgs-stable): `59e618d9` -> `666e1b3f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -454,11 +454,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1738163270,
-        "narHash": "sha256-B/7Y1v4y+msFFBW1JAdFjNvVthvNdJKiN6EGRPnqfno=",
+        "lastModified": 1738277201,
+        "narHash": "sha256-6L+WXKCw5mqnUIExvqkD99pJQ41xgyCk6z/H9snClwk=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "59e618d90c065f55ae48446f307e8c09565d5ab0",
+        "rev": "666e1b3f09c267afd66addebe80fb05a5ef2b554",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                             |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------- |
| [`c3511a3b`](https://github.com/NixOS/nixpkgs/commit/c3511a3b53b482aa7547c9d1626fd7310c1de1c5) | `` siril: 1.2.4 -> 1.2.6 ``                                         |
| [`c821f885`](https://github.com/NixOS/nixpkgs/commit/c821f8858fbb1f1fe14cc9d56aa547d7a99e833b) | `` nixosTests.hound: migrate from 'config' to 'settings' ``         |
| [`ea1349b6`](https://github.com/NixOS/nixpkgs/commit/ea1349b6a78b02cd3e9fa34e43b6ac9ec0bebdff) | `` nixos/hound: add .json extension to the generated config file `` |
| [`f54ca85c`](https://github.com/NixOS/nixpkgs/commit/f54ca85ca8cc16624a2a63d822a544b03d860e13) | `` nixos/hound: restart service on config changes ``                |
| [`11c0db42`](https://github.com/NixOS/nixpkgs/commit/11c0db422e7d0e3dcfda83de6cdca7c63ef58df2) | `` easyeffects: 7.1.9 -> 7.2.3 ``                                   |
| [`6405ca3d`](https://github.com/NixOS/nixpkgs/commit/6405ca3d618f8c42d39c8663bd631dd7de833f4e) | `` lsp-plugins: migrate to by-name ``                               |
| [`5c17ad3f`](https://github.com/NixOS/nixpkgs/commit/5c17ad3fe692427d3760c8e398cc216e56aa32c5) | `` lsp-plugins: modernize ``                                        |
| [`bf0127fa`](https://github.com/NixOS/nixpkgs/commit/bf0127fab4d5847b9b0d7838e70a0d7c68dd2d42) | `` lsp-plugins: 1.2.16 -> 1.2.20 ``                                 |
| [`6e4ffd21`](https://github.com/NixOS/nixpkgs/commit/6e4ffd21bff2ddf403df40864fad5d3d57802b76) | `` clang-tidy-sarif: 0.6.6 -> 0.7.0 ``                              |
| [`6740febc`](https://github.com/NixOS/nixpkgs/commit/6740febcf3e7cbd82cee7d8500426de0daf8be68) | `` immich: 1.125.6 -> 1.125.7 ``                                    |
| [`f28eb598`](https://github.com/NixOS/nixpkgs/commit/f28eb59865e2c82bf5c986539267badd8fc25841) | `` immich: 1.125.3 -> 1.125.6 ``                                    |
| [`4d335d66`](https://github.com/NixOS/nixpkgs/commit/4d335d66adcf4409cbfc62e62be90c138f6dfc02) | `` immich: 1.125.2 -> 1.125.3 ``                                    |
| [`64376d10`](https://github.com/NixOS/nixpkgs/commit/64376d10ba497263c974913871c017714c8e161a) | `` immich: 1.124.2 -> 1.125.2 ``                                    |
| [`d9d221e2`](https://github.com/NixOS/nixpkgs/commit/d9d221e230f4f1c51e4071aa82706badaa28d131) | `` immich: 1.123.0 -> 1.124.2 ``                                    |
| [`695d2dae`](https://github.com/NixOS/nixpkgs/commit/695d2dae2ed13fd8022ec56e6020806cbd0d3e6e) | `` immich: rely on native nodejs ``                                 |
| [`4acb62a8`](https://github.com/NixOS/nixpkgs/commit/4acb62a8d654b975bcedd520037261808bb1c19f) | `` immich: use Node.js 20 ``                                        |
| [`20dc19f0`](https://github.com/NixOS/nixpkgs/commit/20dc19f0912c7c1f9d15e49be174670d61282a17) | `` epson-escpr2: 1.2.25 -> 1.2.26 ``                                |
| [`605b8a60`](https://github.com/NixOS/nixpkgs/commit/605b8a60adc43aee2985fdce5d03a43c5f5058d3) | `` brlaser: Fix cross compilation ``                                |
| [`155c0b60`](https://github.com/NixOS/nixpkgs/commit/155c0b60fef275b1993e3fbca1bfb4bd15bd9ad2) | `` brlaser: Formatting improvements ``                              |
| [`e77edf30`](https://github.com/NixOS/nixpkgs/commit/e77edf30ad8e7875de43691cd5d72acfbc29e6e7) | `` feishin: 1.12.1 -> 1.12.2 ``                                     |
| [`471330ec`](https://github.com/NixOS/nixpkgs/commit/471330ec9594be9013de30b7a7a7dadb2746895c) | `` feishin: 0.12.0 -> 0.12.1 ``                                     |
| [`e30b9b8a`](https://github.com/NixOS/nixpkgs/commit/e30b9b8a262ff8cb722067402f2ab299e00c12ca) | `` feishin: 0.11.1 -> 0.12.0 ``                                     |
| [`560f5f69`](https://github.com/NixOS/nixpkgs/commit/560f5f6955a5f75b1bb5edb5ebf1cc85f950825a) | `` ungoogled-chromium: 132.0.6834.110-1 -> 132.0.6834.159-1 ``      |
| [`1670fbc4`](https://github.com/NixOS/nixpkgs/commit/1670fbc412c277fe925722165983221e19186a37) | `` jetbrains.plugins: update ``                                     |
| [`57122f18`](https://github.com/NixOS/nixpkgs/commit/57122f18d9071cc8a5c86b917dcc7232dc31e157) | `` jetbrains: 2024.1.1 -> 2024.3.4 ``                               |
| [`0756d69e`](https://github.com/NixOS/nixpkgs/commit/0756d69e2a1e1e41fe71d230843303024beeacbf) | `` jetbrains.plugins: update ``                                     |
| [`af488807`](https://github.com/NixOS/nixpkgs/commit/af4888070b055f068cdf6ed0ab6e330e64476374) | `` jetbrains: 2024.3.1 -> 2024.3.3 ``                               |
| [`4f495485`](https://github.com/NixOS/nixpkgs/commit/4f4954855f6982127477a1bdbb0a41f8bcb51cb4) | `` bind: 9.18.28 -> 9.18.33 ``                                      |
| [`d22303a1`](https://github.com/NixOS/nixpkgs/commit/d22303a1ba7f69c4e13afa9e733181b3770af397) | `` prometheus-knot-exporter: 3.4.3 -> 3.4.4 ``                      |
| [`f96184a2`](https://github.com/NixOS/nixpkgs/commit/f96184a2bed779b6e96247827086ac3ee163fb28) | `` python313Packages.libknot: 3.4.3 -> 3.4.4 ``                     |
| [`b19df2e1`](https://github.com/NixOS/nixpkgs/commit/b19df2e178aa06d7796a4e67787af4b61c297ebf) | `` lrcget: 0.9.1 -> 0.9.3 ``                                        |
| [`14f1af4a`](https://github.com/NixOS/nixpkgs/commit/14f1af4a0b84af4656fc69622fd7f69bc8d27067) | `` vencord: 1.11.2 -> 1.11.3 ``                                     |
| [`8ee0bcc1`](https://github.com/NixOS/nixpkgs/commit/8ee0bcc1e78be9947c18d8686fe010f15968f88c) | `` chromium,chromedriver: 132.0.6834.110 -> 132.0.6834.159 ``       |
| [`a7c3a51a`](https://github.com/NixOS/nixpkgs/commit/a7c3a51ac9b47c25aaf951f0cb99a09baad030cd) | `` onlyoffice-documentserver: fix issue with broken nixos module `` |
| [`70808fe3`](https://github.com/NixOS/nixpkgs/commit/70808fe35972d8789f9cf5cc6d2b8d98de8b5d34) | `` gitkraken: remove inactive maintainers ``                        |
| [`6e947449`](https://github.com/NixOS/nixpkgs/commit/6e9474498fdebea427de05492f4b144a70b33fa8) | `` sympa: 6.2.72 -> 6.2.74 ``                                       |
| [`ba2588e1`](https://github.com/NixOS/nixpkgs/commit/ba2588e1662cb4ba3d86b5b93f72f2b5b9828b55) | `` gancio: 1.21.0 -> 1.22.0 ``                                      |
| [`2c353d14`](https://github.com/NixOS/nixpkgs/commit/2c353d14cde7704be71622cbd9780c103d614d67) | `` audiobookshelf: 2.17.7 -> 2.18.1 ``                              |
| [`e744d3e6`](https://github.com/NixOS/nixpkgs/commit/e744d3e607c1fd057db5ee73e143d4838a86ec4f) | `` dataexplorer: 3.9.0 -> 3.9.3 ``                                  |
| [`ff94928c`](https://github.com/NixOS/nixpkgs/commit/ff94928c83e0cb152a90d69b4601afa8905e9187) | `` stalwart-cli: init at 0.10.7 ``                                  |
| [`b76162ae`](https://github.com/NixOS/nixpkgs/commit/b76162aec309d7882290c6c605c87f2bb5f37d6f) | `` why3: 1.7.2 → 1.8.0 ``                                           |
| [`633a4f72`](https://github.com/NixOS/nixpkgs/commit/633a4f728d47e1cfcd250def1fa6cf0c0dffdab4) | `` gnome-podcasts: 0.7.1 -> 0.7.2 ``                                |
| [`4abaee5d`](https://github.com/NixOS/nixpkgs/commit/4abaee5dc0384dd5b8bca6080aa7caba06efb6a6) | `` nodejs_23: 23.6.0 -> 23.6.1 ``                                   |
| [`fd52030e`](https://github.com/NixOS/nixpkgs/commit/fd52030e3b68848e299f6c3e319f616377e686ec) | `` nodejs_18: 18.20.5 -> 18.20.6 ``                                 |
| [`4bbf4847`](https://github.com/NixOS/nixpkgs/commit/4bbf4847207dc25162c4b3461d6e284cc75783da) | `` vivaldi: 7.0.3495.27 -> 7.0.3495.29 ``                           |
| [`3c61f0df`](https://github.com/NixOS/nixpkgs/commit/3c61f0df7e0a4f9298ab67af9b8ae20626ac3e07) | `` vivaldi: 7.0.3495.23 -> 7.0.3495.27 ``                           |
| [`5f16f137`](https://github.com/NixOS/nixpkgs/commit/5f16f137062cccebadc880b5ddfe5286645f6b69) | `` vivaldi: 7.0.3495.18 -> 7.0.3495.23 ``                           |
| [`08897923`](https://github.com/NixOS/nixpkgs/commit/0889792384772f8cbd25fac7367de5bee41ddf79) | `` nixos/headscale: remove much-loosened-up server_url check ``     |