### PR TITLE
chore(flake/zen-browser): `66976a3e` -> `8c7f6ca4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -689,11 +689,11 @@
         "nixpkgs": "nixpkgs_3"
       },
       "locked": {
-        "lastModified": 1739582274,
-        "narHash": "sha256-qDVcTrCMixPzxb9rzgTXkHaF9jxz6ptmGbuzO6RhAhc=",
+        "lastModified": 1739667343,
+        "narHash": "sha256-fNEz+Yd0t9jXz27qKRMAEBradTwYBeBLOECx+ydG25s=",
         "owner": "0xc000022070",
         "repo": "zen-browser-flake",
-        "rev": "66976a3e4a8ee9bf29f89c81b48b4f4126c619e3",
+        "rev": "8c7f6ca49f87b4e114f775a4dad956ceb6df4220",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                          | Message                                                                                 |
| --------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------- |
| [`8c7f6ca4`](https://github.com/0xc000022070/zen-browser-flake/commit/8c7f6ca49f87b4e114f775a4dad956ceb6df4220) | `` chore(sources): removed entry for resilient variant ``                               |
| [`eb5d0b09`](https://github.com/0xc000022070/zen-browser-flake/commit/eb5d0b0982dd825168cde88698e1c260162a4944) | `` readme: explained the new default twilight and twilight-official packages ``         |
| [`5304f5ba`](https://github.com/0xc000022070/zen-browser-flake/commit/5304f5ba5f709b17988a7bc6bc7797b793cc3cf9) | `` Update Zen Browser twilight @ x86_64 && aarch64 to 1.7.7t#8813c51 ``                 |
| [`eb0c54f3`](https://github.com/0xc000022070/zen-browser-flake/commit/eb0c54f3b8e41b2a7a4d2c43c79652fcdac62d5b) | `` revert: "Update Zen Browser twilight @ x86_64 && aarch64 to 1.7.7t#8813c51" ``       |
| [`dd6ba8e7`](https://github.com/0xc000022070/zen-browser-flake/commit/dd6ba8e7920703ec3511f8df5b4fc08c8d5b9b53) | `` feat: variant version will be the default version + official variant ``              |
| [`6997a72c`](https://github.com/0xc000022070/zen-browser-flake/commit/6997a72c8a21337823cab9a01869b46f1dd48ea6) | `` Update Zen Browser twilight @ x86_64 && aarch64 to 1.7.7t#8813c51 ``                 |
| [`8e7e516d`](https://github.com/0xc000022070/zen-browser-flake/commit/8e7e516d8aa349c06550010584a64f50ffb67a94) | `` revert: "Update Zen Browser twilight @ x86_64 && aarch64 to 1.7.7t#8813c51" ``       |
| [`23dd63e6`](https://github.com/0xc000022070/zen-browser-flake/commit/23dd63e6ae9a44767f9cfb122359936a3bf41c41) | `` fix(github/update): aarch64 artifacts for resilient are referenced in source file `` |