### PR TITLE
chore(flake/zen-browser): `0e962f03` -> `3e6f2891`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -672,11 +672,11 @@
         "nixpkgs": "nixpkgs_3"
       },
       "locked": {
-        "lastModified": 1739161281,
-        "narHash": "sha256-cMM5E5EzEnfQFdBurCVqCi9mhsmRCeaEJB4iskPsQ1o=",
+        "lastModified": 1739244669,
+        "narHash": "sha256-yVQv6Z3VoAXMjbsGcQ/10Fyzcy3aMkl+Hek6DJwqH4c=",
         "owner": "0xc000022070",
         "repo": "zen-browser-flake",
-        "rev": "0e962f036e6e2a9dde28f37d80104c7ea477a801",
+        "rev": "3e6f289153033b091f32d0cc658fd0f490a483b3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                          | Message                                                                 |
| --------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------- |
| [`3e6f2891`](https://github.com/0xc000022070/zen-browser-flake/commit/3e6f289153033b091f32d0cc658fd0f490a483b3) | `` fix(flake): mkZen accepts entry name to use against sources file ``  |
| [`30b5295c`](https://github.com/0xc000022070/zen-browser-flake/commit/30b5295c0a8a488d4ab017be699d4d1ee88b1f7e) | `` fix(flake): added missing twilight resilient package ``              |
| [`195e4490`](https://github.com/0xc000022070/zen-browser-flake/commit/195e4490ac87096d087dde93a42a3aa594579259) | `` Update Zen Browser twilight @ x86_64 && aarch64 to 1.7.7t#be2a44d `` |
| [`e5347d41`](https://github.com/0xc000022070/zen-browser-flake/commit/e5347d41c9279bd63ed668ce9a88e77e3eb97eea) | `` ci(zen-update): added GH_TOKEN env var to use gh cli ``              |
| [`12edc373`](https://github.com/0xc000022070/zen-browser-flake/commit/12edc373ebd2d92a68926f3ba5502d9702040a75) | `` feat: resilient variant of twilight version ``                       |