### PR TITLE
chore(flake/spicetify-nix): `0be8bb03` -> `68de149c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -523,11 +523,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1738725875,
-        "narHash": "sha256-KJeErSFeuVVo+EOgoZoAKAbh9jOxgd7g/ldgUjbHvOA=",
+        "lastModified": 1738871202,
+        "narHash": "sha256-L6I6Qpqcqz15mc2Une9YUC5bI9Ih815aTKY08seEFMA=",
         "owner": "Gerg-L",
         "repo": "spicetify-nix",
-        "rev": "0be8bb03478dad374659369be3b2a5017c63fa61",
+        "rev": "68de149c022e04d85d4b79db265fd3a01890127d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                             |
| ----------------------------------------------------------------------------------------------------- | ----------------------------------- |
| [`68de149c`](https://github.com/Gerg-L/spicetify-nix/commit/68de149c022e04d85d4b79db265fd3a01890127d) | `` README: fix flakeless example `` |
| [`91bd81a3`](https://github.com/Gerg-L/spicetify-nix/commit/91bd81a382c61ca37afdf996ef38e9d949e0efaf) | `` remove magic-nix-cache ``        |