### PR TITLE
chore(flake/nixpkgs-stable): `0ff09db9` -> `0b73e36b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -437,11 +437,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1739357830,
-        "narHash": "sha256-9xim3nJJUFbVbJCz48UP4fGRStVW5nv4VdbimbKxJ3I=",
+        "lastModified": 1739484910,
+        "narHash": "sha256-wjWLzdM7PIq4ZAe7k3vyjtgVJn6b0UeodtRFlM/6W5U=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "0ff09db9d034a04acd4e8908820ba0b410d7a33a",
+        "rev": "0b73e36b1962620a8ac551a37229dd8662dac5c8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                                                     |
| ---------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------- |
| [`6d8a5834`](https://github.com/NixOS/nixpkgs/commit/6d8a58341daa1fbad8b67117341956d0cb9101ca) | `` tig: 2.5.11 -> 2.5.12 ``                                                                                                 |
| [`95cda979`](https://github.com/NixOS/nixpkgs/commit/95cda979d66b91d3141008201ef9a2d0abcb3448) | `` adr-tools: init at 3.0.0 ``                                                                                              |
| [`595e25ed`](https://github.com/NixOS/nixpkgs/commit/595e25edf63b116e0d6125f558c3f66b83ff0fa7) | `` nm-file-secret-agent: v1.0.0 -> v1.0.1 ``                                                                                |
| [`16bde49d`](https://github.com/NixOS/nixpkgs/commit/16bde49d0e9f42e5a9220aab0f641aafcd5d00f5) | `` consul: 1.20.2 -> 1.20.3 ``                                                                                              |
| [`e281c173`](https://github.com/NixOS/nixpkgs/commit/e281c1735b055d0c7e8f5dde3783409c382a938b) | `` ltex-ls: set meta.mainProgram to "ltex-ls" ``                                                                            |
| [`f10012bc`](https://github.com/NixOS/nixpkgs/commit/f10012bc7d78ee69a41809cff31115fedb693987) | `` chromium,chromedriver: 133.0.6943.53 -> 133.0.6943.98 ``                                                                 |
| [`126befcd`](https://github.com/NixOS/nixpkgs/commit/126befcd25c7069c0b1171a46c9211a0f1673105) | `` linux_xanmod: remove shawn8901 as maintainer ``                                                                          |
| [`fd23b07a`](https://github.com/NixOS/nixpkgs/commit/fd23b07a61be8298fefd54cbf7c90228c1601143) | `` linux_xanmod, linux_xanmod_latest: 2025-02-08 updates ``                                                                 |
| [`021e7bd9`](https://github.com/NixOS/nixpkgs/commit/021e7bd983371216f54b3ebafef71dffced4b22e) | `` linux_xanmod_latest: 6.12.8 -> 6.12.9 ``                                                                                 |
| [`bcd6b320`](https://github.com/NixOS/nixpkgs/commit/bcd6b320af3a4e4f1fdedb6569205ab043438433) | `` linux_xanmod: 6.6.69 -> 6.6.70 ``                                                                                        |
| [`60d2d7ed`](https://github.com/NixOS/nixpkgs/commit/60d2d7ed0cf6a7fd451a2a55f62642f2a703f038) | `` nginxModules.zstd: 0.1.1 -> 2024-04-22 ``                                                                                |
| [`977f38b2`](https://github.com/NixOS/nixpkgs/commit/977f38b243b8df54dd97d09bf47a3272dbd5765b) | `` smartmontools: update drivedb rev 5388 -> 5661 ``                                                                        |
| [`f3a4bcf3`](https://github.com/NixOS/nixpkgs/commit/f3a4bcf34ef0f108f607d880074f1f542922f27b) | `` ci/eval/compare: Ignore null packages ``                                                                                 |
| [`7c4fead7`](https://github.com/NixOS/nixpkgs/commit/7c4fead7aff0f53e70f8c6b3fb4a26aa2b006962) | `` librewolf-bin: 134.0.1-1 -> 135.0-1 ``                                                                                   |
| [`ed705122`](https://github.com/NixOS/nixpkgs/commit/ed7051226faca608f7788acf09761b4708601d4d) | `` librewolf-bin:  134.0.0-1 -> 134.0.1-1 ``                                                                                |
| [`367a9377`](https://github.com/NixOS/nixpkgs/commit/367a9377bd97abfdd48b25ca135ce760ebd9d556) | `` linux-firmware: 20250109 -> 20250211 ``                                                                                  |
| [`3ed84db1`](https://github.com/NixOS/nixpkgs/commit/3ed84db1d45225965b3a8e5e576ebe8d61369770) | `` nixos/gotosocial: fix failing tests ``                                                                                   |
| [`44b4ddaf`](https://github.com/NixOS/nixpkgs/commit/44b4ddaf4942fba8f2ac4e42552bd0645018b4b6) | `` gotosocial: 0.17.3 -> 0.17.4 ``                                                                                          |
| [`0c989d81`](https://github.com/NixOS/nixpkgs/commit/0c989d8113a50b0b9530e0c2d38c551f85e98244) | `` krunker: init at 2.1.3 ``                                                                                                |
| [`5dcbeb65`](https://github.com/NixOS/nixpkgs/commit/5dcbeb651e0ea1616e1de5e3dbaba0c21edb8c9c) | `` crowdsec: Set tag version as expected by upstream ``                                                                     |
| [`7b0d43a9`](https://github.com/NixOS/nixpkgs/commit/7b0d43a9b19534a2927840f435e067e7996548fb) | `` crowdsec: Correctly add upstream systemd service to outputs ``                                                           |
| [`cdcf5bfe`](https://github.com/NixOS/nixpkgs/commit/cdcf5bfeededa2ad91ea39cafdd9f2adaaeb9209) | `` wivrn: 0.22 -> 0.23 ``                                                                                                   |
| [`4ec17dec`](https://github.com/NixOS/nixpkgs/commit/4ec17dec7bbcf0d04d2f4365bc9831953cdf00f1) | `` microcode-intel: 20241112 -> 20250211 ``                                                                                 |
| [`df9183ed`](https://github.com/NixOS/nixpkgs/commit/df9183ed7c767449140aa50dba250b10416bb578) | `` firefly-iii: 6.2.4 -> 6.2.5 ``                                                                                           |
| [`ac568c8d`](https://github.com/NixOS/nixpkgs/commit/ac568c8daf7906cf5ea27ec86dc8e78ac37b44ed) | `` xwayland-satellite: 0.5 -> 0.5.1 ``                                                                                      |
| [`9be17684`](https://github.com/NixOS/nixpkgs/commit/9be1768420ffea6fe66dd9e428789aef3ac73323) | `` nixos/tests/systemd-journal: test audit behaviour ``                                                                     |
| [`defd7d02`](https://github.com/NixOS/nixpkgs/commit/defd7d025579b0193aa053e6494fa5a49b3b51c0) | `` services/journald: introduce audit option ``                                                                             |
| [`ed1f15c7`](https://github.com/NixOS/nixpkgs/commit/ed1f15c747111e55aaca15d9ec6ef39bfbce8b7e) | `` services/journald: re-enable systemd-journald-audit.socket ``                                                            |
| [`ed2acaeb`](https://github.com/NixOS/nixpkgs/commit/ed2acaebd66df3734f1e23442583298f1c51283a) | `` matrix-synapse: 1.123.0 -> 1.124.0 ``                                                                                    |
| [`88793720`](https://github.com/NixOS/nixpkgs/commit/887937206d9a1445185d7ca1e6d43d938ede5239) | `` pythonPackages.django-ckeditor: Add known vulnerability description following its formal deprecation in Feburary 2024 `` |