### PR TITLE
chore(flake/nixpkgs-stable): `5d7db466` -> `f44bd8ca`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -422,11 +422,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1740463929,
-        "narHash": "sha256-4Xhu/3aUdCKeLfdteEHMegx5ooKQvwPHNkOgNCXQrvc=",
+        "lastModified": 1740603184,
+        "narHash": "sha256-t+VaahjQAWyA+Ctn2idyo1yxRIYpaDxMgHkgCNiMJa4=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "5d7db4668d7a0c6cc5fc8cf6ef33b008b2b1ed8b",
+        "rev": "f44bd8ca21e026135061a0a57dcf3d0775b67a49",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                       |
| ---------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------- |
| [`f44bd8ca`](https://github.com/NixOS/nixpkgs/commit/f44bd8ca21e026135061a0a57dcf3d0775b67a49) | `` usbredir: 0.14.0 -> 0.15.0 ``                                              |
| [`2f209cde`](https://github.com/NixOS/nixpkgs/commit/2f209cded17796e83124d188f5de521c1e62b89a) | `` usbredir: 0.13.0 -> 0.14.0 ``                                              |
| [`8e8712e5`](https://github.com/NixOS/nixpkgs/commit/8e8712e595fedd943bbb2ac1dac288bea53fa21e) | `` inv-sig-helper: 0-unstable-2025-02-15 -> 0-unstable-2025-02-26 ``          |
| [`4276a2c7`](https://github.com/NixOS/nixpkgs/commit/4276a2c7bee9fa0f2b49f64a6468c6c6f0060702) | `` build(deps): bump actions/upload-artifact from 4.6.0 to 4.6.1 ``           |
| [`eef3fb1d`](https://github.com/NixOS/nixpkgs/commit/eef3fb1d95293a2dab124003505bc80bbad690e0) | `` codeberg-cli: 0.4.6 -> 0.4.7 ``                                            |
| [`180441dc`](https://github.com/NixOS/nixpkgs/commit/180441dc9ac9809148ba62590203397c490d2853) | `` forgejo-cli: 0.1.1 -> 0.2.0 ``                                             |
| [`226e7996`](https://github.com/NixOS/nixpkgs/commit/226e7996a3a5ee4e9713cd92aa2391763682eba3) | `` codeberg-cli: 0.4.3 -> 0.4.6 ``                                            |
| [`b1bbb68a`](https://github.com/NixOS/nixpkgs/commit/b1bbb68a26da395c593f74b36803558708b1172d) | `` linux_testing: 6.14-rc3 -> 6.14-rc4 ``                                     |
| [`00e9c142`](https://github.com/NixOS/nixpkgs/commit/00e9c142c856811ca684c409dc95742d006f7ef6) | `` element-desktop.keytar: build against electron's node headers (#384979) `` |
| [`8c97496b`](https://github.com/NixOS/nixpkgs/commit/8c97496b319743c0ac82205fc6ba2197bf7db9a7) | `` google-chrome: 133.0.6943.126 -> 133.0.6943.141 (#385220) ``               |
| [`67425484`](https://github.com/NixOS/nixpkgs/commit/6742548414a7590d2f0f406648426bf300f4b4b9) | `` qt6ct: 0.9 -> 0.10 ``                                                      |
| [`279d4dc2`](https://github.com/NixOS/nixpkgs/commit/279d4dc258b001e7903fd15f5ef1ac5c56765b6d) | `` nixos/tests/gotosocial: adjust for gotosocial 0.18.1+ ``                   |
| [`93c098ff`](https://github.com/NixOS/nixpkgs/commit/93c098ff2ddaaf7cd5a684d51d7ce4d7bec7e987) | `` gotosocial: 0.17.4 -> 0.18.1 ``                                            |
| [`29bf18a4`](https://github.com/NixOS/nixpkgs/commit/29bf18a4ed5b2aacfbb13a69b465ec41ed5c9d1c) | `` xwayland: 24.1.5 -> 24.1.6 ``                                              |
| [`4a138498`](https://github.com/NixOS/nixpkgs/commit/4a1384986c7bf2ab2c39171544ce62f298e87188) | `` halloy: 2025.1 -> 2025.2 ``                                                |
| [`80274106`](https://github.com/NixOS/nixpkgs/commit/802741067d17e6f7a4fc95dd02e3704696e4f8b6) | `` chromium,chromedriver: 133.0.6943.126 -> 133.0.6943.141 ``                 |
| [`b4843d76`](https://github.com/NixOS/nixpkgs/commit/b4843d76c00939d4135a2b9494435ac81a76f75b) | `` consul: 1.20.3 -> 1.20.4 ``                                                |
| [`d766b311`](https://github.com/NixOS/nixpkgs/commit/d766b3110f5d04db08d8bf75c1dcad4e4701c830) | `` matrix-appservice-irc: 3.0.3 -> 3.0.5 ``                                   |
| [`556013b1`](https://github.com/NixOS/nixpkgs/commit/556013b1e4106fb4e6037ddfc128e7cc07dc8c01) | `` linux_xanmod, linux_xanmod_latest: 2025-02-19 ``                           |
| [`83e5b41b`](https://github.com/NixOS/nixpkgs/commit/83e5b41b42c68fc6742808f65599dc8f3a30e9dc) | `` linux_xanmod, linux_xanmod_latest: 2025-02-17 ``                           |
| [`5946d2a4`](https://github.com/NixOS/nixpkgs/commit/5946d2a40d6da0a7225ecc05f4bdd185d8dadad2) | `` nixos/iosched: init module ``                                              |
| [`0fddd351`](https://github.com/NixOS/nixpkgs/commit/0fddd351d18ffa132a2c7a332a156d18f0d23695) | `` waywall: init at 0-unstable-2025-02-07 ``                                  |
| [`675d1242`](https://github.com/NixOS/nixpkgs/commit/675d1242368c8c3863b7a54e4549e3491ea8be83) | `` maintainers: add monkieeboi ``                                             |
| [`8a1ff6c8`](https://github.com/NixOS/nixpkgs/commit/8a1ff6c8f050691d57ac20cc2667637a0324d11e) | `` freetube: mark as broken on darwin ``                                      |
| [`282f3ad7`](https://github.com/NixOS/nixpkgs/commit/282f3ad71f66e993422abbae2ad03b8fb7996193) | `` freetube: 0.23.1 -> 0.23.2 ``                                              |
| [`878a4726`](https://github.com/NixOS/nixpkgs/commit/878a47266bd2a4ef08ad9d00ab7e4093dd4b0178) | `` [Backport release-24.11] k3s_1_31: 1.31.4+k3s1 -> 1.31.5+k3s1 ``           |
| [`0570875d`](https://github.com/NixOS/nixpkgs/commit/0570875d1e69bb00d802a9864a5a964af1262963) | `` zlog: modernize ``                                                         |
| [`4e395172`](https://github.com/NixOS/nixpkgs/commit/4e395172e417c09ceed10a4aa930fecf18f76b82) | `` zlog: 1.2.17 → 1.2.18 ``                                                   |
| [`2a9a587a`](https://github.com/NixOS/nixpkgs/commit/2a9a587af52c950d42e93ad117d9c7c05bf52c63) | `` arma3-unix-launcher: 413 -> 413-unstable-2025-02-10 ``                     |
| [`43bf2457`](https://github.com/NixOS/nixpkgs/commit/43bf2457a5f33d7aa7de2d5244bf8a71d1e73f82) | `` arma3-unix-launcher: update patch disabling steam integration ``           |
| [`f6f4510f`](https://github.com/NixOS/nixpkgs/commit/f6f4510f5e643651ec7fe19f8ab71855538dc70b) | `` halloy: 2024.12 -> 2025.1 ``                                               |