### PR TITLE
chore(flake/akuse-flake): `e7a5348f` -> `4aaa8167`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -5,11 +5,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1740545634,
-        "narHash": "sha256-Cdi9B8Rd7VNXlBZ8iDMNpuLiPJ++kU4XZw7MVEoO0JA=",
+        "lastModified": 1740553035,
+        "narHash": "sha256-YYP9tzhBUc636z3z0N4uVLzQUy74oQng5hZEUFF1X+o=",
         "owner": "Rishabh5321",
         "repo": "akuse-flake",
-        "rev": "e7a5348fe7b112985102fa1f17dc3590d6a11d3c",
+        "rev": "4aaa816759db0d0025565ca68de3f837055ebb02",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                   | Message                                                              |
| -------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------- |
| [`4aaa8167`](https://github.com/Rishabh5321/akuse-flake/commit/4aaa816759db0d0025565ca68de3f837055ebb02) | `` docs: Add nix and flakes installation instructions to README ``   |
| [`cab09fe9`](https://github.com/Rishabh5321/akuse-flake/commit/cab09fe9c50c70dac5fc85a02e4407aa4c450cfb) | `` fix: Update akuse-flake reference in flake configuration ``       |
| [`ee84dd26`](https://github.com/Rishabh5321/akuse-flake/commit/ee84dd26e1f8575bd6a16b62913ae70b5298f664) | `` chore: Update GitHub Actions flake check notification messages `` |
| [`50d44409`](https://github.com/Rishabh5321/akuse-flake/commit/50d4440903111881c66edf21a76247a7db07dad6) | `` chore: auto lint and format ``                                    |
| [`55c69813`](https://github.com/Rishabh5321/akuse-flake/commit/55c6981398762df63e61ed33ac77efe4b0555fcf) | `` refactor: Improve flake.nix structure and package definition ``   |