### PR TITLE
chore(flake/nixpkgs): `c6e957d8` -> `799ba5bf`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -470,11 +470,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1738546358,
-        "narHash": "sha256-nLivjIygCiqLp5QcL7l56Tca/elVqM9FG1hGd9ZSsrg=",
+        "lastModified": 1738680400,
+        "narHash": "sha256-ooLh+XW8jfa+91F1nhf9OF7qhuA/y1ChLx6lXDNeY5U=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "c6e957d81b96751a3d5967a0fd73694f303cc914",
+        "rev": "799ba5bffed04ced7067a91798353d360788b30d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                            |
| ---------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------- |
| [`d677f156`](https://github.com/NixOS/nixpkgs/commit/d677f15696dd8e4177b4829fb997bf994006df52) | `` azure-cli-extensions.rdbms-connect: 1.0.6 -> 1.0.7 ``                           |
| [`84038338`](https://github.com/NixOS/nixpkgs/commit/84038338bd4016b49214047a3f54630a86407901) | `` azure-cli-extensions.ssh: fix changelog ``                                      |
| [`f8a07769`](https://github.com/NixOS/nixpkgs/commit/f8a077696bd946a517830fc93993a43c717daa75) | `` vllm: create application from python package ``                                 |
| [`639263e2`](https://github.com/NixOS/nixpkgs/commit/639263e260482001281657bc7965c6f5ca0bbf7e) | `` openmpi: Fix upstream issue with shared memory backing file creation ``         |
| [`e8e3ded6`](https://github.com/NixOS/nixpkgs/commit/e8e3ded6c988dd6706128fe66171c5115aa5282b) | `` astroterm: 1.0.4 -> 1.0.6 (#378908) ``                                          |
| [`e70ebe98`](https://github.com/NixOS/nixpkgs/commit/e70ebe98290f464f3020fb81844416d2350eae58) | `` python3Packages.vllm: add opencv-python-headless dependency ``                  |
| [`06817e8a`](https://github.com/NixOS/nixpkgs/commit/06817e8a54f4a1b0a9176feb5405f254ed6438c8) | `` python3Packages.mistral-common: add opencv-python-headless dependency ``        |
| [`cd1cf641`](https://github.com/NixOS/nixpkgs/commit/cd1cf641441a2fab192f2cd3574a4924014184cf) | `` go-ethereum: fix incorrect license ``                                           |
| [`dd74c154`](https://github.com/NixOS/nixpkgs/commit/dd74c154a0a5fb7f8ad64a034dded685f1c7a87a) | `` myks: 4.3.1 -> 4.4.2 ``                                                         |
| [`b6ae10af`](https://github.com/NixOS/nixpkgs/commit/b6ae10afbff5d2cd0d065c8d55de69970e27e6e3) | `` azure-cli-extensions.ssh: 2.0.5 -> 2.0.6 ``                                     |
| [`1016fdc9`](https://github.com/NixOS/nixpkgs/commit/1016fdc933b91fe4310b8e9f9473d165824f7772) | `` azure-cli-extensions.containerapp: 1.0.0b1 -> 1.1.0b2 ``                        |
| [`62b9ab4b`](https://github.com/NixOS/nixpkgs/commit/62b9ab4bd4aab48cb50180ee92e673b677801bb6) | `` azure-cli-extensions.application-insights: 1.2.1 -> 1.2.2 ``                    |
| [`2cdb29d2`](https://github.com/NixOS/nixpkgs/commit/2cdb29d247616a7d05277d19bf6cc44039497603) | `` azure-cli-extensions.storage-preview: 1.0.0b2 -> 1.0.0b5 ``                     |
| [`d4c8e9be`](https://github.com/NixOS/nixpkgs/commit/d4c8e9be84be92399014f4a91d7ab96da5b32992) | `` azure-cli-extensions.vm-repair: 2.0.0 -> 2.0.2 ``                               |
| [`92016f20`](https://github.com/NixOS/nixpkgs/commit/92016f20e2b3a3d1d38e34ab204af1a2b957ee2f) | `` vrcx: Simplify update process ``                                                |
| [`6c49e20f`](https://github.com/NixOS/nixpkgs/commit/6c49e20fc017e92602c25b7b40793cba0d6fcc65) | `` vrcx: 2025-01-27T00.10-0ee8137 -> 2025.01.31 ``                                 |
| [`eb351ce5`](https://github.com/NixOS/nixpkgs/commit/eb351ce517878d93e7321d8829050a45c2f2d1df) | `` why3: use zarith from 1.8.0 ``                                                  |
| [`fc5c2c02`](https://github.com/NixOS/nixpkgs/commit/fc5c2c02c443eda14e410a5ec0f45fb4743ef93a) | `` python3Packages.vllm: 0.6.2 -> 0.7.1 ``                                         |
| [`efcfe26a`](https://github.com/NixOS/nixpkgs/commit/efcfe26acbef90aa0d8879ff744ef4d015f1f8eb) | `` python3Packages.xgrammar: init at 0.1.11 ``                                     |
| [`29e1160e`](https://github.com/NixOS/nixpkgs/commit/29e1160e514b286ea9af4de84eddf33f0d10ff8c) | `` python312Packages.pyprecice: cleanup and fix ``                                 |
| [`6daeb20f`](https://github.com/NixOS/nixpkgs/commit/6daeb20f4b246c221f0cdfe410d4cf895b43e9bb) | `` precice: remove gcc ``                                                          |
| [`2e71cf50`](https://github.com/NixOS/nixpkgs/commit/2e71cf50505deb784d3d2e47226416e852b24f77) | `` precice: use lib.cmake* for cmake flags ``                                      |
| [`0a9f9e1c`](https://github.com/NixOS/nixpkgs/commit/0a9f9e1c61915d19091723d4355e6febdbb6043e) | `` precice: fix boost 1.87 compat ``                                               |
| [`a84be67e`](https://github.com/NixOS/nixpkgs/commit/a84be67ec3675e6ac74bd765df8a014ac95b53fa) | `` cloud-hypervisor: 43.0 -> 44.0 ``                                               |
| [`e5e4bdce`](https://github.com/NixOS/nixpkgs/commit/e5e4bdce665e01c0fcd17ff4e9032d384b94a4a2) | `` traefik: 3.3.2 -> 3.3.3 ``                                                      |
| [`2a5c1786`](https://github.com/NixOS/nixpkgs/commit/2a5c17865a9c6481ccddb7d673d483e1793ce3ee) | `` zxpy: use `addBinToPathHook` ``                                                 |
| [`b092a528`](https://github.com/NixOS/nixpkgs/commit/b092a528f30f25e78acfa9dc459912bb8c8ca41f) | `` xonsh: use `addBinToPathHook` ``                                                |
| [`b5279fcb`](https://github.com/NixOS/nixpkgs/commit/b5279fcbed3f27ef0961792f5ac804a93051476b) | `` tts: use `addBinToPathHook`, use `writableTmpDirAsHomeHook` ``                  |
| [`a8ad6d29`](https://github.com/NixOS/nixpkgs/commit/a8ad6d2988b99d8f82723a6df89a972a03ee84d9) | `` pifpaf: use `addBinToPathHook` ``                                               |
| [`11613c42`](https://github.com/NixOS/nixpkgs/commit/11613c422cf952ec67adf32c2265790f633f6365) | `` parquet-tools: use `addBinToPathHook` ``                                        |
| [`29643528`](https://github.com/NixOS/nixpkgs/commit/2964352875f76ece5ec973b89812e0d549797177) | `` multiqc: use `addBinToPathHook` ``                                              |
| [`f0ad9567`](https://github.com/NixOS/nixpkgs/commit/f0ad956733c49080da0d1ad33198aab6f0842c49) | `` gemmi: use `addBinToPathHook` ``                                                |
| [`2f69f99f`](https://github.com/NixOS/nixpkgs/commit/2f69f99ff8db14f549684d68ed0f80f66bfc9b3a) | `` gdtoolkit_4: use `addBinToPathHook`, use `writableTmpDirAsHomeHook` ``          |
| [`b3bba66f`](https://github.com/NixOS/nixpkgs/commit/b3bba66ff3c64871d6ff98b497aa8b9c04835449) | `` gdtoolkit_3: use `addBinToPathHook`, use `writableTmpDirAsHomeHook` ``          |
| [`90c2ed25`](https://github.com/NixOS/nixpkgs/commit/90c2ed254ecdd580928108a5b4136040ef374883) | `` gallia: use `addBinToPathHook` ``                                               |
| [`fbac494a`](https://github.com/NixOS/nixpkgs/commit/fbac494ac20f64b97b80d92088eb22eb8588af75) | `` flye: use `addBinToPathHook` ``                                                 |
| [`df0dc112`](https://github.com/NixOS/nixpkgs/commit/df0dc1125db3ffa75eefd99c5ff2618bc53b63f8) | `` eliot-tree: use `addBinToPathHook` ``                                           |
| [`6a79b58e`](https://github.com/NixOS/nixpkgs/commit/6a79b58e8db5f9226a2c3d9cfcf2fb4867855679) | `` python312Packages.eliot: unbreak, use `addBinToPathHook` ``                     |
| [`b613464a`](https://github.com/NixOS/nixpkgs/commit/b613464a62bafeaaab19f10a14f62a8019d85914) | `` audible-cli: use `addBinToPathHook` ``                                          |
| [`07f14030`](https://github.com/NixOS/nixpkgs/commit/07f14030db30cdd8b0247c6bc728500a3eb4dd56) | `` cedar: 4.3.0 -> 4.3.1 ``                                                        |
| [`92dd18f8`](https://github.com/NixOS/nixpkgs/commit/92dd18f8fa5cc160163ab16d03ccfaae62aae3ca) | `` rainfrog: 0.2.11 -> 0.2.13 ``                                                   |
| [`644ec56e`](https://github.com/NixOS/nixpkgs/commit/644ec56ed303b6e7bc41cba27a171ba23199865e) | `` mangojuice: 0.8.0 -> 0.8.1 ``                                                   |
| [`31d5e15f`](https://github.com/NixOS/nixpkgs/commit/31d5e15f0daddd3d8a7c089368392dcd251ffcb8) | `` v2ray-domain-list-community: 20241221105938 -> 20250124154827 ``                |
| [`a430b350`](https://github.com/NixOS/nixpkgs/commit/a430b350354790d04e03f6654333b9797b612b13) | `` discord: 0.0.82 -> 0.0.83 ``                                                    |
| [`99de8bf2`](https://github.com/NixOS/nixpkgs/commit/99de8bf25cbd33d62c8c9e7169618433d235216b) | `` nom: 2.7.3 -> 2.8.0 ``                                                          |
| [`dee2302c`](https://github.com/NixOS/nixpkgs/commit/dee2302ce2e9eb3b8e3d6a84c5e2bbb7a8069749) | `` sqlite_orm: 1.9 -> 1.9.1 ``                                                     |
| [`cc58c521`](https://github.com/NixOS/nixpkgs/commit/cc58c5213b875221f4e232838b00b2b516168a69) | `` nagiosPlugins.check_ssl_cert: 2.85.1 -> 2.86.0 ``                               |
| [`ef07f4b6`](https://github.com/NixOS/nixpkgs/commit/ef07f4b6d8b7563db9aa176bb4d964a1174aadd2) | `` pdal: 2.8.3 -> 2.8.4 ``                                                         |
| [`d5a8eb09`](https://github.com/NixOS/nixpkgs/commit/d5a8eb09dc5feff6fde7ca5da5ae6caee1065c2a) | `` mubeng: 0.21.0 -> 0.22.0 ``                                                     |
| [`d7a3aab1`](https://github.com/NixOS/nixpkgs/commit/d7a3aab1c88e0d7ba499862da0000fb2c03d4b23) | `` nexusmods-app: 0.7.2 -> 0.7.3 ``                                                |
| [`24fa842a`](https://github.com/NixOS/nixpkgs/commit/24fa842a556c8c78442a0a194dbe758ef9a7cdde) | `` mpich: 4.2.3 -> 4.3.0 ``                                                        |
| [`21c82b82`](https://github.com/NixOS/nixpkgs/commit/21c82b822e311e281e4828859f7af2d30b8bf5ee) | `` sad: 0.4.31 -> 0.4.32 ``                                                        |
| [`5e8ec34a`](https://github.com/NixOS/nixpkgs/commit/5e8ec34a54d78807a25c8a969d9d76566a59702f) | `` allure: 2.32.0 -> 2.32.1 ``                                                     |
| [`df3383ca`](https://github.com/NixOS/nixpkgs/commit/df3383ca0a5db701de80edbc0e2f8e0b3a3b70e2) | `` pretalx: relax django-i18nfield constraint ``                                   |
| [`f7cdcbfc`](https://github.com/NixOS/nixpkgs/commit/f7cdcbfc3c293ace2ffea5cc34b5363112d04190) | `` uv: 0.5.26 -> 0.5.27 ``                                                         |
| [`f4828c6e`](https://github.com/NixOS/nixpkgs/commit/f4828c6e8536bfb13d30c9b3ff5898b1f1d9bb83) | `` novelwriter: 2.6 -> 2.6.1 ``                                                    |
| [`b3633cf4`](https://github.com/NixOS/nixpkgs/commit/b3633cf4a8790d423e201ecff128f381f27fc0d8) | `` kubescape: 3.0.24 -> 3.0.25 ``                                                  |
| [`df3b3bcc`](https://github.com/NixOS/nixpkgs/commit/df3b3bcc8bee9eda0b63e830a38aceaeb9446204) | `` fwupd: 2.0.4 -> 2.0.5 ``                                                        |
| [`34b9816b`](https://github.com/NixOS/nixpkgs/commit/34b9816b51bc8b5c8c7e7a73ebbced707382646c) | `` terraform-providers.harbor: 3.10.17 -> 3.10.18 ``                               |
| [`23829c7e`](https://github.com/NixOS/nixpkgs/commit/23829c7e31c2fc94c34da4efd9d0532bd731bc82) | `` waytrogen: 0.6.3 -> 0.6.7 ``                                                    |
| [`d4e655c9`](https://github.com/NixOS/nixpkgs/commit/d4e655c973b9dd36c90903956415e8c45f3ebe36) | `` python3Package.depyf: init at 0.18.0 ``                                         |
| [`146f1375`](https://github.com/NixOS/nixpkgs/commit/146f1375c192fc695e76870cf93df43be55bafcc) | `` vimPlugins.minuet-ai-nvim: init at 2025-02-03 ``                                |
| [`e0812fc1`](https://github.com/NixOS/nixpkgs/commit/e0812fc1f8a79eaff265e085fc7db78ebde365c3) | `` pypy310Packages.cffi: make proper package ``                                    |
| [`494b2407`](https://github.com/NixOS/nixpkgs/commit/494b2407ef95997176211a8758638205916873a9) | `` nixos/prometheus-restic-exporter: set cache dir (#378228) ``                    |
| [`d4bd8b26`](https://github.com/NixOS/nixpkgs/commit/d4bd8b26d5ca38bc983d21a74e88d69a8dad3cc0) | `` grpc_cli: 1.70.0 -> 1.70.1 ``                                                   |
| [`a4bd2734`](https://github.com/NixOS/nixpkgs/commit/a4bd2734aa2f540b801ac448b792990ff3dc29aa) | `` vimPlugins.blink-cmp-dictionary: init at 2025-01-12 ``                          |
| [`958d1fb8`](https://github.com/NixOS/nixpkgs/commit/958d1fb821de35d0a5ff2e81a7e24728d77508bf) | `` nixos/profiles/hardened: replace 'with' using inherit and add disable option `` |
| [`b30a2c0c`](https://github.com/NixOS/nixpkgs/commit/b30a2c0caa8d5c86bddf55f5a9bb9f3dbb9a55d2) | `` tdl: 0.18.4 -> 0.18.5 ``                                                        |
| [`b441f2e5`](https://github.com/NixOS/nixpkgs/commit/b441f2e55d489756ad875659f8b6ac6410bdbaf3) | `` gitlab-container-registry: Add workaround for failing upstream tests ``         |
| [`8b5a3141`](https://github.com/NixOS/nixpkgs/commit/8b5a31411627bd166811886163c25c440387e3dc) | `` opengamepadui: 0.35.7 -> 0.35.8 ``                                              |
| [`d23f8d25`](https://github.com/NixOS/nixpkgs/commit/d23f8d2582c46305d0373ecf90315eb34b46d04a) | `` python312Packages.milc: refactor and add tests ``                               |
| [`9a05755c`](https://github.com/NixOS/nixpkgs/commit/9a05755c94afd3eac5dc637b60c86680745e174c) | `` python312Packages.milc: 1.8.0 -> 1.9.1 ``                                       |
| [`e543b8a4`](https://github.com/NixOS/nixpkgs/commit/e543b8a4a12b4b439d01fe18ac898efa7b35abab) | `` soteria: update hash after upstream re-tag (#379135) ``                         |
| [`cb90294a`](https://github.com/NixOS/nixpkgs/commit/cb90294a1118326947905c873d190212155bb40e) | `` termius: 9.12.0 -> 9.13.1 ``                                                    |
| [`29baabe3`](https://github.com/NixOS/nixpkgs/commit/29baabe397ec5bfa1e3c147eea11266ea17ce972) | `` werf: 2.22.0 -> 2.24.0 ``                                                       |
| [`eb343178`](https://github.com/NixOS/nixpkgs/commit/eb3431789cef743af9dace58eb2ba7b33a332b56) | `` systemd: add missing patch for Musl ``                                          |
| [`4fe1365e`](https://github.com/NixOS/nixpkgs/commit/4fe1365eba1b0d129bfc3eabeb0a82c951156f2b) | `` shadowsocks-rust: 1.21.2 -> 1.22.0 ``                                           |
| [`ddc4da2c`](https://github.com/NixOS/nixpkgs/commit/ddc4da2c8ba0e7fff69575bf6a0930a491e810de) | `` python313Packages.pynfsclient: disable on > 3.13 ``                             |
| [`9398c621`](https://github.com/NixOS/nixpkgs/commit/9398c621bed20e7d9e65bcc0bd62f9ef4de0d85f) | `` vimPlugins.blink-cmp-git: init at 2025-01-27 ``                                 |
| [`efe51355`](https://github.com/NixOS/nixpkgs/commit/efe51355b4732aff65c99d75133fb7d9aa3690f0) | `` netexec: 1.1.0-unstable-2024-01-15 -> 1.3.0 ``                                  |
| [`5c1fa4a4`](https://github.com/NixOS/nixpkgs/commit/5c1fa4a4381c2e2e11a848bacf7184cd76800931) | `` python312Packages.pynfsclient: init at 0.1.5 ``                                 |
| [`b49bd29d`](https://github.com/NixOS/nixpkgs/commit/b49bd29d0fb39731fb06a78e487cd45015841813) | `` linux_latest-libre: 19683 -> 19707 ``                                           |
| [`faf8bf71`](https://github.com/NixOS/nixpkgs/commit/faf8bf712dd8839b68d7853b73c311ad1eb6dca4) | `` linux-rt_6_6: 6.6.65-rt47 -> 6.6.74-rt48 ``                                     |
| [`32c81b75`](https://github.com/NixOS/nixpkgs/commit/32c81b7581b19fc3fa35049cdc0194b66a012537) | `` linux-rt_6_1: 6.1.120-rt47 -> 6.1.127-rt48 ``                                   |
| [`1017c9f0`](https://github.com/NixOS/nixpkgs/commit/1017c9f0ccf263fed38516f6f439d7f9a76306e6) | `` linux-rt_5_15: 5.15.173-rt82 -> 5.15.177-rt83 ``                                |
| [`e9c363c6`](https://github.com/NixOS/nixpkgs/commit/e9c363c6285a8d767dd51b96fba8bfe7c7985d96) | `` linux-rt_5_10: 5.10.231-rt123 -> 5.10.233-rt125 ``                              |
| [`580ccd0e`](https://github.com/NixOS/nixpkgs/commit/580ccd0ecc820494a77ec52c2e6e402cca180573) | `` linux_testing: 6.13-rc7 -> 6.14-rc1 ``                                          |
| [`2c3fc4c7`](https://github.com/NixOS/nixpkgs/commit/2c3fc4c71575868b72aa4c82a777fa5710c2b9ed) | `` linux/common-config: update for 6.14 ``                                         |
| [`db39cfaa`](https://github.com/NixOS/nixpkgs/commit/db39cfaac9a291610c6393b70190aa1c9cd4f271) | `` pnpm_10: 10.1.0 -> 10.2.0 ``                                                    |
| [`32cd540d`](https://github.com/NixOS/nixpkgs/commit/32cd540d89591b659ebaf7eb8763ede1afb9df71) | `` rutabaga_gfx: fix building with llvm ``                                         |
| [`da713868`](https://github.com/NixOS/nixpkgs/commit/da7138684bdd1e45f26bddfb3a6beb91757d8687) | `` nixos/home-assistant: declarative blueprints ``                                 |