### PR TITLE
chore(flake/nixpkgs-stable): `c618e28f` -> `36864ed7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -403,11 +403,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1739758141,
-        "narHash": "sha256-uq6A2L7o1/tR6VfmYhZWoVAwb3gTy7j4Jx30MIrH0rE=",
+        "lastModified": 1739923778,
+        "narHash": "sha256-BqUY8tz0AQ4to2Z4+uaKczh81zsGZSYxjgvtw+fvIfM=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "c618e28f70257593de75a7044438efc1c1fc0791",
+        "rev": "36864ed72f234b9540da4cf7a0c49e351d30d3f1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                       |
| ---------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------- |
| [`6ea08969`](https://github.com/NixOS/nixpkgs/commit/6ea0896978f7464747618e8d1a1a750c6bf7ab58) | `` jellyfin: 10.10.5 -> 10.10.6 ``                                            |
| [`e43323c8`](https://github.com/NixOS/nixpkgs/commit/e43323c8fbc1ea028f8ed1677830eaa9ed56b155) | `` jellyfin-web: 10.10.5 -> 10.10.6 ``                                        |
| [`b9f207d6`](https://github.com/NixOS/nixpkgs/commit/b9f207d6b2cce184e66049ac0462235aff916045) | `` firefox-bin-unwrapped: 135.0 -> 135.0.1 ``                                 |
| [`48ee941d`](https://github.com/NixOS/nixpkgs/commit/48ee941d65905d8951a2c846f611265aeeb32c76) | `` firefox-unwrapped: 135.0 -> 135.0.1 ``                                     |
| [`60e03389`](https://github.com/NixOS/nixpkgs/commit/60e03389b19b09d2d6ac73c27aeb81d27cca21cf) | `` nixos/kanidm: add home_mount_prefix to BindPaths if set ``                 |
| [`89eddfdc`](https://github.com/NixOS/nixpkgs/commit/89eddfdc3d76bcbf262344f7b1bb2f780fbab0d5) | `` openssh, openssh_hpn, openssh_gssapi: 9.9p1 -> 9.9p2 ``                    |
| [`7d0b83dd`](https://github.com/NixOS/nixpkgs/commit/7d0b83dde9b0dea2f07f9f924fb3d9229ae56fb2) | `` nixos/mobilizon: minor format ``                                           |
| [`f9f83598`](https://github.com/NixOS/nixpkgs/commit/f9f83598a870b1e646629100c469b55f03d7b4d3) | `` nixos/mobilizon: create launch wrapper through runCommand ``               |
| [`d5825c8c`](https://github.com/NixOS/nixpkgs/commit/d5825c8c7d661e5d7f05707cbaba7b296d41f95d) | `` mobilizon: fix media proxy ``                                              |
| [`52ce39f3`](https://github.com/NixOS/nixpkgs/commit/52ce39f3dd2e5c5b8a0081733f50418cfa061cfe) | `` nixosTests.mobilizon: migrate from handleTest to runTest ``                |
| [`47f261dc`](https://github.com/NixOS/nixpkgs/commit/47f261dc9dd6ccb89821d04873a9f0a6385459f4) | `` nixos/mobilizon: remove `with lib;` and unused `rec` ``                    |
| [`d43efe50`](https://github.com/NixOS/nixpkgs/commit/d43efe50059ae20d0af538b516280673e5b8e924) | `` nixos/mobilizon: update nginx config ``                                    |
| [`4e03f988`](https://github.com/NixOS/nixpkgs/commit/4e03f988dcdacdd8f5a3e4d09e07bb5146faa8e3) | `` nixos/prometheus: add missing dns_sd_configs types ``                      |
| [`003717cf`](https://github.com/NixOS/nixpkgs/commit/003717cf2d4354ae8d9e238415c64f0fca37ea39) | `` dependency-track: 4.12.2 -> 4.12.5 ``                                      |
| [`162c1991`](https://github.com/NixOS/nixpkgs/commit/162c199180bd69b214e8f58ebc14200f13594f3c) | `` dependency-track: nix-update specify frontend subpackage ``                |
| [`38a2b9d1`](https://github.com/NixOS/nixpkgs/commit/38a2b9d1454aad408701bcdc3f089be8526d49fc) | `` kube-review: init at 0.4.0 ``                                              |
| [`0e488ce4`](https://github.com/NixOS/nixpkgs/commit/0e488ce47a51c33c0e2014f95130f213479b6bea) | `` mainteiners: add ardubev16 ``                                              |
| [`99ca386d`](https://github.com/NixOS/nixpkgs/commit/99ca386d43bdb0f0f1eb24062e4adfaa8e1ec4d7) | `` php84: 8.4.3 -> 8.4.4 ``                                                   |
| [`9d2606c2`](https://github.com/NixOS/nixpkgs/commit/9d2606c2a6ca8bff090b3e366d3a11c499a797b2) | `` snac2: 2.70 -> 2.72 ``                                                     |
| [`452eddaa`](https://github.com/NixOS/nixpkgs/commit/452eddaa3e8d33d77f4416034be7ea4643174887) | `` outline: 0.81.1 -> 0.82.0 ``                                               |
| [`6216e2a9`](https://github.com/NixOS/nixpkgs/commit/6216e2a913bff16ae1fe6b880eda11e042e26455) | `` rspamd: remove nixspam blocklist ``                                        |
| [`8c284598`](https://github.com/NixOS/nixpkgs/commit/8c284598e5e7478850423ae89b5aa68d8270814e) | `` feat: add package ocamlPackages.nice_parser ``                             |
| [`b64231da`](https://github.com/NixOS/nixpkgs/commit/b64231da77c4d418a48c13d75a1b032f6561fce6) | `` maintainers: add tiferrei ``                                               |
| [`7ec306f5`](https://github.com/NixOS/nixpkgs/commit/7ec306f5702b1f8cc43e8dc18c98f5423470cf15) | `` electron-chromedriver_34: 34.1.1 -> 34.2.0 ``                              |
| [`78fd0f29`](https://github.com/NixOS/nixpkgs/commit/78fd0f29a96d2345bb56d26e9c5000fc03a04971) | `` electron-chromedriver_33: 33.4.0 -> 33.4.1 ``                              |
| [`27dd21aa`](https://github.com/NixOS/nixpkgs/commit/27dd21aae6afcbded2676e7814f28507bdbfd11b) | `` electron-chromedriver_32: 32.3.0 -> 32.3.1 ``                              |
| [`8b7527d6`](https://github.com/NixOS/nixpkgs/commit/8b7527d68f2c17de37f367d376e14305166452ac) | `` electron-source.electron_33: 33.4.0 -> 33.4.1 ``                           |
| [`9319ae82`](https://github.com/NixOS/nixpkgs/commit/9319ae826752566cae4010e6a8b881d64bf82a07) | `` electron-source.electron_32: 32.3.0 -> 32.3.1 ``                           |
| [`e7616340`](https://github.com/NixOS/nixpkgs/commit/e76163400b7567f66943135e8af47091fa04fcb9) | `` electron_34-bin: 34.1.1 -> 34.2.0 ``                                       |
| [`4747c6c0`](https://github.com/NixOS/nixpkgs/commit/4747c6c0920876bbba0214c0498edc99afcf25e7) | `` electron_33-bin: 33.4.0 -> 33.4.1 ``                                       |
| [`507189ee`](https://github.com/NixOS/nixpkgs/commit/507189eee5281472d9b09965af310501b2b4275a) | `` electron_32-bin: 32.3.0 -> 32.3.1 ``                                       |
| [`3c297577`](https://github.com/NixOS/nixpkgs/commit/3c297577c9c5885dc3f6e466b4d93c2cdf8e2b6a) | `` electron_34-bin: fix read out of range on aarch64 16k pages systems ``     |
| [`b5e0cf73`](https://github.com/NixOS/nixpkgs/commit/b5e0cf7374356e004e7b44d4bf5afb44e8c76442) | `` linux-rt_6_6: 6.6.74-rt48 -> 6.6.77-rt50 ``                                |
| [`93cff4d3`](https://github.com/NixOS/nixpkgs/commit/93cff4d3afe1f7f5f4911d0324311a6c1c91f4e6) | `` linux-rt_6_1: 6.1.127-rt48 -> 6.1.128-rt49 ``                              |
| [`d46102e1`](https://github.com/NixOS/nixpkgs/commit/d46102e1d8e1a7b1be0e54c23975c8e05f87078e) | `` linux_6_6: 6.6.77 -> 6.6.78 ``                                             |
| [`df98ab13`](https://github.com/NixOS/nixpkgs/commit/df98ab13d6e96d2e5313d61c891417bfaad40636) | `` linux_6_12: 6.12.13 -> 6.12.14 ``                                          |
| [`0fd1ff1a`](https://github.com/NixOS/nixpkgs/commit/0fd1ff1a21138b0cd975eae74face224df5c2970) | `` linux_6_13: 6.13.2 -> 6.13.3 ``                                            |
| [`184ef477`](https://github.com/NixOS/nixpkgs/commit/184ef477cf32e803fa3c4758ebced74c2ff407c5) | `` linux_testing: 6.14-rc2 -> 6.14-rc3 ``                                     |
| [`187203b8`](https://github.com/NixOS/nixpkgs/commit/187203b801375961b575bbd543fbeb17de9c998d) | `` linux_latest-libre: 19707 -> 19712 ``                                      |
| [`e3d27b94`](https://github.com/NixOS/nixpkgs/commit/e3d27b943acb193521009f14addb1b28b2c3da8c) | `` linux_testing: 6.14-rc1 -> 6.14-rc2 ``                                     |
| [`e2b77c27`](https://github.com/NixOS/nixpkgs/commit/e2b77c27556fbc4a8de2bf8e762991f32a5db1e7) | `` build(deps): bump actions/create-github-app-token from 1.11.3 to 1.11.5 `` |
| [`c24e8e71`](https://github.com/NixOS/nixpkgs/commit/c24e8e71a2cf9ae8255b344de52a4f013af11312) | `` vencord: 1.11.4 -> 1.11.5 ``                                               |
| [`cd6ecaf3`](https://github.com/NixOS/nixpkgs/commit/cd6ecaf321c63ac067ef66d41e154b7a81082a2f) | `` arouteserver: 1.23.1 -> 1.23.2 ``                                          |
| [`eae5a627`](https://github.com/NixOS/nixpkgs/commit/eae5a6270776b35d7996c5692011fab3132da70d) | `` radarr: 5.16.3.9541 -> 5.17.2.9580 ``                                      |
| [`2428e314`](https://github.com/NixOS/nixpkgs/commit/2428e314797fff7337e0171a23032bf7614cbebd) | `` vscode: 1.97.1 -> 1.97.2 ``                                                |
| [`f0072db4`](https://github.com/NixOS/nixpkgs/commit/f0072db45275a4484742f5b11ae95673c2337b00) | `` vscode: Add jefflabonte to maintainers ``                                  |
| [`3054bfea`](https://github.com/NixOS/nixpkgs/commit/3054bfea19089bc405d70b82aa6cd0833e48d215) | `` vscode: 1.97.0 -> 1.97.1 ``                                                |
| [`55d3418b`](https://github.com/NixOS/nixpkgs/commit/55d3418b4e0c6b87bd8a90f5d2b7847000242c31) | `` vscode:1.96.4 -->1.97.0 (#379962) ``                                       |
| [`b2c32a0a`](https://github.com/NixOS/nixpkgs/commit/b2c32a0a7f5a5d5e0670d0be64850e1350a6b3c1) | `` vscode: 1.96.2 -> 1.96.4 ``                                                |
| [`1749fecb`](https://github.com/NixOS/nixpkgs/commit/1749fecb59e231d35e52c2a07b1b099102bc1fce) | `` shellhub-agent: 0.18.0 -> 0.18.3 ``                                        |
| [`83dcfe34`](https://github.com/NixOS/nixpkgs/commit/83dcfe341bb9d55847f898c864d517a4da5c084a) | `` firefox-devedition-unwrapped: 135.0b4 -> 135.0b9 ``                        |