### PR TITLE
chore(flake/home-manager): `25870c66` -> `c1ea92cd`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -339,11 +339,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1739753809,
-        "narHash": "sha256-i7NDuQFk+GcT0p08uAk+qJGEXu2A108K+Vlc5sd2eSc=",
+        "lastModified": 1739790043,
+        "narHash": "sha256-4gK4zdNDQ4PyGFs7B6zp9iPIBy9E+bVJiZ0XAmncvgQ=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "25870c6600660c93c5aa10f0f328a5eecd60150b",
+        "rev": "c1ea92cdfb85bd7b0995b550581d9fd1c3370bf9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                     |
| ----------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------- |
| [`c1ea92cd`](https://github.com/nix-community/home-manager/commit/c1ea92cdfb85bd7b0995b550581d9fd1c3370bf9) | `` nh: change flake option type to singleLineStr (#6468) `` |
| [`5c5697b8`](https://github.com/nix-community/home-manager/commit/5c5697b82a8a34f9ce39dd18690c6ef623565fc4) | `` git: support not configuring signing.format (#6478) ``   |
| [`30b9cd6f`](https://github.com/nix-community/home-manager/commit/30b9cd6f1a69921e59e71df1214604be62636284) | `` mpv: drop old wrapMpv compatibility (#6024) ``           |
| [`662fa98b`](https://github.com/nix-community/home-manager/commit/662fa98bf488daa82ce8dc2bc443872952065ab9) | `` nixpkgs-disabled: warn instead of assert (#6466) ``      |