### PR TITLE
chore(flake/zen-browser): `f9366025` -> `a59701a6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -672,11 +672,11 @@
         "nixpkgs": "nixpkgs_3"
       },
       "locked": {
-        "lastModified": 1738905423,
-        "narHash": "sha256-ZtEnCfeDh6/nvMta96cNUggI0C9FFsL0OCPzQAB0Tyw=",
+        "lastModified": 1739038859,
+        "narHash": "sha256-K1PC3s9aBj5CaaPBJD0fpr0L8taR68rOe6AVZh3i9cs=",
         "owner": "0xc000022070",
         "repo": "zen-browser-flake",
-        "rev": "f9366025bc851b01c56f35b84e687db032343d37",
+        "rev": "a59701a6bd5d1dd3b1732d66d83b03b7930adcc1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                          | Message                                                                 |
| --------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------- |
| [`a59701a6`](https://github.com/0xc000022070/zen-browser-flake/commit/a59701a6bd5d1dd3b1732d66d83b03b7930adcc1) | `` Update Zen Browser twilight @ x86_64 && aarch64 to 1.7.7t#dd9c57a `` |
| [`8fd70f6f`](https://github.com/0xc000022070/zen-browser-flake/commit/8fd70f6fbc28c1c6d3387e256addeb4e5eddd25c) | `` Update Zen Browser twilight @ x86_64 && aarch64 to 1.7.7t#2898dc4 `` |
| [`91255987`](https://github.com/0xc000022070/zen-browser-flake/commit/912559872fec18434c757ffa14c267c359c0f7a6) | `` Update Zen Browser beta @ x86_64 && aarch64 to 1.7.6b ``             |
| [`e81208f1`](https://github.com/0xc000022070/zen-browser-flake/commit/e81208f101c5e6c85630fd3b35c798e1ac77f1d4) | `` Update Zen Browser twilight @ x86_64 && aarch64 to 1.7.7t#bf6f0b1 `` |
| [`e2f657fb`](https://github.com/0xc000022070/zen-browser-flake/commit/e2f657fb55f62fb57e614a1e22e9e667996f5234) | `` readme(installation): updated caution message ``                     |
| [`25356eff`](https://github.com/0xc000022070/zen-browser-flake/commit/25356eff9ab70ccb01e70528fc8543ceb033a0c2) | `` Update Zen Browser beta @ x86_64 && aarch64 to 1.7.5b ``             |