### PR TITLE
chore(flake/zen-browser): `e66c8769` -> `7de16ae3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -673,11 +673,11 @@
         "nixpkgs": "nixpkgs_5"
       },
       "locked": {
-        "lastModified": 1740464728,
-        "narHash": "sha256-1BgSGQTLf48FjQxzNdwp3LkWh+SXxbpTgNwOBoPy3VE=",
+        "lastModified": 1740554227,
+        "narHash": "sha256-xpwZeMw2gGenixGQDyVv+ja+epcR+EJ1BPuGFdgFS18=",
         "owner": "0xc000022070",
         "repo": "zen-browser-flake",
-        "rev": "e66c876920bbfbaf391c1188e7ba8db691d92356",
+        "rev": "7de16ae319e6f6852274fa90b0d41c00049767c9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                          | Message                                                     |
| --------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------- |
| [`7de16ae3`](https://github.com/0xc000022070/zen-browser-flake/commit/7de16ae319e6f6852274fa90b0d41c00049767c9) | `` Update Zen Browser beta @ x86_64 && aarch64 to 1.8.2b `` |