### PR TITLE
chore(flake/zen-browser): `16e8b35d` -> `716b69d4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -689,11 +689,11 @@
         "nixpkgs": "nixpkgs_3"
       },
       "locked": {
-        "lastModified": 1739488634,
-        "narHash": "sha256-AKIMGmOq4l8uUVQSQhMfWvi7TZrmHxoes+VjI9273ME=",
+        "lastModified": 1739506857,
+        "narHash": "sha256-/Kz+iwElxPL7MQf8QGZsgWxvVvAPogdIXK4WJtyz6qk=",
         "owner": "0xc000022070",
         "repo": "zen-browser-flake",
-        "rev": "16e8b35d8618a1c047553ed770bb3f6cd6afe2ea",
+        "rev": "716b69d46754de48b0b85ba2e7198ffd4015b132",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                          | Message                                                                 |
| --------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------- |
| [`716b69d4`](https://github.com/0xc000022070/zen-browser-flake/commit/716b69d46754de48b0b85ba2e7198ffd4015b132) | `` Update Zen Browser twilight @ x86_64 && aarch64 to 1.7.7t#721e121 `` |