### PR TITLE
chore(flake/zen-browser): `0622c0eb` -> `e4cef7c6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -715,11 +715,11 @@
         "nixpkgs": "nixpkgs_3"
       },
       "locked": {
-        "lastModified": 1738710976,
-        "narHash": "sha256-/Zyfku2FxQKMs3LHI90Hy61o8VuXtI16RfvK/d849B0=",
+        "lastModified": 1738754044,
+        "narHash": "sha256-ptZWtXstcE1a3My6N0OrKTA0wQePsYqqKnGpSZZy/bY=",
         "owner": "0xc000022070",
         "repo": "zen-browser-flake",
-        "rev": "0622c0eb2ab953e40e3d167eebe885a1f3bbe8f9",
+        "rev": "e4cef7c609c948a1ebc7f29602554d29fbad500d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                          | Message                                                                 |
| --------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------- |
| [`e4cef7c6`](https://github.com/0xc000022070/zen-browser-flake/commit/e4cef7c609c948a1ebc7f29602554d29fbad500d) | `` Update Zen Browser twilight @ x86_64 && aarch64 to 1.7.6t#b65fbb5 `` |
| [`8f5b2c7a`](https://github.com/0xc000022070/zen-browser-flake/commit/8f5b2c7a1d0236188ac8588b06124147f02f14bf) | `` Update Zen Browser twilight @ x86_64 && aarch64 to 1.7.6t#2540736 `` |