### PR TITLE
chore(flake/stylix): `eb5f8175` -> `4af2686c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -558,11 +558,11 @@
         "tinted-zed": "tinted-zed"
       },
       "locked": {
-        "lastModified": 1739186294,
-        "narHash": "sha256-BfJKfBpmvodPufE9SgP5b3OTPndG/Nt1tTNze3IOAjQ=",
+        "lastModified": 1739215427,
+        "narHash": "sha256-1yIsiPwwxXal7+wkWogjPhsM5BjRlK61lAHQtlX8s04=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "eb5f81756731a3eefa42b1caf494ba5a9c8aedb4",
+        "rev": "4af2686c1c62176d0ce28c4d55e813ae5ed52b6f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                        | Message                                             |
| --------------------------------------------------------------------------------------------- | --------------------------------------------------- |
| [`4af2686c`](https://github.com/danth/stylix/commit/4af2686c1c62176d0ce28c4d55e813ae5ed52b6f) | `` nixcord: use new template format (#852) ``       |
| [`7f0154c3`](https://github.com/danth/stylix/commit/7f0154c371a847d23eace73f6daaa814d2d42261) | `` neovim: fix SignColumn transparency (#628) ``    |
| [`65eae5aa`](https://github.com/danth/stylix/commit/65eae5aaa2169ed4f6a066b4da698cb0e07b2719) | `` kde: fix KDE apps ignoring colorscheme (#850) `` |