### PR TITLE
chore(flake/home-manager): `97ac0801` -> `1c189f01`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -303,11 +303,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1739913864,
-        "narHash": "sha256-WhzgQjadrwnwPJQLLxZUUEIxojxa7UWDkf7raAkB1Lw=",
+        "lastModified": 1739992710,
+        "narHash": "sha256-9kEscmGnXHjSgcqyJR4TzzHhska4yz1inSQs6HuO9qU=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "97ac0801d187b2911e8caa45316399de12f6f199",
+        "rev": "1c189f011447810af939a886ba7bee33532bb1f9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                               |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------- |
| [`1c189f01`](https://github.com/nix-community/home-manager/commit/1c189f011447810af939a886ba7bee33532bb1f9) | `` tests/home-cursor: init (#6496) `` |