### PR TITLE
chore(flake/spicetify-nix): `fb1d78cb` -> `2aa9b36c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -541,11 +541,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1738580832,
-        "narHash": "sha256-xgF3wq6cFYtsgHFNQw8NL6fb+bkeM7LmdNpdp/KTt3Y=",
+        "lastModified": 1738623197,
+        "narHash": "sha256-jOScKIFg8Zo6xi/0Xybu4AflvNal7Whu5JAMIwIXHmQ=",
         "owner": "Gerg-L",
         "repo": "spicetify-nix",
-        "rev": "fb1d78cbac7ceafa01cd8ddddcc1315781852056",
+        "rev": "2aa9b36c5e104e5e8b7d104c11c056b700d3f42d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                              |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------ |
| [`2aa9b36c`](https://github.com/Gerg-L/spicetify-nix/commit/2aa9b36c5e104e5e8b7d104c11c056b700d3f42d) | `` fix build: set SPICETIFY_STATE `` |
| [`87b566dc`](https://github.com/Gerg-L/spicetify-nix/commit/87b566dc20fb5ff4c55d56b0705c42d71eb069c7) | `` CI update 2025-02-03 ``           |