### PR TITLE
chore(flake/zen-browser): `daf9a84c` -> `16e8b35d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -689,11 +689,11 @@
         "nixpkgs": "nixpkgs_3"
       },
       "locked": {
-        "lastModified": 1739409546,
-        "narHash": "sha256-cBnjF6tljmQ9pCA1mC/4aecmlcSMIeBj/IrdQFYKNvA=",
+        "lastModified": 1739488634,
+        "narHash": "sha256-AKIMGmOq4l8uUVQSQhMfWvi7TZrmHxoes+VjI9273ME=",
         "owner": "0xc000022070",
         "repo": "zen-browser-flake",
-        "rev": "daf9a84cd34c3919deaf4adf7a96a8e934aff990",
+        "rev": "16e8b35d8618a1c047553ed770bb3f6cd6afe2ea",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                          | Message                                                                 |
| --------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------- |
| [`16e8b35d`](https://github.com/0xc000022070/zen-browser-flake/commit/16e8b35d8618a1c047553ed770bb3f6cd6afe2ea) | `` Update Zen Browser twilight @ x86_64 && aarch64 to 1.7.7t#31ef8d2 `` |
| [`f36e0e7e`](https://github.com/0xc000022070/zen-browser-flake/commit/f36e0e7e21079151bfe817df3a6ab93dc8d648ea) | `` Update Zen Browser twilight @ x86_64 && aarch64 to 1.7.7t#ab836eb `` |