### PR TITLE
chore(flake/home-manager): `055c6705` -> `18fa9f32`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -355,11 +355,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1738407251,
-        "narHash": "sha256-IDrc1qvFolaEDST/dWKgDcmJsemlfP4Yw6kh5O9TMVs=",
+        "lastModified": 1738448366,
+        "narHash": "sha256-4ATtQqBlgsGqkHTemta0ydY6f7JBRXz4Hf574NHQpkg=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "055c67056d87577a39af4144ad5eadb093cfb97d",
+        "rev": "18fa9f323d8adbb0b7b8b98a8488db308210ed93",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                               |
| ----------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------- |
| [`18fa9f32`](https://github.com/nix-community/home-manager/commit/18fa9f323d8adbb0b7b8b98a8488db308210ed93) | `` yazi: add main.lua support to plugins (#6394) ``                   |
| [`dae6d346`](https://github.com/nix-community/home-manager/commit/dae6d3460c8bab3ac9f38a86affe45b32818e764) | `` git: add default value null to programs.git.signing.key (#6032) `` |
| [`8544cd09`](https://github.com/nix-community/home-manager/commit/8544cd092047a7e92d0dce011108a563de7fc0f2) | `` lapce: add module (#5752) ``                                       |