### PR TITLE
chore(flake/home-manager): `1c189f01` -> `0c0b0ac8`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -303,11 +303,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1739992710,
-        "narHash": "sha256-9kEscmGnXHjSgcqyJR4TzzHhska4yz1inSQs6HuO9qU=",
+        "lastModified": 1740060750,
+        "narHash": "sha256-FOC9OzJ5Ckh6VjzGSRh4F3UCUOdM8NrzQT19PQcQJ44=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "1c189f011447810af939a886ba7bee33532bb1f9",
+        "rev": "0c0b0ac8af6ca76b1fcb514483a9bd73c18f1e8c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                                                  |
| ----------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------- |
| [`0c0b0ac8`](https://github.com/nix-community/home-manager/commit/0c0b0ac8af6ca76b1fcb514483a9bd73c18f1e8c) | `` flake-module: use raw for homeConfgurations and deferredModule for modules (#6504) `` |