### PR TITLE
chore(flake/nixpkgs-stable): `f44bd8ca` -> `b27ba4eb`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -772,11 +772,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1740603184,
-        "narHash": "sha256-t+VaahjQAWyA+Ctn2idyo1yxRIYpaDxMgHkgCNiMJa4=",
+        "lastModified": 1740743217,
+        "narHash": "sha256-brsCRzLqimpyhORma84c3W2xPbIidZlIc3JGIuQVSNI=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "f44bd8ca21e026135061a0a57dcf3d0775b67a49",
+        "rev": "b27ba4eb322d9d2bf2dc9ada9fd59442f50c8d7c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                 |
| ---------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------- |
| [`a8ad62f9`](https://github.com/NixOS/nixpkgs/commit/a8ad62f91814c86932c2def30bb9f4e53b7ec4d7) | `` influxdb3: init at 0-unstable-2025-02-17 ``                                          |
| [`676fbb83`](https://github.com/NixOS/nixpkgs/commit/676fbb83bbd731836517e7d927f71e033623bfe1) | `` nixos-anywhere: 1.6.0 -> 1.7.0 ``                                                    |
| [`31de0a64`](https://github.com/NixOS/nixpkgs/commit/31de0a64ea5f6b02321684e9ef4e552c2051905e) | `` linux_6_6: 6.6.79 -> 6.6.80 ``                                                       |
| [`16f08e45`](https://github.com/NixOS/nixpkgs/commit/16f08e451e7f378477531b5287c106f6a549bb41) | `` linux_6_12: 6.12.16 -> 6.12.17 ``                                                    |
| [`630fca1d`](https://github.com/NixOS/nixpkgs/commit/630fca1debe88a6464d5e0a1d66d24805c536c60) | `` linux_6_13: 6.13.4 -> 6.13.5 ``                                                      |
| [`6459ea3e`](https://github.com/NixOS/nixpkgs/commit/6459ea3eb744ec322386453d045932c84bf0f09f) | `` thunderbird-bin: 128.6.1esr -> 128.7.1esr ``                                         |
| [`bb267ac5`](https://github.com/NixOS/nixpkgs/commit/bb267ac52ce634aa98986c1f576a698e0cf3f74b) | `` mastodon: 4.3.3 -> 4.3.4 ``                                                          |
| [`902ce6ac`](https://github.com/NixOS/nixpkgs/commit/902ce6ac5c2f81016a13fe4739ae6018ce5dfb22) | `` ungoogled-chromium: 133.0.6943.126-1 -> 133.0.6943.141-1 ``                          |
| [`a81d81c4`](https://github.com/NixOS/nixpkgs/commit/a81d81c4326e983413a23f46cf6632dadb8188d7) | `` build(deps): bump korthout/backport-action from 3.1.0 to 3.2.0 ``                    |
| [`97d6455a`](https://github.com/NixOS/nixpkgs/commit/97d6455a79e396d6ccaaf6c224038bf49011f846) | `` amazon-ssm-agent: 3.3.1611.0 -> 3.3.1802.0 ``                                        |
| [`0e2d0d0b`](https://github.com/NixOS/nixpkgs/commit/0e2d0d0b7f42ba1110fc4e52e83f6ac4e2e2d7cf) | `` postfix: 3.9.2 -> 3.9.3 ``                                                           |
| [`7a2a86a4`](https://github.com/NixOS/nixpkgs/commit/7a2a86a4984a527093b104480f9002410b2731de) | `` raycast: 1.92.1 -> 1.93.0 ``                                                         |
| [`fea8354a`](https://github.com/NixOS/nixpkgs/commit/fea8354adff4f5d40ee1f47ecf10ae5402fdd370) | `` crate2nix: prefer environment cargo ``                                               |
| [`19b28dfd`](https://github.com/NixOS/nixpkgs/commit/19b28dfddfb26a75ac038cf006dd61dad397bd59) | `` libreswan: 5.1 -> 5.2 ``                                                             |
| [`8a68ffbc`](https://github.com/NixOS/nixpkgs/commit/8a68ffbc4e83da794ce03192bcdbea6337b2f9d6) | `` nixos-anywhere: 1.5.0 -> 1.6.0 ``                                                    |
| [`c7cd2eb5`](https://github.com/NixOS/nixpkgs/commit/c7cd2eb574ee3f8957702b56f48a3afa064cb3e0) | `` rabbitmqadmin-ng: init at 0.24.0 ``                                                  |
| [`6e8ad00c`](https://github.com/NixOS/nixpkgs/commit/6e8ad00c63440e2d83196d66b75a83d2ec738e49) | `` gitlab: 17.8.2 -> 17.9.1 ``                                                          |
| [`403c0ed5`](https://github.com/NixOS/nixpkgs/commit/403c0ed5086d7c41ebf076db140d00b6a186c99c) | `` jasmin-compiler: 2024.07.2 → 2024.07.3 ``                                            |
| [`6626549e`](https://github.com/NixOS/nixpkgs/commit/6626549edfd65fa2158b99f44829b01502b1fc4f) | `` iperf3: patch to exit with 0 on SIGTERM ``                                           |
| [`c323bd7a`](https://github.com/NixOS/nixpkgs/commit/c323bd7a22ddf71762ae13523d46c3c8846e8f25) | `` immich: 1.126.1 -> 1.127.0 ``                                                        |
| [`6d4d031c`](https://github.com/NixOS/nixpkgs/commit/6d4d031c99f7d0a64c8dc3ee7eb61f9bb7c0d8bd) | `` immich: 1.125.7 -> 1.126.1 ``                                                        |
| [`188e0039`](https://github.com/NixOS/nixpkgs/commit/188e003910a971091bc252a515dce6c9ebe5f59c) | `` lx-music-desktop: 2.9.0 -> 2.10.0 ``                                                 |
| [`a1f27c95`](https://github.com/NixOS/nixpkgs/commit/a1f27c9541a3cd0f4f13d87d58e0e4654d045aaf) | `` wordpress: 6.7.1 -> 6.7.2 ``                                                         |
| [`2e698899`](https://github.com/NixOS/nixpkgs/commit/2e6988995b293f90b13378b24397f5d95b08c31e) | `` garnet: 1.0.55 -> 1.0.57 ``                                                          |
| [`c6301ac3`](https://github.com/NixOS/nixpkgs/commit/c6301ac37ada2fd10866affcc966c1e13468154e) | `` dino: 0.4.4 -> 0.4.5 ``                                                              |
| [`b4b0d3da`](https://github.com/NixOS/nixpkgs/commit/b4b0d3da78d20157a809a1896b2d745a92d9230e) | `` tail-tray: 0.2.15 -> 0.2.16 ``                                                       |
| [`325782dc`](https://github.com/NixOS/nixpkgs/commit/325782dc2a99027b9b2c60cd3e47b342ba077ede) | `` biliup-rs: init at 0.2.2 ``                                                          |
| [`d0d763c5`](https://github.com/NixOS/nixpkgs/commit/d0d763c5bee460b477c21a45e3f0bf14ddfeec57) | `` radarr: 5.17.2.9580 -> 5.18.4.9674 ``                                                |
| [`e05ba16d`](https://github.com/NixOS/nixpkgs/commit/e05ba16d00ea4cd41821247baf2089ea75afee3b) | `` please-cli: 0.3.0 -> 0.4.2 ``                                                        |
| [`72017d4e`](https://github.com/NixOS/nixpkgs/commit/72017d4e8508027392ff0aedb4c0d8b2ea07f21f) | `` osu-lazer: 2025.221.0 -> 2025.225.0 ``                                               |
| [`5d091fc9`](https://github.com/NixOS/nixpkgs/commit/5d091fc94abc8d0567789fc86417a80a428baf3d) | `` osu-lazer-bin: 2025.221.0 -> 2025.225.0 ``                                           |
| [`61940957`](https://github.com/NixOS/nixpkgs/commit/61940957267d3468aa29dfd3acfecd28ddf44b03) | `` ptouch-print: enable build on unix ``                                                |
| [`b67c574c`](https://github.com/NixOS/nixpkgs/commit/b67c574c7adcf7705105b0514571eb95387dd266) | `` navidrome: 0.54.3 -> 0.54.5 ``                                                       |
| [`5cedef70`](https://github.com/NixOS/nixpkgs/commit/5cedef705c04fb7cb856fc332fcc64af03f2b47b) | `` icewm: 3.6.0 -> 3.7.0 ``                                                             |
| [`a0a067d7`](https://github.com/NixOS/nixpkgs/commit/a0a067d725634c21983ebb24490625793340368b) | `` veilid: 0.4.1 -> 0.4.3 ``                                                            |
| [`c678cb69`](https://github.com/NixOS/nixpkgs/commit/c678cb692405d061ff3c5b8d3fce70f754ab8aad) | `` lockbook-desktop: 0.9.18 -> 0.9.20 ``                                                |
| [`fb8b538a`](https://github.com/NixOS/nixpkgs/commit/fb8b538a11815a47613d2bfda97be9ade95e48f8) | `` flyctl: 0.3.75 -> 0.3.85 ``                                                          |
| [`8fffbb54`](https://github.com/NixOS/nixpkgs/commit/8fffbb541371cc7663d4c1b4b629c5d05dc606a1) | `` matrix-appservice-slack: move matrix-sdk-crypto-nodejs@0.1.0-beta3 into subfolder `` |
| [`9669b6ab`](https://github.com/NixOS/nixpkgs/commit/9669b6abae3abc904867c2634d0de9d57804ecd9) | `` matrix-synapse: move to pkgs/by-name ``                                              |
| [`c1ecf9fb`](https://github.com/NixOS/nixpkgs/commit/c1ecf9fb83f0953fa09cdee8ca9834073ec905b5) | `` matrix-appservice-slack: move out of matrix-synapse package ``                       |
| [`98f19679`](https://github.com/NixOS/nixpkgs/commit/98f196794e558205e66f3b69daa40cf1bfa24384) | `` rust-synapse-state-compress: move out of matrix-synapse package ``                   |
| [`0a42fc97`](https://github.com/NixOS/nixpkgs/commit/0a42fc9770495dd5186b95f3c74177c1e1b5fb0c) | `` synadm: split out of matrix-synapse package ``                                       |
| [`04bb69cd`](https://github.com/NixOS/nixpkgs/commit/04bb69cd2a9c2dffad7b3ebba966afb107cf1dca) | `` tclPackages.tclreadline: 2.4.0 -> 2.4.1 ``                                           |
| [`073db274`](https://github.com/NixOS/nixpkgs/commit/073db274263746b7330c825afd98649e13cba419) | `` astromenace: 1.4.2 -> 1.4.3 ``                                                       |
| [`f0af3728`](https://github.com/NixOS/nixpkgs/commit/f0af3728ecf593a9b93be6dc948766c694e6ec5a) | `` koboldcpp: 1.83.1 -> 1.84.2 (#383573) ``                                             |
| [`f681e44d`](https://github.com/NixOS/nixpkgs/commit/f681e44d3c25a3e905cf31f6190a36f72fcde744) | `` matomo: fix postFixup ``                                                             |
| [`3f65a981`](https://github.com/NixOS/nixpkgs/commit/3f65a981a7bf4af7f0799a393b4c2016f070922d) | `` mautrix-whatsapp: 0.11.2 -> 0.11.3 ``                                                |
| [`eb5292e6`](https://github.com/NixOS/nixpkgs/commit/eb5292e643921a6196333a97c054eaf442b956fb) | `` matomo: update patch ``                                                              |
| [`7e63d4a2`](https://github.com/NixOS/nixpkgs/commit/7e63d4a218fa074b2a207ec45fff6cc60afda0da) | `` skypeforlinux: 8.136.0.202 -> 8.136.0.203 ``                                         |
| [`f502d92c`](https://github.com/NixOS/nixpkgs/commit/f502d92cdc8e5a5c03dbcb44297706de57c4c51f) | `` open62541: 1.4.8 -> 1.4.10 ``                                                        |
| [`aff10f55`](https://github.com/NixOS/nixpkgs/commit/aff10f5503025ea6bb691224acfaa8f8f56a7685) | `` nixos/alertmanager-gotify-bridge: init module ``                                     |
| [`5c301c0f`](https://github.com/NixOS/nixpkgs/commit/5c301c0f4c8ef7226c9c43005d1a9662b976bd4d) | `` alertmanager-gotify-bridge: init at 2.3.2 ``                                         |
| [`41b458e1`](https://github.com/NixOS/nixpkgs/commit/41b458e1611be1d77d70db0d61c7f0a839561877) | `` maintainers: add juli0604 ``                                                         |
| [`6f21cf55`](https://github.com/NixOS/nixpkgs/commit/6f21cf55500ed1d51dd1d5ce3ed52796db55a4cf) | `` koto: init at 0.15.2 ``                                                              |
| [`58aee812`](https://github.com/NixOS/nixpkgs/commit/58aee8124fe4d49d6af41e23b9382d6035188a9e) | `` prowlarr: 1.28.2.4885 -> 1.29.2.4915 ``                                              |
| [`d13e1da0`](https://github.com/NixOS/nixpkgs/commit/d13e1da0d4e694b245908fc00f7a6a05e0c5161a) | `` protonplus: 0.4.20 -> 0.4.23 ``                                                      |
| [`afafc62b`](https://github.com/NixOS/nixpkgs/commit/afafc62b9e12bc9eacca9e64bbd1c76fba6677c2) | `` koto-ls: init at 0.15.0 ``                                                           |