### PR TITLE
chore(flake/home-manager): `f99c704f` -> `43379927`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -339,11 +339,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1738841109,
-        "narHash": "sha256-sEgE3nifaRU5gfAx33ds0tx/j+qM0/5/bHopv/w6c0c=",
+        "lastModified": 1738878603,
+        "narHash": "sha256-fmhq8B3MvQLawLbMO+LWLcdC2ftLMmwSk+P29icJ3tE=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "f99c704fe3a4cf8d72b2d568ec80bc38be1a9407",
+        "rev": "433799271274c9f2ab520a49527ebfe2992dcfbd",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                              |
| ----------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------- |
| [`43379927`](https://github.com/nix-community/home-manager/commit/433799271274c9f2ab520a49527ebfe2992dcfbd) | `` wayland: create tray.target if xsession is not enabled (#6332) `` |