### PR TITLE
chore(flake/zen-browser): `716b69d4` -> `f055e58c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -689,11 +689,11 @@
         "nixpkgs": "nixpkgs_3"
       },
       "locked": {
-        "lastModified": 1739506857,
-        "narHash": "sha256-/Kz+iwElxPL7MQf8QGZsgWxvVvAPogdIXK4WJtyz6qk=",
+        "lastModified": 1739564326,
+        "narHash": "sha256-abeXrjoos+hlxA7/PsEVDgJGzGYkdJnJ0Qx0tmAiUzU=",
         "owner": "0xc000022070",
         "repo": "zen-browser-flake",
-        "rev": "716b69d46754de48b0b85ba2e7198ffd4015b132",
+        "rev": "f055e58cc3a2b49291b92520b9f86e2e9f15ea40",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                          | Message                                                                 |
| --------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------- |
| [`f055e58c`](https://github.com/0xc000022070/zen-browser-flake/commit/f055e58cc3a2b49291b92520b9f86e2e9f15ea40) | `` Update Zen Browser twilight @ x86_64 && aarch64 to 1.7.7t#786a377 `` |
| [`17ff1150`](https://github.com/0xc000022070/zen-browser-flake/commit/17ff1150dd9d356274823087d21130d76865635e) | `` Update Zen Browser twilight @ x86_64 && aarch64 to 1.7.7t#c27a26e `` |