### PR TITLE
chore(flake/akuse-flake): `2427ab80` -> `2d0bd186`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -5,11 +5,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1740655095,
-        "narHash": "sha256-rPUvMaW+1GUydptgYeuz763eSdHdg8M0hvAOCUc/JAQ=",
+        "lastModified": 1740733879,
+        "narHash": "sha256-8GXnwJG14lVJ03M+hYwsnv3ufbEuKHT042ruyMWM9Io=",
         "owner": "Rishabh5321",
         "repo": "akuse-flake",
-        "rev": "2427ab800d3d9dd8d3d60cdb92e0be48e06d4159",
+        "rev": "2d0bd186d8cf3545ea67f8434ffda91a310691f9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                   | Message                                                                               |
| -------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------- |
| [`2d0bd186`](https://github.com/Rishabh5321/akuse-flake/commit/2d0bd186d8cf3545ea67f8434ffda91a310691f9) | `` docs: Remove testing workflow note from README ``                                  |
| [`9f32c953`](https://github.com/Rishabh5321/akuse-flake/commit/9f32c9537e27ff3d305fd4356d3854e228a5491f) | `` chore: remove dead code ``                                                         |
| [`ccf0ada4`](https://github.com/Rishabh5321/akuse-flake/commit/ccf0ada48382ed6946ecd222ad2af3e457cec6f6) | `` docs: Update testing workflow note in README ``                                    |
| [`d42a3e9a`](https://github.com/Rishabh5321/akuse-flake/commit/d42a3e9ab7fcc030d694f1bd354385c784012ef5) | `` docs: Add testing workflow note to README ``                                       |
| [`28ddefbc`](https://github.com/Rishabh5321/akuse-flake/commit/28ddefbc7776ab2ec72ee8b105d8aee8f5cb90e1) | `` chore: auto lint and format ``                                                     |
| [`0c9cd90e`](https://github.com/Rishabh5321/akuse-flake/commit/0c9cd90e100dee13d716c480cdd032b2eaea3da3) | `` fix: Simplify default package configuration in flake.nix ``                        |
| [`e5322079`](https://github.com/Rishabh5321/akuse-flake/commit/e53220795f82077aa18fa40805159066ef02f5a7) | `` update: update guidelines according to nix-unstable pkg and remove this warning `` |