### PR TITLE
chore(flake/home-manager): `f0b5e7e8` -> `fcac3d6d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -412,11 +412,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1740796616,
-        "narHash": "sha256-JU97wIfRxeFN6rpTsUVCwWAdix+Wka4Or23907YIrFI=",
+        "lastModified": 1740845322,
+        "narHash": "sha256-AXEgFj3C0YJhu9k1OhbRhiA6FnDr81dQZ65U3DhaWpw=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "f0b5e7e8a75abdea32bbff09ddd7b6eeb4b9b445",
+        "rev": "fcac3d6d88302a5e64f6cb8014ac785e08874c8d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                                          |
| ----------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------- |
| [`fcac3d6d`](https://github.com/nix-community/home-manager/commit/fcac3d6d88302a5e64f6cb8014ac785e08874c8d) | `` xdg: use mkOptionDefault ``                                                   |
| [`66505b85`](https://github.com/nix-community/home-manager/commit/66505b851b160a6937053a73b9b9808659df8c56) | `` xdg: add missing stateHome default for legacy ``                              |
| [`47c69496`](https://github.com/nix-community/home-manager/commit/47c694963e86b3e0f5d387506642a830871f331e) | `` tests: move xdg to cross platform tests ``                                    |
| [`17fd27a8`](https://github.com/nix-community/home-manager/commit/17fd27a8ea2d38c52f66c7685e766113ca4b2982) | `` tests: use mkDefault with enable ``                                           |
| [`30da4310`](https://github.com/nix-community/home-manager/commit/30da4310935450ea38931abf775ffe1dfab15355) | `` librewolf: support darwin (#6561) ``                                          |
| [`4f05ef6a`](https://github.com/nix-community/home-manager/commit/4f05ef6a8adb5c2e9de83fee6d316ce168daf705) | `` firefox: fix wrong syntax grammar for search setting isAppProvided (#6556) `` |