### PR TITLE
chore(flake/nix-gaming): `e319f4c8` -> `8172a58d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -365,11 +365,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1740102075,
-        "narHash": "sha256-4ZFfFwcPTWVVxZKcfouAVx8eDBDTaHUSySHJCe+xQus=",
+        "lastModified": 1740162289,
+        "narHash": "sha256-jYhBd5VR2BKo75qDUQaWrhHVC5GJPJraTbGJVVQkfgM=",
         "owner": "fufexan",
         "repo": "nix-gaming",
-        "rev": "e319f4c8f0082f2b69cf7580b41cf577211f3742",
+        "rev": "8172a58da94446a15ad5801a6d091a8d13f88e6c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                              | Message                           |
| --------------------------------------------------------------------------------------------------- | --------------------------------- |
| [`8172a58d`](https://github.com/fufexan/nix-gaming/commit/8172a58da94446a15ad5801a6d091a8d13f88e6c) | `` osu-lazer-bin: SDL2 -> sdl3 `` |