### PR TITLE
chore(flake/nix-gaming): `1d23e26a` -> `04339b6f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -394,11 +394,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1739237977,
-        "narHash": "sha256-4b1zfzDjBzITuI4md7Kdu9dgh/FepOSgiBqvfWMCEg4=",
+        "lastModified": 1739389409,
+        "narHash": "sha256-kZNrjC35TcyrjUvc8ILTp60fp5cpESzeIx14IGHbyOo=",
         "owner": "fufexan",
         "repo": "nix-gaming",
-        "rev": "1d23e26a88c30f401ecd8a654d71ac6441d0d324",
+        "rev": "04339b6fdbe00890ff3a09fbb251ae0a333f452b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                              | Message                                  |
| --------------------------------------------------------------------------------------------------- | ---------------------------------------- |
| [`04339b6f`](https://github.com/fufexan/nix-gaming/commit/04339b6fdbe00890ff3a09fbb251ae0a333f452b) | `` osu-stable: add useGameMode option `` |