### PR TITLE
chore(flake/nixpkgs-stable): `44534bc0` -> `0ff09db9`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -437,11 +437,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1739206421,
-        "narHash": "sha256-PwQASeL2cGVmrtQYlrBur0U20Xy07uSWVnFup2PHnDs=",
+        "lastModified": 1739357830,
+        "narHash": "sha256-9xim3nJJUFbVbJCz48UP4fGRStVW5nv4VdbimbKxJ3I=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "44534bc021b85c8d78e465021e21f33b856e2540",
+        "rev": "0ff09db9d034a04acd4e8908820ba0b410d7a33a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                       |
| ---------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------- |
| [`0ff09db9`](https://github.com/NixOS/nixpkgs/commit/0ff09db9d034a04acd4e8908820ba0b410d7a33a) | `` koboldcpp: 1.82.4 -> 1.83.1 ``                                             |
| [`2a7fb045`](https://github.com/NixOS/nixpkgs/commit/2a7fb0458f08f0e89c4e94f3f15ba3881d3f0dab) | `` nodejs_22: 22.13.1 -> 22.14.0 ``                                           |
| [`c62934d2`](https://github.com/NixOS/nixpkgs/commit/c62934d283a3899a7069868e87b2a4cfd5054bec) | `` distribution: 3.0.0-rc.2 -> 3.0.0-rc.3 ``                                  |
| [`ceb4df44`](https://github.com/NixOS/nixpkgs/commit/ceb4df449ae2cf54431c8b1d9351f9f12a8c8cec) | `` distribution: 3.0.0-rc.1 -> 3.0.0-rc.2 ``                                  |
| [`7d83f668`](https://github.com/NixOS/nixpkgs/commit/7d83f668aee9e41d574c398a9bb569047e8a3f5d) | `` workflows/eval-lib-tests: Run on maintainer changes ``                     |
| [`c5fca56c`](https://github.com/NixOS/nixpkgs/commit/c5fca56c9064963bec9ad82396561049eed2cbd0) | `` sdl3: assert that wayland is built with opengl ``                          |
| [`46c2bcaa`](https://github.com/NixOS/nixpkgs/commit/46c2bcaa326541b29708b4c63308b2b1cfe8524d) | `` sdl3: fix building for static windows ``                                   |
| [`63a7ccbf`](https://github.com/NixOS/nixpkgs/commit/63a7ccbf4200e2e8c302bbf4ca07436e6c019d8e) | `` postgresqlPackages.pgrouting: 3.7.2 -> 3.7.3 ``                            |
| [`1be1b949`](https://github.com/NixOS/nixpkgs/commit/1be1b9498dbf847fa302898175601fa20efd5687) | `` postgresqlPackages.plpgsql_check: 2.7.13 -> 2.7.15 ``                      |
| [`866e7f45`](https://github.com/NixOS/nixpkgs/commit/866e7f45225c12e7a61063d317b20e200c63974a) | `` slskd: 0.22.1 -> 0.22.2 ``                                                 |
| [`c933532a`](https://github.com/NixOS/nixpkgs/commit/c933532ad6b53a79e60738b8faf9aa5ceecf8e85) | `` freeipa: add missing ifaddr dependency ``                                  |
| [`01fed98e`](https://github.com/NixOS/nixpkgs/commit/01fed98e751d35342a74dde632a6876f448fd45c) | `` sssd: build with python3.12 ``                                             |
| [`68f82cae`](https://github.com/NixOS/nixpkgs/commit/68f82cae32e296a4599cb4cde540174fa839c2b4) | `` wiki-js: 2.5.305 -> 2.5.306 ``                                             |
| [`5e7a00a9`](https://github.com/NixOS/nixpkgs/commit/5e7a00a9be16ade9857b60b8e50299b5d1a9583b) | `` keycloak: 26.1.1 -> 26.1.2 ``                                              |
| [`8a5b2d13`](https://github.com/NixOS/nixpkgs/commit/8a5b2d133ed0dbc0823d18d45cef9578db5a7d0a) | `` electron-chromedriver_34: 34.0.2 -> 34.1.1 ``                              |
| [`cf507578`](https://github.com/NixOS/nixpkgs/commit/cf507578ff4c4638426b39a240e33ceb4888ca68) | `` electron_34-bin: 34.0.2 -> 34.1.1 ``                                       |
| [`ae1a47b2`](https://github.com/NixOS/nixpkgs/commit/ae1a47b29cc6b3a443c4bdae68ce89977c439e15) | `` electron-chromedriver_33: 33.3.2 -> 33.4.0 ``                              |
| [`ddae4365`](https://github.com/NixOS/nixpkgs/commit/ddae43658d6e8502a96b41aa2a197d91fdf8e59c) | `` electron-source.electron_33: 33.3.2 -> 33.4.0 ``                           |
| [`614dcaf7`](https://github.com/NixOS/nixpkgs/commit/614dcaf7ba004051d6fd456708474b637b05b5da) | `` electron_33-bin: 33.3.2 -> 33.4.0 ``                                       |
| [`d3247e08`](https://github.com/NixOS/nixpkgs/commit/d3247e0878a90908c1fcbd377e5ee1cd6fdcac54) | `` electron-chromedriver_34: init at 34.0.2 ``                                |
| [`205ce824`](https://github.com/NixOS/nixpkgs/commit/205ce824cbf92c70b5f1da12a418188991274ad3) | `` electron_34-bin: init at 34.0.2 ``                                         |
| [`9c669fdb`](https://github.com/NixOS/nixpkgs/commit/9c669fdb218c1701e4bb88534a0cb789facbbd25) | `` kanidm_1_3,kanidm_1_4: useFetchCargoVendor ``                              |
| [`1298b2ee`](https://github.com/NixOS/nixpkgs/commit/1298b2eeb5c0983993bb23cb068d67afdf872f9a) | `` kanidm_1_5: init at 1.5.0 ``                                               |
| [`4abe0b88`](https://github.com/NixOS/nixpkgs/commit/4abe0b889cd387d0fb6a5cdc1e8a709e348f7216) | `` discord: add `startupWMClass` ``                                           |
| [`3b66bbd2`](https://github.com/NixOS/nixpkgs/commit/3b66bbd2cb9b68fa57fef9a1572f1ae78bea48f7) | `` google-chrome: 132.0.6834.110 -> 133.0.6943.53 ``                          |
| [`d153ac40`](https://github.com/NixOS/nixpkgs/commit/d153ac40af54f31b783d35fafc1cd21f63649847) | `` libvirt: fix shutdownTimeout not working, fix #171618 ``                   |
| [`1754095a`](https://github.com/NixOS/nixpkgs/commit/1754095a4b61507be48f8e11a33769e326474f5c) | `` refine: 0.4.2 -> 0.4.4 ``                                                  |
| [`39a28286`](https://github.com/NixOS/nixpkgs/commit/39a282864c9c2fe5ad71235ea06634d655ff0349) | `` warp: 0.8.0 -> 0.8.1 ``                                                    |
| [`d7bdd13d`](https://github.com/NixOS/nixpkgs/commit/d7bdd13dc39fde857737c81c292f16c2963bcb3b) | `` warp: move to pkgs/by-name ``                                              |
| [`f69962a0`](https://github.com/NixOS/nixpkgs/commit/f69962a0c4f1900c0e43724e780c5ddeee6d49ff) | `` warp: 0.7.0 -> 0.8.0 ``                                                    |
| [`dd805483`](https://github.com/NixOS/nixpkgs/commit/dd80548362f29d0fe790e8f0f3da00fea26b7ff9) | `` nginx: add fixed zlib-ng patch ``                                          |
| [`b1e90b4a`](https://github.com/NixOS/nixpkgs/commit/b1e90b4af7bd28152630ac1071b08d71c75103b7) | `` nginxStable: 1.26.2 -> 1.26.3 ``                                           |
| [`b6853a65`](https://github.com/NixOS/nixpkgs/commit/b6853a65dc8bcd3f5d3718a42308271d8dcd0927) | `` nginxMainline: 1.27.3 -> 1.27.4 ``                                         |
| [`6f537204`](https://github.com/NixOS/nixpkgs/commit/6f53720429b21e46094fa60b311a0edbe71bd0c0) | `` arc-browser: 1.79.0-57949 -> 1.79.1-58230 ``                               |
| [`633464ba`](https://github.com/NixOS/nixpkgs/commit/633464ba2f347d95eb2450838a37b7abd4fc02d3) | `` nixos/tests/vaultwarden: adapt to new webvault ``                          |
| [`7db01d25`](https://github.com/NixOS/nixpkgs/commit/7db01d256924846ede47a8f4763b83a17a7f5236) | `` vaultwarden: 1.33.1 -> 1.33.2 ``                                           |
| [`4400768b`](https://github.com/NixOS/nixpkgs/commit/4400768b949175d0088f9f7ce7414663d8fa12b7) | `` build(deps): bump actions/create-github-app-token from 1.11.1 to 1.11.3 `` |
| [`47d0c5a2`](https://github.com/NixOS/nixpkgs/commit/47d0c5a20cae9ce00da84b56d7008ae3868e7373) | `` palemoon-bin: 33.5.1 -> 33.6.0 ``                                          |
| [`2c3ee6d4`](https://github.com/NixOS/nixpkgs/commit/2c3ee6d4a0c323532c5e7368d101520c63b07839) | `` rustic: 0.9.4 -> 0.9.5 ``                                                  |
| [`dc34eae1`](https://github.com/NixOS/nixpkgs/commit/dc34eae150b1f4cc1b5dac063e1bb6f88142b545) | `` dovecot: build with textcat ``                                             |
| [`20a503bc`](https://github.com/NixOS/nixpkgs/commit/20a503bcf00ee09f58badc2fc88345369f849ab8) | `` dovecot-fts-flatcurve: init at 1.0.5 ``                                    |
| [`02123e89`](https://github.com/NixOS/nixpkgs/commit/02123e894a08076f9447bbb63f049bc1b92841e3) | `` nixos/tests/{sway,swayfx}: fix pgrep commands to match wrapped swaylock `` |
| [`cb6015ab`](https://github.com/NixOS/nixpkgs/commit/cb6015ab32833e8c9af903f897a13bd9fa912125) | `` swaylock,swaybg: fix svg support ``                                        |
| [`9358e8b9`](https://github.com/NixOS/nixpkgs/commit/9358e8b9ef1ae4ed7bc4dd27fda6c0c653c8cf5f) | `` swaylock,swaybg: nixfmt ``                                                 |
| [`df8a9c95`](https://github.com/NixOS/nixpkgs/commit/df8a9c95077965682a58aeae372de1b6d019bbe1) | `` nextcloud-notify_push.app: move out of automatically generated set ``      |
| [`161c401e`](https://github.com/NixOS/nixpkgs/commit/161c401ef5bd17cf0119403778b463f2e2724f91) | `` nextcloudApps: update ``                                                   |