### PR TITLE
chore(flake/stylix): `e72aa84d` -> `eb5f8175`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -558,11 +558,11 @@
         "tinted-zed": "tinted-zed"
       },
       "locked": {
-        "lastModified": 1739117494,
-        "narHash": "sha256-HqUir6OE3oNrQRtlLA7oRHkKMGNMKHkAPqG5HFcODK8=",
+        "lastModified": 1739186294,
+        "narHash": "sha256-BfJKfBpmvodPufE9SgP5b3OTPndG/Nt1tTNze3IOAjQ=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "e72aa84da1c6982c11620a4154ded8c603f33f46",
+        "rev": "eb5f81756731a3eefa42b1caf494ba5a9c8aedb4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                        | Message                                                   |
| --------------------------------------------------------------------------------------------- | --------------------------------------------------------- |
| [`eb5f8175`](https://github.com/danth/stylix/commit/eb5f81756731a3eefa42b1caf494ba5a9c8aedb4) | `` {vencord,vesktop}: support fonts without IFD (#846) `` |
| [`2c1d493c`](https://github.com/danth/stylix/commit/2c1d493c5f5af6caec9f02a5c3d88d84ee2f10b8) | `` qt: respect stylix.enable (#847) ``                    |