### PR TITLE
chore(flake/akuse-flake): `4aaa8167` -> `2427ab80`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -5,11 +5,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1740553035,
-        "narHash": "sha256-YYP9tzhBUc636z3z0N4uVLzQUy74oQng5hZEUFF1X+o=",
+        "lastModified": 1740655095,
+        "narHash": "sha256-rPUvMaW+1GUydptgYeuz763eSdHdg8M0hvAOCUc/JAQ=",
         "owner": "Rishabh5321",
         "repo": "akuse-flake",
-        "rev": "4aaa816759db0d0025565ca68de3f837055ebb02",
+        "rev": "2427ab800d3d9dd8d3d60cdb92e0be48e06d4159",
         "type": "github"
       },
       "original": {
@@ -394,11 +394,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1740367490,
-        "narHash": "sha256-WGaHVAjcrv+Cun7zPlI41SerRtfknGQap281+AakSAw=",
+        "lastModified": 1740560979,
+        "narHash": "sha256-Vr3Qi346M+8CjedtbyUevIGDZW8LcA1fTG0ugPY/Hic=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "0196c0175e9191c474c26ab5548db27ef5d34b05",
+        "rev": "5135c59491985879812717f4c9fea69604e7f26f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                   | Message                                          |
| -------------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
| [`2427ab80`](https://github.com/Rishabh5321/akuse-flake/commit/2427ab800d3d9dd8d3d60cdb92e0be48e06d4159) | `` chore(flake/nixpkgs): 0196c017 -> 5135c594 `` |