### PR TITLE
chore(flake/spicetify-nix): `fd31f20e` -> `f8d3757d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -914,11 +914,11 @@
         "systems": "systems_2"
       },
       "locked": {
-        "lastModified": 1740284169,
-        "narHash": "sha256-Ne+3kEyOFD2sNfw3cnKk+Zi/tTk+WkmnsfE7PDLNEXU=",
+        "lastModified": 1740889006,
+        "narHash": "sha256-A1iyKVvZrLdLwqWPC9OvPjC85ADQn2R1EGfCzJBl+wI=",
         "owner": "Gerg-L",
         "repo": "spicetify-nix",
-        "rev": "fd31f20e2bd2bf3894d729590bf578c02c252239",
+        "rev": "f8d3757d4ae3af2175a631fb9598a42d30ee75fc",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                    |
| ----------------------------------------------------------------------------------------------------- | -------------------------- |
| [`f8d3757d`](https://github.com/Gerg-L/spicetify-nix/commit/f8d3757d4ae3af2175a631fb9598a42d30ee75fc) | `` CI update 2025-03-02 `` |