### PR TITLE
chore(flake/home-manager): `b5ab2c7f` -> `12e26a74`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -308,11 +308,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1740318342,
-        "narHash": "sha256-fjr9+3Iru6O5qE+2oERQkabqAUXx4awm0+i2MBcta1U=",
+        "lastModified": 1740347597,
+        "narHash": "sha256-st5q9egkPGz8TUcVVlIQX7y6G3AzHob+6M963bwVq74=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "b5ab2c7fdaa807cf425066ab7cd34b073946b1ca",
+        "rev": "12e26a74e5eb1a31e13daaa08858689e25ebd449",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                         |
| ----------------------------------------------------------------------------------------------------------- | ----------------------------------------------- |
| [`12e26a74`](https://github.com/nix-community/home-manager/commit/12e26a74e5eb1a31e13daaa08858689e25ebd449) | `` tests/neovim: resolve deprecation (#6522) `` |
| [`6a2af4ff`](https://github.com/nix-community/home-manager/commit/6a2af4ffb26f812c353415c7316dff0a8b52b525) | `` tests/swayidle: bash -> bash-interactive ``  |
| [`3002f1ae`](https://github.com/nix-community/home-manager/commit/3002f1aedfde6d4d8112491ead088897a77ae661) | `` tests/mpd: bash -> bash-interactive ``       |