### PR TITLE
chore(flake/home-manager): `43379927` -> `5af1b9a0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -339,11 +339,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1738878603,
-        "narHash": "sha256-fmhq8B3MvQLawLbMO+LWLcdC2ftLMmwSk+P29icJ3tE=",
+        "lastModified": 1739051380,
+        "narHash": "sha256-p1QSLO8DJnANY+ppK7fjD8GqfCrEIDjso1CSRHsXL7Y=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "433799271274c9f2ab520a49527ebfe2992dcfbd",
+        "rev": "5af1b9a0f193ab6138b89a8e0af8763c21bbf491",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                               |
| ----------------------------------------------------------------------------------------------------------- | ----------------------------------------------------- |
| [`5af1b9a0`](https://github.com/nix-community/home-manager/commit/5af1b9a0f193ab6138b89a8e0af8763c21bbf491) | `` treewide: standardize shell integration options `` |
| [`bf9a1a06`](https://github.com/nix-community/home-manager/commit/bf9a1a068919ccdfa7d130873936c5fd4c826e85) | `` Translate using Weblate (Swedish) ``               |
| [`90a4374b`](https://github.com/nix-community/home-manager/commit/90a4374b174edb88a2e36889ee39ce45a186c7f6) | `` Translate using Weblate (Portuguese) ``            |
| [`947eef9e`](https://github.com/nix-community/home-manager/commit/947eef9e99c42346cf0aac2bebe1cd94924c173b) | `` neovim: disable neovim-coc-config test ``          |