### PR TITLE
chore(flake/nixpkgs): `9d3ae807` -> `3a228057`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -470,11 +470,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1738142207,
-        "narHash": "sha256-NGqpVVxNAHwIicXpgaVqJEJWeyqzoQJ9oc8lnK9+WC4=",
+        "lastModified": 1738410390,
+        "narHash": "sha256-xvTo0Aw0+veek7hvEVLzErmJyQkEcRk6PSR4zsRQFEc=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "9d3ae807ebd2981d593cddd0080856873139aa40",
+        "rev": "3a228057f5b619feb3186e986dbe76278d707b6e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                    |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------ |
| [`3a228057`](https://github.com/NixOS/nixpkgs/commit/3a228057f5b619feb3186e986dbe76278d707b6e) | `` cloc: 2.02 -> 2.04 ``                                                                   |
| [`a3b3dab2`](https://github.com/NixOS/nixpkgs/commit/a3b3dab22f4a240e1377080c6a067d637f242733) | `` gh: 2.66.0 -> 2.66.1 ``                                                                 |
| [`f1e8cbd2`](https://github.com/NixOS/nixpkgs/commit/f1e8cbd2f29fc6348bdfb1104e4dc270b1a71a9f) | `` OWNERS: add wolfgangwalther to ci/workflows ``                                          |
| [`2c0109fa`](https://github.com/NixOS/nixpkgs/commit/2c0109fa0bcae73878cf622c2463c1a2699f4026) | `` elementary-xfce-icon-theme: 0.20 -> 0.20.1 ``                                           |
| [`0d265349`](https://github.com/NixOS/nixpkgs/commit/0d2653498687a25a088a7b2850a821d49cfa7c11) | `` python312Packages.angrcli: 1.2.0 -> 1.3.0 ``                                            |
| [`dce20bc9`](https://github.com/NixOS/nixpkgs/commit/dce20bc95b491603229bd56b439f789d9c2f346c) | `` python311Packages.angr: 9.2.138 -> 9.2.139 ``                                           |
| [`01a0aa92`](https://github.com/NixOS/nixpkgs/commit/01a0aa921b56a4bae6cb6b27a4845978013ff96e) | `` python313Packages.cle: 9.2.138 -> 9.2.139 ``                                            |
| [`0f3d56a8`](https://github.com/NixOS/nixpkgs/commit/0f3d56a8ed7e95dd7ca159d514c64b0c4e4f4b19) | `` python313Packages.claripy: 9.2.138 -> 9.2.139 ``                                        |
| [`610a1f33`](https://github.com/NixOS/nixpkgs/commit/610a1f338fabd19f39be2f2749c9c6758d53752a) | `` python313Packages.pyvex: 9.2.138 -> 9.2.139 ``                                          |
| [`ac347bcc`](https://github.com/NixOS/nixpkgs/commit/ac347bccb35b1405b06bdc9ff851ab4a531f2412) | `` python313Packages.ailment: 9.2.138 -> 9.2.139 ``                                        |
| [`3412fb14`](https://github.com/NixOS/nixpkgs/commit/3412fb142d7179b4ca10386159c934282c605274) | `` python313Packages.archinfo: 9.2.138 -> 9.2.139 ``                                       |
| [`807a159f`](https://github.com/NixOS/nixpkgs/commit/807a159fde1da0376bd25b876a9ab77827dd4213) | `` python312Packages.pyswitchbot: 0.55.4 -> 0.56.0 ``                                      |
| [`e4e6bb82`](https://github.com/NixOS/nixpkgs/commit/e4e6bb82d981f0d4d541909bccfc03ccc175944f) | `` python313Packages.whirlpool-sixth-sense: 0.18.11 -> 0.18.12 ``                          |
| [`99055465`](https://github.com/NixOS/nixpkgs/commit/99055465f6ce389f2eed4ca966e33167b5159224) | `` python313Packages.deebot-client: 11.0.0 -> 11.1.0b2 ``                                  |
| [`7dc73876`](https://github.com/NixOS/nixpkgs/commit/7dc7387653a244dd563bdece32ee2af3218f79b6) | `` mpvScripts.modernz: fix pname ``                                                        |
| [`7306aa64`](https://github.com/NixOS/nixpkgs/commit/7306aa64cf5553d7f86d890d3f36cfd9f7cd7cc2) | `` xfitter: fetch from GitLab (#377876) ``                                                 |
| [`55884a62`](https://github.com/NixOS/nixpkgs/commit/55884a623429916d201c07bb4f662fa0a1dd17b8) | `` python312Packages.pyexploitdb: 0.2.64 -> 0.2.65 ``                                      |
| [`4aa04493`](https://github.com/NixOS/nixpkgs/commit/4aa0449341ac1f0f95a1db3a76188816657afacd) | `` vscode-extensions.saoudrizwan.claude-dev: 3.2.5 -> 3.2.9 (#378366) ``                   |
| [`1043de25`](https://github.com/NixOS/nixpkgs/commit/1043de2517beef240b442cc99e6b588035717125) | `` python312Packages.mozart-api: 4.1.1.116.5 -> 4.1.1.116.6 ``                             |
| [`f38d462b`](https://github.com/NixOS/nixpkgs/commit/f38d462b9b5771a8e429bb34d46275754f32398d) | `` nixosTests.networking.networkd.bond: fix flakiness ``                                   |
| [`259778d9`](https://github.com/NixOS/nixpkgs/commit/259778d9afc6ead4cb52b29d8503b7b32fea8417) | `` globalarrays: 5.8.2 -> 5.9 ``                                                           |
| [`ce86fc6d`](https://github.com/NixOS/nixpkgs/commit/ce86fc6dd04350e91f2637bfe8780a10b752c1fd) | `` python313Packages.pyais: 2.8.3 -> 2.8.4 ``                                              |
| [`cad67087`](https://github.com/NixOS/nixpkgs/commit/cad67087489093664b54440d17e1cee59b7b6d49) | `` python313Packages.peaqevcore: 19.11.2 -> 19.11.3 ``                                     |
| [`d3ceac29`](https://github.com/NixOS/nixpkgs/commit/d3ceac29e9587048472bbb8a5764b2f6e8a6d118) | `` python313Packages.lxmf: 0.6.1 -> 0.6.2 ``                                               |
| [`82cd17dd`](https://github.com/NixOS/nixpkgs/commit/82cd17dd849e25e65803239b749568e2da859829) | `` python312Packages.publicsuffixlist: 1.0.2.20250124 -> 1.0.2.20250127 ``                 |
| [`510ff966`](https://github.com/NixOS/nixpkgs/commit/510ff9664430b317744ca1398231cb3c15d28447) | `` proton-pass: 1.27.2 -> 1.29.0 ``                                                        |
| [`eb408716`](https://github.com/NixOS/nixpkgs/commit/eb40871602415e10baf5eb9d7be04b5ecbac06d7) | `` autotier: init at 1.2.0 ``                                                              |
| [`7d7ba531`](https://github.com/NixOS/nixpkgs/commit/7d7ba531cae64c40feffb2ae8e532b910537cf77) | `` python312Packages.google-cloud-logging: 3.11.3 -> 3.11.4 ``                             |
| [`056a8754`](https://github.com/NixOS/nixpkgs/commit/056a87547c2476cc6e9751867003d781ee5cdbdb) | `` movim: switch to buldComposerProject2 ``                                                |
| [`5cb096a5`](https://github.com/NixOS/nixpkgs/commit/5cb096a5a71fe03df2d2400a559a4628edc54b5e) | `` simplesamlphp: switch to buildComposerProject2 and tag (#378348) ``                     |
| [`80bb9aec`](https://github.com/NixOS/nixpkgs/commit/80bb9aec247b87f9947f9ce0c6727c7632c3a978) | `` kimai: switch to buildComposerProject2 and tag (#378353) ``                             |
| [`4c40a6b1`](https://github.com/NixOS/nixpkgs/commit/4c40a6b19f6330832d6d0ecab2a86e547dc5fae9) | `` ocamlPackages.eliom: 11.1.0 -> 11.1.1 ``                                                |
| [`f916efa6`](https://github.com/NixOS/nixpkgs/commit/f916efa6abe63c61f8fcbd1aaa827f3025037177) | `` nvidia-modprobe: 565.77 -> 570.86.16 ``                                                 |
| [`c37ed4ec`](https://github.com/NixOS/nixpkgs/commit/c37ed4ec59baca61c80e92af097dbb6475dac480) | `` python313Packages.scmrepo: 3.3.9 -> 3.3.10 ``                                           |
| [`44f3a4f1`](https://github.com/NixOS/nixpkgs/commit/44f3a4f1ed78f3e3d1f587b53c050ae55e5a5acf) | `` checkov: 3.2.357 -> 3.2.360 ``                                                          |
| [`dbfedcd6`](https://github.com/NixOS/nixpkgs/commit/dbfedcd694afb4f0d176c8c29a875a76d8535ced) | `` python312Packages.mypy-boto3-verifiedpermissions: 1.36.0 -> 1.36.10 ``                  |
| [`fd0c9a4e`](https://github.com/NixOS/nixpkgs/commit/fd0c9a4e9efdbc04cc02ed6b8eb952492a971a84) | `` python312Packages.mypy-boto3-mediatailor: 1.36.0 -> 1.36.10 ``                          |
| [`d68e4686`](https://github.com/NixOS/nixpkgs/commit/d68e46862089646e4cc60c953f97f75faee67d27) | `` python312Packages.mypy-boto3-ecr-public: 1.36.9 -> 1.36.10 ``                           |
| [`f5f4102c`](https://github.com/NixOS/nixpkgs/commit/f5f4102cc52117e760e8be8a36b4eccaa90bf8f9) | `` python312Packages.mypy-boto3-ecr: 1.36.9 -> 1.36.10 ``                                  |
| [`6dc43247`](https://github.com/NixOS/nixpkgs/commit/6dc43247c5ce02191c2e0001e6bea4bbb9fad835) | `` python312Packages.mypy-boto3-appstream: 1.36.0 -> 1.36.10 ``                            |
| [`81addbd9`](https://github.com/NixOS/nixpkgs/commit/81addbd93855d6582f1887c052288955fced5d2b) | `` python313Packages.botocore-stubs: 1.36.9 -> 1.36.10 ``                                  |
| [`64d80df7`](https://github.com/NixOS/nixpkgs/commit/64d80df7d93f63a3787a3e5a6a1585166b831a7f) | `` python313Packages.boto3-stubs: 1.36.9 -> 1.36.10 ``                                     |
| [`ec5a00ee`](https://github.com/NixOS/nixpkgs/commit/ec5a00eea798c4a20b1d95e0901b705d589b5e05) | `` emacsPackages.lua: init at 0-unstable-2025-01-27 ``                                     |
| [`66d835c2`](https://github.com/NixOS/nixpkgs/commit/66d835c228e83a392d105123efa3b67e5d72d1d8) | `` coqPackages.equations: 1.3.1+8.20 -> 1.3.1+9.0 ``                                       |
| [`b502ccc3`](https://github.com/NixOS/nixpkgs/commit/b502ccc397be58ea3e4892b0c5112b4264ed231f) | `` hyprlandPlugins.hy3: 0.46.0 -> 0.47.0 ``                                                |
| [`63203ec1`](https://github.com/NixOS/nixpkgs/commit/63203ec17fe13e64df501f415913bb68ac0a1771) | `` organicmaps: 2024.11.27-12 -> 2025.01.26-9 ``                                           |
| [`049a854b`](https://github.com/NixOS/nixpkgs/commit/049a854b4be087eaa3a09012b9c452fbc838dd41) | `` ladybird: 0-unstable-2024-12-30 -> 0-unstable-2025-01-28 ``                             |
| [`81715a6a`](https://github.com/NixOS/nixpkgs/commit/81715a6a7d4c966ff074539df69d1133eb71e115) | `` python312Packages.twilio: 9.4.3 -> 9.4.4 ``                                             |
| [`86d9ea0c`](https://github.com/NixOS/nixpkgs/commit/86d9ea0c97e776e38b1e5454dc9b33178cc49bb9) | `` patchy: 1.2.7 -> 1.3.0 ``                                                               |
| [`7e44df49`](https://github.com/NixOS/nixpkgs/commit/7e44df498f1e99e9e67babe31bc375911ae30368) | `` obsidian: 1.8.3 -> 1.8.4 ``                                                             |
| [`54c1c0c2`](https://github.com/NixOS/nixpkgs/commit/54c1c0c2e3e5d8a8aa89f9f178d0d7df08c59c3a) | `` python312Packages.dm-tree: 0.1.8 -> 0.1.9 ``                                            |
| [`c6ad98f2`](https://github.com/NixOS/nixpkgs/commit/c6ad98f23ab85872ea117fbc976d94acbe2e9c52) | `` python312Packages.clustershell: install shell completion files ``                       |
| [`b2cd3eb3`](https://github.com/NixOS/nixpkgs/commit/b2cd3eb31964cb9e999047d0bd3506c32f8e8614) | `` python312Packages.clustershell: 1.9.2 -> 1.9.3 ``                                       |
| [`e44a400c`](https://github.com/NixOS/nixpkgs/commit/e44a400cd25777d496a74900316310699ab3939f) | `` zed-editor: 0.171.3 -> 0.171.4 ``                                                       |
| [`5586a120`](https://github.com/NixOS/nixpkgs/commit/5586a12019f8b5db9acdbedaac14616b06408e90) | `` phpExtensions.tideways: 5.17.0 -> 5.17.2 ``                                             |
| [`09d36479`](https://github.com/NixOS/nixpkgs/commit/09d364794722cd72b880a6adc8717410f4b29e58) | `` graphene-hardened-malloc: 2024123000 -> 2025012700 ``                                   |
| [`a8b94a64`](https://github.com/NixOS/nixpkgs/commit/a8b94a6450c6de87c635ca15b97afa2e17fc120d) | `` phpPackages.phpstan: 2.1.1 -> 2.1.2 ``                                                  |
| [`396722d9`](https://github.com/NixOS/nixpkgs/commit/396722d9dfe88b593d728b06922140dca45601f4) | `` phpPackages.php-codesniffer: 3.11.2 -> 3.11.3 ``                                        |
| [`5f9c6013`](https://github.com/NixOS/nixpkgs/commit/5f9c601362b345735aa09a99f5c1307e34b94f54) | `` gdm-settings: 4.4 -> 5.0 ``                                                             |
| [`0d1c991c`](https://github.com/NixOS/nixpkgs/commit/0d1c991cd6d0f98836ad31cb0fd4b2f729c18b8b) | `` sbom4python: init at 0.12.1 ``                                                          |
| [`c9b06bac`](https://github.com/NixOS/nixpkgs/commit/c9b06bac4233b31c789edf361fdcd09552d77361) | `` sbom4files: init at 0.4.5 ``                                                            |
| [`d7268355`](https://github.com/NixOS/nixpkgs/commit/d7268355b49caae12b2f9d5fabeb5161f57530a0) | `` sbom2dot: init at 0.3.1 ``                                                              |
| [`b789945d`](https://github.com/NixOS/nixpkgs/commit/b789945ddb4c50a3064c852ed2d9b0b8c075732d) | `` moonpalace: init at 0.12.0 ``                                                           |
| [`ee322555`](https://github.com/NixOS/nixpkgs/commit/ee3225552454cab433690c0d963b8a324d96746f) | `` plan9port: 2024-10-22 -> 2025-01-29 ``                                                  |
| [`26dbd7f2`](https://github.com/NixOS/nixpkgs/commit/26dbd7f24ede4c98f3e4c983fcf331595eee7503) | `` inv-sig-helper: 0-unstable-2024-12-17 -> 0-unstable-2025-01-31, add tests ``            |
| [`b297159b`](https://github.com/NixOS/nixpkgs/commit/b297159b45298714fbc661aa6bea9a8c76d8fa65) | `` zipline: 3.7.11 -> 3.7.12 ``                                                            |
| [`9b02dcd4`](https://github.com/NixOS/nixpkgs/commit/9b02dcd4670c5729882d166adfadba90ac92d03f) | `` go-blueprint: 0.10.4 -> 0.10.5 ``                                                       |
| [`dfdc09bb`](https://github.com/NixOS/nixpkgs/commit/dfdc09bbe31a76417baa6606236f91b115e38c22) | `` ja2-stracciatella: 0.17.0 -> 0.21.0 ``                                                  |
| [`6f5506cd`](https://github.com/NixOS/nixpkgs/commit/6f5506cd2803f75681ed61cbbfaf7d75314d5878) | `` ja2-stracciatella: clean up and modernize ``                                            |
| [`882709be`](https://github.com/NixOS/nixpkgs/commit/882709bee7ba01f0b26b46d795d23a8bb6a0f81d) | `` ja2-stracciatella: remove helper derivation by using cargoSetupHook ``                  |
| [`fd7329e1`](https://github.com/NixOS/nixpkgs/commit/fd7329e1509850fe3210726b4d64f3840d34c32b) | `` ja2-stracciatella: move to pkgs/by-name ``                                              |
| [`9db3afd9`](https://github.com/NixOS/nixpkgs/commit/9db3afd92e1774905f10590cf38f2cb5f5a8da74) | `` ja2-stracciatella: remove darwin stubs ``                                               |
| [`819a6661`](https://github.com/NixOS/nixpkgs/commit/819a66615724165d8519ef0d5822bfd5570ea378) | `` tuisky: 0.1.5 -> 0.2.0 ``                                                               |
| [`b01f28a8`](https://github.com/NixOS/nixpkgs/commit/b01f28a8474136d773fd761c79dc6f6b2fa60580) | `` ayatana-indicator-messages: fix PIE hardening ``                                        |
| [`d3829fc7`](https://github.com/NixOS/nixpkgs/commit/d3829fc7977488eea371d4b7f927c9f9269b06c2) | `` cargo-make: 0.37.23 -> 0.37.24 ``                                                       |
| [`85a67001`](https://github.com/NixOS/nixpkgs/commit/85a6700195893f7109cbff48ff91096531c71fbb) | `` gocryptfs: 2.5.0 -> 2.5.1 ``                                                            |
| [`2fce179e`](https://github.com/NixOS/nixpkgs/commit/2fce179e76acb5c09d763892bf53f4ed348d357f) | `` kodiPackages.visualization-goom: 21.0.1 -> 21.0.2 ``                                    |
| [`b87aec31`](https://github.com/NixOS/nixpkgs/commit/b87aec3187bb0ad71e69c16f27acea0f073486fc) | `` python312Packages.tivars: init at 0.9.2 ``                                              |
| [`68e497ca`](https://github.com/NixOS/nixpkgs/commit/68e497ca1a0e6c57137128553a59bfa397e5a032) | `` kodiPackages.visualization-fishbmc: 21.0.1 -> 21.0.2 ``                                 |
| [`0762e821`](https://github.com/NixOS/nixpkgs/commit/0762e82122601c5c44ac488d56eb3f508ddf8cb3) | `` kodiPackages.visualization-waveform: 21.0.1 -> 21.0.2 ``                                |
| [`2544a204`](https://github.com/NixOS/nixpkgs/commit/2544a204aa808a5fab26da993b6ed05cd0d3b29a) | `` kodiPackages.visualization-pictureit: 21.0.1 -> 21.0.2 ``                               |
| [`050ff075`](https://github.com/NixOS/nixpkgs/commit/050ff0755c1b00530cf253db7651bdfb42f26eed) | `` vimPlugins.remote-sshfs-nvim: init at 2024-08-29 ``                                     |
| [`1f95d585`](https://github.com/NixOS/nixpkgs/commit/1f95d585108265af303bdbd4192a1031ab14ee19) | `` python3Packages.podgen: init at 1.1.0 ``                                                |
| [`c6611e31`](https://github.com/NixOS/nixpkgs/commit/c6611e311912c87f46544bd9dfb1b73693bf62d7) | `` kuttl: 0.20.0 -> 0.21.0 ``                                                              |
| [`79187e68`](https://github.com/NixOS/nixpkgs/commit/79187e681cbdfd8c4ef90de90cdd0be68337c810) | `` lixVersions: use fetchCargoVendor ``                                                    |
| [`4b948481`](https://github.com/NixOS/nixpkgs/commit/4b9484816d0a58582eb79e790b9cb0bddcd8ecdd) | `` teleport_16: 16.4.6 -> 16.4.14 ``                                                       |
| [`fcafb1ed`](https://github.com/NixOS/nixpkgs/commit/fcafb1ed0e07346b011ec92273cec8ef04c13281) | `` nextcloud28: remove 28.json ``                                                          |
| [`c69f0bed`](https://github.com/NixOS/nixpkgs/commit/c69f0bedf5cd7aebd122442bccadd7862a6b42e9) | `` openpgp-card-tools: 0.11.7 -> 0.11.8 ``                                                 |
| [`721fea00`](https://github.com/NixOS/nixpkgs/commit/721fea00643d32789286cc7569b46daafab94381) | `` tippecanoe: 2.74.0 -> 2.75.0 ``                                                         |
| [`e7d0fb1f`](https://github.com/NixOS/nixpkgs/commit/e7d0fb1fb6e30a96e79cbaf538115b357ded707e) | `` vscode-extensions.mongodb.mongodb-vscode: 1.11.0 -> 1.12.0 ``                           |
| [`48c84f55`](https://github.com/NixOS/nixpkgs/commit/48c84f55754bfe902af6bb39ada94b19af443ed5) | `` uv: 0.5.25 -> 0.5.26 ``                                                                 |
| [`e1d2e1cd`](https://github.com/NixOS/nixpkgs/commit/e1d2e1cdbd605605d4a54d171a67c9d928937ae3) | `` snyk: 1.1295.0 -> 1.1295.2 ``                                                           |
| [`916add98`](https://github.com/NixOS/nixpkgs/commit/916add980f75e10cdc1d67fefc7b4b7d045265a6) | `` teleport_15: 15.4.21 -> 15.4.26 ``                                                      |
| [`a963a872`](https://github.com/NixOS/nixpkgs/commit/a963a8727306bd274d589229e777ed2363dffb90) | `` teleport: Add juliusfreudenberger as maintainer ``                                      |
| [`8268a3d9`](https://github.com/NixOS/nixpkgs/commit/8268a3d9145fcf3fd2b07c59cf34275cb3a9bd24) | `` maintainers: add juliusfreudenberger ``                                                 |
| [`e252f960`](https://github.com/NixOS/nixpkgs/commit/e252f9601de29e0eba9dbb8195d82111942bb36b) | `` falkor: init at 0.0.92 ``                                                               |
| [`dec861ca`](https://github.com/NixOS/nixpkgs/commit/dec861ca4e7ebb4717ef7fd489527c19b38e61d5) | `` maintainers: add icedborn ``                                                            |
| [`7ba807e7`](https://github.com/NixOS/nixpkgs/commit/7ba807e730a38c9ac884468617cdd813630a4100) | `` mysql-shell-innovation: 9.1.0 -> 9.2.0 (#378249) ``                                     |
| [`822c0af5`](https://github.com/NixOS/nixpkgs/commit/822c0af5a187e8b63a34120c6d6f11e342029f27) | `` whisper-ctranslates2: mark as broken on aarch64-linux ``                                |
| [`2592a2fd`](https://github.com/NixOS/nixpkgs/commit/2592a2fd8012f61e176477ef218ecdb3234cc9d0) | `` gojo: init at 0.3.2 (#378200) ``                                                        |
| [`bc1027ef`](https://github.com/NixOS/nixpkgs/commit/bc1027ef1e8fbacfa3c6895992c91751f60050db) | `` renpy: disable steam ``                                                                 |
| [`4b9de235`](https://github.com/NixOS/nixpkgs/commit/4b9de23515fc6240c1c0a4fbc42ab2ec0e7978e3) | `` nixos/open-webui: quote `services.open-webui.host` in start script ``                   |
| [`836718a1`](https://github.com/NixOS/nixpkgs/commit/836718a18f9c0146d27021a27f3a03ec433fc98b) | `` python312Packages.lightning-utilities: 0.11.9 -> 0.12.0 ``                              |
| [`cb61bb4d`](https://github.com/NixOS/nixpkgs/commit/cb61bb4dea8520055280d1557494c135b540e833) | `` python312Packages.lib4package: init at 0.3.1 ``                                         |
| [`41afb4c7`](https://github.com/NixOS/nixpkgs/commit/41afb4c7c5a13b95c128f2f0e460662f5d47db81) | `` pmtiles: 1.23.1 -> 1.25.0 ``                                                            |
| [`77667232`](https://github.com/NixOS/nixpkgs/commit/776672324c87c5d3c416df9fcc262094c2598f88) | `` faiss: 1.9.0 -> 1.10.0 ``                                                               |
| [`97ffcf94`](https://github.com/NixOS/nixpkgs/commit/97ffcf946ac5fd43a349995e7e975f89ab28b859) | `` faiss: move to by-name ``                                                               |
| [`1782a3c7`](https://github.com/NixOS/nixpkgs/commit/1782a3c7ffcb940784106a96fbe7091174ad1e74) | `` python312Packages.autofaiss: fix build ``                                               |
| [`04aaf2c3`](https://github.com/NixOS/nixpkgs/commit/04aaf2c3cd0ba1188ce29d14262a04a229903b39) | `` hyprprop: 0.1-unstable-2024-12-01 -> 0.1-unstable-2025-01-29 (#378230) ``               |
| [`71cfe3bc`](https://github.com/NixOS/nixpkgs/commit/71cfe3bc7cd2b1f10b66d9aaa44459af561757cc) | `` python312Packages.accelerate: use `addBinToPathHook`, use `writableTmpDirAsHomeHook` `` |
| [`a74cba71`](https://github.com/NixOS/nixpkgs/commit/a74cba712de4263f7897a3f5828ab89aa5e57b70) | `` podman-tui: reformat + cleanup ``                                                       |
| [`6f6f5736`](https://github.com/NixOS/nixpkgs/commit/6f6f5736b38a0c6573aed4ac501876c3a9afb75c) | `` apx: use `writableTmpDirAsHomeHook` ``                                                  |