### PR TITLE
chore(flake/home-manager): `6c93eea8` -> `5cfbf5cc`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -339,11 +339,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1739823458,
-        "narHash": "sha256-uHjpcdlWKrZEJxsGdlMRTe4jlMYAnNsjRxPSTrNMFvo=",
+        "lastModified": 1739845242,
+        "narHash": "sha256-rNMXpDubNWGLTs45MuoH9YHtXfXye/fn2u4YMSTPt9I=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "6c93eea85daddd0dc8d4a3a687473461f3122961",
+        "rev": "5cfbf5cc37a3bd1da07ae84eea1b828909c4456b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                        |
| ----------------------------------------------------------------------------------------------------------- | ---------------------------------------------- |
| [`5cfbf5cc`](https://github.com/nix-community/home-manager/commit/5cfbf5cc37a3bd1da07ae84eea1b828909c4456b) | `` flake: don't import modules (#6481) ``      |
| [`69dfc316`](https://github.com/nix-community/home-manager/commit/69dfc316c5b5f2de1d68e477393fecbf19a0cdba) | `` mise: enable nushell integration (#6363) `` |