### PR TITLE
chore(flake/zen-browser): `f9366025` -> `e2f657fb`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -672,11 +672,11 @@
         "nixpkgs": "nixpkgs_3"
       },
       "locked": {
-        "lastModified": 1738905423,
-        "narHash": "sha256-ZtEnCfeDh6/nvMta96cNUggI0C9FFsL0OCPzQAB0Tyw=",
+        "lastModified": 1738951757,
+        "narHash": "sha256-I0Bmxpjid9m7Gg+z2HVASlpQpKzR7QJq5X8b9wCZFVY=",
         "owner": "0xc000022070",
         "repo": "zen-browser-flake",
-        "rev": "f9366025bc851b01c56f35b84e687db032343d37",
+        "rev": "e2f657fb55f62fb57e614a1e22e9e667996f5234",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                          | Message                                                     |
| --------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------- |
| [`e2f657fb`](https://github.com/0xc000022070/zen-browser-flake/commit/e2f657fb55f62fb57e614a1e22e9e667996f5234) | `` readme(installation): updated caution message ``         |
| [`25356eff`](https://github.com/0xc000022070/zen-browser-flake/commit/25356eff9ab70ccb01e70528fc8543ceb033a0c2) | `` Update Zen Browser beta @ x86_64 && aarch64 to 1.7.5b `` |