### PR TITLE
chore(flake/nixpkgs): `3a228057` -> `c6e957d8`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -470,11 +470,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1738410390,
-        "narHash": "sha256-xvTo0Aw0+veek7hvEVLzErmJyQkEcRk6PSR4zsRQFEc=",
+        "lastModified": 1738546358,
+        "narHash": "sha256-nLivjIygCiqLp5QcL7l56Tca/elVqM9FG1hGd9ZSsrg=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "3a228057f5b619feb3186e986dbe76278d707b6e",
+        "rev": "c6e957d81b96751a3d5967a0fd73694f303cc914",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                               |
| ---------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------- |
| [`78c76520`](https://github.com/NixOS/nixpkgs/commit/78c76520200bbdf6272c90f5b1ac021c99ab598b) | `` twitch-hls-client: init at 1.3.13 (#365656) ``                                                     |
| [`ee9a3cae`](https://github.com/NixOS/nixpkgs/commit/ee9a3cae8e6dfed8bc7538a04e5221a080e246bb) | `` kubo: remove myself as maintainer ``                                                               |
| [`d46f17d3`](https://github.com/NixOS/nixpkgs/commit/d46f17d384be4dae589c4750779102423abee53b) | `` tecoc: remove AndersonTorres from maintainers ``                                                   |
| [`83a6297c`](https://github.com/NixOS/nixpkgs/commit/83a6297cda5cdf31400fc15082df96d8dbffa082) | `` zpaqfranz: remove AndersonTorres from maintainers ``                                               |
| [`fbd78fe4`](https://github.com/NixOS/nixpkgs/commit/fbd78fe40d9729c2fd1079c498a0920402361aa5) | `` nixos/grafana-to-nfy: init ``                                                                      |
| [`40cbb24d`](https://github.com/NixOS/nixpkgs/commit/40cbb24d1b605f943f7e6df19a5d82540fa7f413) | `` bmake: remove AndersonTorres from maintainers ``                                                   |
| [`bbae05de`](https://github.com/NixOS/nixpkgs/commit/bbae05deac2fb7d255e8efcbf2f50ad7f3803831) | `` nixos/privatebin: fix defaultText ``                                                               |
| [`73631465`](https://github.com/NixOS/nixpkgs/commit/736314654d0ede857a249cb06ae7afaea8bcd185) | `` ntfy: use https in meta.homepage ``                                                                |
| [`629e9fea`](https://github.com/NixOS/nixpkgs/commit/629e9feaae4d584ca7a1cab2047c2e9e60b12d3c) | `` ntfy: drop optional brackets ``                                                                    |
| [`002d82c9`](https://github.com/NixOS/nixpkgs/commit/002d82c95fdc43b69b58357791fe4474c0160b0c) | `` ntfy: switch to default python, disable xmpp support by default, also switch to pytestCheckHook `` |
| [`affd866d`](https://github.com/NixOS/nixpkgs/commit/affd866de9e9cbe7c2028a2e103b41f9eed19baa) | `` hedgedoc: 1.10.0 -> 1.10.1 ``                                                                      |
| [`2c704b65`](https://github.com/NixOS/nixpkgs/commit/2c704b65f9c4e6aec9fa9649fd9b4b8de9d69800) | `` nfd: pin to boost 1.86 (#378537) ``                                                                |
| [`34ae57af`](https://github.com/NixOS/nixpkgs/commit/34ae57af26dfa8e97276a56b481fd838bf27c09e) | `` iperf2: modernize & refactor ``                                                                    |
| [`94ad953c`](https://github.com/NixOS/nixpkgs/commit/94ad953c220dfd52d123b5885b324968312b3cb5) | `` torch: enable autoAddCudaCompatRunpath on Jetsons ``                                               |
| [`23b117dd`](https://github.com/NixOS/nixpkgs/commit/23b117dda8db4824f0b6a9e9a5af9c4194aaca13) | `` python3Packages.cupy: format with nixfmt ``                                                        |
| [`f7f3f15f`](https://github.com/NixOS/nixpkgs/commit/f7f3f15f7f32356e0f8fd851ced90a3dc9a3543e) | `` python3Packages.cupy: drop upstreamed patch ``                                                     |
| [`5325b6be`](https://github.com/NixOS/nixpkgs/commit/5325b6bee625458963d8de12a27a28d684b92144) | `` python312Packages.django-registration: remove (incorrect) disabled attribute ``                    |
| [`e016cde6`](https://github.com/NixOS/nixpkgs/commit/e016cde61e7256e5c4045ec6ef4b1e8c6d996e64) | `` presenterm: 0.9.0 -> 0.10.0 ``                                                                     |
| [`c26df0c1`](https://github.com/NixOS/nixpkgs/commit/c26df0c165ac0340d030cae36d6f7de7315f776c) | `` python3Packages.cupy: make cuda_nvprof, cutensor and nccl optional ``                              |
| [`253e4ff7`](https://github.com/NixOS/nixpkgs/commit/253e4ff72a460db714683bfa43f12b4c8bfb370c) | `` python3Packages.cupy: update build toolchain ``                                                    |
| [`c3826c22`](https://github.com/NixOS/nixpkgs/commit/c3826c2220a15fb91b12782405d178e18e13f809) | `` python3Packages.cupy: remove pin to cudaPackages_11 ``                                             |
| [`3442181e`](https://github.com/NixOS/nixpkgs/commit/3442181eb98862d04ca2a7747616784d08564413) | `` python3Packages.strip-tags: Init at 0.5.1 ``                                                       |
| [`fa2e0b9c`](https://github.com/NixOS/nixpkgs/commit/fa2e0b9c7500d753ca232b7833a58d02e78c8552) | `` python312Packages.unstructured-inference: 0.8.5 -> 0.8.6 ``                                        |
| [`33d6e619`](https://github.com/NixOS/nixpkgs/commit/33d6e619948df85f5d31dc61bb54c0b47fdc89cb) | `` ray: add support for aarch64-linux ``                                                              |
| [`01f9ddad`](https://github.com/NixOS/nixpkgs/commit/01f9ddad8e1aa39c51a95071699a2cb2430598ef) | `` zeroad: 0.0.26 -> 0.27.0 ``                                                                        |
| [`08d1de26`](https://github.com/NixOS/nixpkgs/commit/08d1de263a220f95a675ccb0c58cff99d2626897) | `` hoarder: init at 0.21.0 ``                                                                         |
| [`713fd7e8`](https://github.com/NixOS/nixpkgs/commit/713fd7e838a6bf9a6336a096d20b0b9caba5dabb) | `` maintainers: add three ``                                                                          |
| [`93342e3e`](https://github.com/NixOS/nixpkgs/commit/93342e3e44cb8743e93767907268e03a1794ef0d) | `` python312Packages.django-registration: init at 5.1.0 ``                                            |
| [`e5666a0a`](https://github.com/NixOS/nixpkgs/commit/e5666a0ae9496a6b590387905838250d85f31abf) | `` python312Packages.scalene: 1.5.49 -> 1.5.51 ``                                                     |
| [`062e6ffe`](https://github.com/NixOS/nixpkgs/commit/062e6ffec74679799c7073f45e5bb8d7ebc1cbff) | `` python313Packages.pyhomee: init at 1.2.5 ``                                                        |
| [`97ae8286`](https://github.com/NixOS/nixpkgs/commit/97ae8286a5d9c51d8c2bf48d39629b7f174dbc61) | `` restinio: fix darwin ``                                                                            |
| [`bb0fe02c`](https://github.com/NixOS/nixpkgs/commit/bb0fe02c06ab1cac429aa60ddeb379c04cf91371) | `` restinio: fix build ``                                                                             |
| [`90160dbd`](https://github.com/NixOS/nixpkgs/commit/90160dbd10552a81803eca55d68d13d16b29ec01) | `` Revert "mbrola: Fix compilation on Darwin" ``                                                      |
| [`2e7dcac1`](https://github.com/NixOS/nixpkgs/commit/2e7dcac1c37e8ce57293efc941e272a34bb2fecd) | `` vimPlugins.terminal-nvim: init at 2024-10-14 ``                                                    |
| [`e6db0cb2`](https://github.com/NixOS/nixpkgs/commit/e6db0cb29060a3f34e88691d4e146786d92f0b53) | `` ryubing: 1.2.80 -> 1.2.81 ``                                                                       |
| [`13b1d082`](https://github.com/NixOS/nixpkgs/commit/13b1d08271114b22353a87f737e1fc4c2e6ecd67) | `` pkgsCross.aarch64-darwin.discord-canary: 0.0.686 -> 0.0.692 ``                                     |
| [`6fcfeebf`](https://github.com/NixOS/nixpkgs/commit/6fcfeebf68a1ec1c5fbfb69b434d3cdaa74aadd3) | `` pkgsCross.aarch64-darwin.discord: 0.0.333 -> 0.0.334 ``                                            |
| [`2e342723`](https://github.com/NixOS/nixpkgs/commit/2e342723f8dfa649d27f4e2f09ed50a51a045a74) | `` discord-ptb: 0.0.127 -> 0.0.128 ``                                                                 |
| [`624b7e0b`](https://github.com/NixOS/nixpkgs/commit/624b7e0b80fad3f1e6ce781bca5f51f57bafea7e) | `` discord-development: 0.0.67 -> 0.0.68 ``                                                           |
| [`037350e0`](https://github.com/NixOS/nixpkgs/commit/037350e0e6b829ae850ad291dc1344eb4e208d75) | `` discord-canary: 0.0.574 -> 0.0.581 ``                                                              |
| [`e5edfc35`](https://github.com/NixOS/nixpkgs/commit/e5edfc35878b8441735f3d1e5add10b55d6d7959) | `` discord: 0.0.81 -> 0.0.82 ``                                                                       |
| [`84e13bf3`](https://github.com/NixOS/nixpkgs/commit/84e13bf3fdb99c617292892416208e346a4a112e) | `` yash: 2.57 -> 2.58 ``                                                                              |
| [`2d271095`](https://github.com/NixOS/nixpkgs/commit/2d271095d8604fbd6d6fbe03a0437efc20dbc7d9) | `` python312Packages.mpi4py: 4.0.1 -> 4.0.2 ``                                                        |
| [`8b9c16e2`](https://github.com/NixOS/nixpkgs/commit/8b9c16e209b0b5bafe6c837476a1e1d0d900c9e6) | `` zizmor: 1.2.2 -> 1.3.0 ``                                                                          |
| [`00754851`](https://github.com/NixOS/nixpkgs/commit/007548518e8aee3e10df187f7df25e3ed8a3c4b3) | `` python312Packages.aioesphomeapi: 28.0.1 -> 29.0.0 (#378833) ``                                     |
| [`075d5411`](https://github.com/NixOS/nixpkgs/commit/075d541165a381b2ef753ff46c941a7ad32ab56f) | `` home-assistant: don't patch & test overriden pytradfri package ``                                  |
| [`09a045c0`](https://github.com/NixOS/nixpkgs/commit/09a045c065f1231bcf3b9c244f52d09292185b41) | `` python313Packages.tradfri: refactor and fix pydantic 2 compat ``                                   |
| [`5cd63591`](https://github.com/NixOS/nixpkgs/commit/5cd635914afc68a0546f03b091713e26121de306) | `` vsce: 3.2.1 -> 3.2.2 ``                                                                            |
| [`b9024d4b`](https://github.com/NixOS/nixpkgs/commit/b9024d4b3367112941c35720e0579ebdd248cb52) | `` python3Packages.fenics: pin boost186, add patches ``                                               |
| [`36f1c1a6`](https://github.com/NixOS/nixpkgs/commit/36f1c1a660d72d64b688204e099ac106d17d2740) | `` lief: 0.16.2 -> 0.16.3 ``                                                                          |
| [`9c912175`](https://github.com/NixOS/nixpkgs/commit/9c9121755402bf478475e0ac911b24ef8a93df6c) | `` python312Packages.experiment-utilities: 0.3.8 -> 0.3.9 ``                                          |
| [`4dc63418`](https://github.com/NixOS/nixpkgs/commit/4dc6341855d8a39c31cc663835c120ad711efb3a) | `` firebase-tools: 13.29.2 -> 13.29.3 ``                                                              |
| [`2a6f860d`](https://github.com/NixOS/nixpkgs/commit/2a6f860d88f085f4891a319d1a4f81549a3d1c5b) | `` python312Packages.django-localflavor: refactor ``                                                  |
| [`d14cc4ae`](https://github.com/NixOS/nixpkgs/commit/d14cc4ae043f3bcaafb9f9a867c4d9f5ec3f3dd5) | `` pretix.plugins: migrate to auto-calling ``                                                         |
| [`f5d47da8`](https://github.com/NixOS/nixpkgs/commit/f5d47da8739ff0b036dbd08ab95af5310421ed03) | `` pretix.plugins.zugferd: 2.2.2 -> 2.3.0 ``                                                          |
| [`7f1052a1`](https://github.com/NixOS/nixpkgs/commit/7f1052a12c58a9e942981d952dc3b0a91fe1025e) | `` pretix.plugins.mollie: 2.2.1 -> 2.2.2 ``                                                           |
| [`bce9b0fd`](https://github.com/NixOS/nixpkgs/commit/bce9b0fde9d50fa2db330fbd1de51a7bc2d49e2e) | `` pretix: 2024.11.0 -> 2025.1.0 ``                                                                   |
| [`9f1dc3e6`](https://github.com/NixOS/nixpkgs/commit/9f1dc3e6cd9344c1c4e79d05d6d0ff9d611d961f) | `` hugo: 0.141.0 -> 0.143.0 ``                                                                        |
| [`eeb060be`](https://github.com/NixOS/nixpkgs/commit/eeb060be62ee3fe08dfc82615b8424808e0c8288) | `` lxqt-panel-profiles: init at 1.1 ``                                                                |
| [`5f0d2802`](https://github.com/NixOS/nixpkgs/commit/5f0d280210d0e4e9ca516f5522786d1247677820) | `` python312Packages.django-statici18n: 2.5.0 -> 2.6.0 ``                                             |
| [`a8dc5506`](https://github.com/NixOS/nixpkgs/commit/a8dc5506dcf44703914c30a69bcd850e4e9082a9) | `` python312Packages.django-i18nfield: fix 1.10.2 version bump ``                                     |
| [`33155824`](https://github.com/NixOS/nixpkgs/commit/331558245cb29baf0f5acba9f2d30fecab6c8e9c) | `` jna: 5.15.0 -> 5.16.0 ``                                                                           |
| [`2d4d57fd`](https://github.com/NixOS/nixpkgs/commit/2d4d57fd436902d34cd8c573ab94b855bbc38ae3) | `` runzip: enable tests ``                                                                            |
| [`fe28eb11`](https://github.com/NixOS/nixpkgs/commit/fe28eb11705adf8b244a33a94017de03eae53b20) | `` runzip: fix build ``                                                                               |
| [`c0e2fbbc`](https://github.com/NixOS/nixpkgs/commit/c0e2fbbcad694e99e22dd3f099b2b8288b0ae750) | `` nixos/amazon-image: fix eval ``                                                                    |
| [`ccde39b0`](https://github.com/NixOS/nixpkgs/commit/ccde39b06741b92c7ec07abc35702296450ae963) | `` tana: 1.0.21 -> 1.0.23 ``                                                                          |
| [`db98a21b`](https://github.com/NixOS/nixpkgs/commit/db98a21bb417e5a1f82c7207b27eee73b1e24f1c) | `` brave: 1.74.50 -> 1.74.51 ``                                                                       |
| [`89c1b0eb`](https://github.com/NixOS/nixpkgs/commit/89c1b0ebde249a6a28edb52d50195da1d3622690) | `` hyprlandPlugins.hyprspace: 0-unstable-2024-12-08 -> 0-unstable-2025-01-18 ``                       |
| [`b75edc29`](https://github.com/NixOS/nixpkgs/commit/b75edc29b38c038fa7cbc8fc34134476e5e0b81b) | `` hyprlandPlugins.hyprgrass: 0.8.2-unstable-2024-12-13 -> 0.8.2-unstable-2025-02-01 ``               |
| [`e647b29d`](https://github.com/NixOS/nixpkgs/commit/e647b29de17233dcc563f8ead57a482c047a306a) | `` hyprlandPlugins.hyprfocus: 0-unstable-2024-11-09 -> 0-unstable-2025-01-04 ``                       |
| [`619ccc28`](https://github.com/NixOS/nixpkgs/commit/619ccc288832b325d2644fdaa12316ccfe546c27) | `` hyprlandPlugins.hypr-dynamic-cursors: 0-unstable-2024-12-19 -> 0-unstable-2025-01-27 ``            |
| [`0d077b6d`](https://github.com/NixOS/nixpkgs/commit/0d077b6d64f5626cc373d3f08921c29ebe48f50e) | `` hyprlandPlugins/hyprland-plugins: 0.46.0 -> 0.47.0 ``                                              |
| [`e0d9b82e`](https://github.com/NixOS/nixpkgs/commit/e0d9b82e97d88215f4cea533ea8b6478f04e152b) | `` whoogle-search: 0.9.2 -> 0.9.3 ``                                                                  |
| [`7ee9eb31`](https://github.com/NixOS/nixpkgs/commit/7ee9eb310eb455e700a02a6fc160b60d712caacd) | `` python3Packages.partial-json-parser: init at 0.2.1.1.post5 ``                                      |
| [`bce8e5a9`](https://github.com/NixOS/nixpkgs/commit/bce8e5a90caae919981ca6e13feea02945690ba3) | `` python3Packages.mistral-common: init at 1.5.2 ``                                                   |
| [`9abe16fa`](https://github.com/NixOS/nixpkgs/commit/9abe16fad92dfe378a511a10d638a4c667948325) | `` python3Packages.compressed-tensors: init at 0.9.1 ``                                               |
| [`682a3b16`](https://github.com/NixOS/nixpkgs/commit/682a3b16575ea1d6d9d2dd20543afc41eab5a2d3) | `` cyberpunk-neon: 0-unstable-2024-11-07 -> 0-unstable-2025-02-01 ``                                  |
| [`d975047a`](https://github.com/NixOS/nixpkgs/commit/d975047add65e45bd63f278b923a2f5160b4c169) | `` postgresqlPackages.pgddl: refactor strictDeps ``                                                   |
| [`7abfe415`](https://github.com/NixOS/nixpkgs/commit/7abfe415360545836eded3dc9a4ebe08e637fd1c) | `` basex: 11.6 -> 11.7 ``                                                                             |
| [`1210fe43`](https://github.com/NixOS/nixpkgs/commit/1210fe439e1adf63a17ef5e6464bee227dec3cd2) | `` python312Packages.sagemaker: 2.237.3 -> 2.239.0 ``                                                 |
| [`5fa945ee`](https://github.com/NixOS/nixpkgs/commit/5fa945ee36cbcf15100281d32d4cc2873fc021aa) | `` arrow-cpp: 18.1.0 -> 19.0.0 ``                                                                     |
| [`688ae50a`](https://github.com/NixOS/nixpkgs/commit/688ae50a81ad139947838eca8bd243826f3465fb) | `` knot-resolver: disable a problematic test ``                                                       |
| [`0ad9996e`](https://github.com/NixOS/nixpkgs/commit/0ad9996e9b2083b9e2124925b463292b6da69914) | `` comrak: 0.34.0 -> 0.35.0 ``                                                                        |
| [`8ec2155f`](https://github.com/NixOS/nixpkgs/commit/8ec2155f617183565a861fba93a7e3fd6308c095) | `` vscode-extensions.vscode-icons-team.vscode-icons: 12.10.0 -> 12.11.0 ``                            |
| [`8c90e788`](https://github.com/NixOS/nixpkgs/commit/8c90e7887c3d48215bc43c3e26bd822994a55712) | `` lixVersions: don't allowGitDependencies ``                                                         |
| [`5a878990`](https://github.com/NixOS/nixpkgs/commit/5a8789906f825ad741558da047d95370eb3edb91) | `` stevenblack-blocklist: 3.15.10 -> 3.15.15 ``                                                       |
| [`477d26d1`](https://github.com/NixOS/nixpkgs/commit/477d26d111feea02901d740cb4b9cae3b679e8d9) | `` bun: 1.2.1 -> 1.2.2 ``                                                                             |
| [`86950f00`](https://github.com/NixOS/nixpkgs/commit/86950f00de1fc363ad622a574f8f66492d229c8c) | `` chickenPackages.chickenEggs: update ``                                                             |
| [`6c6784a1`](https://github.com/NixOS/nixpkgs/commit/6c6784a197ebae4cdf9fc9e7f7139a21dd129b7e) | `` chickenPackages.chickenEggs: adapt update script ``                                                |
| [`29327895`](https://github.com/NixOS/nixpkgs/commit/29327895083b2c33668cbd663dd708a62819f1fb) | `` abcmidi: 2025.01.20 -> 2025.01.30 ``                                                               |
| [`bf4d134f`](https://github.com/NixOS/nixpkgs/commit/bf4d134f5c93d5b802fa51e3cb7ba240b8202050) | `` minio: 2025-01-18T00-31-37Z -> 2025-01-20T14-49-07Z ``                                             |
| [`3da5bae7`](https://github.com/NixOS/nixpkgs/commit/3da5bae74d7bf3c661e985085a55ea463bcbd8ec) | `` cargo-bundle-licenses: 2.3.0 -> 3.0.0 ``                                                           |
| [`c12ad209`](https://github.com/NixOS/nixpkgs/commit/c12ad209fed52cd51aaa5e1433da5a9ab4e5b361) | `` tabby-agent: 0.23.0 -> 0.23.1 ``                                                                   |
| [`c97e9a5b`](https://github.com/NixOS/nixpkgs/commit/c97e9a5bd668f71e0b69db34a92ff618ace68e78) | `` skeditor: 2.8.3 -> 2.8.5 ``                                                                        |
| [`1460db45`](https://github.com/NixOS/nixpkgs/commit/1460db45f63a3d402aaff35b7463805c2b6d98a1) | `` waagent: optimize option descriptions ``                                                           |
| [`0896abdc`](https://github.com/NixOS/nixpkgs/commit/0896abdce1d25454672b26341e720fab6fa9a0a1) | `` google-cloud-sql-proxy: 2.14.3 -> 2.15.0 ``                                                        |
| [`cb7b05fa`](https://github.com/NixOS/nixpkgs/commit/cb7b05fa5f1e5c303e4fe2f00c3b4ff33942491d) | `` shopware-cli: 0.4.62 -> 0.5.2 ``                                                                   |
| [`f03d3d63`](https://github.com/NixOS/nixpkgs/commit/f03d3d637f72e6e90845f10f0d0d7e52e9145d1d) | `` parca-agent: 0.35.2 -> 0.36.0 ``                                                                   |
| [`efe01663`](https://github.com/NixOS/nixpkgs/commit/efe016639593855054f4805732266a5219dc88bd) | `` arkade: 0.11.32 -> 0.11.33 ``                                                                      |