### PR TITLE
chore(flake/nixpkgs-stable): `a60651b2` -> `c618e28f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -437,11 +437,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1739624908,
-        "narHash": "sha256-f84lBmLl4tkDp1ZU5LBTSFzlxXP4926DVW3KnXrke10=",
+        "lastModified": 1739758141,
+        "narHash": "sha256-uq6A2L7o1/tR6VfmYhZWoVAwb3gTy7j4Jx30MIrH0rE=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "a60651b217d2e529729cbc7d989c19f3941b9250",
+        "rev": "c618e28f70257593de75a7044438efc1c1fc0791",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                            |
| ---------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------- |
| [`ea9df35f`](https://github.com/NixOS/nixpkgs/commit/ea9df35f4cdc5578d7b8d33b8bd665605f9a98e1) | `` azuredatastudio: fix file dialogs ``                                            |
| [`cb80eb14`](https://github.com/NixOS/nixpkgs/commit/cb80eb14f36098c84f608ecf3f95e0e5a7667038) | `` bisq2: 2.1.2 -> 2.1.6 ``                                                        |
| [`19a46e63`](https://github.com/NixOS/nixpkgs/commit/19a46e632bc41dfd75b35e9c3594ab009d7595ab) | `` discord-stable: 0.0.84 → 0.0.85 ``                                              |
| [`338f1a87`](https://github.com/NixOS/nixpkgs/commit/338f1a87c39799007d51978de78c4f001863bf58) | `` firefly-iii: 6.2.5 -> 6.2.6 ``                                                  |
| [`c77c0aaa`](https://github.com/NixOS/nixpkgs/commit/c77c0aaa533336383187f827f6711d7143cb42d6) | `` nixos/zigbee2mqtt: set StateDirectory ``                                        |
| [`fbd5aea3`](https://github.com/NixOS/nixpkgs/commit/fbd5aea387424b8e7c394b236d8ae5ee6cca3c02) | `` grafanaPlugin.victoriametrics-metrics-datasource: init at 0.13.1 ``             |
| [`61959bcf`](https://github.com/NixOS/nixpkgs/commit/61959bcf80fa2ffc4ace3686f5e5eb3027827a44) | `` arc-browser: 1.79.1-58230 -> 1.81.0-58533 ``                                    |
| [`59f655ee`](https://github.com/NixOS/nixpkgs/commit/59f655ee57cd188fce159fa3dd2d80ef85082892) | `` sonarr: 4.0.12.2823 -> 4.0.13.2932 ``                                           |
| [`893eb62a`](https://github.com/NixOS/nixpkgs/commit/893eb62ad0b7da77146cd2b00e32a00f25cd8cae) | `` sonarr: fix lint error in update script ``                                      |
| [`4a197d4f`](https://github.com/NixOS/nixpkgs/commit/4a197d4f1dc840c7a1365e20d95d413f7304104d) | `` bilibili: 1.16.2-2 -> 1.16.2-3 ``                                               |
| [`09857bff`](https://github.com/NixOS/nixpkgs/commit/09857bff736ed21b369043509ba115a75d0bd176) | `` rcu: 2024.001q -> 2025.001r ``                                                  |
| [`500a7ce3`](https://github.com/NixOS/nixpkgs/commit/500a7ce3b8320459fd5c0e70cac98a9d7c40bc0f) | `` dafny: 4.9.1 -> 4.10.0 ``                                                       |
| [`13655ec5`](https://github.com/NixOS/nixpkgs/commit/13655ec5fb27ad0155585d2faa93e43d95d16207) | `` victoriametrics: 1.110.0 -> 1.111.0 ``                                          |
| [`e6983fe5`](https://github.com/NixOS/nixpkgs/commit/e6983fe5b2164e16c98cc456f2a6800010bc2920) | `` linux_6_6: 6.6.76 -> 6.6.77 ``                                                  |
| [`58b3090f`](https://github.com/NixOS/nixpkgs/commit/58b3090fa6776aac5cd4b9e38968757431e21d6b) | `` tuxedo-drivers: update license ``                                               |
| [`93ab0ee8`](https://github.com/NixOS/nixpkgs/commit/93ab0ee826d157303ab4f036e3a014fe04f6e616) | `` flare-signal: 0.15.8 -> 0.15.9 ``                                               |
| [`dac57c08`](https://github.com/NixOS/nixpkgs/commit/dac57c080b8965877b5cfe3ee1c01c59e873a59e) | `` flare-signal: 0.15.7 -> 0.15.8 ``                                               |
| [`f26e5cd8`](https://github.com/NixOS/nixpkgs/commit/f26e5cd8c0f89c9f1530f8386d49771068c8f7d9) | `` flare-signal: 0.15.6 -> 0.15.7 ``                                               |
| [`bad3f503`](https://github.com/NixOS/nixpkgs/commit/bad3f503966f34a4c74fca2c89e255d3a1e6226a) | `` flare-signal: 0.15.2 -> 0.15.6 (#359047) ``                                     |
| [`208fd183`](https://github.com/NixOS/nixpkgs/commit/208fd18309516abcfb5999d3b3c4669a29e59aa3) | `` hedgedoc: 1.10.1 -> 1.10.2 ``                                                   |
| [`177fd844`](https://github.com/NixOS/nixpkgs/commit/177fd844cd80abc094f341c3aba0a62c200ba66a) | `` hedgedoc: 1.10.0 -> 1.10.1 ``                                                   |
| [`45983e20`](https://github.com/NixOS/nixpkgs/commit/45983e20057b723a9e7099594a373b12f924cca5) | `` linux_xanmod, linux_xanmod_latest: 2025-02-09 ``                                |
| [`b3a8760d`](https://github.com/NixOS/nixpkgs/commit/b3a8760d6e1565ff75a1d6d94abb9229f62e11bf) | `` linuxPackages_latest.prl-tools: 20.2.0-55872 -> 20.2.1-55876 ``                 |
| [`9f6ea2cf`](https://github.com/NixOS/nixpkgs/commit/9f6ea2cffed4d428f70440a43812f4fdf32fba8a) | `` pam_u2f: 1.3.1 -> 1.3.2 ``                                                      |
| [`d5801fe9`](https://github.com/NixOS/nixpkgs/commit/d5801fe96a380718c82d5ae97fbc717581ce4296) | `` pocket-casts: 0.8.0 -> 0.9.0 ``                                                 |
| [`355f19f4`](https://github.com/NixOS/nixpkgs/commit/355f19f43637398d483883c49808c0d5dbb1d328) | `` yewtube: 2.12.0 -> 2.12.1 ``                                                    |
| [`8dd030af`](https://github.com/NixOS/nixpkgs/commit/8dd030af7adc177fdf2567c4b2cca158cb40e6ea) | `` ghostty: 1.1.0 -> 1.1.2 ``                                                      |
| [`187a7451`](https://github.com/NixOS/nixpkgs/commit/187a7451e637b5d77c54cd2e449cc481176a4ada) | `` garnet: 1.0.54 -> 1.0.55 ``                                                     |
| [`400331a0`](https://github.com/NixOS/nixpkgs/commit/400331a01d9e42637e27895f6b6454617f48d64d) | `` badkeys: add version test ``                                                    |
| [`fa80b830`](https://github.com/NixOS/nixpkgs/commit/fa80b83065400eb8c1d965ce856796a3bfd1d756) | `` badkeys: 0.0.12 -> 0.0.13 ``                                                    |
| [`9ff4588e`](https://github.com/NixOS/nixpkgs/commit/9ff4588ed9bc08acbbf04996f34e7650cd96bd9c) | `` dosage-tracker: 1.8.0 -> 1.8.3 ``                                               |
| [`82e05b88`](https://github.com/NixOS/nixpkgs/commit/82e05b88e52949523acf982aee156299fcd2bd9e) | `` cloudflare-warp: include desktop-file-util to allow browser to open ``          |
| [`ad4702b9`](https://github.com/NixOS/nixpkgs/commit/ad4702b943080e3696ac1e8c2c4f8f6a4fcbe7c6) | `` angular-language-server: 19.0.4 -> 19.1.0 ``                                    |
| [`d18bec99`](https://github.com/NixOS/nixpkgs/commit/d18bec998906760e768db7e108afd713f99cb993) | `` nixos/nextcloud: reword docs about logs a bit ``                                |
| [`630b30d9`](https://github.com/NixOS/nixpkgs/commit/630b30d9979f38cf2215a4b12b2c3b194426b439) | `` nixos/nextcloud: Update logreader warning description ``                        |
| [`2c7c4e79`](https://github.com/NixOS/nixpkgs/commit/2c7c4e79826050551de14c50f657b5267410683c) | `` cups-brother-dcpl3550cdw: init at 1.0.2-0 ``                                    |
| [`fb1c1b80`](https://github.com/NixOS/nixpkgs/commit/fb1c1b802291db227693e2270a0c575bbe866536) | `` maintainers: add Tert0 ``                                                       |
| [`2a4b35b2`](https://github.com/NixOS/nixpkgs/commit/2a4b35b218e9a88f8eba36d2e1dcf7d2861685df) | `` prowlarr: 1.26.1.4844 -> 1.28.2.4885 ``                                         |
| [`1ce83955`](https://github.com/NixOS/nixpkgs/commit/1ce83955efe52280ac0fab22aaef4a4f6b30dda8) | `` radarr: 5.14.0.9383 -> 5.16.3.9541 ``                                           |
| [`0d98a042`](https://github.com/NixOS/nixpkgs/commit/0d98a04256ac9297c11c685a0239d4f5bbc9a5c1) | `` lock: 1.3.9 -> 1.4.1 ``                                                         |
| [`de021515`](https://github.com/NixOS/nixpkgs/commit/de021515a5eb9b675c89a3ebf98fd270d018ba7b) | `` vscode-extensions.dendron.adjust-heading-level: init at 0.1.0 ``                |
| [`48b1a5ed`](https://github.com/NixOS/nixpkgs/commit/48b1a5ed8bb778a177fe283e035f700c89f27519) | `` vscode-extensions.dendron.dendron-snippet-maker: init at 0.1.6 ``               |
| [`9b5387ad`](https://github.com/NixOS/nixpkgs/commit/9b5387adf19b281fa023bc8bb30cd06e69a6303c) | `` vscode-extensions.dendron.dendron-paste-image: init at 1.1.1 ``                 |
| [`16f8a310`](https://github.com/NixOS/nixpkgs/commit/16f8a310b8741dd975d972fed540b0d60e1abad3) | `` vscode-extensions.dendron.dendron-markdown-preview-enhanced: init at 0.10.57 `` |
| [`d4115f2b`](https://github.com/NixOS/nixpkgs/commit/d4115f2b4726162d088d7aba57ff6166fa3a23e7) | `` vscode-extensions.dendron.dendron: init at 0.124.0 ``                           |
| [`16c440c0`](https://github.com/NixOS/nixpkgs/commit/16c440c04d5a87000e749bb345d028f22ffdd7e9) | `` veracrypt: 1.26.18 -> 1.26.20, fix bug with system paths/sudo detection ``      |
| [`e07d90fb`](https://github.com/NixOS/nixpkgs/commit/e07d90fb231d878e86b62700e265ba1f92a22791) | `` tuxedo-drivers: 4.11.3 -> 4.12.1 ``                                             |