### PR TITLE
chore(flake/nixpkgs): `799ba5bf` -> `550e11f2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -453,11 +453,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1738680400,
-        "narHash": "sha256-ooLh+XW8jfa+91F1nhf9OF7qhuA/y1ChLx6lXDNeY5U=",
+        "lastModified": 1738824222,
+        "narHash": "sha256-U3SNq+waitGIotmgg/Et3J7o4NvUtP2gb2VhME5QXiw=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "799ba5bffed04ced7067a91798353d360788b30d",
+        "rev": "550e11f27ba790351d390d9eca3b80ad0f0254e7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                                           |
| ---------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------- |
| [`3282b5f2`](https://github.com/NixOS/nixpkgs/commit/3282b5f2cb02f86539d0015720efeffda82f3a66) | `` python312Packages.thinc: relax blis constraint ``                                                              |
| [`41b9be71`](https://github.com/NixOS/nixpkgs/commit/41b9be717760853e2b8f727734182461177142bf) | `` Revert "python3Packages.thinc: 8.3.0 -> 9.1.1" ``                                                              |
| [`60e3142c`](https://github.com/NixOS/nixpkgs/commit/60e3142cc0925cc31f34005d26b96095605d8cbc) | `` i2p: 2.7.0 -> 2.8.0 ``                                                                                         |
| [`28805613`](https://github.com/NixOS/nixpkgs/commit/2880561343679257f008bebc7e3f7163a874fb05) | `` portmod: 2.6.2 -> 2.8.1 ``                                                                                     |
| [`6c7920c1`](https://github.com/NixOS/nixpkgs/commit/6c7920c12b5f09868dbfe669bf703e39a4289ef8) | `` nixos/doc/rl-2505: removal of zig_0_9 and zig_0_10 ``                                                          |
| [`546222ab`](https://github.com/NixOS/nixpkgs/commit/546222ab3515862604e9f7112e2db47ef4404b02) | `` zig_0_10: remove ``                                                                                            |
| [`243dd29d`](https://github.com/NixOS/nixpkgs/commit/243dd29d891a1e8bb85fa4295c08291a1dca8448) | `` zig_0_9: remove ``                                                                                             |
| [`4031bbdd`](https://github.com/NixOS/nixpkgs/commit/4031bbdd0b8852f7b71bfb5956190ee7075f3390) | `` python3Packages.cloudflare: add marie and jemand771 to maintainers ``                                          |
| [`48f4b2e1`](https://github.com/NixOS/nixpkgs/commit/48f4b2e1292272111085466908cbd7a9cbb3f936) | `` vimPlugins.avante-nvim: 0.0.15 -> 0.0.16 ``                                                                    |
| [`04d9a418`](https://github.com/NixOS/nixpkgs/commit/04d9a4185bce5907f1e332a1ea2339b3586543e4) | `` python313Packages.langgraph-checkpoint-duckdb: skip bulk update ``                                             |
| [`19e0df72`](https://github.com/NixOS/nixpkgs/commit/19e0df72e07aa92096e652fe3291d3291d5fb0c7) | `` Revert "python3Packages.langgraph-checkpoint-duckdb: 2.0.1 -> 2.0.13" ``                                       |
| [`4481e50d`](https://github.com/NixOS/nixpkgs/commit/4481e50da9cd5708b0b5ce86cfe0dde884cbfaeb) | `` python3Packages.cloudflare: fix build ``                                                                       |
| [`2a1698f8`](https://github.com/NixOS/nixpkgs/commit/2a1698f84653af04e5bb46489f5f01daf15cbccf) | `` lean4: from rev to tag ``                                                                                      |
| [`e43c53cf`](https://github.com/NixOS/nixpkgs/commit/e43c53cfc11b8ea55791429e22280783f840fe4d) | `` kbd: fix cross compilation to musl ``                                                                          |
| [`6c2df641`](https://github.com/NixOS/nixpkgs/commit/6c2df6415e61504e335afcc758a2cc6a71afafc7) | `` qt6: backport patches recommended by KDE folks ``                                                              |
| [`000a5ebd`](https://github.com/NixOS/nixpkgs/commit/000a5ebdd75ac63272f20be6ede9623633a1ab20) | `` surrealdb-migrations: 2.1.0 -> 2.1.2 ``                                                                        |
| [`d7fe3bca`](https://github.com/NixOS/nixpkgs/commit/d7fe3bcaca37e79d8b3cbde4dd69edeafbd35313) | `` crosvm: 0-unstable-2025-01-21 -> 0-unstable-2025-02-04 ``                                                      |
| [`a15f1ded`](https://github.com/NixOS/nixpkgs/commit/a15f1ded3672fcab804150b7bbf2a97e8503965a) | `` modelscan: 0.8.3 -> 0.8.4 ``                                                                                   |
| [`948f9416`](https://github.com/NixOS/nixpkgs/commit/948f94167ee275f88db8a27abf5a95a7221a733a) | `` [staging-next] mailmanPackages.hyperkitty: fix build with mistune >= 3.1 (#379578) ``                          |
| [`ccf2ba9b`](https://github.com/NixOS/nixpkgs/commit/ccf2ba9bbbb785d69d5c9a8b43088a2abab0612c) | `` k3s: use available sha256sum instead of prefetching in update script ``                                        |
| [`7aacf613`](https://github.com/NixOS/nixpkgs/commit/7aacf613b1d943f77da4eea0b7787c54cf86dd9b) | `` chromium,chromedriver: 132.0.6834.159 -> 133.0.6943.53 ``                                                      |
| [`d7955ef5`](https://github.com/NixOS/nixpkgs/commit/d7955ef56930118d03a79e3e6d6dedaca31f507f) | `` kubeshark: fix meta.changelog ``                                                                               |
| [`740e22da`](https://github.com/NixOS/nixpkgs/commit/740e22da628e19d21821010fe60990d1db6f0d43) | `` libretro.mame2003-plus: 0-unstable-2025-01-24 -> 0-unstable-2025-02-04 ``                                      |
| [`d316f463`](https://github.com/NixOS/nixpkgs/commit/d316f463316dbd52cecf5a0432aef88314c7daa6) | `` libretro.mame2003: 0-unstable-2024-12-10 -> 0-unstable-2025-01-26 ``                                           |
| [`355d787b`](https://github.com/NixOS/nixpkgs/commit/355d787bc9a4ae1012f712d838dd9ebba5250285) | `` rke2: 1.31.4+rke2r1 -> 1.31.5+rke2r1 (#379550) ``                                                              |
| [`e1931499`](https://github.com/NixOS/nixpkgs/commit/e19314990d03f743f31ce49194ab54e75a8a8f2a) | `` vector: add dependency for darwin builds ``                                                                    |
| [`8cae4b0d`](https://github.com/NixOS/nixpkgs/commit/8cae4b0d6959c147747ec6939e24ef256046b5fc) | `` python3Packages.firebase-admin: init at 6.6.0 ``                                                               |
| [`d2e2d6c0`](https://github.com/NixOS/nixpkgs/commit/d2e2d6c06a64d06535c657d53f6952c5c91afa09) | `` neovimRequireCheckHook: improve error message ``                                                               |
| [`3e83bf8c`](https://github.com/NixOS/nixpkgs/commit/3e83bf8c9bdc17a16cd976a9e56ac2d1d508d1e9) | `` php84Extensions.decimal: init at 1.5.0 ``                                                                      |
| [`54584114`](https://github.com/NixOS/nixpkgs/commit/5458411446e35a3e4dcef2c88a75156a431e66f3) | `` xwayland: 24.1.4 -> 24.1.5 ``                                                                                  |
| [`b51ff390`](https://github.com/NixOS/nixpkgs/commit/b51ff390b618c551c648122fe6e8d6e20c09d6f0) | `` pass-git-helper: 3.1.0 -> 3.2.0 ``                                                                             |
| [`9f927fb4`](https://github.com/NixOS/nixpkgs/commit/9f927fb4f5620f0911d5ef97071a4da88073e396) | `` klipper: 0.12.0-unstable-2024-10-26 -> 0.12.0-unstable-2025-02-02 ``                                           |
| [`20c55b2d`](https://github.com/NixOS/nixpkgs/commit/20c55b2d12619f61d2745474920c404fb1d3c148) | `` dnstwist: 20240812 -> 20250130 ``                                                                              |
| [`aeeac9c7`](https://github.com/NixOS/nixpkgs/commit/aeeac9c7efbafb06c5cdecb697150ca786b9757f) | `` firefox-esr-128-unwrapped: 128.6.0esr -> 128.7.0esr ``                                                         |
| [`8f3e620d`](https://github.com/NixOS/nixpkgs/commit/8f3e620dedde1e64d56637f325f24ba4f5a64f30) | `` firefox-bin-unwrapped: 134.0.2 -> 135.0 ``                                                                     |
| [`079025c3`](https://github.com/NixOS/nixpkgs/commit/079025c3f968363e16fd640a1e02943b0ae3e32b) | `` firefox-unwrapped: 134.0.2 -> 135.0 ``                                                                         |
| [`00d03666`](https://github.com/NixOS/nixpkgs/commit/00d0366641e84bf45ef9991e72486ec6a4458564) | `` phraze: 0.3.17 -> 0.3.18 ``                                                                                    |
| [`11ab3e5d`](https://github.com/NixOS/nixpkgs/commit/11ab3e5db5edcaf8306c2ce496577be0fb370de9) | `` steam: restore and document timezone hack ``                                                                   |
| [`f3cd7fc3`](https://github.com/NixOS/nixpkgs/commit/f3cd7fc32e8bfe18549c6e9fe0a36cd554f68163) | `` python312Packages.knx-frontend: 2025.1.18.164225 -> 2025.1.30.194235 ``                                        |
| [`8651d496`](https://github.com/NixOS/nixpkgs/commit/8651d496376183071d5932aeab4d5878d3c8a404) | `` urn-timer: 0-unstable-2024-03-05 -> 0-unstable-2025-02-02 ``                                                   |
| [`a0478f49`](https://github.com/NixOS/nixpkgs/commit/a0478f49d1c34727e886096f99d33f57990877f3) | `` qemu: fix symlink hack for minimal builds ``                                                                   |
| [`bf11aeb6`](https://github.com/NixOS/nixpkgs/commit/bf11aeb6217fdefac60d074e236b8a1cc4199811) | `` ameba: 1.6.1 -> 1.6.4 ``                                                                                       |
| [`0b47fba2`](https://github.com/NixOS/nixpkgs/commit/0b47fba23078cc01251b136c7af0127abd57112b) | `` Revert "nixos/nixpkgs: make config.nixpkgs.{localSystem,crossSystem,buildPlatform,hostPlatform} write only" `` |
| [`e7b0ce07`](https://github.com/NixOS/nixpkgs/commit/e7b0ce07bd78344bb0384444200feeaf96d019cb) | `` keycloak: 16.1.0 -> 16.1.1 ``                                                                                  |
| [`692a57e6`](https://github.com/NixOS/nixpkgs/commit/692a57e61d8e960a0163140eaec831158edb051b) | `` Revert "Reapply "pkgs/top-level: make package sets composable"" ``                                             |
| [`623541a1`](https://github.com/NixOS/nixpkgs/commit/623541a18b3540f9bf90029966fce44943ca9004) | `` Revert "pkgs/top-level: add assert to prevent passing elaborated systems" ``                                   |
| [`cb22d09a`](https://github.com/NixOS/nixpkgs/commit/cb22d09ac651583d4345818a67c2fc38edb3c4a6) | `` kubeone: 1.9.1 -> 1.9.2 ``                                                                                     |
| [`e234b4c7`](https://github.com/NixOS/nixpkgs/commit/e234b4c77e480c8a4a2ed71a2017456ed68f0b96) | `` hayagriva: 0.8.0 -> 0.8.1 ``                                                                                   |
| [`55f2fbb0`](https://github.com/NixOS/nixpkgs/commit/55f2fbb04d386bc4d5578007bbaef0b447d7b4e3) | `` hcledit: 0.2.15 -> 0.2.16 ``                                                                                   |
| [`674b249a`](https://github.com/NixOS/nixpkgs/commit/674b249a6798564dcfae7fe1ad8aecc6f5db45eb) | `` vista-fonts-cht: add missing hooks ``                                                                          |
| [`1a01ddec`](https://github.com/NixOS/nixpkgs/commit/1a01ddec3a4006ce58537011e82a328514c3aee0) | `` vista-fonts-chs: add missing hooks ``                                                                          |
| [`893ddcd0`](https://github.com/NixOS/nixpkgs/commit/893ddcd098e744c30994b45556beae8e8d11ead0) | `` pmccabe: format with nixfmt ``                                                                                 |
| [`8ec5ad48`](https://github.com/NixOS/nixpkgs/commit/8ec5ad480a145af3022e01bbfacba5d8d1a5db23) | `` pmccabe: fix build with gcc 14 ``                                                                              |
| [`be1e7c88`](https://github.com/NixOS/nixpkgs/commit/be1e7c88ccbf72da87ee9c7efcf603109fa687b9) | `` gcfflasher: 4.5.2 -> 4.6.0 ``                                                                                  |
| [`f2957001`](https://github.com/NixOS/nixpkgs/commit/f2957001854822c3832abd89e261e4c492a87c99) | `` kubecm: 0.32.2 -> 0.32.3 ``                                                                                    |
| [`b07df3f3`](https://github.com/NixOS/nixpkgs/commit/b07df3f3ae0f90ab8c9616bc0ee188cac4c8314e) | `` vista-fonts: add missing hooks ``                                                                              |
| [`70f230dd`](https://github.com/NixOS/nixpkgs/commit/70f230ddd4d4d021bf1e0081cd356e06f651613e) | `` crun: 1.19.1 -> 1.20 ``                                                                                        |
| [`9ad7cda5`](https://github.com/NixOS/nixpkgs/commit/9ad7cda54eeb44e3a7008d991a918267501138f0) | `` wit-bindgen: fix merge ``                                                                                      |
| [`08a0013f`](https://github.com/NixOS/nixpkgs/commit/08a0013f5843180c0f9c80bb4e3efca507bec08c) | `` numix-icon-theme: 24.12.12 -> 25.01.31 ``                                                                      |
| [`40a56333`](https://github.com/NixOS/nixpkgs/commit/40a5633396212f2861def73fdfae6b59724ec70d) | `` python3Packages.kaleido: fix broken etc/fonts symlinks ``                                                      |
| [`bba6b37c`](https://github.com/NixOS/nixpkgs/commit/bba6b37c9d0898867a7d9c38a1b5b77efcfb07b9) | `` nixos: make initrd-network-ssh test a channel blocker ``                                                       |
| [`72136fac`](https://github.com/NixOS/nixpkgs/commit/72136fac64ca499726c32057d232199044e3a5b1) | `` nixos/homebox: fix 'settings' default description ``                                                           |
| [`1d15050d`](https://github.com/NixOS/nixpkgs/commit/1d15050d3e936b0ced8613b30e295f15d596d925) | `` ubuntu-themes: dontCheckForBrokenSymlinks = true ``                                                            |
| [`aa83268e`](https://github.com/NixOS/nixpkgs/commit/aa83268e2a065e69b39953836f207616b392b47e) | `` rke2: 1.32.0+rke2r1 -> 1.32.1+rke2r1 (#379549) ``                                                              |
| [`a180cd3b`](https://github.com/NixOS/nixpkgs/commit/a180cd3bc40a18ba8125778e968b570a6b211a46) | `` ocamlPackages.ca-certs-nss: 3.107 -> 3.108 ``                                                                  |
| [`563789c6`](https://github.com/NixOS/nixpkgs/commit/563789c693dea83b806a4176cc2aad74154864ab) | `` open-webui: 0.5.7 -> 0.5.9 ``                                                                                  |
| [`e6f73424`](https://github.com/NixOS/nixpkgs/commit/e6f734247301dc03507307ab1064be8a3d3c3e57) | `` rtfm: write preBuild onto multiple lines ``                                                                    |
| [`a6bed322`](https://github.com/NixOS/nixpkgs/commit/a6bed32284011d80b71146457a6a8880f3d16369) | `` hifile: 0.9.9.15 -> 0.9.9.16 ``                                                                                |
| [`149eb07e`](https://github.com/NixOS/nixpkgs/commit/149eb07ea3cfa71f7dc1bea05ea81bd6725e9301) | `` python312Packages.pyexploitdb: 0.2.65 -> 0.2.66 ``                                                             |
| [`601161ee`](https://github.com/NixOS/nixpkgs/commit/601161ee17fadad0d1326461020fcbbcd9e455cd) | `` ggshield: 1.35.0 -> 1.36.0 ``                                                                                  |
| [`da9c18e1`](https://github.com/NixOS/nixpkgs/commit/da9c18e1d2a0d77d87b0f6fbc19cde0762cff9c1) | `` python313Packages.pipdeptree: 2.24.0 -> 2.25.0 ``                                                              |
| [`30155a26`](https://github.com/NixOS/nixpkgs/commit/30155a2635b42d99a373b29a13ca30323dabb892) | `` python313Packages.aiotankerkoenig: 0.4.2 -> 0.5.0 ``                                                           |