### PR TITLE
chore(flake/spicetify-nix): `2aa9b36c` -> `ac59ecec`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -541,11 +541,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1738623197,
-        "narHash": "sha256-jOScKIFg8Zo6xi/0Xybu4AflvNal7Whu5JAMIwIXHmQ=",
+        "lastModified": 1738671423,
+        "narHash": "sha256-V8pD27b6YmU4zN9kurtBCQ9SfkYaVDq0Z2tm8JQyCGc=",
         "owner": "Gerg-L",
         "repo": "spicetify-nix",
-        "rev": "2aa9b36c5e104e5e8b7d104c11c056b700d3f42d",
+        "rev": "ac59ecec59685225698100b06d0b742a6415eb9a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                       |
| ----------------------------------------------------------------------------------------------------- | --------------------------------------------- |
| [`ac59ecec`](https://github.com/Gerg-L/spicetify-nix/commit/ac59ecec59685225698100b06d0b742a6415eb9a) | `` Update README.md ``                        |
| [`e4f7efb1`](https://github.com/Gerg-L/spicetify-nix/commit/e4f7efb1151c6002321ae9c34f401219b5f836dc) | `` Update README.md ``                        |
| [`4956ec83`](https://github.com/Gerg-L/spicetify-nix/commit/4956ec8372bbb5242c6ade44249da1ce571274ed) | `` remove uneccesary mkIf, and dontInstall `` |