### PR TITLE
chore(flake/nixpkgs-stable): `f5a32fa2` -> `a45fa362`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -437,11 +437,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1738843498,
-        "narHash": "sha256-7x+Q4xgFj9UxZZO9aUDCR8h4vyYut4zPUvfj3i+jBHE=",
+        "lastModified": 1739055578,
+        "narHash": "sha256-2MhC2Bgd06uI1A0vkdNUyDYsMD0SLNGKtD8600mZ69A=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "f5a32fa27df91dfc4b762671a0e0a859a8a0058f",
+        "rev": "a45fa362d887f4d4a7157d95c28ca9ce2899b70e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                       |
| ---------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------- |
| [`c6120d98`](https://github.com/NixOS/nixpkgs/commit/c6120d98d964a121bf7a4eb4d9153d908c81b272) | `` forgejo: 10.0.0 -> 10.0.1 ``                                                               |
| [`ae0c5ed5`](https://github.com/NixOS/nixpkgs/commit/ae0c5ed53ef030858d7a2c21b152288a59664897) | `` forgejo-lts: 7.0.12 -> 7.0.13 ``                                                           |
| [`599bf838`](https://github.com/NixOS/nixpkgs/commit/599bf8388adebb7a2efcb581ef77f567b63996e0) | `` pdns: 4.9.3 -> 4.9.4 ``                                                                    |
| [`33cb23cf`](https://github.com/NixOS/nixpkgs/commit/33cb23cfe3abc685dc063402bad49703815d717c) | `` linux_6_6: 6.6.75 -> 6.6.76 ``                                                             |
| [`2f30912d`](https://github.com/NixOS/nixpkgs/commit/2f30912d0845a9ce3c495ec1d4b19498677b3cae) | `` linux_6_12: 6.12.12 -> 6.12.13 ``                                                          |
| [`716d598f`](https://github.com/NixOS/nixpkgs/commit/716d598f1f599fcaa504f216bfec9cf841d9668d) | `` linux_6_13: 6.13.1 -> 6.13.2 ``                                                            |
| [`908a2512`](https://github.com/NixOS/nixpkgs/commit/908a251268d0cc1597bdfcfe54babc013e3b99c6) | `` ungoogled-chromium: 132.0.6834.159-1 -> 133.0.6943.53-1 ``                                 |
| [`bba1acdc`](https://github.com/NixOS/nixpkgs/commit/bba1acdc447a17339b25c8467116fc1ea3b17730) | `` inv-sig-helper: 0-unstable-2025-01-31 -> 0-unstable-2025-02-07 ``                          |
| [`65cf8ee8`](https://github.com/NixOS/nixpkgs/commit/65cf8ee81752196a5b43e874c3d0cde94e63a6b1) | `` pdns: 4.9.2 -> 4.9.3 ``                                                                    |
| [`86345ae5`](https://github.com/NixOS/nixpkgs/commit/86345ae5fc4602129ea69f8da62f2b8ee41d06db) | `` [Backport release-24.11] roave-backward-compatibility-check: 8.10.0 -> 8.13.0 (#380191) `` |
| [`f460d2e9`](https://github.com/NixOS/nixpkgs/commit/f460d2e9a40b5d81a1eb58cce00195676726c626) | `` tor: 0.4.8.13 -> 0.4.8.14 ``                                                               |
| [`66355555`](https://github.com/NixOS/nixpkgs/commit/66355555192e0e76228ed172e710ecc23786d262) | `` gancio: 1.22.0 -> 1.23.1 ``                                                                |
| [`87306ec2`](https://github.com/NixOS/nixpkgs/commit/87306ec2959047046cdf2cb2d83b02102a8f104e) | `` wireplumber: 0.5.7 -> 0.5.8 ``                                                             |
| [`7a09aa47`](https://github.com/NixOS/nixpkgs/commit/7a09aa47e01e6a4c36f209ec658d3c4fbfcf8e4c) | `` skypeforlinux: 8.134.0.202 -> 8.136.0.202 ``                                               |
| [`7f0cf82f`](https://github.com/NixOS/nixpkgs/commit/7f0cf82fa5f3c5aab7267aa6bd560408a5e3c390) | `` tor-browser: 14.0.4 -> 14.0.5 ``                                                           |
| [`89aabb5a`](https://github.com/NixOS/nixpkgs/commit/89aabb5a40fa37134ab7d79c92f38e5851bbd7d3) | `` signal-desktop(darwin): 7.40.0 -> 7.41.0 ``                                                |
| [`88f3f483`](https://github.com/NixOS/nixpkgs/commit/88f3f4830009906aef1f867a3338a93b4eeb5d24) | `` signal-desktop: 7.40.0 -> 7.41.0 ``                                                        |
| [`d5abc424`](https://github.com/NixOS/nixpkgs/commit/d5abc4242b3e489ac943d992fd6155a2078167cd) | `` lockbook-desktop: 0.9.17 -> 0.9.18 ``                                                      |
| [`4d955307`](https://github.com/NixOS/nixpkgs/commit/4d9553077eea9b6cca876ab1649fb75e36cc1847) | `` lockbook: 0.9.17 -> 0.9.18 ``                                                              |
| [`aed50e2e`](https://github.com/NixOS/nixpkgs/commit/aed50e2e7f8ea6229d34409482a8bf0fb513e69a) | `` nextcloudPackages.integration_deepl: init ``                                               |
| [`7d3bf848`](https://github.com/NixOS/nixpkgs/commit/7d3bf84885d1e1d6ea3cd3f73f3381588d7ca8e0) | `` nextcloudPackages.quota_warning: init ``                                                   |
| [`ca17a55a`](https://github.com/NixOS/nixpkgs/commit/ca17a55a576362dbc22a76e4ef30b333e392885e) | `` python313Packages.django_5: 5.1.5 -> 5.1.6 ``                                              |
| [`988e317e`](https://github.com/NixOS/nixpkgs/commit/988e317e87153f59d90e6de913e6ecbe571076e1) | `` xonsh: use `addBinToPathHook` ``                                                           |
| [`2ff86554`](https://github.com/NixOS/nixpkgs/commit/2ff86554c583396d67abd319125f96e98450962b) | `` nixos/bird: add package option ``                                                          |
| [`0bad4cad`](https://github.com/NixOS/nixpkgs/commit/0bad4cade51f1f2aefed77aaae8fca38c2fd8309) | `` bird3: init at 3.0.1 ``                                                                    |
| [`bfa445d5`](https://github.com/NixOS/nixpkgs/commit/bfa445d55b45d7b865b459139c519c3bfd5c6fed) | `` bird2: fetch src url via https ``                                                          |
| [`784dcefb`](https://github.com/NixOS/nixpkgs/commit/784dcefb3e7a12da1851044b7c7be5601a47f562) | `` bird: rename bird to bird2 ``                                                              |
| [`ecca3b0f`](https://github.com/NixOS/nixpkgs/commit/ecca3b0f30ec35344403ae161b68ef5f70647c27) | `` xonsh: 0.19.0 -> 0.19.1, use nix-update-script ``                                          |
| [`2ee59ca5`](https://github.com/NixOS/nixpkgs/commit/2ee59ca55b7f55383d380a9ab766b32d55554a6b) | `` python312Packages.xonsh: 0.18.4 -> 0.19.0 ``                                               |
| [`357afa86`](https://github.com/NixOS/nixpkgs/commit/357afa86266a4bc5cb4671c6909c7198736240ec) | `` fishPlugins.hydro: 2024-03-24 -> 2024-11-02 ``                                             |
| [`9ebb6df8`](https://github.com/NixOS/nixpkgs/commit/9ebb6df8e70eec637bb193f26e3f6e09bcf0371a) | `` telegram-desktop: 5.10.6 -> 5.10.7 ``                                                      |
| [`568182eb`](https://github.com/NixOS/nixpkgs/commit/568182eb65392fcaf94363865d0934dbdc4963a7) | `` telegram-desktop: 5.10.5 -> 5.10.6 ``                                                      |
| [`919c69bc`](https://github.com/NixOS/nixpkgs/commit/919c69bc28221604e806ac31e3187bd35e17033a) | `` nixos: make initrd-network-ssh test a channel blocker ``                                   |
| [`25c8fd4a`](https://github.com/NixOS/nixpkgs/commit/25c8fd4a4a29de4f40ef102c621005e66abdfe52) | `` virtualboxKvm: 20241220 -> 20250207 ``                                                     |
| [`577612f1`](https://github.com/NixOS/nixpkgs/commit/577612f1c877c907708e3b572c7ed4903fe301f1) | `` brave: 1.74.51 -> 1.75.175 ``                                                              |
| [`01e2505f`](https://github.com/NixOS/nixpkgs/commit/01e2505fe90a30126626627d04ca8e228ba99e54) | `` build-support: update `writableTmpDirAsHome`, use `postHooks` ``                           |
| [`f4ee5dbf`](https://github.com/NixOS/nixpkgs/commit/f4ee5dbf059ee60d18a489fb8eeff26b7b57641d) | `` build-support: update `addBinToPathHook`, use `postHooks` ``                               |
| [`309d875d`](https://github.com/NixOS/nixpkgs/commit/309d875dab80917b8fb97dce44614234f7f626ae) | `` build-support: update `addBinToPathHook` hook ``                                           |
| [`e82cefe5`](https://github.com/NixOS/nixpkgs/commit/e82cefe50cfc4cf8a21f47bd1097c65eff5d6838) | `` build-support: add `writableTmpDirAsHomeHook` hook ``                                      |
| [`4c3fbca1`](https://github.com/NixOS/nixpkgs/commit/4c3fbca1adcf927f4804737050fb63387f94871e) | `` build-support: add `addBinToPathHook` hook ``                                              |
| [`857093d1`](https://github.com/NixOS/nixpkgs/commit/857093d118228d9831ea58234b8f8cf7fa9f1f4a) | `` webex: 44.8.0.30404 -> 44.10.2.31237 ``                                                    |
| [`0b58bee2`](https://github.com/NixOS/nixpkgs/commit/0b58bee21d3dd09e2ed15816c7ff0febb6a4a5dc) | `` volatility2-bin: init at 2.6.1 ``                                                          |
| [`917b4eab`](https://github.com/NixOS/nixpkgs/commit/917b4eab9ca7fa612661013d9ef51c84d8670542) | `` systemd: fix typo in boot.kernelParams (hierachy → hierarchy) ``                           |
| [`8d9b2b6d`](https://github.com/NixOS/nixpkgs/commit/8d9b2b6d1a8932112b4aee1525f8fff72a61acbe) | `` hashrat: 1.22 -> 1.23 ``                                                                   |
| [`1ae12749`](https://github.com/NixOS/nixpkgs/commit/1ae12749c7c75d72a1e79431c8a8824066ebc295) | `` hashrat: refactor ``                                                                       |
| [`db8ff677`](https://github.com/NixOS/nixpkgs/commit/db8ff6778905648dc149bff186d4333087be3eb1) | `` flyctl: 0.3.68 -> 0.3.75 ``                                                                |
| [`769a157e`](https://github.com/NixOS/nixpkgs/commit/769a157ef3d6af82dfa8efda401aaa3c75d780ba) | `` nixos/tests/mysql-autobackup: fix eval ``                                                  |
| [`534282b3`](https://github.com/NixOS/nixpkgs/commit/534282b31bc7e6beb91a3914de6062c7a867fb60) | `` mariadb: 10.5.28, 10.6.21,  10.11.11, 11.4.5 ``                                            |
| [`5a744d0d`](https://github.com/NixOS/nixpkgs/commit/5a744d0dfa1bbcfd3711141d495e122221c56f4e) | `` vencord: 1.11.3 -> 1.11.4 ``                                                               |
| [`9b1267ca`](https://github.com/NixOS/nixpkgs/commit/9b1267ca3c3ebf88e6974a0dbe27e42d0043d89f) | `` maintainers: add name for tris203 ``                                                       |
| [`eaba0167`](https://github.com/NixOS/nixpkgs/commit/eaba01674716ea540ab6cf1fb7829815a2fbd350) | `` freeipa: add benley to maintainers ``                                                      |
| [`6da3ef3a`](https://github.com/NixOS/nixpkgs/commit/6da3ef3af0cffa4bd26be2fed386b788a6cbde23) | `` freeipa: 4.12.1 -> 4.12.3 ``                                                               |
| [`08f597d3`](https://github.com/NixOS/nixpkgs/commit/08f597d324b1fb72a8d3dc384cb50d8ba56f034f) | `` python312Packages.mike: unstable-2023-05-06 -> 2.1.3 ``                                    |
| [`5cd7c404`](https://github.com/NixOS/nixpkgs/commit/5cd7c404c6cd140ac967694d0d8c82ed8aaeeead) | `` python312Packages.mkdocs-glightbox: init at 0.4.0 ``                                       |
| [`a72ea30f`](https://github.com/NixOS/nixpkgs/commit/a72ea30f172161219b0184b062417f258ef8237d) | `` angular-language-server: 19.0.3 -> 19.0.4 ``                                               |
| [`d86185f2`](https://github.com/NixOS/nixpkgs/commit/d86185f2f9d2a2711f7c8110313dd71ba514e2ee) | `` rzls: init at 9.0.0-preview.25052.3 ``                                                     |
| [`426474a1`](https://github.com/NixOS/nixpkgs/commit/426474a10f1b74e61ae375e1948983454cc2ea14) | `` maintainers: add bretek ``                                                                 |
| [`fcf4803a`](https://github.com/NixOS/nixpkgs/commit/fcf4803a889b208069226b289872e173cc3fba87) | `` maintainers: add tris203 ``                                                                |
| [`64552dee`](https://github.com/NixOS/nixpkgs/commit/64552dee1d2aa66de85de8dea8d160e96be2e24c) | ``  nixos/glpi-agent: init ``                                                                 |
| [`03282d1b`](https://github.com/NixOS/nixpkgs/commit/03282d1b7933afa680754bbc11698861b019de8f) | `` garnet: 1.0.53 -> 1.0.54 ``                                                                |
| [`10f75da4`](https://github.com/NixOS/nixpkgs/commit/10f75da4c11396f68e9e13d88a5dccf2f92c0fcc) | `` dosage-tracker: init at 1.8.0 ``                                                           |
| [`6d5e9df8`](https://github.com/NixOS/nixpkgs/commit/6d5e9df85bc17441ae996bf9f6883b6230a9e165) | `` keycloak: 16.1.0 -> 16.1.1 ``                                                              |
| [`76129e66`](https://github.com/NixOS/nixpkgs/commit/76129e66d75c7260ee11d7be4b3169c45908d72b) | `` timeshift: timeshift-launcher: hard-code the timeshift-gtk path ``                         |
| [`d2886be2`](https://github.com/NixOS/nixpkgs/commit/d2886be25983136ccfb694686333e8bcc042d0bb) | `` timeshift: explain the timeshift-launcher string substitution ``                           |
| [`11b9d7bc`](https://github.com/NixOS/nixpkgs/commit/11b9d7bcb510269542e1cb96c49b604209cfd94e) | `` timeshift: patch timeshift-launcher with escapeShellArg instead of a patch file ``         |
| [`66233876`](https://github.com/NixOS/nixpkgs/commit/662338760ea49bb906f8ef5091ae1e6db10e03ab) | `` timeshift: use substituteInPlace --replace-fail ``                                         |
| [`d42b5348`](https://github.com/NixOS/nixpkgs/commit/d42b5348f06d2ca5060e60b9da5b4ad7f763e579) | `` thunderbird-128-unwrapped: 128.6.0esr -> 128.6.1esr ``                                     |
| [`cc12c7e2`](https://github.com/NixOS/nixpkgs/commit/cc12c7e2b406edb34ba10d80ce8cd594f53593c6) | `` wavebox: 10.131.18-2 -> 10.132.2-2 ``                                                      |
| [`984e9beb`](https://github.com/NixOS/nixpkgs/commit/984e9bebdeea6b96d4c0cede5099f2417e9948f3) | `` wasm-tools: 1.222.0 -> 1.222.1 ``                                                          |
| [`c9a682fa`](https://github.com/NixOS/nixpkgs/commit/c9a682fa1423cbdbf64489c93150a2744ee60bba) | `` ncspot: 1.2.1 -> 1.2.2 ``                                                                  |
| [`fa555827`](https://github.com/NixOS/nixpkgs/commit/fa555827b236393f8d59d008020832525f1aef40) | `` nixos/restic: add progressFps option ``                                                    |
| [`a8f86439`](https://github.com/NixOS/nixpkgs/commit/a8f8643960e9fe5fc92528971a94683feaa49ada) | `` nixos/restic: nixfmt ``                                                                    |
| [`ae67ecde`](https://github.com/NixOS/nixpkgs/commit/ae67ecde81c013252b384cb0205493057d204e97) | `` privatebin: 1.7.5 -> 1.7.6 ``                                                              |
| [`68289b3e`](https://github.com/NixOS/nixpkgs/commit/68289b3eb46ce5e923826a69e5eba467991ae21d) | `` privatebin: refactor ``                                                                    |
| [`300839a1`](https://github.com/NixOS/nixpkgs/commit/300839a17753d0bc27c5efdfcd0a48ea5121688f) | `` privatebin: 1.7.4 -> 1.7.5 ``                                                              |
| [`054e0852`](https://github.com/NixOS/nixpkgs/commit/054e08529ba11bf61e8ac85fff3e7d3d04c2a699) | `` shellhub-agent: 0.17.2 -> 0.18.0 ``                                                        |
| [`e4a3f47b`](https://github.com/NixOS/nixpkgs/commit/e4a3f47b54a4f23e32002b6870cc484ab5cf1cc7) | `` sdl3: 3.2.0 -> 3.2.2 ``                                                                    |
| [`68d06be3`](https://github.com/NixOS/nixpkgs/commit/68d06be39c35bcbaea4f7e4d4042d9e05725916e) | `` komikku: 1.68.0 -> 1.69.0 ``                                                               |
| [`89d78426`](https://github.com/NixOS/nixpkgs/commit/89d78426d9b4cde2e0877bb1d72e59d63fcd4ed0) | `` teleport_16: 16.4.6 -> 16.4.14 ``                                                          |
| [`aac0cafa`](https://github.com/NixOS/nixpkgs/commit/aac0cafa6213541411c72273503f7638e6bf0efb) | `` teleport_15: 15.4.21 -> 15.4.26 ``                                                         |
| [`ff37eecd`](https://github.com/NixOS/nixpkgs/commit/ff37eecd0a5063803db97bd53b4463be09589e93) | `` teleport: Add juliusfreudenberger as maintainer ``                                         |
| [`2b716f7f`](https://github.com/NixOS/nixpkgs/commit/2b716f7f5925b611b110bc8e4c1e24034ea4cb80) | `` maintainers: add juliusfreudenberger ``                                                    |
| [`26a19b2f`](https://github.com/NixOS/nixpkgs/commit/26a19b2ff8b6f2eee96973702f68c5c2a09bedc3) | `` openafs: 1.8.13.1 → 1.8.13.2 ``                                                            |
| [`6e92d10f`](https://github.com/NixOS/nixpkgs/commit/6e92d10ffbaf227e9de594fb09d4f8769e4a14a0) | `` conjure-tor: init at 0-unstable-2024-11-11 ``                                              |
| [`643874e1`](https://github.com/NixOS/nixpkgs/commit/643874e1df9430bc3e337daf97682cffaafea088) | `` av1an: 0.4.3 -> 0.4.4 ``                                                                   |
| [`4347ef8d`](https://github.com/NixOS/nixpkgs/commit/4347ef8d28a29a9221bcae937714b1d54ac0c442) | `` av1an: mark broken on x86_64-darwin ``                                                     |
| [`9dd62995`](https://github.com/NixOS/nixpkgs/commit/9dd6299521133d4522ac3471e230d282605a7687) | `` gdm-settings: 4.4 -> 5.0 ``                                                                |
| [`ade137d8`](https://github.com/NixOS/nixpkgs/commit/ade137d8cb4813e02d3b13f4bf88efea6f5f81a4) | `` tangram: 3.1 -> 3.3 ``                                                                     |
| [`881280c2`](https://github.com/NixOS/nixpkgs/commit/881280c26f55353c14dfe8fd0c0a77435a9e4505) | `` krita: 5.2.6 -> 5.2.9 ``                                                                   |
| [`355653c6`](https://github.com/NixOS/nixpkgs/commit/355653c68fbc67cf929ba9b667a309a93a24f486) | `` libxls: 1.6.2 -> 1.6.3 ``                                                                  |
| [`24794246`](https://github.com/NixOS/nixpkgs/commit/247942461c30d027927f28aae09a13fe2f7e7842) | `` jbig2enc: 0.29.0 -> 0.30.0 ``                                                              |
| [`0d21e034`](https://github.com/NixOS/nixpkgs/commit/0d21e034be2ce661808895b56154fffd8c05d63d) | `` impression: use fetchCargoVendor ``                                                        |
| [`32fe2ea8`](https://github.com/NixOS/nixpkgs/commit/32fe2ea88607467bb705bb1f6797c01374d471ea) | `` impression: 3.2.0 -> 3.3.0 ``                                                              |
| [`8ff8fd80`](https://github.com/NixOS/nixpkgs/commit/8ff8fd80c2d322b3936efbe300f2307c8b1cb87c) | `` oxefmsynth: use the packaged version of `vst2-sdk` ``                                      |
| [`610b10f0`](https://github.com/NixOS/nixpkgs/commit/610b10f005b02fd4a6e92c73b8964ec4e4dd8b58) | `` jackass: use the packaged version of `vst2-sdk` ``                                         |
| [`1f71418b`](https://github.com/NixOS/nixpkgs/commit/1f71418b15ee93e4bc63d76476d199d3847648b2) | `` bespokesynth: use the packaged version of `vst2-sdk` ``                                    |
| [`edccc286`](https://github.com/NixOS/nixpkgs/commit/edccc286d4e122884952fdf00bb2368be59f72a6) | `` airwave: use the packaged version of `vst2-sdk` ``                                         |
| [`aa459ab1`](https://github.com/NixOS/nixpkgs/commit/aa459ab1cf776db591a1bce034f65503eca13237) | `` vst2-sdk: init at 2018-06-11 ``                                                            |
| [`39aab3ec`](https://github.com/NixOS/nixpkgs/commit/39aab3ec0efc77886b223873354854af6411cd35) | `` flake-checker: 0.2.1 -> 0.2.4 ``                                                           |
| [`fefe7c1c`](https://github.com/NixOS/nixpkgs/commit/fefe7c1c52470074d6629f74b551bdfbea2b1c47) | `` imagemagick: move to openexr_3 ``                                                          |
| [`7448011e`](https://github.com/NixOS/nixpkgs/commit/7448011ea7decf4feda623d0063c9f70b605aa69) | `` salt: fix urllib.parse module ``                                                           |