### PR TITLE
chore(flake/alejandra): `7da44e09` -> `bf8c8250`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -9,11 +9,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1739043869,
-        "narHash": "sha256-cx9QYEm5WyNcAbmmiHNLKD/8paz0yaQCNXdRfnDddrM=",
+        "lastModified": 1740354050,
+        "narHash": "sha256-1tQe1SzaSlWK/O3G08PtZUmy2biDS+kD6ndyQw1vvI8=",
         "owner": "kamadorueda",
         "repo": "alejandra",
-        "rev": "7da44e09433c337e651ee7caa5f91f958b20d342",
+        "rev": "bf8c8250817499cabeb810333f2b9ce958d33e0e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                 | Message                                                                  |
| ------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------ |
| [`bf8c8250`](https://github.com/kamadorueda/alejandra/commit/bf8c8250817499cabeb810333f2b9ce958d33e0e) | `` build(deps): bump nanoid ``                                           |
| [`d6ac7ad4`](https://github.com/kamadorueda/alejandra/commit/d6ac7ad4d0619c96fc4471aef65076f019882aa7) | `` refac: use clap's builtin env reader ``                               |
| [`3ce9e7d1`](https://github.com/kamadorueda/alejandra/commit/3ce9e7d11511805eac98b5d177982c3dde479b8a) | `` Make tests green on systems with different number of physical CPUs `` |