### PR TITLE
chore(flake/spicetify-nix): `6835108e` -> `fb1d78cb`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -541,11 +541,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1738527890,
-        "narHash": "sha256-y5WosmqAtq3P1cXX4vhP58t6i6zEX9PeO8LF1onPTWY=",
+        "lastModified": 1738580832,
+        "narHash": "sha256-xgF3wq6cFYtsgHFNQw8NL6fb+bkeM7LmdNpdp/KTt3Y=",
         "owner": "Gerg-L",
         "repo": "spicetify-nix",
-        "rev": "6835108e9a472b99ab9e1f43a0fee3bdefaae14a",
+        "rev": "fb1d78cbac7ceafa01cd8ddddcc1315781852056",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                                       |
| ----------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------- |
| [`fb1d78cb`](https://github.com/Gerg-L/spicetify-nix/commit/fb1d78cbac7ceafa01cd8ddddcc1315781852056) | `` build(deps): bump DeterminateSystems/nix-installer-action from 14 to 16 `` |
| [`c637fe37`](https://github.com/Gerg-L/spicetify-nix/commit/c637fe378573d99a5f7c32143c1216c6b17c8b4c) | `` build(deps): bump actions/checkout from 4.1.7 to 4.2.2 ``                  |
| [`a7777bf0`](https://github.com/Gerg-L/spicetify-nix/commit/a7777bf00000afd72dc0e67728140c9ebce785da) | `` build(deps): bump DeterminateSystems/magic-nix-cache-action from 8 to 9 `` |