### PR TITLE
chore(flake/home-manager): `c9d343cf` -> `5031c6d2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -339,11 +339,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1739416022,
-        "narHash": "sha256-Af1CIT+XlXEb+Dk11sgPDzJoOUiada2Xoj5hA8TBvLY=",
+        "lastModified": 1739470101,
+        "narHash": "sha256-NxNe32VB4XI/xIXrsKmIfrcgtEx5r/5s52pL3CpEcA4=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "c9d343cfa0565671cc7e8d5aefebaf61cc840abd",
+        "rev": "5031c6d2978109336637977c165f82aa49fa16a7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                     |
| ----------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------- |
| [`5031c6d2`](https://github.com/nix-community/home-manager/commit/5031c6d2978109336637977c165f82aa49fa16a7) | `` syncthing: remove with lib ``                            |
| [`20fac9bb`](https://github.com/nix-community/home-manager/commit/20fac9bbdf22d697ad68faabb7f95d4deba4f712) | `` syncthing: use package options ``                        |
| [`22b418c1`](https://github.com/nix-community/home-manager/commit/22b418c13fb0be43f4bc5c185f323a3237028594) | `` bash: Make HISTFILESIZE and HISTSIZE nullable (#6443) `` |
| [`a70d7889`](https://github.com/nix-community/home-manager/commit/a70d788923061a00a488f60a01768ca4c6a8b727) | `` aerospace: fix workspace assignment config (#6442) ``    |