### PR TITLE
chore(flake/nixpkgs-stable): `f6687779` -> `fecfeb86`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -454,11 +454,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1738435198,
-        "narHash": "sha256-5+Hmo4nbqw8FrW85FlNm4IIrRnZ7bn0cmXlScNsNRLo=",
+        "lastModified": 1738574474,
+        "narHash": "sha256-rvyfF49e/k6vkrRTV4ILrWd92W+nmBDfRYZgctOyolQ=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "f6687779bf4c396250831aa5a32cbfeb85bb07a3",
+        "rev": "fecfeb86328381268e29e998ddd3ebc70bbd7f7c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                              |
| ---------------------------------------------------------------------------------------------- | -------------------------------------------------------------------- |
| [`fecfeb86`](https://github.com/NixOS/nixpkgs/commit/fecfeb86328381268e29e998ddd3ebc70bbd7f7c) | `` ocamlPackages.reanalyze: init at 2.25.1 ``                        |
| [`a9011ba6`](https://github.com/NixOS/nixpkgs/commit/a9011ba62b4676843a2eda5288a0c2673b85746f) | `` pkgsCross.aarch64-darwin.discord-canary: 0.0.686 -> 0.0.692 ``    |
| [`c9d14c99`](https://github.com/NixOS/nixpkgs/commit/c9d14c99f733ee084dfd414b213256fab77f3513) | `` pkgsCross.aarch64-darwin.discord: 0.0.333 -> 0.0.334 ``           |
| [`609b9ba9`](https://github.com/NixOS/nixpkgs/commit/609b9ba93200b67c454d3624fa6b8c037cf4ef3a) | `` discord-ptb: 0.0.127 -> 0.0.128 ``                                |
| [`7e548144`](https://github.com/NixOS/nixpkgs/commit/7e54814479494c22a0ecb2e4a7a1603273e2d44f) | `` discord-development: 0.0.67 -> 0.0.68 ``                          |
| [`0b19376b`](https://github.com/NixOS/nixpkgs/commit/0b19376b03a14fd8b5516d045984d05d7f5f251d) | `` discord-canary: 0.0.574 -> 0.0.581 ``                             |
| [`0af6958f`](https://github.com/NixOS/nixpkgs/commit/0af6958fd1f74cc6b5908869a4e942caace9146e) | `` discord: 0.0.81 -> 0.0.82 ``                                      |
| [`3e1e4bdb`](https://github.com/NixOS/nixpkgs/commit/3e1e4bdb47a8aff1b290b6df3f3dcf764a742b97) | `` diebahn: 2.7.2 -> 2.7.3 ``                                        |
| [`ade20d87`](https://github.com/NixOS/nixpkgs/commit/ade20d870b674399fafc4a87db2a9228edc21213) | `` frigate: fix missing path substitution ``                         |
| [`c370f9fb`](https://github.com/NixOS/nixpkgs/commit/c370f9fb5cf867ab7cb7ff26b40bab7d219c9af5) | `` matrix-synapse: 1.122.0 -> 1.123.0 ``                             |
| [`1513c6d8`](https://github.com/NixOS/nixpkgs/commit/1513c6d886e898cfb18df1503400503bc614c737) | `` mozillavpn: Switch rev to tag ``                                  |
| [`433a6c22`](https://github.com/NixOS/nixpkgs/commit/433a6c22adcddde06af6cc44237f5652f1bc9d27) | `` mozillavpn: 2.24.3 → 2.25.0 ``                                    |
| [`a8cca9ad`](https://github.com/NixOS/nixpkgs/commit/a8cca9ad37ff9176aabee9afb6197bacc745ab24) | `` mozillavpn: Use fetchCargoVendor ``                               |
| [`38b49b89`](https://github.com/NixOS/nixpkgs/commit/38b49b892a59904f472e6b5cfefc22aff66cee03) | `` linux_5_4: 5.4.289 -> 5.4.290 ``                                  |
| [`04be8536`](https://github.com/NixOS/nixpkgs/commit/04be85369993c74bbea99dd45b3b9eacb3129aa4) | `` linux_5_10: 5.10.233 -> 5.10.234 ``                               |
| [`1f9177be`](https://github.com/NixOS/nixpkgs/commit/1f9177be7b952f6e8f97fd9a72582e90701db8f6) | `` linux_5_15: 5.15.177 -> 5.15.178 ``                               |
| [`32dbc89e`](https://github.com/NixOS/nixpkgs/commit/32dbc89e4a61bac0008a52ae0ee47ee9441630bb) | `` linux_6_1: 6.1.127 -> 6.1.128 ``                                  |
| [`b3d6beb7`](https://github.com/NixOS/nixpkgs/commit/b3d6beb79bf757df0f9d789eae3f916cfc96b6a2) | `` linux_6_6: 6.6.74 -> 6.6.75 ``                                    |
| [`b36c4ef5`](https://github.com/NixOS/nixpkgs/commit/b36c4ef52150cd5157b77671dd05194014b0aca8) | `` linux_6_12: 6.12.11 -> 6.12.12 ``                                 |
| [`9c98d1a1`](https://github.com/NixOS/nixpkgs/commit/9c98d1a1fc9eb9d6313faca634b4d2a8877d99aa) | `` linux_6_13: 6.13 -> 6.13.1 ``                                     |
| [`494fb813`](https://github.com/NixOS/nixpkgs/commit/494fb8133e133d73c120c3694bccf5eb4803261e) | `` prrte: fix to make multi-node openmpi jobs work out-of-the-box `` |
| [`1623729f`](https://github.com/NixOS/nixpkgs/commit/1623729fa0ce3b4e56d85567b9027ddf488f4a1f) | `` phpunit: 11.5.3 -> 11.5.6 ``                                      |