### PR TITLE
chore(flake/home-manager): `c1ea92cd` -> `6c93eea8`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -339,11 +339,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1739790043,
-        "narHash": "sha256-4gK4zdNDQ4PyGFs7B6zp9iPIBy9E+bVJiZ0XAmncvgQ=",
+        "lastModified": 1739823458,
+        "narHash": "sha256-uHjpcdlWKrZEJxsGdlMRTe4jlMYAnNsjRxPSTrNMFvo=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "c1ea92cdfb85bd7b0995b550581d9fd1c3370bf9",
+        "rev": "6c93eea85daddd0dc8d4a3a687473461f3122961",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                      |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------ |
| [`6c93eea8`](https://github.com/nix-community/home-manager/commit/6c93eea85daddd0dc8d4a3a687473461f3122961) | `` firefox: add HPSaucii maintainer ``                       |
| [`27ffa351`](https://github.com/nix-community/home-manager/commit/27ffa35178bc6f359293a8809d32c5da23aaabc7) | `` firefox: add support for configuring extensions ``        |
| [`3a0cf8f1`](https://github.com/nix-community/home-manager/commit/3a0cf8f1aae507ec9bb8c141369458ca0244a01b) | `` maintainers: add HPsaucii ``                              |
| [`edad23eb`](https://github.com/nix-community/home-manager/commit/edad23ebc1bcc226ef5eb57c8d779b9b425adca1) | `` mako: add max-history option (#6009) ``                   |
| [`f4f6dd26`](https://github.com/nix-community/home-manager/commit/f4f6dd26985f1e44721325cb6d783d0cf4cd4dbc) | `` git: fix setting format on >=25.05 (#6480) ``             |
| [`9d0d48f4`](https://github.com/nix-community/home-manager/commit/9d0d48f4c3d2fb1a8c8607da143bb567a741d914) | ``  nh: fixes and addition to warnings/assertions (#6470) `` |