### PR TITLE
chore(flake/home-manager): `5cfbf5cc` -> `97ac0801`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -338,11 +338,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1739845242,
-        "narHash": "sha256-rNMXpDubNWGLTs45MuoH9YHtXfXye/fn2u4YMSTPt9I=",
+        "lastModified": 1739913864,
+        "narHash": "sha256-WhzgQjadrwnwPJQLLxZUUEIxojxa7UWDkf7raAkB1Lw=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "5cfbf5cc37a3bd1da07ae84eea1b828909c4456b",
+        "rev": "97ac0801d187b2911e8caa45316399de12f6f199",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                     |
| ----------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------- |
| [`97ac0801`](https://github.com/nix-community/home-manager/commit/97ac0801d187b2911e8caa45316399de12f6f199) | `` firefox: prevent extensions settings override (#6490) `` |
| [`4044ad19`](https://github.com/nix-community/home-manager/commit/4044ad191fb07bf3b17714d6aedec1960bc079d4) | `` fish: accept multiple events (#6489) ``                  |
| [`a135aae1`](https://github.com/nix-community/home-manager/commit/a135aae1be749a10227413f9eb944a6f887dab86) | `` flake.nix: remove deprecations (#6485) ``                |