### PR TITLE
chore(flake/stylix): `e86de61b` -> `7feb1c29`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -151,11 +151,11 @@
     "firefox-gnome-theme": {
       "flake": false,
       "locked": {
-        "lastModified": 1736899990,
-        "narHash": "sha256-S79Hqn2EtSxU4kp99t8tRschSifWD4p/51++0xNWUxw=",
+        "lastModified": 1739223196,
+        "narHash": "sha256-vAxN2f3rvl5q62gQQjZGVSvF93nAsOxntuFz+e/655w=",
         "owner": "rafaelmardojai",
         "repo": "firefox-gnome-theme",
-        "rev": "91ca1f82d717b02ceb03a3f423cbe8082ebbb26d",
+        "rev": "a89108e6272426f4eddd93ba17d0ea101c34fb21",
         "type": "github"
       },
       "original": {
@@ -559,11 +559,11 @@
         "tinted-zed": "tinted-zed"
       },
       "locked": {
-        "lastModified": 1739375014,
-        "narHash": "sha256-0fNbvZ1Dod4rDIfwGnC7CzJ3wRFSF1v5AvNCmNkVgXo=",
+        "lastModified": 1739826051,
+        "narHash": "sha256-q1E9/4Hyahz/+Bd6HEKZq+Wi9HpI4XmAZG3P8CALT1E=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "e86de61bb8f5f2b6459d0be3e3291ad16db4b777",
+        "rev": "7feb1c29bf39ebe6b2984b2f77f9ad38f486e311",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                        | Message                                                                      |
| --------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------- |
| [`7feb1c29`](https://github.com/danth/stylix/commit/7feb1c29bf39ebe6b2984b2f77f9ad38f486e311) | `` discord: combine nixcord, vencord, and vesktop modules (#854) ``          |
| [`21d68dab`](https://github.com/danth/stylix/commit/21d68dab9dff35d88125f9ddd7d11477a628d071) | `` firefox: update GNOME theme input (#871) ``                               |
| [`ba560ec1`](https://github.com/danth/stylix/commit/ba560ec19c78ce954f846f16fb9d5556d14a5c2a) | `` stylix: prevent silently overriding testbeds with the same name (#861) `` |
| [`211a8440`](https://github.com/danth/stylix/commit/211a8440e7ebcbae5fa272d95612a4c1732d8bc4) | `` stylix: support multiple testbeds per module (#858) ``                    |