### PR TITLE
chore(flake/nixpkgs-stable): `a45fa362` -> `44534bc0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -437,11 +437,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1739055578,
-        "narHash": "sha256-2MhC2Bgd06uI1A0vkdNUyDYsMD0SLNGKtD8600mZ69A=",
+        "lastModified": 1739206421,
+        "narHash": "sha256-PwQASeL2cGVmrtQYlrBur0U20Xy07uSWVnFup2PHnDs=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "a45fa362d887f4d4a7157d95c28ca9ce2899b70e",
+        "rev": "44534bc021b85c8d78e465021e21f33b856e2540",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                           |
| ---------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------- |
| [`42191d96`](https://github.com/NixOS/nixpkgs/commit/42191d96537c413615ac7a1b1f0934d3d3784976) | `` jenkins: 2.479.3 -> 2.492.1 ``                                                 |
| [`b4a7f3f2`](https://github.com/NixOS/nixpkgs/commit/b4a7f3f24196e0a1554f4c614a62b72ae050e48c) | `` roslyn-ls:  4.14.0-1.25060.2 -> 4.14.0-1.25074.7 ``                            |
| [`178e3100`](https://github.com/NixOS/nixpkgs/commit/178e310040c55c8b3bca247e96ca18aa4c2f2078) | `` roslyn-ls: 4.13.0-3.25051.1 -> 4.14.0-1.25060.2 ``                             |
| [`4b9245b0`](https://github.com/NixOS/nixpkgs/commit/4b9245b00fb6cb46c079935ea33bc695fd607f88) | `` roslyn-ls: fix read-only cache dir (#376364) ``                                |
| [`75b5ef2b`](https://github.com/NixOS/nixpkgs/commit/75b5ef2bfeca4455a3281deb486284a528d23440) | `` nixos/sway: restore list type of xdg.portal.config.sway.default ``             |
| [`91b988a4`](https://github.com/NixOS/nixpkgs/commit/91b988a499d9c456ca333ca3aa44953ce2074fa7) | `` proton-ge-bin: remove uneeded changes ``                                       |
| [`f3070a32`](https://github.com/NixOS/nixpkgs/commit/f3070a32ff8e4323d61c188f6ea14107c14edac0) | `` proton-ge-bin: allow overriding display name in steam ``                       |
| [`c60ebd5b`](https://github.com/NixOS/nixpkgs/commit/c60ebd5bce38edc14f988093cd40dba51b8f1439) | `` pkgsCross.aarch64-darwin.discord-canary: 0.0.692 -> 0.0.696 ``                 |
| [`8c8ed23e`](https://github.com/NixOS/nixpkgs/commit/8c8ed23e29b177bd30b6359d1cb9c5d3cbeb14fd) | `` pkgsCross.aarch64-darwin.discord-ptb: 0.0.157 -> 0.0.159 ``                    |
| [`7ff6e56c`](https://github.com/NixOS/nixpkgs/commit/7ff6e56c35c7b8b95214998af5319d7a44611b06) | `` pkgsCross.aarch64-darwin.discord: 0.0.334 -> 0.0.335 ``                        |
| [`ca4fbf7c`](https://github.com/NixOS/nixpkgs/commit/ca4fbf7cd2036b1c982707742a89d9a26de42c31) | `` discord-canary: 0.0.581 -> 0.0.585 ``                                          |
| [`12b8b48f`](https://github.com/NixOS/nixpkgs/commit/12b8b48f05cf5ba7c549330c84079c70adb7d528) | `` discord-ptb: 0.0.128 -> 0.0.130 ``                                             |
| [`d0dc2ead`](https://github.com/NixOS/nixpkgs/commit/d0dc2eadcb2b58fe465cfcb696c816e1ce62cd2b) | `` discord: 0.0.83 -> 0.0.84 ``                                                   |
| [`ed726c2b`](https://github.com/NixOS/nixpkgs/commit/ed726c2bdc2af1f417bd4155ca94d671f809c2e8) | `` proton-ge-bin: add Scrumplex as maintainer ``                                  |
| [`ec58cf30`](https://github.com/NixOS/nixpkgs/commit/ec58cf302a89045c25c7e38db5b4816f123a3d63) | `` proton-ge-bin: refactor ``                                                     |
| [`d0d0460c`](https://github.com/NixOS/nixpkgs/commit/d0d0460c419081ed966a3b3cb4158e37d0680b02) | `` refine: 0.4.2 -> 0.4.3 ``                                                      |
| [`54af94aa`](https://github.com/NixOS/nixpkgs/commit/54af94aa94cbb50f37fac754d71cc84f8531fe7a) | `` warp-terminal: 0.2025.01.22.08.02.stable_05 -> 0.2025.02.05.08.02.stable_03 `` |
| [`6c496f12`](https://github.com/NixOS/nixpkgs/commit/6c496f12cd4fb72d9dfaec8340231743eee77f63) | `` vimPlugins.bufresize-nvim: init at 2022-03-21 ``                               |
| [`ba36c548`](https://github.com/NixOS/nixpkgs/commit/ba36c548b4d01ae16eb79b12f7e7cab7d4d56a02) | `` mullvad-browser: 14.0.4 -> 14.0.5 ``                                           |
| [`9d269455`](https://github.com/NixOS/nixpkgs/commit/9d26945508534e838c33da1d13f6564e67cda5ee) | `` oscavmgr: 0.4.3 -> 0.4.4 ``                                                    |
| [`ce2a842a`](https://github.com/NixOS/nixpkgs/commit/ce2a842a3fb4009736aaf31d186d1af0b20e95bf) | `` maintainers: add qxrein ``                                                     |
| [`017e49d8`](https://github.com/NixOS/nixpkgs/commit/017e49d85f5692b731ca2ebe3143ea98499d40c5) | `` nakama: init at 3.26.0 (#378552) ``                                            |
| [`ef503dd6`](https://github.com/NixOS/nixpkgs/commit/ef503dd62eec4aa7a47793ae43ad38e5716873c4) | `` gnome-graphs: 1.8.2 -> 1.8.4 ``                                                |
| [`c9fada00`](https://github.com/NixOS/nixpkgs/commit/c9fada00817021e621bf74ffed800e70b422a730) | `` z3: add installCheckPhase ``                                                   |
| [`ee2d8553`](https://github.com/NixOS/nixpkgs/commit/ee2d855315aa9d66c52bd1496262dc83ce3804b9) | `` z3_4_{8_5,8,11,12}: fix clang-19 build ``                                      |
| [`af2543a9`](https://github.com/NixOS/nixpkgs/commit/af2543a99d3a9fb6c729d5c37cb5509100ce060c) | `` z3: run through nixfmt-rfc-style ``                                            |
| [`b5a5263d`](https://github.com/NixOS/nixpkgs/commit/b5a5263d6ea10a6a37128b2f7446b2fb4026a883) | `` z3_4_13: init at 4.13.4 ``                                                     |
| [`43602eaf`](https://github.com/NixOS/nixpkgs/commit/43602eafb5086283d5fdd44693c56fa208db452f) | `` z3_4_12: 4.12.5 -> 4.12.6 ``                                                   |
| [`d7b0057b`](https://github.com/NixOS/nixpkgs/commit/d7b0057b733a73060cdca4970182c574f671fcb2) | `` z3: add numinit as maintainer ``                                               |
| [`d3481746`](https://github.com/NixOS/nixpkgs/commit/d3481746a1302ea77e84dcc31661b7a853bc0aa2) | `` z3: fix 4.8.5 compile on Python 3.12 ``                                        |
| [`ad936481`](https://github.com/NixOS/nixpkgs/commit/ad936481eda4bf2d3d7a1331356d722a7ddf4484) | `` sonarr: add niklaskorz to maintainers ``                                       |
| [`2e4cb56f`](https://github.com/NixOS/nixpkgs/commit/2e4cb56f56911c67ae79249de3892d764f69332e) | `` sonarr: disable failing darwin tests ``                                        |
| [`712018f8`](https://github.com/NixOS/nixpkgs/commit/712018f8668dd1bc746d5932ae0bf139650eb6db) | `` sonarr: upgrade to dotnet 8 ``                                                 |
| [`50fdb281`](https://github.com/NixOS/nixpkgs/commit/50fdb281dbf7ad3f2efec92966c86efe06f8c115) | `` sonarr: 4.0.11.2680 -> 4.0.12.2823 ``                                          |
| [`4688953e`](https://github.com/NixOS/nixpkgs/commit/4688953e695bed1247e77f360f3a904114be4f1b) | `` sonarr: format ``                                                              |
| [`fcef091b`](https://github.com/NixOS/nixpkgs/commit/fcef091b7b70b1d003c71a93f4d192ac918ea331) | `` broadcom_sta: add j0hax as maintainer ``                                       |
| [`1fc5db0b`](https://github.com/NixOS/nixpkgs/commit/1fc5db0b96654083e3dcf6ab08787fb97e83a34c) | `` broadcom_sta: add patch to compile on kernel 6.13 ``                           |
| [`14aa3b04`](https://github.com/NixOS/nixpkgs/commit/14aa3b042a08a49cb503a034b0ab73d4f10cec2b) | `` broadcom_sta: source kernel 6.12 patch from RPM Fusion ``                      |
| [`6ff3f131`](https://github.com/NixOS/nixpkgs/commit/6ff3f131ab4602222899e310a1415f5d23156bb8) | `` python3Packages.xdis: remove backport patches after update to 6.1.3 ``         |
| [`3e5ebb19`](https://github.com/NixOS/nixpkgs/commit/3e5ebb19363aee1e728c7f148c997fe4296966ec) | `` python3Packages.xdis: 6.1.1 -> 6.1.3 ``                                        |
| [`28033a64`](https://github.com/NixOS/nixpkgs/commit/28033a648936179ffd12795c4afa041149caf084) | `` firefly-iii-data-importer: 1.5.7 -> 1.6.0 ``                                   |
| [`78f81fb8`](https://github.com/NixOS/nixpkgs/commit/78f81fb8eab5d31cfecc9aafd85472c4d760cc98) | `` firefly-iii: 6.1.25 -> 6.2.4 ``                                                |
| [`dc1ee1ab`](https://github.com/NixOS/nixpkgs/commit/dc1ee1ab4ec002b780faf5faa0348900b4d67a13) | `` batman-adv: 2024.4 -> 2025.0 ``                                                |
| [`d531ff09`](https://github.com/NixOS/nixpkgs/commit/d531ff090ee878fe3ac41e01cb06b0143a9f85f2) | `` floorp: 11.22.0 -> 11.23.0 ``                                                  |
| [`40c4716d`](https://github.com/NixOS/nixpkgs/commit/40c4716d8c967b6e02a213531ddeaf9121f6a183) | `` cargo-lambda: remove with lib; usage ``                                        |
| [`78b78696`](https://github.com/NixOS/nixpkgs/commit/78b7869641d3e8cec33398ba764387a34d8d8123) | `` cargo-lambda: refactor src ``                                                  |
| [`a28531ff`](https://github.com/NixOS/nixpkgs/commit/a28531ff5719e478e1ec92b797a5b1d7ba146aeb) | `` cargo-lambda: move to pkgs/by-name ``                                          |
| [`8c9d8d8f`](https://github.com/NixOS/nixpkgs/commit/8c9d8d8fbbd2fdc0bb0722d7b71c09b653934065) | `` cargo-lambda: remove obsolete darwin frameworks ``                             |
| [`c68fcf5b`](https://github.com/NixOS/nixpkgs/commit/c68fcf5b381e35fc2f29f573c3a0f6b9660dafda) | `` nextcloudPackages.apps: add sociallogin ``                                     |
| [`28e38e6c`](https://github.com/NixOS/nixpkgs/commit/28e38e6c4012049b8db253fe5959dbd9e1bb296c) | `` nextcloudPackages.apps: add files_retention ``                                 |
| [`fb922b56`](https://github.com/NixOS/nixpkgs/commit/fb922b56cc1e1d9134cd77247257405a17686b94) | `` nextcloudPackages.apps: add files_automatedtagging ``                          |
| [`be1e05ec`](https://github.com/NixOS/nixpkgs/commit/be1e05ec9aee1249676eb6cd3100de67ffc1a5f2) | `` nextcloudPackages.apps: add app_api ``                                         |
| [`4995e9e0`](https://github.com/NixOS/nixpkgs/commit/4995e9e07a61a2eda1446925d37debf2e0f0441e) | `` nextcloudPackages.apps: update ``                                              |
| [`02686572`](https://github.com/NixOS/nixpkgs/commit/02686572d30aace07618fca9f899977a402a3d4e) | `` nss_latest: 3.107 -> 3.108 ``                                                  |
| [`dd1bb49c`](https://github.com/NixOS/nixpkgs/commit/dd1bb49c004c307e46eba1c88c01ed3f44c74b5b) | `` vaultwarden: 1.33.0 -> 1.33.1 ``                                               |