### PR TITLE
chore(flake/nixpkgs-stable): `666e1b3f` -> `f6687779`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -454,11 +454,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1738277201,
-        "narHash": "sha256-6L+WXKCw5mqnUIExvqkD99pJQ41xgyCk6z/H9snClwk=",
+        "lastModified": 1738435198,
+        "narHash": "sha256-5+Hmo4nbqw8FrW85FlNm4IIrRnZ7bn0cmXlScNsNRLo=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "666e1b3f09c267afd66addebe80fb05a5ef2b554",
+        "rev": "f6687779bf4c396250831aa5a32cbfeb85bb07a3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                     |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------- |
| [`0da1dadc`](https://github.com/NixOS/nixpkgs/commit/0da1dadc890ba0945678f29ea3cfb2bda68a68a5) | `` fastfetch: 2.34.1 -> 2.35.0 ``                                                           |
| [`32b3eddc`](https://github.com/NixOS/nixpkgs/commit/32b3eddcd6c4742eb1d953b93205055717c35606) | `` fastfetch: 2.34.0 -> 2.34.1 ``                                                           |
| [`63b83acc`](https://github.com/NixOS/nixpkgs/commit/63b83accb402408df95e1f0a87bf957e48a3b187) | `` fastfetch: 2.33.0 → 2.34.0 ``                                                            |
| [`33bbe500`](https://github.com/NixOS/nixpkgs/commit/33bbe500dbc596183e96604d91d95c07657d2eb9) | `` fastfetch: disable flashfetch binary by default ``                                       |
| [`a3e150fa`](https://github.com/NixOS/nixpkgs/commit/a3e150fa8bcb8279ebeb35d0414aa28a12fe51c3) | `` fastfetch: 2.32.1 -> 2.33.0 ``                                                           |
| [`3253e860`](https://github.com/NixOS/nixpkgs/commit/3253e860e114a6ae656c0ff035c2862c18b7ae28) | `` fastfetch: 2.31.0 -> 2.32.1 ``                                                           |
| [`b5cd5a00`](https://github.com/NixOS/nixpkgs/commit/b5cd5a0044a4e7e531cb1f1462b4ad20130b1e89) | `` fastfetch: 2.30.1 -> 2.31.0 ``                                                           |
| [`ffbfa3a4`](https://github.com/NixOS/nixpkgs/commit/ffbfa3a4ef60c9f69290092c60662e8556e93c77) | `` fastfetch: 2.29.0 -> 2.30.1 ``                                                           |
| [`7672ef74`](https://github.com/NixOS/nixpkgs/commit/7672ef7452230390cc0e171e1ad0139f45736d4b) | `` postgresqlPackages.pgrouting: 3.7.1 -> 3.7.2 ``                                          |
| [`3823e592`](https://github.com/NixOS/nixpkgs/commit/3823e5928ffada287c2786d5db23926fc2bd5801) | `` workflows/eval: no maintainer reviews in draft mode ``                                   |
| [`3945055b`](https://github.com/NixOS/nixpkgs/commit/3945055b40942a3b7515d43b2eef9db4431cdcae) | `` ci: Update pinned Nixpkgs ``                                                             |
| [`2affe032`](https://github.com/NixOS/nixpkgs/commit/2affe0326d7e558eecc964bc4feea42233497049) | `` add python-updates to dev branches ``                                                    |
| [`85ff67a2`](https://github.com/NixOS/nixpkgs/commit/85ff67a2c2d3ba28bfc126291fd560f66806258a) | `` workflows/backport: switch to new variables ``                                           |
| [`0e8dc9b9`](https://github.com/NixOS/nixpkgs/commit/0e8dc9b9277345f4089b08c392f3f85661a3e1d7) | `` workflows/periodic-merges: explicitly inherit the secrets ``                             |
| [`e4326da1`](https://github.com/NixOS/nixpkgs/commit/e4326da195eff75ddc3494ed34375e25d4146b93) | `` workflows/periodic-merges: use nixpkgs-ci's token ``                                     |
| [`4c2a7e35`](https://github.com/NixOS/nixpkgs/commit/4c2a7e35a1be08ef22407db38a3a0153a71adea4) | `` workflows/periodic-merge: move fork condition to calling workflow ``                     |
| [`78ff5388`](https://github.com/NixOS/nixpkgs/commit/78ff538815004bc67898e6151f0b259ba8b81dd4) | `` workflows/periodic-merge: support merge bases in re-usable workflow ``                   |
| [`434e4058`](https://github.com/NixOS/nixpkgs/commit/434e4058cd44f6e01558debfe7077963ccb4656e) | `` workflows/periodic-merge: create re-usable workflow ``                                   |
| [`ad26714e`](https://github.com/NixOS/nixpkgs/commit/ad26714e776fa78d73dc9807ff494acd8e96c77b) | `` workflows: basic consistency in formatting workflows ``                                  |
| [`d7355042`](https://github.com/NixOS/nixpkgs/commit/d73550426d2200370199ed538ee87d9fd14347f2) | `` workflows: update Ubuntu runner to ubuntu-24.04 ``                                       |
| [`73d745f1`](https://github.com/NixOS/nixpkgs/commit/73d745f1c2783aecf5d68ad26be9fb238e58682e) | `` workflows: lock Ubuntu runner to ubuntu-22.04 ``                                         |
| [`dea6a2ab`](https://github.com/NixOS/nixpkgs/commit/dea6a2abae885eab060fb7ee670a50ef69bbb3b5) | `` workflows/periodic-merge: merge merge-base into haskell-updates ``                       |
| [`efc3df9c`](https://github.com/NixOS/nixpkgs/commit/efc3df9c522ea536ee2705edcdc596e99463ca8b) | `` workflows: remove 24.05 merges ``                                                        |
| [`428e0059`](https://github.com/NixOS/nixpkgs/commit/428e0059f5d394d83881db41b58b75f6f56ba84e) | `` postgresqlPackages.pgsql-http: 1.6.2 -> 1.6.3 ``                                         |
| [`cfbab720`](https://github.com/NixOS/nixpkgs/commit/cfbab720d834784c0b8e5ec92cf021967251bfd6) | `` ci/eval/compare: Improve performance and avoid large stacks ``                           |
| [`cfba7d13`](https://github.com/NixOS/nixpkgs/commit/cfba7d138ea1a0a65160e791d7c55cea610a955a) | `` maintainers.nix: Remove unused code ``                                                   |
| [`ef7d8a32`](https://github.com/NixOS/nixpkgs/commit/ef7d8a3262da9a1c9eb23ac934cfcedd60027e8e) | `` postgresqlPackages.pg_repack: 1.5.1 -> 1.5.2 ``                                          |
| [`1e36a67e`](https://github.com/NixOS/nixpkgs/commit/1e36a67e2352ca923584b48c0766bd98afd27cc0) | `` postgresqlPackages.plpgsql_check: 2.7.12 -> 2.7.13 ``                                    |
| [`884f25d9`](https://github.com/NixOS/nixpkgs/commit/884f25d9c4d94066d87cf9c8c6a32f636e20f491) | `` postgresqlPackages.pgrouting: 3.7.0 -> 3.7.1 ``                                          |
| [`ab0ac618`](https://github.com/NixOS/nixpkgs/commit/ab0ac618ddc4a038be129cc255aad4a78b12124f) | `` postgresqlPackages.citus: 12.1.6 -> 13.0.0 ``                                            |
| [`4501e236`](https://github.com/NixOS/nixpkgs/commit/4501e236c565895abcfcbcba77e2eb5c1d4f206f) | `` postgresqlPackages.postgis: 3.5.0 -> 3.5.2 ``                                            |
| [`bcc6ca24`](https://github.com/NixOS/nixpkgs/commit/bcc6ca247f80d2bf8cb990e496f24518a6fedbbd) | `` postgresqlPackages.pgsql-http: 1.6.1 -> 1.6.2 ``                                         |
| [`e69a6775`](https://github.com/NixOS/nixpkgs/commit/e69a6775c6803d6810d0b783879ecbe32a76f267) | `` microsoft-identity-broker: fix hash mismatch ``                                          |
| [`7d84bdf9`](https://github.com/NixOS/nixpkgs/commit/7d84bdf9cb85f399a8eafe8e17acee2354f13a21) | `` python312Packages.clustershell: install shell completion files ``                        |
| [`fb6237e8`](https://github.com/NixOS/nixpkgs/commit/fb6237e88d0d02ce3f38fc36fe7ad6128e425f1b) | `` python312Packages.clustershell: 1.9.2 -> 1.9.3 ``                                        |
| [`09d6c644`](https://github.com/NixOS/nixpkgs/commit/09d6c644d0512d806d78a92857420e5987b91a33) | `` raycast: 1.89.0 -> 1.90.0 ``                                                             |
| [`117a8408`](https://github.com/NixOS/nixpkgs/commit/117a8408bf662b95a212347bfc26da9b99c9c890) | `` gitlab: 17.7.1 -> 17.8.0 ``                                                              |
| [`c68a176e`](https://github.com/NixOS/nixpkgs/commit/c68a176e51edde0a2938e7075d900045e060ee04) | `` gitlab: update prometheus-client-mmap gem to fix aarch64 ``                              |
| [`f6dd396e`](https://github.com/NixOS/nixpkgs/commit/f6dd396ea0e949f7822be7674cb6ab109735547c) | `` victoriametrics: 1.109.0 -> 1.110.0 ``                                                   |
| [`3a9f9044`](https://github.com/NixOS/nixpkgs/commit/3a9f90440c016aa6758682f756ac81e9309292f9) | `` patchy: 1.2.7 -> 1.3.0 ``                                                                |
| [`1a3b4a4b`](https://github.com/NixOS/nixpkgs/commit/1a3b4a4bfb3af3955496927e218966ceba37c93e) | `` doc: emphasize trade-off between versionCheckHook and testers.testVersion ``             |
| [`d0848ba4`](https://github.com/NixOS/nixpkgs/commit/d0848ba4e3e892976e8e0810fd8a967108f9952d) | `` inv-sig-helper: 0-unstable-2024-12-17 -> 0-unstable-2025-01-31, add tests ``             |
| [`bff40119`](https://github.com/NixOS/nixpkgs/commit/bff401190a036ff01401d57f3b1a30b311cfdec9) | `` jenkins: 2.479.2 -> 2.479.3 ``                                                           |
| [`6ab61e7e`](https://github.com/NixOS/nixpkgs/commit/6ab61e7ecbfae1816ddf3994f5ec09d7e8e60681) | `` nextcloudPackages.apps.collectives: init at 2.16.0 ``                                    |
| [`b1ea0b02`](https://github.com/NixOS/nixpkgs/commit/b1ea0b02555ec4fed177acd53b365a799830e54f) | `` tig: 2.5.10 -> 2.5.11 ``                                                                 |
| [`79bd5f28`](https://github.com/NixOS/nixpkgs/commit/79bd5f2857e9913515fc90182493402bee063909) | `` warp-terminal: 0.2025.01.08.08.02.stable_04 -> 0.2025.01.22.08.02.stable_05 ``           |
| [`78969b41`](https://github.com/NixOS/nixpkgs/commit/78969b41bd4e5ccfaec6bc947a627374e41e92ca) | `` warp-terminal: 0.2024.12.18.08.02.stable_05 -> 0.2025.01.08.08.02.stable_04 ``           |
| [`c55556e9`](https://github.com/NixOS/nixpkgs/commit/c55556e9b1666dcae3054f223065aa05d9932578) | `` warp-terminal: 0.2024.12.18.08.02.stable_03 -> 0.2024.12.18.08.02.stable_05 ``           |
| [`7132d5b4`](https://github.com/NixOS/nixpkgs/commit/7132d5b4577bbca41045c14209be81c6bcb69730) | `` warp-terminal: 0.2024.12.10.15.55.stable_04 -> 0.2024.12.18.08.02.stable_03 (#366843) `` |
| [`564f2d90`](https://github.com/NixOS/nixpkgs/commit/564f2d90ce0f177feffc7c87c54c05981aff4d76) | `` warp-terminal: 0.2024.12.10.15.55.stable_02 -> 0.2024.12.10.15.55.stable_04 ``           |
| [`808bf7f4`](https://github.com/NixOS/nixpkgs/commit/808bf7f49c7ee953869f7c6b6bfc673322808c26) | `` warp-terminal: 0.2024.12.03.08.02.stable_04 -> 0.2024.12.10.15.55.stable_02 (#364374) `` |
| [`636cd257`](https://github.com/NixOS/nixpkgs/commit/636cd2573e0ad4c6e59ab51c0833ea08c605371c) | `` warp-terminal: 0.2024.11.19.08.02.stable_03 -> 0.2024.12.03.08.02.stable_04 ``           |
| [`d4e1a651`](https://github.com/NixOS/nixpkgs/commit/d4e1a6513844ee2e26c035ae8a6b2c31842ec5fb) | `` matrix-synapse: fetchCargoTarball -> fetchCargoVendor ``                                 |
| [`fb22b998`](https://github.com/NixOS/nixpkgs/commit/fb22b998f95cc321a13069fd71f97413bd991de7) | `` ankama-launcher: 3.12.30 -> 3.12.31 ``                                                   |
| [`fdeb865f`](https://github.com/NixOS/nixpkgs/commit/fdeb865faa742f8ebbcf05f15c5330ed71137a83) | `` virtualbox: 7.1.4 -> 7.1.6a ``                                                           |
| [`433c039f`](https://github.com/NixOS/nixpkgs/commit/433c039f3bafd25c68a4df74397e407d977b0daa) | `` ghostty: 1.0.1 -> 1.1.0 ``                                                               |
| [`fc5c1741`](https://github.com/NixOS/nixpkgs/commit/fc5c1741d9284b0690e032fc8761d9274aeb2987) | `` arc-browser: 1.78.1-57736 -> 1.79.0-57949 ``                                             |
| [`fda1a942`](https://github.com/NixOS/nixpkgs/commit/fda1a9423328423a6c40ce32df3af40abdc801cb) | `` jellyfin-rpc: 1.3.0 -> 1.3.1 ``                                                          |
| [`3ba738af`](https://github.com/NixOS/nixpkgs/commit/3ba738af8c04daa012189efdd3b209a0f6bcae54) | `` wike: 3.1.0 -> 3.1.1 ``                                                                  |
| [`527e5f90`](https://github.com/NixOS/nixpkgs/commit/527e5f9005f318d775e62861762fe58f7a248669) | `` mattermostLatest: 10.4.1 -> 10.4.2 ``                                                    |
| [`681e0570`](https://github.com/NixOS/nixpkgs/commit/681e057011bee489b98220e6841f8e14b7b610c3) | `` brave: 1.74.48 -> 1.74.50 ``                                                             |
| [`6cd61fd2`](https://github.com/NixOS/nixpkgs/commit/6cd61fd28fa85da80d533131dd0308b45254b23b) | `` sydbox: 3.29.4 -> 3.30.0 ``                                                              |
| [`2517b23e`](https://github.com/NixOS/nixpkgs/commit/2517b23edfc7fb01b10e3d96979395c69f5f2228) | `` recordbox: 0.9.0 -> 0.9.2 ``                                                             |
| [`bda6486c`](https://github.com/NixOS/nixpkgs/commit/bda6486cdb3149e1c1a3e6a94558bde23480d451) | `` recordbox: fix updateScript ``                                                           |
| [`43e0d3ff`](https://github.com/NixOS/nixpkgs/commit/43e0d3ff4bee6245c977164f909ff5d6303e8028) | `` systemd-netlogd: add version test ``                                                     |
| [`e930ada9`](https://github.com/NixOS/nixpkgs/commit/e930ada97ae85d032e08aafa31174542c3c76b8c) | `` systemd-netlogd: 1.4.3 -> 1.4.4 ``                                                       |
| [`ce11cc18`](https://github.com/NixOS/nixpkgs/commit/ce11cc183cf4285bf2d56ddc23e8f9c18a72aa74) | `` grafana: 11.3.2 -> 11.3.3 ``                                                             |
| [`2d5b60ee`](https://github.com/NixOS/nixpkgs/commit/2d5b60ee9cec405367c5b15e72bd2bedd0adb433) | `` linux: expose make flags for modules in `linuxKernel.packages.linux_X_Y` ``              |
| [`d002f168`](https://github.com/NixOS/nixpkgs/commit/d002f16854f87b1e1514104b016d138a11010ebc) | `` mysql84: 8.4.3 -> 8.4.4 ``                                                               |
| [`80a32b53`](https://github.com/NixOS/nixpkgs/commit/80a32b537953ffb0229358bb1119b8f03815d866) | `` mysql80: 8.0.40 -> 8.0.41 ``                                                             |
| [`4fef8159`](https://github.com/NixOS/nixpkgs/commit/4fef8159cccd6ce4218931e8e76cc8e8f85f6d5a) | `` percona-xtrabackup: 8.0.35-31 -> 8.0.35-32 ``                                            |
| [`4fd85157`](https://github.com/NixOS/nixpkgs/commit/4fd851574f6c971ba3e431b006ab701a2d04156e) | `` lk-jwt-service: 0-unstable-2024-04-27 -> 0.1.1 ``                                        |
| [`9c2238c6`](https://github.com/NixOS/nixpkgs/commit/9c2238c63cf6b727ea1c1ca38b241da18d57d95f) | `` element-call: add dist to output ``                                                      |
| [`7cd34282`](https://github.com/NixOS/nixpkgs/commit/7cd34282eb34bcc23c2e4f944f8e556843134d48) | `` thunderbird-bin-unwrapped: 128.6.0esr -> 128.6.1esr ``                                   |
| [`1ac0aa10`](https://github.com/NixOS/nixpkgs/commit/1ac0aa109b77ba8f4a8d6248937c9999977f4491) | `` amazon-ssm-agent: 3.3.1345.0 -> 3.3.1611.0 ``                                            |
| [`507a649b`](https://github.com/NixOS/nixpkgs/commit/507a649b3321b7923615e85c7484c2663b58d572) | `` dafny: 4.8.0 -> 4.9.1 ``                                                                 |
| [`ba08bc27`](https://github.com/NixOS/nixpkgs/commit/ba08bc277131ba604a8039b49f9690eb333b1762) | `` legcord: 1.0.6 -> 1.0.8 ``                                                               |
| [`c34f31cb`](https://github.com/NixOS/nixpkgs/commit/c34f31cba6659e9b566c0d16d029143c19eab32e) | `` db-rest: 6.0.5 -> 6.0.6 ``                                                               |
| [`7e2c191d`](https://github.com/NixOS/nixpkgs/commit/7e2c191ddb4bf7f147e1ea5f0c5d96b104de01af) | `` vigra: add ShamrockLee as a maintainer ``                                                |
| [`d5812ee2`](https://github.com/NixOS/nixpkgs/commit/d5812ee23c0d0be2dd566017b90779a82026dd11) | `` vigra: run upstream tests as tests.check ``                                              |
| [`9710ca20`](https://github.com/NixOS/nixpkgs/commit/9710ca208ed078213743c11f38295a9e4c9b90f9) | `` vigra: use fixed-point arguments ``                                                      |
| [`07905bda`](https://github.com/NixOS/nixpkgs/commit/07905bdade86c81fa1f3f5e45c41edaa78131329) | `` vigra: enableParallelBuilding = true ``                                                  |
| [`44efde64`](https://github.com/NixOS/nixpkgs/commit/44efde64b8f068b84128be3efef0b721748b8e93) | `` vips: move to openexr_3 ``                                                               |
| [`7b10e80b`](https://github.com/NixOS/nixpkgs/commit/7b10e80b40320d5cc9daa6c6e591ddb2d94ff6e0) | `` yt-dlp: 2025.1.15 -> 2025.1.26 ``                                                        |
| [`93ecd52c`](https://github.com/NixOS/nixpkgs/commit/93ecd52cbe14f36f28e9b10302111d136a3a7c5d) | `` grafanaPlugins.marcusolsson-dynamictext-panel: 5.4.0 -> 5.6.0 ``                         |
| [`e641e3d1`](https://github.com/NixOS/nixpkgs/commit/e641e3d13efd9fee660a817d1d6781e175f197f3) | `` krita: switch to openexr_3 ``                                                            |
| [`d4d6a1fc`](https://github.com/NixOS/nixpkgs/commit/d4d6a1fc7a4a6c12aeb633f90e7d132927376303) | `` kanidm: 1.4.5 -> 1.4.6 ``                                                                |
| [`37f1994b`](https://github.com/NixOS/nixpkgs/commit/37f1994b3833d236ce5ab57cfd1d9a87462950b2) | `` python3Packages.outlines: 0.0.46 -> 0.1.13 ``                                            |
| [`fc248e11`](https://github.com/NixOS/nixpkgs/commit/fc248e11ee95158ba10495914dfc25743e5efdb6) | `` python3Packages.outlines-core: init at 0.1.26 ``                                         |
| [`8db0e6fe`](https://github.com/NixOS/nixpkgs/commit/8db0e6fea8ad93818e4dbb7cc4e845466e62ce75) | `` python3Packages.airportsdata: init at 20241001 ``                                        |