### PR TITLE
chore(flake/home-manager): `f2d32e46` -> `f20b7a8a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -355,11 +355,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1738709900,
-        "narHash": "sha256-8Bo5xFlCH5q72ExvAnH7TzStMlLZldKOSLMClRSfmTc=",
+        "lastModified": 1738753876,
+        "narHash": "sha256-yXT82kERWL4R81hfun9BuT478Q6ut0dJzdQjAxjRS38=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "f2d32e46fac9d51da6912948ae1156044c71774b",
+        "rev": "f20b7a8ab527a2482f13754dc00b2deaddc34599",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                                           |
| ----------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------- |
| [`f20b7a8a`](https://github.com/nix-community/home-manager/commit/f20b7a8ab527a2482f13754dc00b2deaddc34599) | `` firefox: fix referencing firefox fork name in profile-specific docs (#6407) `` |
| [`3b6fde96`](https://github.com/nix-community/home-manager/commit/3b6fde96d8b41a4a21cbacba8de7debf7ea78021) | `` Translate using Weblate (Russian) ``                                           |
| [`987f622c`](https://github.com/nix-community/home-manager/commit/987f622cc4368626d8b041ea495edf0d243714ba) | `` Add translation using Weblate (Bulgarian) ``                                   |
| [`39602525`](https://github.com/nix-community/home-manager/commit/396025251ae173da389133ed3aa7a3f18d333ea3) | `` Translate using Weblate (Bulgarian) ``                                         |
| [`d092f0a4`](https://github.com/nix-community/home-manager/commit/d092f0a4c07fea79f14886da83c9ee7249c6a84f) | `` Translate using Weblate (Spanish) ``                                           |
| [`59971126`](https://github.com/nix-community/home-manager/commit/5997112695f3b02d3992764760fc6ddfef51fba3) | `` flake.lock: Update ``                                                          |