### PR TITLE
chore(flake/nixpkgs): `8bb37161` -> `d74a2335`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -453,11 +453,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1739580444,
-        "narHash": "sha256-+/bSz4EAVbqz8/HsIGLroF8aNaO8bLRL7WfACN+24g4=",
+        "lastModified": 1739736696,
+        "narHash": "sha256-zON2GNBkzsIyALlOCFiEBcIjI4w38GYOb+P+R4S8Jsw=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "8bb37161a0488b89830168b81c48aed11569cb93",
+        "rev": "d74a2335ac9c133d6bbec9fc98d91a77f1604c1f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                 |
| ---------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------- |
| [`47f92261`](https://github.com/NixOS/nixpkgs/commit/47f92261d9e0e6bdad2637dd3ac26c8bf4ae27d2) | `` qmk: 1.1.5 -> 1.1.6 ``                                                               |
| [`0aa19db9`](https://github.com/NixOS/nixpkgs/commit/0aa19db96829f4d00fb0399c2a83d6acaff4b54b) | `` nodePackages: fix eval ``                                                            |
| [`7f931c6d`](https://github.com/NixOS/nixpkgs/commit/7f931c6d1f9a482a8fe93aa402e8f570f6a314a5) | `` luaPackages.fzf-lua: add tests ``                                                    |
| [`992464cb`](https://github.com/NixOS/nixpkgs/commit/992464cb61903d0c3f63fe434af5c408c1cedbd5) | `` python312Packages.phonopy: 2.34.1 -> 2.37.0 ``                                       |
| [`f5615c1e`](https://github.com/NixOS/nixpkgs/commit/f5615c1eb0c292836c211eeed56f4952dd6f35d0) | `` python312Packages.symfc: init at 1.0.1 ``                                            |
| [`c263be1d`](https://github.com/NixOS/nixpkgs/commit/c263be1dee447ea1e60605dcfd023f6587fe11b6) | `` nixos/prometheus: add missing dns_sd_configs types ``                                |
| [`34f95a47`](https://github.com/NixOS/nixpkgs/commit/34f95a47f44e8110a204a475593437be4337d221) | `` python312Packages.docling-core: 2.17.2 -> 2.18.1 ``                                  |
| [`5b2a6ebe`](https://github.com/NixOS/nixpkgs/commit/5b2a6ebed19546dbf25aea6512f1071cf056dac9) | `` minio-client: 2025-01-17T23-25-50Z -> 2025-02-08T19-14-21Z ``                        |
| [`33df3499`](https://github.com/NixOS/nixpkgs/commit/33df34994e250f8aad5e4c0be9b5560f2d46f366) | `` flatpak: remove gtk-doc build input ``                                               |
| [`057dd407`](https://github.com/NixOS/nixpkgs/commit/057dd40779eed66d79abb31c21a795f1faa8c471) | `` flatpak: fix cross ``                                                                |
| [`a7459efb`](https://github.com/NixOS/nixpkgs/commit/a7459efbbb0f21128f74431d1aec79ba75a72ecb) | `` flatpak: fix building with with{DocbookDocs,GtkDoc} = false ``                       |
| [`554ca40f`](https://github.com/NixOS/nixpkgs/commit/554ca40fdb1b52afcb2fab0308a2023d0b12eeb8) | `` flatpak: fix building with withMan = false ``                                        |
| [`0aedf7e2`](https://github.com/NixOS/nixpkgs/commit/0aedf7e299aa543b9d86cd962f8bed790507ac9e) | `` e-imzo: init at 4.64 ``                                                              |
| [`ba9416df`](https://github.com/NixOS/nixpkgs/commit/ba9416dfe8e7a345ca398b344b31c0b877fd9c77) | `` magma: mark dynamic build of cuda broken ``                                          |
| [`e1fd1bff`](https://github.com/NixOS/nixpkgs/commit/e1fd1bff19e51856918280175eb05aedecfc0f19) | `` sigtop: from 0.12.0 → to 0.18.0 ``                                                   |
| [`dad407f4`](https://github.com/NixOS/nixpkgs/commit/dad407f42f502609c8f2c792ec7846fea09e3a3b) | `` python312Packages.docling-parse: 3.3.0 -> 3.3.1 ``                                   |
| [`d6e2920b`](https://github.com/NixOS/nixpkgs/commit/d6e2920b73cb5662d66c4c0e66db3411bf423465) | `` python312Packages.napari-svg: 0.1.10 -> 0.2.1 ``                                     |
| [`aaf1eed9`](https://github.com/NixOS/nixpkgs/commit/aaf1eed950fdb4008cc173a987786810b89f16b5) | `` python312Packages.napari: 0.5.5 -> 0.5.6 ``                                          |
| [`8fb03d91`](https://github.com/NixOS/nixpkgs/commit/8fb03d916b0ca1f8db534a416614c48da305c482) | `` python312Packages.napari-console: 0.0.9 -> 0.1.3 ``                                  |
| [`92ff8c3e`](https://github.com/NixOS/nixpkgs/commit/92ff8c3ec74eb805fdedcc7b9240dc22b9c5873a) | `` typstyle: 0.12.14 -> 0.12.15 ``                                                      |
| [`92ea9147`](https://github.com/NixOS/nixpkgs/commit/92ea9147823b3402b75076b87b731c9d7f6869cb) | `` nixos/zigbee2mqtt: set StateDirectory ``                                             |
| [`1da41509`](https://github.com/NixOS/nixpkgs/commit/1da41509fe740208f246a46ffb42b2b506f33eb1) | `` clorinde: 0.11.4 -> 0.12.0 ``                                                        |
| [`594efeee`](https://github.com/NixOS/nixpkgs/commit/594efeee2c0752cc18b36e43866cc139473cab96) | `` koto-ls: init at 0.15.0 ``                                                           |
| [`30b0f070`](https://github.com/NixOS/nixpkgs/commit/30b0f070cd20ce49293f87b9037e48ed55dc5388) | `` libretro.vice-x128: 0-unstable-2025-01-28 -> 0-unstable-2025-02-07 ``                |
| [`cae84c87`](https://github.com/NixOS/nixpkgs/commit/cae84c874841e04ae0648a056f302952ada9a8fb) | `` harlequin: fix build on aarch64-linux ``                                             |
| [`88c2343c`](https://github.com/NixOS/nixpkgs/commit/88c2343c7915440956045aab7d36702024b484f8) | `` mpris-notifier: 0.1.10 -> 0.2.0 ``                                                   |
| [`0e815f7e`](https://github.com/NixOS/nixpkgs/commit/0e815f7e8be476af45a864be490c697276bfacc1) | `` live-server: 0.9.1 -> 0.10.0 ``                                                      |
| [`c019ccc8`](https://github.com/NixOS/nixpkgs/commit/c019ccc81c3c9a601f2122987de938477fd69845) | `` python3Packages.spacy: remove debug code ``                                          |
| [`b721552b`](https://github.com/NixOS/nixpkgs/commit/b721552b22b8631f5a331939ff4d97e3038b8aa0) | `` nodePackages: update package set ``                                                  |
| [`e99dc412`](https://github.com/NixOS/nixpkgs/commit/e99dc4128d23c6cfe8d86e8dc4ea1f6edfbcff0a) | `` nodePackages: migrate to nodejs_22 ``                                                |
| [`4fc8078a`](https://github.com/NixOS/nixpkgs/commit/4fc8078a260b7233a35928934d3d8e86468952fe) | `` hishtory: 0.328 -> 0.335 ``                                                          |
| [`776868ce`](https://github.com/NixOS/nixpkgs/commit/776868ce712918511e17fe26abcf2a5254a4a3f9) | `` nodePackages.graphql*: drop ``                                                       |
| [`9baf01ed`](https://github.com/NixOS/nixpkgs/commit/9baf01ed4949e8c6bf78b1c05bfd42e85d25bdf2) | `` pyotherside: 1.6.1 -> 1.6.2 ``                                                       |
| [`f54a0b27`](https://github.com/NixOS/nixpkgs/commit/f54a0b27b1247f080a0e84773df6501f2b6b3ec0) | `` zizmor: 1.3.0 -> 1.3.1 ``                                                            |
| [`0b31f1df`](https://github.com/NixOS/nixpkgs/commit/0b31f1df1cd1b60de4e50892b8b3e0794df8365f) | `` python312Packages.plotpy: 2.7.1 -> 2.7.2 ``                                          |
| [`b3703a08`](https://github.com/NixOS/nixpkgs/commit/b3703a081e28c8ced5661d6cf0ef1870503f852e) | `` python312Packages.cohere: 5.13.11 -> 5.13.12 ``                                      |
| [`d296d542`](https://github.com/NixOS/nixpkgs/commit/d296d54294e796473ef4650a8147429bf6ddb437) | `` vimPlugins: return deleted plugins ``                                                |
| [`e6e9979f`](https://github.com/NixOS/nixpkgs/commit/e6e9979f2c1adbe729bf6e034cdad2e24aab7fb5) | `` vimPlugins.nvim-treesitter: update grammars ``                                       |
| [`521f819b`](https://github.com/NixOS/nixpkgs/commit/521f819b0c1024b35d49a47aa0241d5604ff1959) | `` hugo: 0.143.0 -> 0.143.1 ``                                                          |
| [`bd4149c9`](https://github.com/NixOS/nixpkgs/commit/bd4149c9c62857a482b667b68dea3e6bff5827df) | `` chezmoi: 2.59.0 -> 2.59.1 ``                                                         |
| [`bb64412d`](https://github.com/NixOS/nixpkgs/commit/bb64412de73922f18b1ee191332bb43b9bb204ad) | `` python312Packages.sagemaker: 2.239.0 -> 2.239.1 ``                                   |
| [`47fc29ee`](https://github.com/NixOS/nixpkgs/commit/47fc29eec96ce20f88a134a9ee2df86de0f79ee2) | `` python312Packages.sagemaker-core: 1.0.19 -> 1.0.22 ``                                |
| [`2496369a`](https://github.com/NixOS/nixpkgs/commit/2496369a9d1f68dc232ed08622dae292447c7389) | `` vimPlugins: update on 2025-02-15 ``                                                  |
| [`05ae7c63`](https://github.com/NixOS/nixpkgs/commit/05ae7c632313ccb3008011269112b281f1510068) | `` vimPlugins.feline-nvim: remove ``                                                    |
| [`a59d3b79`](https://github.com/NixOS/nixpkgs/commit/a59d3b7934d7a56a3c7190481040700582c4f599) | `` tana: 1.0.23 -> 1.0.24 ``                                                            |
| [`052b285f`](https://github.com/NixOS/nixpkgs/commit/052b285f4201a9253fc6e56c9c9e73c1ce5fcefa) | `` parrot: 1.6.0-unstable-2024-02-28 -> 1.6.0-unstable-2024-07-12 ``                    |
| [`c1e1cbce`](https://github.com/NixOS/nixpkgs/commit/c1e1cbce963eeeffd85543872865ecd20fff5e16) | `` tectonic-unwrapped: no with lib; in meta ``                                          |
| [`b9f83c70`](https://github.com/NixOS/nixpkgs/commit/b9f83c704711dc3bb8dc2cb09cbdf80db06d9e04) | `` tectonic-unwrapped: move to pkgs/by-name ``                                          |
| [`1d4d82c1`](https://github.com/NixOS/nixpkgs/commit/1d4d82c19bdfb56d5815e958faaae682d273332b) | `` biber-for-tectonic: move to pkgs/by-name ``                                          |
| [`fcf20b1b`](https://github.com/NixOS/nixpkgs/commit/fcf20b1bd0180faee89b24b6853fb663702c9a6d) | `` tectonic: move to pkgs/by-name ``                                                    |
| [`1585820c`](https://github.com/NixOS/nixpkgs/commit/1585820c20b38ab5157673984063f58ad3dcc4d1) | `` pax-britannica: init at 1.0.0-5 ``                                                   |
| [`94b03910`](https://github.com/NixOS/nixpkgs/commit/94b03910fdd4fe9c951cad5cb34cd34dab7b76c9) | `` obs-do: 0.1.6 -> 0.1.7 ``                                                            |
| [`5cdadd71`](https://github.com/NixOS/nixpkgs/commit/5cdadd71f48d28361b9c0330dfbc445b8e1689bb) | `` ghciwatch: 1.0.2 -> 1.1.3 ``                                                         |
| [`82b26280`](https://github.com/NixOS/nixpkgs/commit/82b26280e3f2b931bfe8fa01c5adda20ba494ac1) | `` writeShellApplication: optionally do not inherit PATH ``                             |
| [`cdd4bc0b`](https://github.com/NixOS/nixpkgs/commit/cdd4bc0b5f3a4d5b5b41bbae84dfa0830b03d1f0) | `` mdbook: move to pkgs/by-name ``                                                      |
| [`34b10cb2`](https://github.com/NixOS/nixpkgs/commit/34b10cb2d3e0097a4dda2696fbe0dc10b33fb227) | `` python312Packages.sagemaker: 2.239.0 -> 2.239.1 ``                                   |
| [`5c4a1fb7`](https://github.com/NixOS/nixpkgs/commit/5c4a1fb7fd488f17839044e6863f232eb40d4d8c) | `` emacsPackages.el-easydraw: 1.2.0-unstable-2025-02-01 -> 1.2.0-unstable-2025-02-15 `` |
| [`8f31d533`](https://github.com/NixOS/nixpkgs/commit/8f31d5335e3ae6c4bbc181aa8cfdd8a0ae7dbdfd) | `` stp: 2.3.3 -> 2.3.4 ``                                                               |
| [`bdc92bf1`](https://github.com/NixOS/nixpkgs/commit/bdc92bf1fa2650cd59a507d2d8fd90341d98e697) | `` dart-sass: 1.83.4 -> 1.85.0 ``                                                       |
| [`6cae0d6e`](https://github.com/NixOS/nixpkgs/commit/6cae0d6e407e95ce79871065518406eb8a491418) | `` kubelogin-oidc: 1.31.1 -> 1.32.2 ``                                                  |
| [`c406b124`](https://github.com/NixOS/nixpkgs/commit/c406b1243525f53ef6d0bb21d9a39c4dac783ff9) | `` aws-lambda-rie: 1.20 -> 1.23 ``                                                      |
| [`b2e6b300`](https://github.com/NixOS/nixpkgs/commit/b2e6b3009a3d952826d37c5167743f8c5833111d) | `` python312Packages.llama-index: 0.12.15 -> 0.12.17.post2 ``                           |
| [`59c5ee22`](https://github.com/NixOS/nixpkgs/commit/59c5ee2297906c4792c736f2d32418deb0382af0) | `` stern: 1.31.0 -> 1.32.0 ``                                                           |
| [`2d1e5d93`](https://github.com/NixOS/nixpkgs/commit/2d1e5d93c8b9a40705a58d89b2b3bf688d4c2dfd) | `` deck: 1.43.1 -> 1.44.1 ``                                                            |
| [`a056a3a9`](https://github.com/NixOS/nixpkgs/commit/a056a3a9e86f95d4fea71af722875b2bf4a42dec) | `` terramate: 0.11.8 -> 0.11.9 ``                                                       |
| [`10075fb3`](https://github.com/NixOS/nixpkgs/commit/10075fb30308470d70ee24c0a7861a74d470efe1) | `` terraform-providers.datadog: 3.53.0 -> 3.54.0 ``                                     |
| [`69e74e27`](https://github.com/NixOS/nixpkgs/commit/69e74e271d53f754e097ec3ea240fcaf74ea0f6d) | `` terraform-providers.opentelekomcloud: 1.36.30 -> 1.36.31 ``                          |
| [`810597aa`](https://github.com/NixOS/nixpkgs/commit/810597aa59d2d59ea78e10d98a034c0886915ba5) | `` terraform-providers.migadu: 2025.1.23 -> 2025.2.13 ``                                |
| [`7e0ee50b`](https://github.com/NixOS/nixpkgs/commit/7e0ee50b29b8a2c3f14e9fd712b5b920410f6e92) | `` bilibili: 1.16.2-3 -> 1.16.2-4 ``                                                    |
| [`e7fdaf73`](https://github.com/NixOS/nixpkgs/commit/e7fdaf7308732a32b3daff9e0181cc331b66cc2f) | `` prometheus-restic-exporter: 1.6.0 -> 1.7.0 ``                                        |
| [`ce8f2f3e`](https://github.com/NixOS/nixpkgs/commit/ce8f2f3e66428c59bd8f093bfcb77129f47ab642) | `` python312Packages.rubicon-objc: fix build ``                                         |
| [`5c62831c`](https://github.com/NixOS/nixpkgs/commit/5c62831c73babfb31b4ab4d72b40dd04f4c2057f) | `` terraform-providers.aiven: 4.34.0 -> 4.34.2 ``                                       |
| [`b4636d14`](https://github.com/NixOS/nixpkgs/commit/b4636d14c24facd6ab2ce393f2b0e50e98ea7b06) | `` lua-modules/overrides: remove unused inputs ``                                       |
| [`b76cde04`](https://github.com/NixOS/nixpkgs/commit/b76cde04030aeab479cac3772fa34c631608959a) | `` flashmq: 1.19.0 -> 1.20.0 ``                                                         |
| [`c1c622a8`](https://github.com/NixOS/nixpkgs/commit/c1c622a84d999f733dd27f4d34d02ce10958e259) | `` python312Packages.neurokit2: fix ``                                                  |
| [`c8be082d`](https://github.com/NixOS/nixpkgs/commit/c8be082d43d308b017b10ffc12fc0562dfcbcf52) | `` kmscon: fix virtual terminal logout bug ``                                           |
| [`1b91c4ae`](https://github.com/NixOS/nixpkgs/commit/1b91c4ae1ae9e0e36dceb458348323d21bd4235c) | `` lua-modules/overrides: format ``                                                     |
| [`cd90ea85`](https://github.com/NixOS/nixpkgs/commit/cd90ea8571650b022f9681cdf5936f6632006d38) | `` neovim-wrapper: format ``                                                            |
| [`2570e429`](https://github.com/NixOS/nixpkgs/commit/2570e429aae9c360ec647d9d49deae3825b1c9d3) | `` neovim-utils: format ``                                                              |
| [`6ae78bfc`](https://github.com/NixOS/nixpkgs/commit/6ae78bfc94ed0954b0cebe6e3f2ea1fe5aabd65f) | `` build-neovim-plugin: format ``                                                       |
| [`5913382a`](https://github.com/NixOS/nixpkgs/commit/5913382ad7165e631ecb77a220f4a261e0554919) | `` clouddrive2: 0.8.7 -> 0.8.9 ``                                                       |
| [`9cd47749`](https://github.com/NixOS/nixpkgs/commit/9cd47749086722dfcd5c499a31810943277c260b) | `` add versionCheckHook ``                                                              |
| [`0eb593f7`](https://github.com/NixOS/nixpkgs/commit/0eb593f7a376159ab7f38b969ed74e01ef61e2c6) | `` ytdl-sub: 2025.01.28 -> 2025.02.05 ``                                                |
| [`6e07d223`](https://github.com/NixOS/nixpkgs/commit/6e07d223fb3d32154a65686e56fd2cd3c6cf3abc) | `` v2rayn: 7.7.1 -> 7.8.3 ``                                                            |
| [`5a96ad64`](https://github.com/NixOS/nixpkgs/commit/5a96ad6424b9ceb3d91f13ed6e575384de75fbfe) | `` terraform-providers.artifactory: 12.8.3 -> 12.8.4 ``                                 |
| [`dc371d36`](https://github.com/NixOS/nixpkgs/commit/dc371d36973af4c867ed8e2ce6b0ee6e4b838829) | `` vimPlugins.blink-cmp: 0.11.0 -> 0.12.2 ``                                            |
| [`1f9e6007`](https://github.com/NixOS/nixpkgs/commit/1f9e6007cfad942b34d536e017a0e3955ab79b31) | `` add maintainer ``                                                                    |
| [`2744d988`](https://github.com/NixOS/nixpkgs/commit/2744d988fa116fc6d46cdfa3d1c936d0abd7d121) | `` anytype: 0.44.0 -> 0.45.2 ``                                                         |
| [`06f4d3f7`](https://github.com/NixOS/nixpkgs/commit/06f4d3f7c24b2ee27c94d450050382758a0e00db) | `` changedetection-io: 0.49.0 -> 0.49.1 ``                                              |
| [`5be72c9a`](https://github.com/NixOS/nixpkgs/commit/5be72c9adb9d3b21298a4e4ba74aec55351fdf7b) | `` re-add update.sh ``                                                                  |
| [`bdb5b00b`](https://github.com/NixOS/nixpkgs/commit/bdb5b00b4ca39bd54b53abd5c2b997f685135340) | `` luaPackages: update on 2025-02-15 ``                                                 |
| [`8c77c6b2`](https://github.com/NixOS/nixpkgs/commit/8c77c6b24dc9150f72b813cb46c973f2a55e08ec) | `` yandex-cloud: 0.142.0 -> 0.143.0 ``                                                  |
| [`8020c72a`](https://github.com/NixOS/nixpkgs/commit/8020c72a3aff5fc74831e50f69514a7d0cc9be7f) | `` keycloak: use jre_headless to reduce closure size ``                                 |
| [`b0fcfd46`](https://github.com/NixOS/nixpkgs/commit/b0fcfd46b5343a4e9e40dd0c0975715981980f40) | `` tinyssh: 20241201 -> 20250201 ``                                                     |
| [`78fc3ac6`](https://github.com/NixOS/nixpkgs/commit/78fc3ac69446f584c924e7b84b8b6d4ff104894a) | `` tinyssh: correct installation path ``                                                |
| [`57d4ad52`](https://github.com/NixOS/nixpkgs/commit/57d4ad52cc6cf26d820b11456619c3efe2699b19) | `` wrap program for dynamically linked libraries ``                                     |
| [`e8ac482e`](https://github.com/NixOS/nixpkgs/commit/e8ac482ec7deff61cee7ca4cfb7fcd8ee87aa07e) | `` vdrPlugins.softhddevice: 2.4.3 -> 2.4.4 ``                                           |
| [`3751db18`](https://github.com/NixOS/nixpkgs/commit/3751db18bf9cb28dcab29399afc01699d093138d) | `` xan: 0.43.0 -> 0.45.0 ``                                                             |
| [`0bf29839`](https://github.com/NixOS/nixpkgs/commit/0bf298395140d9696ba7d46d8871f16020c8a656) | `` man-pages: provide simple install check ``                                           |
| [`be2a5c11`](https://github.com/NixOS/nixpkgs/commit/be2a5c11b6b4ff4c7d77b2476ee0a5cd18bae248) | `` man-pages: 6.9.1 -> 6.11 ``                                                          |