### PR TITLE
chore(flake/zen-browser): `8c7f6ca4` -> `e8ac7b95`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -642,11 +642,11 @@
         "nixpkgs": "nixpkgs_4"
       },
       "locked": {
-        "lastModified": 1739667343,
-        "narHash": "sha256-fNEz+Yd0t9jXz27qKRMAEBradTwYBeBLOECx+ydG25s=",
+        "lastModified": 1740390943,
+        "narHash": "sha256-F8EuAkiLuDZlJ+jKaSJENVZnLz0/9T2rq7qB7vuUIak=",
         "owner": "0xc000022070",
         "repo": "zen-browser-flake",
-        "rev": "8c7f6ca49f87b4e114f775a4dad956ceb6df4220",
+        "rev": "e8ac7b958a121a4fdb7daf14894c9c029054b9f6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                          | Message                                                              |
| --------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------- |
| [`e8ac7b95`](https://github.com/0xc000022070/zen-browser-flake/commit/e8ac7b958a121a4fdb7daf14894c9c029054b9f6) | `` Update Zen Browser beta @ x86_64 && aarch64 to 1.8b ``            |
| [`d00e735e`](https://github.com/0xc000022070/zen-browser-flake/commit/d00e735e0be56c9bcbbac53c91957eecb7d4ce64) | `` fix(github/update): using correct entry name for beta releases `` |
| [`3d2537e5`](https://github.com/0xc000022070/zen-browser-flake/commit/3d2537e56d48e84fdf7e21858de1be5ffb1d5ec8) | `` Revert "Update Zen Browser beta @ x86_64 && aarch64 to 1.8b" ``   |
| [`75678841`](https://github.com/0xc000022070/zen-browser-flake/commit/75678841e1d57e78eb7d6921758eb5415bee4b1e) | `` Update Zen Browser beta @ x86_64 && aarch64 to 1.8b ``            |