### PR TITLE
chore(flake/akuse-flake): `72151b0f` -> `5638d7da`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -5,11 +5,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1740793565,
-        "narHash": "sha256-dOWbY63adLquDNy0QNu7PI0T91UHOzkXnoi7reWzPos=",
+        "lastModified": 1740925161,
+        "narHash": "sha256-fE94KJ/oNjrUfJ4hiDar0bZrgGTdcAVXGV9lmmiW4O8=",
         "owner": "Rishabh5321",
         "repo": "akuse-flake",
-        "rev": "72151b0f5a987475fd075b239305db987a7f06ef",
+        "rev": "5638d7da343b2a0dcce2b981ff68ecd2ef3e2ee2",
         "type": "github"
       },
       "original": {
@@ -744,11 +744,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1740695751,
-        "narHash": "sha256-D+R+kFxy1KsheiIzkkx/6L63wEHBYX21OIwlFV8JvDs=",
+        "lastModified": 1740828860,
+        "narHash": "sha256-cjbHI+zUzK5CPsQZqMhE3npTyYFt9tJ3+ohcfaOF/WM=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "6313551cd05425cd5b3e63fe47dbc324eabb15e4",
+        "rev": "303bd8071377433a2d8f76e684ec773d70c5b642",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                   | Message                                          |
| -------------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
| [`5638d7da`](https://github.com/Rishabh5321/akuse-flake/commit/5638d7da343b2a0dcce2b981ff68ecd2ef3e2ee2) | `` chore(flake/nixpkgs): 6313551c -> 303bd807 `` |