### PR TITLE
chore(flake/zen-browser): `3e6f2891` -> `8c391758`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -672,11 +672,11 @@
         "nixpkgs": "nixpkgs_3"
       },
       "locked": {
-        "lastModified": 1739244669,
-        "narHash": "sha256-yVQv6Z3VoAXMjbsGcQ/10Fyzcy3aMkl+Hek6DJwqH4c=",
+        "lastModified": 1739294172,
+        "narHash": "sha256-SQiAzwlNQaymcMmHl7TL7s+2zojOimWUWhKhY95Q3H4=",
         "owner": "0xc000022070",
         "repo": "zen-browser-flake",
-        "rev": "3e6f289153033b091f32d0cc658fd0f490a483b3",
+        "rev": "8c391758dcca59a35c196d07b78af251c5341b08",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                          | Message                                                                 |
| --------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------- |
| [`8c391758`](https://github.com/0xc000022070/zen-browser-flake/commit/8c391758dcca59a35c196d07b78af251c5341b08) | `` Update Zen Browser twilight @ x86_64 && aarch64 to 1.7.7t#48badb8 `` |