### PR TITLE
chore(flake/nix-gaming): `1e6dc4b9` -> `452fbd6a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -379,11 +379,11 @@
         "nixpkgs": "nixpkgs_3"
       },
       "locked": {
-        "lastModified": 1740361404,
-        "narHash": "sha256-hKaJ6QDZuxcbwifzcfLyiK9nmlIx1uQqWQwJ45PBn88=",
+        "lastModified": 1740552472,
+        "narHash": "sha256-KiGmSYyO9MJJqYD7nbQ0NQgsAR2VVY/wRra0Bob4KtE=",
         "owner": "fufexan",
         "repo": "nix-gaming",
-        "rev": "1e6dc4b9895602f9459d6ff3a11b0cd144321207",
+        "rev": "452fbd6a30f128dddf26c63f727cf685b5af5658",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                              | Message                                         |
| --------------------------------------------------------------------------------------------------- | ----------------------------------------------- |
| [`452fbd6a`](https://github.com/fufexan/nix-gaming/commit/452fbd6a30f128dddf26c63f727cf685b5af5658) | `` star-citizen: make EAC disabling optional `` |
| [`e86e8b45`](https://github.com/fufexan/nix-gaming/commit/e86e8b45e2ad4215949b2b3f69bb14cf7b860398) | `` star-citizen: fixes for EAC ``               |