### PR TITLE
chore(flake/nixpkgs-stable): `030ba197` -> `f5a32fa2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -437,11 +437,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1738702386,
-        "narHash": "sha256-nJj8f78AYAxl/zqLiFGXn5Im1qjFKU8yBPKoWEeZN5M=",
+        "lastModified": 1738843498,
+        "narHash": "sha256-7x+Q4xgFj9UxZZO9aUDCR8h4vyYut4zPUvfj3i+jBHE=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "030ba1976b7c0e1a67d9716b17308ccdab5b381e",
+        "rev": "f5a32fa27df91dfc4b762671a0e0a859a8a0058f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                             |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------- |
| [`33bc5f17`](https://github.com/NixOS/nixpkgs/commit/33bc5f174eac669e4d2968f0f86dd3e5158e6485) | `` vesktop: 1.5.4 -> 1.5.5 ``                                       |
| [`d1b15ade`](https://github.com/NixOS/nixpkgs/commit/d1b15ade9d09d8154d7b9e9ad151fd880412e169) | `` chromium,chromedriver: 132.0.6834.159 -> 133.0.6943.53 ``        |
| [`79e94332`](https://github.com/NixOS/nixpkgs/commit/79e943327f3cb0daf373df2244e505351d3bf71a) | `` xwayland: 24.1.4 -> 24.1.5 ``                                    |
| [`b1015d8b`](https://github.com/NixOS/nixpkgs/commit/b1015d8b9ed465f88081d14764ff2124d53b752a) | `` firefox-esr-128-unwrapped: 128.6.0esr -> 128.7.0esr ``           |
| [`7c409c26`](https://github.com/NixOS/nixpkgs/commit/7c409c262897f23a564703a1954d3ae673fa4e09) | `` firefox-bin-unwrapped: 134.0.2 -> 135.0 ``                       |
| [`80f5d3fa`](https://github.com/NixOS/nixpkgs/commit/80f5d3fac452d69b26fa056a4020c4a437435456) | `` firefox-unwrapped: 134.0.2 -> 135.0 ``                           |
| [`c940b324`](https://github.com/NixOS/nixpkgs/commit/c940b324a645f423b8552d39ba23a768c46134d2) | `` python3Packages.kaleido: fix broken etc/fonts symlinks ``        |
| [`becb721c`](https://github.com/NixOS/nixpkgs/commit/becb721cbf6766de9d6134489255f6f32cc44340) | `` opencomposite: 0-unstable-2024-12-26 -> 0-unstable-2025-01-23 `` |
| [`f4d87b4a`](https://github.com/NixOS/nixpkgs/commit/f4d87b4a9b43dd4cac22290296025a15b9aaccda) | `` traefik: fix eval for 24.11 Go tooling ``                        |
| [`c8210786`](https://github.com/NixOS/nixpkgs/commit/c8210786f62e2978c09f82ca3469f72138600867) | `` go_1_22: 1.22.11 -> 1.22.12 ``                                   |
| [`a51a2003`](https://github.com/NixOS/nixpkgs/commit/a51a20036daefd92da40f187dc311b7007b11d46) | `` traefik: 3.3.2 -> 3.3.3 ``                                       |
| [`8c6fbe80`](https://github.com/NixOS/nixpkgs/commit/8c6fbe801e5f489eff2f9f16815684c76fff58dc) | `` traefik: add djds as maintainer ``                               |
| [`b6f5f9ca`](https://github.com/NixOS/nixpkgs/commit/b6f5f9caa6fb92b7a15456a8dce4ec1cc0bc5fc2) | `` maintainers: add djds ``                                         |
| [`d9662e38`](https://github.com/NixOS/nixpkgs/commit/d9662e38f4103ce46a8e036940be56b9b8543d86) | `` traefik: 3.2.2 -> 3.3.2 ``                                       |
| [`69846c45`](https://github.com/NixOS/nixpkgs/commit/69846c45915ef6ae82a021575e563c6fb2473142) | `` traefik: 3.2.1 -> 3.2.2 ``                                       |
| [`980bea5e`](https://github.com/NixOS/nixpkgs/commit/980bea5ec1e069b8b9ed934266ce62fe3bcf7f6e) | `` github-runner: 2.321.0 -> 2.322.0 ``                             |