### PR TITLE
chore(flake/zen-browser): `e2f657fb` -> `e81208f1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -672,11 +672,11 @@
         "nixpkgs": "nixpkgs_3"
       },
       "locked": {
-        "lastModified": 1738951757,
-        "narHash": "sha256-I0Bmxpjid9m7Gg+z2HVASlpQpKzR7QJq5X8b9wCZFVY=",
+        "lastModified": 1738984719,
+        "narHash": "sha256-bejXG9u1z3Er7kcsCF3L9v7pb94J9OiuIYoO/TQgEiQ=",
         "owner": "0xc000022070",
         "repo": "zen-browser-flake",
-        "rev": "e2f657fb55f62fb57e614a1e22e9e667996f5234",
+        "rev": "e81208f101c5e6c85630fd3b35c798e1ac77f1d4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                          | Message                                                                 |
| --------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------- |
| [`e81208f1`](https://github.com/0xc000022070/zen-browser-flake/commit/e81208f101c5e6c85630fd3b35c798e1ac77f1d4) | `` Update Zen Browser twilight @ x86_64 && aarch64 to 1.7.7t#bf6f0b1 `` |