### PR TITLE
chore(flake/nixpkgs-stable): `04ef94c4` -> `5d7db466`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -422,11 +422,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1740339700,
-        "narHash": "sha256-cbrw7EgQhcdFnu6iS3vane53bEagZQy/xyIkDWpCgVE=",
+        "lastModified": 1740463929,
+        "narHash": "sha256-4Xhu/3aUdCKeLfdteEHMegx5ooKQvwPHNkOgNCXQrvc=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "04ef94c4c1582fd485bbfdb8c4a8ba250e359195",
+        "rev": "5d7db4668d7a0c6cc5fc8cf6ef33b008b2b1ed8b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                     |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------- |
| [`0a3e3d97`](https://github.com/NixOS/nixpkgs/commit/0a3e3d970c6cedf4a172bf650bffbdd92077321e) | `` finamp: 0.9.12-beta -> 0.9.13-beta ``                                                    |
| [`6821c7b5`](https://github.com/NixOS/nixpkgs/commit/6821c7b513be24477d4858e10f7b7075a7ac908f) | `` warp-terminal: 0.2025.02.19.08.02.stable_04 -> 0.2025.02.19.08.02.stable_05 ``           |
| [`c09f9d6d`](https://github.com/NixOS/nixpkgs/commit/c09f9d6dc1b69162669f92b879e847f68c91ea62) | `` warp-terminal: 0.2025.02.12.16.51.stable_03 -> 0.2025.02.19.08.02.stable_04 (#383998) `` |
| [`bfbe088b`](https://github.com/NixOS/nixpkgs/commit/bfbe088bb1ae30d94348004186542be57b69ed44) | `` warp-terminal: 0.2025.02.05.08.02.stable_03 -> 0.2025.02.12.16.51.stable_03 ``           |
| [`cc5eed6f`](https://github.com/NixOS/nixpkgs/commit/cc5eed6fdf32fd9f527957bec80b6bae683572ad) | `` niri: add versionCheckHook ``                                                            |
| [`b267ca54`](https://github.com/NixOS/nixpkgs/commit/b267ca545479703dc135d44a19bcce0bfd418b7e) | `` niri: remove XDG_RUNTIME_DIR in check phase ``                                           |
| [`dd13ee73`](https://github.com/NixOS/nixpkgs/commit/dd13ee734ba185d83f04ee01d1e789d0b4fc53d5) | `` niri: 25.01 -> 25.02 ``                                                                  |
| [`cb5e26df`](https://github.com/NixOS/nixpkgs/commit/cb5e26df3f78eca8422fda1378ecdff7f86be726) | `` raycast: 1.91.2 -> 1.92.1 ``                                                             |
| [`fa90bc0e`](https://github.com/NixOS/nixpkgs/commit/fa90bc0ec4c5041ab3d7600451c3dd18cacd414f) | `` raycast: 1.91.0 -> 1.91.2 ``                                                             |
| [`0854510b`](https://github.com/NixOS/nixpkgs/commit/0854510b2206d6e107344f608c5a308b9d4ac544) | `` raycast: 1.90.0 -> 1.91.0 ``                                                             |
| [`3133e42e`](https://github.com/NixOS/nixpkgs/commit/3133e42e3ef45fd6ae93da6e8ac337f6f3317b5a) | `` rose-pine-hyprcursor: init at 0.3.2 ``                                                   |
| [`8f09718d`](https://github.com/NixOS/nixpkgs/commit/8f09718db303164e455390656cf5913c0fc283b2) | `` firefly-iii-data-importer: 1.6.0 -> 1.6.1 ``                                             |
| [`8da1b4a1`](https://github.com/NixOS/nixpkgs/commit/8da1b4a1b9a8fa26b63475facb01d4f665ed2d34) | `` firefly-iii: 6.2.6 -> 6.2.9 ``                                                           |
| [`6b5c097d`](https://github.com/NixOS/nixpkgs/commit/6b5c097d5ed0b859869f603ccba8efdbd41b6e5a) | `` iperf3: 3.17.1 -> 3.18 ``                                                                |
| [`07f90d76`](https://github.com/NixOS/nixpkgs/commit/07f90d76fd5e79f61392a3c8499ad3399dba0133) | `` python312Packages.pandoc-xnos: patch for Pandoc 3 support ``                             |
| [`741b5f86`](https://github.com/NixOS/nixpkgs/commit/741b5f86e167d44267f2e63f07fdae12c4f6af07) | `` bs-manager: init at 1.5.2 ``                                                             |
| [`2c877d9d`](https://github.com/NixOS/nixpkgs/commit/2c877d9d63244707705566af347864ec9ba7322a) | `` maintainers: add mistyttm ``                                                             |
| [`bc0f4f2a`](https://github.com/NixOS/nixpkgs/commit/bc0f4f2a11dae32173e0db019fccdffa20c7b9b1) | `` oscavmgr: 0.4.4 -> 25.2 ``                                                               |
| [`44de6872`](https://github.com/NixOS/nixpkgs/commit/44de687210bef4b8e8d18c4d20c0304d90a1f55b) | `` mdevctl: fix script dir location ``                                                      |
| [`68943bb0`](https://github.com/NixOS/nixpkgs/commit/68943bb0566badd6fc9d5a249eb88f8e4899839e) | `` python312Packages.img2pdf: skip failing tests ``                                         |
| [`dc6d9d0c`](https://github.com/NixOS/nixpkgs/commit/dc6d9d0ccca6df1a142810570e073752a39a9272) | `` imagemagick: 7.1.1-40 -> 7.1.1-43 ``                                                     |
| [`ee0f5491`](https://github.com/NixOS/nixpkgs/commit/ee0f54912937414f4a4b384fb867d499a6a05766) | `` discord: updates ``                                                                      |
| [`5f153a2c`](https://github.com/NixOS/nixpkgs/commit/5f153a2c45095d746bbb1061606541004d8e53eb) | `` miniflux: 2.2.5 -> 2.2.6 ``                                                              |
| [`928022d5`](https://github.com/NixOS/nixpkgs/commit/928022d566098411eda367846119b238edb805ef) | `` lockbook: 0.9.18 -> 0.9.20 ``                                                            |
| [`03ca88a9`](https://github.com/NixOS/nixpkgs/commit/03ca88a9432959b757446ef03e2d48333e671d09) | `` weston: add patch allowing neatvnc 0.9.0 ``                                              |
| [`163c05fb`](https://github.com/NixOS/nixpkgs/commit/163c05fb96058af4c14408f2c829d43407f8a48c) | `` wayvnc: 0.9.0 -> 0.9.1 ``                                                                |
| [`300f6a8f`](https://github.com/NixOS/nixpkgs/commit/300f6a8f629f5de4fdc293e039791b503ec79063) | `` wayvnc: 0.8.0 -> 0.9.0 ``                                                                |
| [`a1b82064`](https://github.com/NixOS/nixpkgs/commit/a1b82064ea7a8b0fa8fc542489c73397501df455) | `` neatvnc: 0.9.2 -> 0.9.3 ``                                                               |
| [`22130d8d`](https://github.com/NixOS/nixpkgs/commit/22130d8dd4e032003a36034b0d14be1834b79562) | `` neatvnc: 0.9.1 -> 0.9.2 ``                                                               |
| [`912aa3e1`](https://github.com/NixOS/nixpkgs/commit/912aa3e19bd6c9b2cf6077c320f8f0726dac2cbe) | `` neatvnc: 0.9.0 -> 0.9.1 ``                                                               |
| [`a678d45f`](https://github.com/NixOS/nixpkgs/commit/a678d45f1daf638dd5811e6ad7bc2d839c4e8032) | `` neatvnc: 0.8.1 -> 0.9.0 ``                                                               |
| [`7ce8c1b0`](https://github.com/NixOS/nixpkgs/commit/7ce8c1b0521abd6b7d40077f048b83737ace949a) | `` palemoon-bin: 33.6.0 -> 33.6.0.1 ``                                                      |
| [`de1e93e9`](https://github.com/NixOS/nixpkgs/commit/de1e93e94c673756d006e8422613755d90a4f091) | `` osu-lazer: 2025.118.3 -> 2025.221.0 ``                                                   |
| [`1995358b`](https://github.com/NixOS/nixpkgs/commit/1995358b4b41183aac3eaf97643bd1feb921dcb1) | `` osu-lazer-bin: 2025.118.3 -> 2025.221.0 ``                                               |
| [`c03bebb8`](https://github.com/NixOS/nixpkgs/commit/c03bebb86487731270ea42fc6d21491ce043a8ad) | `` musl: apply patch for CVE-2025-26519 ``                                                  |