### PR TITLE
chore(flake/nixpkgs-stable): `0b73e36b` -> `a60651b2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -437,11 +437,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1739484910,
-        "narHash": "sha256-wjWLzdM7PIq4ZAe7k3vyjtgVJn6b0UeodtRFlM/6W5U=",
+        "lastModified": 1739624908,
+        "narHash": "sha256-f84lBmLl4tkDp1ZU5LBTSFzlxXP4926DVW3KnXrke10=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "0b73e36b1962620a8ac551a37229dd8662dac5c8",
+        "rev": "a60651b217d2e529729cbc7d989c19f3941b9250",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                            |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------ |
| [`ff12c3a1`](https://github.com/NixOS/nixpkgs/commit/ff12c3a1cfcaacb4188d282736bbec546112a92f) | `` xonsh: 0.19.1 -> 0.19.2 ``                                      |
| [`aa666413`](https://github.com/NixOS/nixpkgs/commit/aa6664130f4838c61b6455adb36dc66c3f1c5da3) | `` xonsh: use `addBinToPathHook` ``                                |
| [`25cf9dc3`](https://github.com/NixOS/nixpkgs/commit/25cf9dc376397f5cf5ae5394e94d1c338bd4c846) | `` komikku: 1.69.0 -> 1.70.0 ``                                    |
| [`9f1f611a`](https://github.com/NixOS/nixpkgs/commit/9f1f611a798f4c5010cedff397aebdf1c5e43eef) | `` telegram-desktop: 5.10.7 -> 5.11.1 ``                           |
| [`dccd2b76`](https://github.com/NixOS/nixpkgs/commit/dccd2b762c18fa071962c6be39be0dad4a7ee75f) | `` ci/eval: Fail on non-empty stderr ``                            |
| [`1199390d`](https://github.com/NixOS/nixpkgs/commit/1199390daa66d227b2cd50793b00c5638e8b2384) | `` ci/eval: Refactor to cleanly separate stderr ``                 |
| [`83c11396`](https://github.com/NixOS/nixpkgs/commit/83c11396267503eb3ae26e289baa0afd6de78218) | `` ci/eval: make eval for non-native platforms less incorrect ``   |
| [`eacfb012`](https://github.com/NixOS/nixpkgs/commit/eacfb0124f928b6ddde6aa9124ae28ab7fda0063) | `` signal-desktop(darwin): 7.41.0 -> 7.42.0 ``                     |
| [`e645590e`](https://github.com/NixOS/nixpkgs/commit/e645590ee580d664704f9d2ef8fe5f59f705549b) | `` signal-desktop: 7.41.0 -> 7.42.0 ``                             |
| [`0272f39c`](https://github.com/NixOS/nixpkgs/commit/0272f39c2709397fb2cedb6380be3cf0bfbd8115) | `` passes: 0.9 -> 0.10 ``                                          |
| [`4eea18b2`](https://github.com/NixOS/nixpkgs/commit/4eea18b2165eb1cf9c2c4db3f5ecded86fbdd083) | `` haskellPackages.mkDerivation: optionally support testTargets `` |
| [`3fa60ce7`](https://github.com/NixOS/nixpkgs/commit/3fa60ce7a62e1680b76b7a7ebe121dce6d89fd5e) | `` npth.meta.mainProgram: remove non-existent ``                   |
| [`b4f44532`](https://github.com/NixOS/nixpkgs/commit/b4f4453215503bfa6298f383b2030fa16fbfaf15) | `` audacity: use xwayland on wayland by default ``                 |
| [`79399e60`](https://github.com/NixOS/nixpkgs/commit/79399e607975e838cab8b47053b24b080c78c378) | `` nextcloud30Packages.apps: update ``                             |
| [`f488ecae`](https://github.com/NixOS/nixpkgs/commit/f488ecae54fdf178b05ec69494353d4ff98ef6b8) | `` nextcloud29Packages.apps: update ``                             |
| [`f85846aa`](https://github.com/NixOS/nixpkgs/commit/f85846aa395a0de2fc2749cc870891d80e7281f3) | `` nextcloud30: 30.0.5 -> 30.0.6 ``                                |
| [`547b2457`](https://github.com/NixOS/nixpkgs/commit/547b2457e90969ce5abda995ba0dfc9c88345dfb) | `` nextcloud29: 29.0.11 -> 29.0.12 ``                              |
| [`4358f04c`](https://github.com/NixOS/nixpkgs/commit/4358f04c2e72405db13ce8c7ef686a746cf4f82e) | `` google-chrome: 133.0.6943.53 -> 133.0.6943.98 ``                |
| [`f9e8aafe`](https://github.com/NixOS/nixpkgs/commit/f9e8aafeb98614cb4a5297360ec03232248905ee) | `` nixos/glpi-agent: fix missing directory ``                      |
| [`5017bc5b`](https://github.com/NixOS/nixpkgs/commit/5017bc5bb4c85a10cdbcf6b400888568421bde7f) | `` nix//.version: Drop newline ``                                  |
| [`cb4ab655`](https://github.com/NixOS/nixpkgs/commit/cb4ab6555913d96d6c7d140cb3f4f1540652aa94) | `` nixVersions.nix_2_26: Use default boost package ``              |
| [`e51d53eb`](https://github.com/NixOS/nixpkgs/commit/e51d53ebe7c59ac412e8b7676ba25aedf3f65dac) | `` nixVersions.nix_2_26: 2.26.0 -> 2.26.1 ``                       |
| [`2da58580`](https://github.com/NixOS/nixpkgs/commit/2da58580b923a1d7578a354ab39f618f8b7a4feb) | `` Format ``                                                       |
| [`617ada41`](https://github.com/NixOS/nixpkgs/commit/617ada413a83ca4fb3644c714ed5d9af0275842a) | `` nix_2_26: Fix dev output shim ``                                |
| [`b7855b1a`](https://github.com/NixOS/nixpkgs/commit/b7855b1a0af1d242b6de83d78761cfb887c2a34c) | `` refactor: Extract pkgs/.../nix/tests.nix ``                     |
| [`a0907f88`](https://github.com/NixOS/nixpkgs/commit/a0907f88edb93e8ec7024a72545e5903cae520b1) | `` Format ``                                                       |
| [`f4d8e532`](https://github.com/NixOS/nixpkgs/commit/f4d8e532b799767c206746387b219a46352a9834) | `` nixVersions.nix_2_26: init ``                                   |
| [`e2b445fd`](https://github.com/NixOS/nixpkgs/commit/e2b445fd76b7260f0d8cdaafec503c2a01e6db73) | `` nix/2_26: Add files ``                                          |
| [`e6cf1e2b`](https://github.com/NixOS/nixpkgs/commit/e6cf1e2b88e954ef23ef7b310708c5924c1726d3) | `` ungoogled-chromium: 133.0.6943.53-1 -> 133.0.6943.98-1 ``       |
| [`683eecb0`](https://github.com/NixOS/nixpkgs/commit/683eecb06ae04b8be331c51c23855657a4bc981a) | `` gitlab: 17.8.1 -> 17.8.2 ``                                     |
| [`19dda21f`](https://github.com/NixOS/nixpkgs/commit/19dda21fd28e2bf3e83a3243a7181dfe1407f7b6) | `` simple-scan: install missing icons ``                           |
| [`3d8a894a`](https://github.com/NixOS/nixpkgs/commit/3d8a894a68d4a20bd3a9ac30ec6a3cad2dbc9520) | `` webkitgtk: 2.46.5 → 2.46.6 ``                                   |