### PR TITLE
chore(flake/stylix): `d513f59d` -> `7818098f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -360,11 +360,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1736785676,
-        "narHash": "sha256-TY0jUwR3EW0fnS0X5wXMAVy6h4Z7Y6a3m+Yq++C9AyE=",
+        "lastModified": 1737630279,
+        "narHash": "sha256-wJQCxyMRc4P26zDrHmZiRD5bbfcJpqPG3e2djdGG3pk=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "fc52a210b60f2f52c74eac41a8647c1573d2071d",
+        "rev": "0db5c8bfcce78583ebbde0b2abbc95ad93445f7c",
         "type": "github"
       },
       "original": {
@@ -558,11 +558,11 @@
         "tinted-zed": "tinted-zed"
       },
       "locked": {
-        "lastModified": 1738611626,
-        "narHash": "sha256-IgjqlYPaS8Bg+jc6a691w27XDFhBeM7gkP4eDcR2EBs=",
+        "lastModified": 1739049610,
+        "narHash": "sha256-oPrTmixNln7tpLz2flsZBPgYqMuGksmIHla9oZDc9Uo=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "d513f59da5856978c363d2f82103f708f4a6024d",
+        "rev": "7818098f4df4ee73667036c65909cf311d36968b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                        | Message                                                                     |
| --------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------- |
| [`7818098f`](https://github.com/danth/stylix/commit/7818098f4df4ee73667036c65909cf311d36968b) | `` treewide: remove trailing whitespaces and add trailing newline (#841) `` |
| [`be606eaa`](https://github.com/danth/stylix/commit/be606eaa87dfcf22c98f80453b42ec40dcbcdf36) | `` {vencord,vesktop}: fonts (#840) ``                                       |
| [`ff8ce4f3`](https://github.com/danth/stylix/commit/ff8ce4f3d2ad4d09291fa079c12a523d9b1c6aa6) | `` kde: make wallpaper optional and nondestructive (#823) ``                |
| [`708770fc`](https://github.com/danth/stylix/commit/708770fcb045b6efb4c419ff7be9760d010699bc) | `` wayfire: init (#765) ``                                                  |
| [`b3ef236d`](https://github.com/danth/stylix/commit/b3ef236d22572618828f9e7019362cc89d877bd0) | `` glance: init (#827) ``                                                   |
| [`87791e06`](https://github.com/danth/stylix/commit/87791e0665bd345127b7f35aca6e9195e74ef39c) | `` halloy: init (#825) ``                                                   |