### PR TITLE
chore(flake/spicetify-nix): `366191fe` -> `dea71773`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -523,11 +523,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1739074574,
-        "narHash": "sha256-dLfT4/nIU3RzMHk7I5UigRehSWzq7wGkZxwuQdflO6s=",
+        "lastModified": 1739223162,
+        "narHash": "sha256-YrbYTM0CkZQG38Ysr2gF4BYdsQDNQtQ4YdQTDgw/zWM=",
         "owner": "Gerg-L",
         "repo": "spicetify-nix",
-        "rev": "366191fe8e9375d280e9a6b0ed9823468b49f6e7",
+        "rev": "dea717737d04a2a3e877c082bfd2c7f91c1a33ff",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                           |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------- |
| [`dea71773`](https://github.com/Gerg-L/spicetify-nix/commit/dea717737d04a2a3e877c082bfd2c7f91c1a33ff) | `` fix infrec when importing modules flakeless `` |
| [`f7f11a39`](https://github.com/Gerg-L/spicetify-nix/commit/f7f11a39882fa5be5c18e74d03ff1fb4c25b1281) | `` flake: pass pkgs instead of system ``          |