### PR TITLE
chore(flake/home-manager): `74f0a854` -> `6be185eb`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -322,11 +322,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1740494361,
-        "narHash": "sha256-Dd/GhJ9qKmUwuhgt/PAROG8J6YdU2ZjtJI9SQX5sVQI=",
+        "lastModified": 1740606115,
+        "narHash": "sha256-GKe3vrIWcei4gSTckEzHr5Zf/g9NSofmsAnbkNYU+lM=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "74f0a8546e3f2458c870cf90fc4b38ac1f498b17",
+        "rev": "6be185eb76295e7562f5bf2da42afe374b8beb15",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                                   |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------- |
| [`6be185eb`](https://github.com/nix-community/home-manager/commit/6be185eb76295e7562f5bf2da42afe374b8beb15) | `` screen-locker: set Restart=always for all services (#6534) ``          |
| [`44b86a72`](https://github.com/nix-community/home-manager/commit/44b86a72e73a7c3040ac54ed1c5eab5f156929bd) | `` xidlehook: set Restart=always (#6533) ``                               |
| [`53c587d2`](https://github.com/nix-community/home-manager/commit/53c587d263f94aaf6a281745923c76bbec62bcf3) | `` tmux: fix shell example (#5361) ``                                     |
| [`87743e93`](https://github.com/nix-community/home-manager/commit/87743e9383d4cbf4138dc65dd644822fc38e7bbf) | `` firefox: deprecate vendorPath (#6519) ``                               |
| [`18e74c2e`](https://github.com/nix-community/home-manager/commit/18e74c2e0225189858cd29890eb68212844efccc) | `` aerc-accounts: improve logic for parsing XOAUTH2 URL params (#6530) `` |