### PR TITLE
chore(flake/nixpkgs): `799ba5bf` -> `a79cfe0e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -453,11 +453,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1738680400,
-        "narHash": "sha256-ooLh+XW8jfa+91F1nhf9OF7qhuA/y1ChLx6lXDNeY5U=",
+        "lastModified": 1739020877,
+        "narHash": "sha256-mIvECo/NNdJJ/bXjNqIh8yeoSjVLAuDuTUzAo7dzs8Y=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "799ba5bffed04ced7067a91798353d360788b30d",
+        "rev": "a79cfe0ebd24952b580b1cf08cd906354996d547",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                   |
| ---------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------- |
| [`1004b767`](https://github.com/NixOS/nixpkgs/commit/1004b767a493b32b439401d207075eb88e3baca1) | `` vscode-extensions.ms-python.mypy-type-checker: do not set default `mypy` path ``       |
| [`cb4d0ab0`](https://github.com/NixOS/nixpkgs/commit/cb4d0ab07ec97faa2feee76123a37e32e2ac8a0e) | `` librenms: switch to tag ``                                                             |
| [`7eba5949`](https://github.com/NixOS/nixpkgs/commit/7eba5949724b15a982b197b4b2dd316330d887ae) | `` librenms: switch from --replace to --replace-fail ``                                   |
| [`d12c4194`](https://github.com/NixOS/nixpkgs/commit/d12c4194c22a78bc9d2edcf84bad6c625de9997e) | `` librenms: switch to buildComposerProject2 ``                                           |
| [`fa648b28`](https://github.com/NixOS/nixpkgs/commit/fa648b2835f6cc0e77bd3b246cf8c80f126f0139) | `` Revert "llvmPackages.openmp: Make OMPD customisable, add missing Python dependency" `` |
| [`c006d5f0`](https://github.com/NixOS/nixpkgs/commit/c006d5f0637d9a98d990e80e80b1fd932bb6025e) | `` Revert "llvmPackages.openmp: Build static libraries when appropriate" ``               |
| [`21a8b8d4`](https://github.com/NixOS/nixpkgs/commit/21a8b8d45ef459b0984e95d135ab38aa3619e352) | `` llvmPackages.openmp: Build static libraries when appropriate ``                        |
| [`ecd9d988`](https://github.com/NixOS/nixpkgs/commit/ecd9d98879729b38bc3c347b9f2d2708f7027f5b) | `` llvmPackages.openmp: Make OMPD customisable, add missing Python dependency ``          |
| [`04670cfe`](https://github.com/NixOS/nixpkgs/commit/04670cfe227af20dd57537ea57722c0aca38a82b) | `` vscode-extensions.ms-python.mypy-type-checker: init at 2025.1.10381011 ``              |
| [`0b57b99c`](https://github.com/NixOS/nixpkgs/commit/0b57b99c00a488a20ec83591580cde5ee7e8877a) | `` vimPlugins.lze: 0.7.5 -> 0.7.9 ``                                                      |
| [`d9151c8a`](https://github.com/NixOS/nixpkgs/commit/d9151c8ae1b87cc3766dcd2ca467f86bc7993e8b) | `` vscode-extensions.github.copilot-chat: 0.24.2024121201 -> 0.24.2025020602 ``           |
| [`217d1f4d`](https://github.com/NixOS/nixpkgs/commit/217d1f4de52b96fdc28e6b48c4559ec7d19c9d75) | `` vscode-extensions.github.copilot: 1.251.0 -> 1.266.1363 ``                             |
| [`97dfe7ae`](https://github.com/NixOS/nixpkgs/commit/97dfe7ae298ccfbaa8550ac27c72d8a5c9c586ed) | `` aporetic: init at 1.0.0 ``                                                             |
| [`33a769c9`](https://github.com/NixOS/nixpkgs/commit/33a769c951edf6acf646380a3e8f2f3fcd5cc89f) | `` python3Packages.qtile: dbus-next -> dbus-fast ``                                       |
| [`44114d27`](https://github.com/NixOS/nixpkgs/commit/44114d2703e050d4488068db68d79c3705ddf062) | `` python3Packages.pulsectl-asyncio: fix build ``                                         |
| [`ff705b9d`](https://github.com/NixOS/nixpkgs/commit/ff705b9dd566b0a7668c13dc271aa091b458bc2a) | `` windsurf: init at 1.2.6 ``                                                             |
| [`61018ca6`](https://github.com/NixOS/nixpkgs/commit/61018ca62ef5d8e79a60ad227fd66a7614192379) | `` turn-rs:3.2.0 -> 3.3.3 ``                                                              |
| [`8e987526`](https://github.com/NixOS/nixpkgs/commit/8e9875265f6504b27ceb18ee97b22c81bc9ddfa1) | `` keepalived: add meta.mainProgram ``                                                    |
| [`22b3d78d`](https://github.com/NixOS/nixpkgs/commit/22b3d78d9f8a68bcbc8a4de2fe9aae21fe80187c) | `` python313Packages.sacrebleu: 2.5.0 -> 2.5.1 ``                                         |
| [`f5138449`](https://github.com/NixOS/nixpkgs/commit/f51384492939c906342c96cbac0b352309d685a9) | `` python313Packages.sacrebleu: refactor, add missing setuptools-scm ``                   |
| [`b6c8f0a8`](https://github.com/NixOS/nixpkgs/commit/b6c8f0a8979fd377b9d158701b4292950ad00280) | `` udev: choose implementation with availableOn check ``                                  |
| [`8393b376`](https://github.com/NixOS/nixpkgs/commit/8393b3761f3b50661911afa572e80e0e6c996a1f) | `` inv-sig-helper: 0-unstable-2025-01-31 -> 0-unstable-2025-02-07 ``                      |
| [`c1193da0`](https://github.com/NixOS/nixpkgs/commit/c1193da08af5e4638d948f2215b8c5e2c735649b) | `` python3Packages.mkdocs-redirects: switch to pyproject, hatchling ``                    |
| [`d339cc6d`](https://github.com/NixOS/nixpkgs/commit/d339cc6d0dc7fcef02e335d5ce4bc9da2a791ead) | `` nixos/tests/cinnamon: Scale slick-greeter for OCR tests ``                             |
| [`f7ef0c35`](https://github.com/NixOS/nixpkgs/commit/f7ef0c35ac9609f9ba08755f9710b2fa5980d29d) | `` qogir-icon-theme: Temporarily set dontCheckForBrokenSymlinks ``                        |
| [`52c91284`](https://github.com/NixOS/nixpkgs/commit/52c912847694c4847af2593b89e39a2c5630a2bc) | `` nixos/tests/pantheon: Pgrep io.elementary.files.xdg-desktop-portal ``                  |
| [`2bafb0e9`](https://github.com/NixOS/nixpkgs/commit/2bafb0e95a6f5b71deaa059feb5a9d5505605dcc) | `` neovim-node-client: add versionCheckHook and updateScript ``                           |
| [`b4014e21`](https://github.com/NixOS/nixpkgs/commit/b4014e21f553028204300eedfb6b38261f2cd722) | `` python3Packages.langgraph-cli: 0.1.52 -> 0.1.70 ``                                     |
| [`5699ec02`](https://github.com/NixOS/nixpkgs/commit/5699ec02572a3904db23f15f8f2f482c8b3c6717) | `` python3Packages.langgraph-checkpoint-sqlite: 2.0.1 -> 2.0.3 ``                         |
| [`8a1334a6`](https://github.com/NixOS/nixpkgs/commit/8a1334a62beb3c84eec0c75d5329303840722a19) | `` python3Packages.langgraph-checkpoint-duckdb: 2.0.1 -> 2.0.2 ``                         |
| [`2529ca71`](https://github.com/NixOS/nixpkgs/commit/2529ca71c17aa2efba2062cbb1f8673056c53af0) | `` python3Packages.langgraph-checkpoint: 2.0.8 -> 2.0.10 ``                               |
| [`40b72309`](https://github.com/NixOS/nixpkgs/commit/40b72309ebcbaf7116fbd1c1ffd4390645873d03) | `` python3Packages.langgraph-sdk: 0.1.46 -> 0.1.51 ``                                     |
| [`417aac8e`](https://github.com/NixOS/nixpkgs/commit/417aac8ea5d4dd4c7a6590c67b39362d4f749812) | `` python3Packages.langgraph: 0.2.56 -> 0.2.70 ``                                         |
| [`98cc4354`](https://github.com/NixOS/nixpkgs/commit/98cc4354ee8de6cef8e0163f503dd3a0b9eb7a73) | `` memogram: init at 0.2.2 ``                                                             |
| [`50382338`](https://github.com/NixOS/nixpkgs/commit/503823388fe5bd02b16912963b418f91b4f18b7d) | `` neovim-node-client: create binary in $out/bin ``                                       |
| [`cb467f0e`](https://github.com/NixOS/nixpkgs/commit/cb467f0e1f3219ebf9e6e12bebe4b32c69481e09) | `` python312Packages.python-lsp-server: 1.12.1 -> 1.12.2 ``                               |
| [`92c26282`](https://github.com/NixOS/nixpkgs/commit/92c262824d525b7dd63361f18607bd66ca33b683) | `` vacuum-go: 0.16.1 -> 0.16.2 ``                                                         |
| [`5e69c8f2`](https://github.com/NixOS/nixpkgs/commit/5e69c8f295ca14ae11947531554e042bd5f9e802) | `` mint-l-icons: Temporarily set dontCheckForBrokenSymlinks ``                            |
| [`7098d532`](https://github.com/NixOS/nixpkgs/commit/7098d5322ac8915cb2a06cf88c78204d9dc2eee2) | `` ungoogled-chromium: 132.0.6834.159-1 -> 133.0.6943.53-1 ``                             |
| [`332c7fe1`](https://github.com/NixOS/nixpkgs/commit/332c7fe132f90964639167721464d93aa25abf09) | `` python312Packages.python-gvm: 25.1.1 -> 26.0.0 ``                                      |
| [`b90176a2`](https://github.com/NixOS/nixpkgs/commit/b90176a221626c6c7e2449673da089b9586ee035) | `` python312Packages.niaclass: 0.2.2 -> 0.2.3 ``                                          |
| [`b1ffdffb`](https://github.com/NixOS/nixpkgs/commit/b1ffdffb010759f842ac20b1db4f81e941c2bcd7) | `` vimPlugins: disallow packaging plugins that are already in luaPackages ``              |
| [`ea51b761`](https://github.com/NixOS/nixpkgs/commit/ea51b761844c6748a3ef9c871207ac250bb25b33) | `` llvmPackages.compiler-rt: drop libc-free patch ``                                      |
| [`f39eb448`](https://github.com/NixOS/nixpkgs/commit/f39eb448eb043bb0329a7f4549aae048675067a6) | `` python312Packages.orbax-checkpoint: 0.11.2 -> 0.11.4 ``                                |
| [`9eadc594`](https://github.com/NixOS/nixpkgs/commit/9eadc59459dbfbc2fdd9f1c9d4ee0312df06e6a4) | `` lua-language-server: 3.13.5 -> 3.13.6 ``                                               |
| [`09526f37`](https://github.com/NixOS/nixpkgs/commit/09526f37b5fa36ff11704823da63d20d1c7607c4) | `` vimPlugins.nvim-dap-cortex-debug: init at 2024-12-01 ``                                |
| [`8fff5437`](https://github.com/NixOS/nixpkgs/commit/8fff54379ca15c3f4fa2a8fc62acc1b0b0a15c31) | `` lobster: 2024.0 -> 2025.0 ``                                                           |
| [`d1e4dfa0`](https://github.com/NixOS/nixpkgs/commit/d1e4dfa05782028cd6f0eb366cc9f84da3df86ad) | `` nvidia_oc: add driver runpath hook ``                                                  |
| [`1207a9b7`](https://github.com/NixOS/nixpkgs/commit/1207a9b70f7761514999d33e1797251a6549807a) | `` home-assistant: 2025.2.0 -> 2025.2.1 ``                                                |
| [`e7f92d93`](https://github.com/NixOS/nixpkgs/commit/e7f92d9368444277402b11ffbb0ba0d73bc9bd44) | `` python313Packages.aiohttp-asyncmdnsresolver: 0.0.3 -> 0.1.0 ``                         |
| [`e46e36e4`](https://github.com/NixOS/nixpkgs/commit/e46e36e4062bfe201cf95fda8499a451b9752f91) | `` python313Packages.zha: 0.0.47 -> 0.0.48 ``                                             |
| [`38e87d26`](https://github.com/NixOS/nixpkgs/commit/38e87d26c7171ad2a025baf8bb6f250cb800034f) | `` python313Packages.zha-quirks: 0.0.131 -> 0.0.132 ``                                    |
| [`864c7366`](https://github.com/NixOS/nixpkgs/commit/864c73667b9cae72bfe1c3f02edd17e1383c1f30) | `` python313Packages.reolink-aio: 0.11.9 -> 0.11.10 ``                                    |
| [`b84070a2`](https://github.com/NixOS/nixpkgs/commit/b84070a22450830d7902b55472375595678959a3) | `` python313Packages.pyfireservicerota: 0.0.45 -> 0.0.46 ``                               |
| [`fe999877`](https://github.com/NixOS/nixpkgs/commit/fe9998772269de9b60d23bced5137c67406dd3e6) | `` python313Packages.govee-ble: 0.42.0 -> 0.43.0 ``                                       |
| [`59aadb77`](https://github.com/NixOS/nixpkgs/commit/59aadb772f9cb989f6e5204e7514ad2e32ca52ed) | `` python313Packages.google-nest-sdm: 7.1.1 -> 7.1.3 ``                                   |
| [`5acafd6a`](https://github.com/NixOS/nixpkgs/commit/5acafd6ac581fa7b63b591e31a21961cae7f667b) | `` python313Packages.eheimdigital: 1.0.5 -> 1.0.6 ``                                      |
| [`74c425c7`](https://github.com/NixOS/nixpkgs/commit/74c425c7a62de863c0cc63dd22dd7d6dac958607) | `` python313Packages.aioshelly: 12.3.2 -> 12.4.1 ``                                       |
| [`c2b636ff`](https://github.com/NixOS/nixpkgs/commit/c2b636ffa8e8f8451f39d316da77343981e848f6) | `` python313Packages.pyezvizapi: fix pname ``                                             |
| [`c4d32967`](https://github.com/NixOS/nixpkgs/commit/c4d329677af117fd46379753403cd5d13e13e490) | `` python312Packages.mariadb: add missing propagated build input (#379580) ``             |
| [`830a2ca7`](https://github.com/NixOS/nixpkgs/commit/830a2ca72eb06ff87c1f851cec637feaedebd30f) | `` vangers: init at 2.0-unstable-2024-09-30 ``                                            |
| [`10b4344b`](https://github.com/NixOS/nixpkgs/commit/10b4344b185e7731e80d4050abb7a8ea75fd5825) | `` zed-editor: 0.172.9 -> 0.172.10 ``                                                     |
| [`e8d0b02a`](https://github.com/NixOS/nixpkgs/commit/e8d0b02af0958823c955aaab3c82b03f54411d91) | `` Add rocqPackages.bignums ``                                                            |
| [`b34fef32`](https://github.com/NixOS/nixpkgs/commit/b34fef3268597e3f4b42364914cb6178569dbe5f) | `` coq: now a shim on top of rocq (starting with 9.0) ``                                  |
| [`064a3047`](https://github.com/NixOS/nixpkgs/commit/064a30473b2aa7cf3b9f0346bad5a5506a9a62b0) | `` rocq: init at 9.0+rc1 ``                                                               |
| [`182fd631`](https://github.com/NixOS/nixpkgs/commit/182fd63145b3b172dc93ef406195d526959a1fa2) | `` lua51Packages.luarocks-nix: 0-unstable-2024-04-29 -> 0-unstable-2024-05-31 ``          |
| [`fb58323e`](https://github.com/NixOS/nixpkgs/commit/fb58323ee3b4665871e925aa2e7d93cec0616099) | `` mise: 2025.2.0 -> 2025.2.1 ``                                                          |
| [`547acecd`](https://github.com/NixOS/nixpkgs/commit/547acecdf336bfda4e3d355657e066269b57455d) | `` teamspeak5_client: 5.0.0-beta77 -> 6.0.0-beta2; teamspeak refactors (#377748) ``       |
| [`651df657`](https://github.com/NixOS/nixpkgs/commit/651df657551ae52ae343be55539970758cfaef38) | `` nextcloudPackages.hmr_enabler: switch to buildComposerProject2 (#380114) ``            |
| [`35390c3d`](https://github.com/NixOS/nixpkgs/commit/35390c3d7470d075081fc8cb9926b416a7fbc248) | `` davis: switch to buildComposerProject2 (#380098) ``                                    |
| [`3aaea786`](https://github.com/NixOS/nixpkgs/commit/3aaea78679c68616fbf11a424460134fc6822c8e) | `` fastjet-contrib: 1.055 -> 1.100 ``                                                     |
| [`283424e7`](https://github.com/NixOS/nixpkgs/commit/283424e706bbf3c7f8f672b239ce1a96d14040aa) | `` gleam: 1.7.0 -> 1.8.0 ``                                                               |
| [`dd768e90`](https://github.com/NixOS/nixpkgs/commit/dd768e90b44b296bfbe0d4906a21008c3c15acb1) | `` livepeer: 0.8.1 -> 0.8.3 ``                                                            |
| [`3a3f931f`](https://github.com/NixOS/nixpkgs/commit/3a3f931fd25e5f46ebc138430f64cbb7d05fe1ef) | `` invoiceplane: switch to buildComposerProject2 and tag (#380112) ``                     |
| [`6431bc14`](https://github.com/NixOS/nixpkgs/commit/6431bc1445447eee455a7b713b5eb3f67f326e05) | `` vscode:1.96.4 -->1.97.0 (#379962) ``                                                   |
| [`2d215c6a`](https://github.com/NixOS/nixpkgs/commit/2d215c6ad3b3dbda08b76caf2bc605ca45324f52) | `` bao: 0.12.1 -> 0.13.0 ``                                                               |
| [`58d0c70e`](https://github.com/NixOS/nixpkgs/commit/58d0c70e7abddae2eac04762e0d537e5ca091640) | `` gparted: 1.6.0 -> 1.7.0 ``                                                             |
| [`192a5218`](https://github.com/NixOS/nixpkgs/commit/192a52188cb7a31dd8482acb438e793f53d5d98e) | `` gpt4all: 3.4.2 -> 3.9.0 ``                                                             |
| [`bd44651c`](https://github.com/NixOS/nixpkgs/commit/bd44651c90b20cf4e9dedeedacc08ba5df2287d1) | `` projectable: 1.3.0 -> 1.3.2 ``                                                         |
| [`1abd560a`](https://github.com/NixOS/nixpkgs/commit/1abd560a083afc717c74a8426fc435631d39f66c) | `` duckx: init at 1.2.2 ``                                                                |
| [`a436a9dd`](https://github.com/NixOS/nixpkgs/commit/a436a9dd6d6164ccc7cdd28c82809856bf17551d) | `` string-view-lite: init at 1.8.0 ``                                                     |
| [`22d656db`](https://github.com/NixOS/nixpkgs/commit/22d656db36abc30512136328e43426a48c5fac8e) | `` optional-lite: init at 3.6.0 ``                                                        |
| [`77ad0f57`](https://github.com/NixOS/nixpkgs/commit/77ad0f574f6dfb8d5c8d39d8cc1ae96c723b36db) | `` variant-lite: init at 2.0.0 ``                                                         |
| [`2d9b8fe5`](https://github.com/NixOS/nixpkgs/commit/2d9b8fe5d3a044d58f219544045eea6c422dfa3c) | `` composefs: 1.0.7 -> 1.0.8 ``                                                           |
| [`800da9b6`](https://github.com/NixOS/nixpkgs/commit/800da9b609ddaf3c00f34fe9560978414584f137) | `` python313Packages.ocrmypdf: use headless ghostscript ``                                |
| [`4f59e814`](https://github.com/NixOS/nixpkgs/commit/4f59e814255edba848689be6a7b7cb6719ce1398) | `` gnome-graphs: 1.8.2 -> 1.8.4 ``                                                        |
| [`d5d0d5a9`](https://github.com/NixOS/nixpkgs/commit/d5d0d5a96e2b89f14c817c47535f5581e258944e) | `` trunk-io: add meta.MainProgram ``                                                      |
| [`8af087b4`](https://github.com/NixOS/nixpkgs/commit/8af087b47c875cae57139adfd6a96fff7b42ce78) | `` wireplumber: 0.5.7 -> 0.5.8 ``                                                         |
| [`1bc4ebfb`](https://github.com/NixOS/nixpkgs/commit/1bc4ebfb35a9f74f9b0d1d22bb3a76a47461239f) | `` python312Packages.qutip: add aarch64-linux to badPlatforms ``                          |
| [`36078884`](https://github.com/NixOS/nixpkgs/commit/3607888438881d7a182560e967c11f9896b950dd) | `` gancio: 1.22.0 -> 1.23.1 ``                                                            |
| [`cf53cd61`](https://github.com/NixOS/nixpkgs/commit/cf53cd618af9ec744e9deb57b127eb993ce847bc) | `` python312Packages.cvxpy: disable failing tests ``                                      |
| [`c30829cc`](https://github.com/NixOS/nixpkgs/commit/c30829cc0cd6b1fd7e6d4c03a20088089d1bc565) | `` python312Packages.blackjax: 1.2.4 -> 1.2.5 ``                                          |
| [`9527ead8`](https://github.com/NixOS/nixpkgs/commit/9527ead890f07a6a343cb65ecebe80221dbb47a1) | `` vimPlugins.telescope-glyph-nvim: init at 2022-08-22 ``                                 |
| [`670a9eee`](https://github.com/NixOS/nixpkgs/commit/670a9eeeb11e226a3b15cfe1ff0c44500789dd4b) | `` mieru: 3.11.1 -> 3.11.2 ``                                                             |
| [`e9394294`](https://github.com/NixOS/nixpkgs/commit/e93942948aa4091bbce5d658d065915f17b0977b) | `` vimPlugins.telescope-emoji-nvim: init at 2022-12-08 ``                                 |
| [`5f2795bd`](https://github.com/NixOS/nixpkgs/commit/5f2795bdaee658fffbcad034378d86ba7a03bd31) | `` nextcloudPackages.apps: add sociallogin ``                                             |
| [`7ba831bc`](https://github.com/NixOS/nixpkgs/commit/7ba831bcd119c38e26e48646b157d63c640b0daa) | `` nextcloudPackages.apps: add files_retention ``                                         |
| [`c9166470`](https://github.com/NixOS/nixpkgs/commit/c91664705434fe31350d1adaefc3d8daf2513030) | `` nextcloudPackages.apps: add files_automatedtagging ``                                  |
| [`d0ec1ddc`](https://github.com/NixOS/nixpkgs/commit/d0ec1ddc0e9f188d716405b995466cf3376b70ec) | `` nextcloudPackages.apps: add app_api ``                                                 |
| [`aa5f054f`](https://github.com/NixOS/nixpkgs/commit/aa5f054f25d5afe378af7cecd465161a4ef7a179) | `` nextcloudPackages.apps: update ``                                                      |
| [`93c1978b`](https://github.com/NixOS/nixpkgs/commit/93c1978b59862807cd9c3856117becae58fa355d) | `` lxgw-wenkai-tc: 1.501 -> 1.510 ``                                                      |
| [`a55ff0c1`](https://github.com/NixOS/nixpkgs/commit/a55ff0c1edac7f7cfc2a352e3b8505cc157da42f) | `` python312Packages.experiment-utilities: fix build ``                                   |
| [`298e6c47`](https://github.com/NixOS/nixpkgs/commit/298e6c473edb37adcd50b7e9295ac9dbe94d0e1e) | `` php84Extensions.mysqlnd: enable `--with-mysqlnd-ssl` flag ``                           |
| [`d45d5d9c`](https://github.com/NixOS/nixpkgs/commit/d45d5d9c6d8ca770c96a197b470b5983c9b09bbc) | `` dep-scan: fix build ``                                                                 |
| [`4455338f`](https://github.com/NixOS/nixpkgs/commit/4455338f9e38b677d671ccc86a3120b4f0abdfad) | `` vpl-gpu-rt: 25.1.0 -> 25.1.1 ``                                                        |
| [`40cb5a99`](https://github.com/NixOS/nixpkgs/commit/40cb5a996cced79ad4beef8df9ac5ee154cb54f4) | `` astroterm: 1.0.6 -> 1.0.7 ``                                                           |
| [`be389e61`](https://github.com/NixOS/nixpkgs/commit/be389e61bec01cf5c9435868affe329fc61c76c9) | `` twm: 0.11.0 -> 0.12.3 ``                                                               |
| [`dc81385e`](https://github.com/NixOS/nixpkgs/commit/dc81385ef189ce7d84492184d514db9f903f2c39) | `` walk: 1.10.0 -> 1.10.1 ``                                                              |
| [`9eea4de7`](https://github.com/NixOS/nixpkgs/commit/9eea4de768ad7220a61cd723ac495676b75a888d) | `` radicle-httpd: 0.18.0 -> 0.18.1 ``                                                     |
| [`9440dc20`](https://github.com/NixOS/nixpkgs/commit/9440dc204ee058c6c233a0161927cde062e0bc8c) | `` python312Packages.reflex-hosting-cli: add pyyaml ``                                    |
| [`05e45b51`](https://github.com/NixOS/nixpkgs/commit/05e45b5131a468fe238ca35dff68941525c918e7) | `` television: 0.10.2 -> 0.10.4 ``                                                        |
| [`a7920d85`](https://github.com/NixOS/nixpkgs/commit/a7920d854ab23e343ec800b27a8c6c19ddb03d7e) | `` mopac: 23.0.3 -> 23.1.0 ``                                                             |
| [`b92e8eee`](https://github.com/NixOS/nixpkgs/commit/b92e8eeefa29843f6b8e6416afab90a793a802a2) | `` python312Packages.diff-cover: refactor ``                                              |
| [`436b335c`](https://github.com/NixOS/nixpkgs/commit/436b335c14928b849fbfba7fa38ccd4f0de47de6) | `` python312Packages.diff-cover: disable failing test ``                                  |
| [`e8345e3d`](https://github.com/NixOS/nixpkgs/commit/e8345e3d1b53963f1d6b7ea0f28249eac5c3b63a) | `` release-cuda: add vllm ``                                                              |
| [`cfd3cd93`](https://github.com/NixOS/nixpkgs/commit/cfd3cd93d9eec12664bbd7fdfbe976682e9dde29) | `` grocy: switch to tag ``                                                                |
| [`f3e34484`](https://github.com/NixOS/nixpkgs/commit/f3e34484a4df1c10af4a58fbf66939c918d41cdf) | `` grocy: switch to buildComposerProject2 ``                                              |
| [`79aa62f5`](https://github.com/NixOS/nixpkgs/commit/79aa62f5f10bdc7f57c8d88623ae2006fcd40104) | `` python313Packages.aiomqtt: fix broken condition ``                                     |
| [`f2d6fedd`](https://github.com/NixOS/nixpkgs/commit/f2d6feddeb1726f9b362038ac70dda28cec2328f) | `` pixelfed: switch to tag ``                                                             |
| [`ed17d529`](https://github.com/NixOS/nixpkgs/commit/ed17d529a8bfb7ee642b09fc032e76de5628586c) | `` pixelfed: switch to buildComposerProject2 ``                                           |
| [`65cb8da1`](https://github.com/NixOS/nixpkgs/commit/65cb8da1ef2d869eecdc8b91426ef3ee730f49e5) | `` roon-server: 2.0-1483 -> 2.0-1496 ``                                                   |
| [`9674800b`](https://github.com/NixOS/nixpkgs/commit/9674800b20025c5dded8cc37fea9630717bc360c) | `` debootstrap: Add util-linux to bin path (#380066) ``                                   |