### PR TITLE
chore(flake/nixpkgs-stable): `fecfeb86` -> `030ba197`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -454,11 +454,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1738574474,
-        "narHash": "sha256-rvyfF49e/k6vkrRTV4ILrWd92W+nmBDfRYZgctOyolQ=",
+        "lastModified": 1738702386,
+        "narHash": "sha256-nJj8f78AYAxl/zqLiFGXn5Im1qjFKU8yBPKoWEeZN5M=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "fecfeb86328381268e29e998ddd3ebc70bbd7f7c",
+        "rev": "030ba1976b7c0e1a67d9716b17308ccdab5b381e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                    |
| ---------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------- |
| [`9b7647e5`](https://github.com/NixOS/nixpkgs/commit/9b7647e5fc1295b7deebe17bc5340850652944c6) | `` mangojuice: 0.8.0 -> 0.8.1 ``                                           |
| [`c1d0ae99`](https://github.com/NixOS/nixpkgs/commit/c1d0ae992cf5991a9ea6040abe0be08a34ecda94) | `` discord: 0.0.82 -> 0.0.83 ``                                            |
| [`768e0def`](https://github.com/NixOS/nixpkgs/commit/768e0defd5cf2c93df46fecf53a53811b111af72) | `` why3: use zarith from 1.8.0 ``                                          |
| [`5ec6b119`](https://github.com/NixOS/nixpkgs/commit/5ec6b119e33c661ba731ea39d40f72758ae6d6de) | `` workflows/eval: rename BASE_SHA to TARGET_SHA ``                        |
| [`0efb3c5f`](https://github.com/NixOS/nixpkgs/commit/0efb3c5f143918a64892823bf83fba2d5667701d) | `` workflows/eval: fail hard without target run ``                         |
| [`514792d5`](https://github.com/NixOS/nixpkgs/commit/514792d5cf7c39a01c6ce3cba66b159355a20cfe) | `` gitlab: 17.8.0 -> 17.8.1 ``                                             |
| [`e15d3060`](https://github.com/NixOS/nixpkgs/commit/e15d3060769a770ca4849763a64c114ee0dadb71) | `` gitlab-container-registry: Add workaround for failing upstream tests `` |
| [`5362b9ea`](https://github.com/NixOS/nixpkgs/commit/5362b9ea8085acbef6c444ce8547dd602f70eec9) | `` linux_latest-libre: 19683 -> 19707 ``                                   |
| [`d9e87629`](https://github.com/NixOS/nixpkgs/commit/d9e87629c16ae01344e5f01df188f805920dcbe8) | `` linux-rt_6_6: 6.6.65-rt47 -> 6.6.74-rt48 ``                             |
| [`b23c46fa`](https://github.com/NixOS/nixpkgs/commit/b23c46fa4c7fa84ec61be38756f141a79f1359ab) | `` linux-rt_6_1: 6.1.120-rt47 -> 6.1.127-rt48 ``                           |
| [`81f78cf3`](https://github.com/NixOS/nixpkgs/commit/81f78cf3e04ffaa4daf954f3e35b12aa1b86d1bc) | `` linux-rt_5_15: 5.15.173-rt82 -> 5.15.177-rt83 ``                        |
| [`2a5844c6`](https://github.com/NixOS/nixpkgs/commit/2a5844c600e379f2f4e1b56a2f401b8b4550241e) | `` linux-rt_5_10: 5.10.231-rt123 -> 5.10.233-rt125 ``                      |
| [`450ff937`](https://github.com/NixOS/nixpkgs/commit/450ff93720f55cfbc7e1a4fef88cf4753e2d069f) | `` linux_testing: 6.13-rc7 -> 6.14-rc1 ``                                  |
| [`8cca64f8`](https://github.com/NixOS/nixpkgs/commit/8cca64f80604469b6735094a7413e682778ff933) | `` freetube: 0.22.1 -> 0.23.1 ``                                           |
| [`f56b3cdf`](https://github.com/NixOS/nixpkgs/commit/f56b3cdfcf9acc3b916a85e6df43044f4b539140) | `` freetube: build from source ``                                          |
| [`52b45fe5`](https://github.com/NixOS/nixpkgs/commit/52b45fe51aad534de2277c47abff46f4d32eacbc) | `` snac2: 2.68 -> 2.70 ``                                                  |
| [`6892a0c4`](https://github.com/NixOS/nixpkgs/commit/6892a0c438a863914ca98dc6eb805496ba03a4a5) | `` pnpm_9: 9.15.3 -> 9.15.5 ``                                             |
| [`a97cbce7`](https://github.com/NixOS/nixpkgs/commit/a97cbce71dac32ea015e92c0b906b78eeb18bdda) | `` knot-resolver: disable a problematic test ``                            |
| [`0c2f15e7`](https://github.com/NixOS/nixpkgs/commit/0c2f15e71232d53be9ca15962ae4bd300d8fd58c) | `` brave: 1.74.50 -> 1.74.51 ``                                            |
| [`f296f91c`](https://github.com/NixOS/nixpkgs/commit/f296f91c973720c413ceeaace8dfdf93ce2f4d07) | `` nixos/homepage-dashboard: fix links ``                                  |
| [`6e261e2f`](https://github.com/NixOS/nixpkgs/commit/6e261e2fa7093f4edddeda1e6b05b6dbd5f43eb0) | `` buildDotnetModule: add support for installing pre-release tools ``      |
| [`2ce48461`](https://github.com/NixOS/nixpkgs/commit/2ce48461fdcc6912a42dcf73631cd04b1885db87) | `` easyrsa: 3.2.1 -> 3.2.2 ``                                              |
| [`5f3d2677`](https://github.com/NixOS/nixpkgs/commit/5f3d26774745789b59faa52d6c98923871dc88fd) | `` signal-desktop(darwin): 7.38.0 -> 7.40.0 ``                             |
| [`21f20471`](https://github.com/NixOS/nixpkgs/commit/21f20471e81417bcc6303419672b3efcd95a88de) | `` signal-desktop: 7.38.0 -> 7.40.0 ``                                     |