### PR TITLE
chore(flake/zen-browser): `8c391758` -> `f5a23944`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -689,11 +689,11 @@
         "nixpkgs": "nixpkgs_3"
       },
       "locked": {
-        "lastModified": 1739294172,
-        "narHash": "sha256-SQiAzwlNQaymcMmHl7TL7s+2zojOimWUWhKhY95Q3H4=",
+        "lastModified": 1739377372,
+        "narHash": "sha256-LynHMIeLlnUm+ryyt/il7W3mggiMoZmFPczzTk8Dnvw=",
         "owner": "0xc000022070",
         "repo": "zen-browser-flake",
-        "rev": "8c391758dcca59a35c196d07b78af251c5341b08",
+        "rev": "f5a239448bcefdb9b9c689ed90491281a3b2ca5d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                          | Message                                                                 |
| --------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------- |
| [`f5a23944`](https://github.com/0xc000022070/zen-browser-flake/commit/f5a239448bcefdb9b9c689ed90491281a3b2ca5d) | `` Update Zen Browser twilight @ x86_64 && aarch64 to 1.7.7t#40a8432 `` |
| [`336c4105`](https://github.com/0xc000022070/zen-browser-flake/commit/336c41058ac2ac78c3f2b2f3e92da9f3da8e7659) | `` Update Zen Browser twilight @ x86_64 && aarch64 to 1.7.7t#22cad83 `` |