### PR TITLE
chore(flake/zen-browser): `a82cff5b` -> `d999e91b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -715,11 +715,11 @@
         "nixpkgs": "nixpkgs_3"
       },
       "locked": {
-        "lastModified": 1738304685,
-        "narHash": "sha256-9/33VmuaWVVLjdkiKI/mhzfvyf3FwAQUCMLrjDxgpSg=",
+        "lastModified": 1738421772,
+        "narHash": "sha256-d1VNonkIZKFSfffnPZqUPaNFWDzGy4Fe+i6BmtU0JBA=",
         "owner": "0xc000022070",
         "repo": "zen-browser-flake",
-        "rev": "a82cff5bc15ff8aa1aa6d0bf44e1f377b16e564b",
+        "rev": "d999e91b1cb667bc7b7dc875b93abcaf33fb67df",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                          | Message                                                                 |
| --------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------- |
| [`d999e91b`](https://github.com/0xc000022070/zen-browser-flake/commit/d999e91b1cb667bc7b7dc875b93abcaf33fb67df) | `` Update Zen Browser twilight @ x86_64 && aarch64 to 1.7.4t#2b17b5b `` |
| [`ba88b9a5`](https://github.com/0xc000022070/zen-browser-flake/commit/ba88b9a589bda90532e26cb50d4d8598d7e66290) | `` fix: change from magic-nix-cache to flakehub-cache ``                |
| [`ba822e10`](https://github.com/0xc000022070/zen-browser-flake/commit/ba822e10f3ccf3949567f272c60e712191fb788e) | `` fix: change from tar.bz2 to tar.xz ``                                |