### PR TITLE
chore(flake/nixpkgs-stable): `36864ed7` -> `11415c7a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -408,11 +408,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1739923778,
-        "narHash": "sha256-BqUY8tz0AQ4to2Z4+uaKczh81zsGZSYxjgvtw+fvIfM=",
+        "lastModified": 1740162160,
+        "narHash": "sha256-SSYxFhqCOb3aiPb6MmN68yEzBIltfom8IgRz7phHscM=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "36864ed72f234b9540da4cf7a0c49e351d30d3f1",
+        "rev": "11415c7ae8539d6292f2928317ee7a8410b28bb9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                           |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------- |
| [`db139324`](https://github.com/NixOS/nixpkgs/commit/db13932429b40ce1c05fd9aa140aa1582958eee8) | `` linux_6_1: 6.1.128 -> 6.1.129 ``                                                               |
| [`58d7d0a6`](https://github.com/NixOS/nixpkgs/commit/58d7d0a67f325daf58b3339c1b5d52dccc80f530) | `` linux_6_6: 6.6.78 -> 6.6.79 ``                                                                 |
| [`10699c8c`](https://github.com/NixOS/nixpkgs/commit/10699c8ce44d286ee26d9f9ce65d7c54ddda43f3) | `` linux_6_12: 6.12.15 -> 6.12.16 ``                                                              |
| [`202a12af`](https://github.com/NixOS/nixpkgs/commit/202a12af288282091e28fd0b7f44fc2397df656e) | `` linux_6_13: 6.13.3 -> 6.13.4 ``                                                                |
| [`20088ea4`](https://github.com/NixOS/nixpkgs/commit/20088ea463ae12770f6dd14bc146f3bcc88cba25) | `` teams-for-linux: 1.12.6 -> 1.12.7 ``                                                           |
| [`25fdcdd2`](https://github.com/NixOS/nixpkgs/commit/25fdcdd2bce071df3032bdaee5ad5bdb17eead86) | `` teams-for-linux: 1.12.5 -> 1.12.6 ``                                                           |
| [`d2e60c26`](https://github.com/NixOS/nixpkgs/commit/d2e60c26b886bfdd60ef086e94bc95d63dc2a55a) | `` teams-for-linux: 1.12.3 -> 1.12.5 ``                                                           |
| [`3354582f`](https://github.com/NixOS/nixpkgs/commit/3354582f469259e7f4bc01773eb7a4b6673b873e) | `` teams-for-linux: 1.11.2 -> 1.12.3 ``                                                           |
| [`68cd0c06`](https://github.com/NixOS/nixpkgs/commit/68cd0c0666edfad46046325199b7ec9f850c82e1) | `` teams-for-linux: electron_32 -> electron_33 ``                                                 |
| [`44ae64db`](https://github.com/NixOS/nixpkgs/commit/44ae64dbb34073989a8fa24da797c21791564984) | `` vivaldi: 7.1.3570.47 -> 7.1.3570.54 ``                                                         |
| [`e5d611c4`](https://github.com/NixOS/nixpkgs/commit/e5d611c4b960994349e40b0a4a7c4c4e96f1beca) | `` vivaldi: 7.1.3570.39 -> 7.1.3570.47 ``                                                         |
| [`0dce213d`](https://github.com/NixOS/nixpkgs/commit/0dce213d25c469a879c54e93a273aac75ccada23) | `` vivaldi: 7.0.3495.29 -> 7.1.3570.39 ``                                                         |
| [`cb4243f3`](https://github.com/NixOS/nixpkgs/commit/cb4243f3a739d30d6440d76d1b1adc263d2944fa) | `` exim: 4.98 -> 4.98.1 ``                                                                        |
| [`d507858a`](https://github.com/NixOS/nixpkgs/commit/d507858a30cd45149bc86ee4782b9dbeef3d8b3b) | `` nixos/postgresql/citus: fix syscall filter and add test ``                                     |
| [`e9ad9d2b`](https://github.com/NixOS/nixpkgs/commit/e9ad9d2bf69ff8bbaec12953bfaaa55a3f9a7977) | `` tail-tray: 0.2.13 -> 0.2.15 ``                                                                 |
| [`f71f8133`](https://github.com/NixOS/nixpkgs/commit/f71f81336366a5f68d29eed7750b7d61393edbe6) | `` ecapture: 0.9.2 -> 0.9.3 ``                                                                    |
| [`08fe39e2`](https://github.com/NixOS/nixpkgs/commit/08fe39e293e16f783580caf727c6b97032a7c23c) | `` arc-browser: 1.81.0-58533 -> 1.82.1-58845 ``                                                   |
| [`d313e2c7`](https://github.com/NixOS/nixpkgs/commit/d313e2c7efe37c27fc4d18de85e381d12cad0af3) | `` inv-sig-helper: 0-unstable-2025-02-07 -> 0-unstable-2025-02-15 ``                              |
| [`d78cc28a`](https://github.com/NixOS/nixpkgs/commit/d78cc28a73103dd281829eb006b7e638e40fc91e) | `` nodejs_23: 23.7.0 -> 23.8.0 ``                                                                 |
| [`241977f3`](https://github.com/NixOS/nixpkgs/commit/241977f385a45082754d2f10a153efbc4e87a2f9) | `` nodejs_23: 23.6.1 -> 23.7.0 ``                                                                 |
| [`62754b38`](https://github.com/NixOS/nixpkgs/commit/62754b38199ea947fd7cbac9e40d8ac6c731ce96) | `` ocelot-desktop: init at 1.13.1 ``                                                              |
| [`cf766e36`](https://github.com/NixOS/nixpkgs/commit/cf766e36896eea5e925403523132440bff6216b4) | `` rundeck: 5.8.0 -> 5.9.0 ``                                                                     |
| [`839976e6`](https://github.com/NixOS/nixpkgs/commit/839976e628a527cacc4101d762aa646104075fe9) | `` mautrix-signal: fix darwin build ``                                                            |
| [`c6016e22`](https://github.com/NixOS/nixpkgs/commit/c6016e22ed87a84b43df1e579632dd131f542786) | `` libsignal-ffi: 0.64.1 -> 0.66.2 ``                                                             |
| [`e3e64d16`](https://github.com/NixOS/nixpkgs/commit/e3e64d161ee7a050a327411e35cf1fadc1dc629d) | `` mautrix-signal: 0.7.5 -> 0.8.0 ``                                                              |
| [`45cc2bf5`](https://github.com/NixOS/nixpkgs/commit/45cc2bf5d7771f206a7499f151d860b2d38612ff) | `` google-chrome: 133.0.6943.98 -> 133.0.6943.126 (#383605) ``                                    |
| [`2a41fc4c`](https://github.com/NixOS/nixpkgs/commit/2a41fc4c265af42949dbc73bb348c628f02c2183) | `` linux_6_12: 6.12.14 -> 6.12.15 ``                                                              |
| [`238b37e3`](https://github.com/NixOS/nixpkgs/commit/238b37e3983c732ea00d1264811eb74973e7cc60) | `` grafana: 11.3.3 -> 11.3.4 ``                                                                   |
| [`2a4acde8`](https://github.com/NixOS/nixpkgs/commit/2a4acde8a902194ea9b1c9ab131501ca5bb6d384) | `` ungoogled-chromium: 133.0.6943.98-1 -> 133.0.6943.126-1 ``                                     |
| [`b7bb4f7b`](https://github.com/NixOS/nixpkgs/commit/b7bb4f7bb8713855ba60df2767e6d7d975d3b39e) | `` alt-tab-macos: 7.19.1 -> 7.20.0 ``                                                             |
| [`6333b915`](https://github.com/NixOS/nixpkgs/commit/6333b9152853a9f582f725acc2c9e05ad7797070) | `` chromium,chromedriver: 133.0.6943.98 -> 133.0.6943.126 ``                                      |
| [`917b2220`](https://github.com/NixOS/nixpkgs/commit/917b222052655660666ef1e88895dce6c88a33f0) | `` .github/workflows: build the nixos manual also when doc/ changed ``                            |
| [`5b6a8be0`](https://github.com/NixOS/nixpkgs/commit/5b6a8be04a0063b30561558f2c4356cefb929180) | `` bicep: relax dotnet SDK rollForward ``                                                         |
| [`8c8c6575`](https://github.com/NixOS/nixpkgs/commit/8c8c6575944cab323d3266154448fceea3ed5dfa) | `` dotnetCorePackages.dotnet_9.vmr: 9.0.1 -> 9.0.2 ``                                             |
| [`14a9908b`](https://github.com/NixOS/nixpkgs/commit/14a9908b6c77f5c1c1c715f9749dad4604f10ed8) | `` dotnetCorePackages.dotnet_8.vmr: 8.0.12 -> 8.0.13 ``                                           |
| [`181a3efe`](https://github.com/NixOS/nixpkgs/commit/181a3efe97dc4c3224ebab372cb62f812f6ff50f) | `` dotnetCorePackages.sdk_9_0-bin: 9.0.102 -> 9.0.200 ``                                          |
| [`d73a1d58`](https://github.com/NixOS/nixpkgs/commit/d73a1d588f820545fcae4d5ecab397d64a6300e0) | `` dotnet-sdk: 8.0.405 -> 8.0.406 ``                                                              |
| [`f90a4d56`](https://github.com/NixOS/nixpkgs/commit/f90a4d567f0a45cbacd0e4548835047467494ff5) | `` dotnet: add passthru.icu to VMR runtimes ``                                                    |
| [`7ae43d2d`](https://github.com/NixOS/nixpkgs/commit/7ae43d2db132d327f52d13667d7d8114905c5c2e) | `` yt-dlp: 2025.1.26 -> 2025.2.19 ``                                                              |
| [`792bdede`](https://github.com/NixOS/nixpkgs/commit/792bdede9b2d9ec6df31381a9c262c23cb19186d) | `` rundeck: remove unnecessary option ``                                                          |
| [`aa351c8b`](https://github.com/NixOS/nixpkgs/commit/aa351c8b6506790e7430501ca0fb79dba950a877) | `` rundeck: add mainProgram ``                                                                    |
| [`27433df7`](https://github.com/NixOS/nixpkgs/commit/27433df7a58598f6416fbf574330b6c0e82759b3) | `` switch-to-configuration: add a test to make sure that we don't block on the lockfile ``        |
| [`1f3351dc`](https://github.com/NixOS/nixpkgs/commit/1f3351dc1ebb907bb1db57090f68a9e9c3b00791) | `` switch-to-configuration: don't block on flock, see 7a56ddaf9d42e9aee8ddbf2d95f9ea82502d094c `` |
| [`f464592d`](https://github.com/NixOS/nixpkgs/commit/f464592d2779933bd2e2f918e239bae217082aaf) | `` switch-to-configuration-ng: don't block when the lockfile is already locked ``                 |
| [`06573f5a`](https://github.com/NixOS/nixpkgs/commit/06573f5a1d9838a7ad9a0ca8d8400398815cb44f) | `` cppreference-doc: 20241110 -> 20250209 ``                                                      |
| [`36c3b90e`](https://github.com/NixOS/nixpkgs/commit/36c3b90eb84377355e04cdc1a7058ab0c611b0d0) | `` openfortivpn: 1.22.1 -> 1.23.1 ``                                                              |
| [`06e99365`](https://github.com/NixOS/nixpkgs/commit/06e993654b6ad2b214569e3c963d612acb6caad1) | `` openfortivpn: format ``                                                                        |
| [`3ceca820`](https://github.com/NixOS/nixpkgs/commit/3ceca820258635cf8a4993a77a8080a4a3f8b8bc) | `` php83: 8.3.16 -> 8.3.17 ``                                                                     |
| [`410d8004`](https://github.com/NixOS/nixpkgs/commit/410d8004b33ac9a2f984db81e3ee1a276d3bbaf0) | `` opencomposite: 0-unstable-2025-01-23 -> 0-unstable-2025-02-08 ``                               |
| [`efa18698`](https://github.com/NixOS/nixpkgs/commit/efa1869810341ca4ab28dd7030ac075dd104ea79) | `` postfix: 3.9.1 -> 3.9.2 ``                                                                     |
| [`01986430`](https://github.com/NixOS/nixpkgs/commit/0198643093fb97007faffb1cf83d3442dc3cc7df) | `` tail-tray: init at 0.2.13 ``                                                                   |
| [`a1862133`](https://github.com/NixOS/nixpkgs/commit/a18621338edc5b036aca034f63b804c6f967521a) | `` maintainers: add Svenum ``                                                                     |
| [`39409241`](https://github.com/NixOS/nixpkgs/commit/3940924116ea32ded3d99caaea56a80c0417dc4d) | `` stalwart-mail-webadmin: top-level alias for hydra build ``                                     |
| [`9f13dc45`](https://github.com/NixOS/nixpkgs/commit/9f13dc458d9f3cc6a19c37aae4beb8c1a2b9d7b6) | `` tailscale: 1.78.1 -> 1.80.0 ``                                                                 |