### PR TITLE
chore(flake/nixpkgs-stable): `b27ba4eb` -> `5ef6c425`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -772,11 +772,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1740743217,
-        "narHash": "sha256-brsCRzLqimpyhORma84c3W2xPbIidZlIc3JGIuQVSNI=",
+        "lastModified": 1740865531,
+        "narHash": "sha256-h00vGIh/jxcGl8aWdfnVRD74KuLpyY3mZgMFMy7iKIc=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "b27ba4eb322d9d2bf2dc9ada9fd59442f50c8d7c",
+        "rev": "5ef6c425980847c78a80d759abc476e941a9bf42",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                         |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------- |
| [`5b522a13`](https://github.com/NixOS/nixpkgs/commit/5b522a138bc033b79fba3ec4263555fcd1fbb9da) | `` dcmtk: 3.6.8 -> 3.6.9 ``                                                     |
| [`8a9c9f01`](https://github.com/NixOS/nixpkgs/commit/8a9c9f01413069dedd3993e25e2dc56cb8a52483) | `` meshcentral: 1.1.38 -> 1.1.39 ``                                             |
| [`13400dce`](https://github.com/NixOS/nixpkgs/commit/13400dcefa1bfb4d4da9a23a47ce12c7e5d761d0) | `` vscode-extensions.equinusocio.vsc-material-theme{-icons}: move to aliases `` |
| [`80c2d4e5`](https://github.com/NixOS/nixpkgs/commit/80c2d4e5fd3b148bdaf6cd3db779718d4b981ca0) | `` ntpd-rs: 1.4.0 -> 1.5.0 ``                                                   |
| [`c1393555`](https://github.com/NixOS/nixpkgs/commit/c13935555c372d7ac65e4d1ab0b0c3dc275bf328) | `` keycloak: 26.1.2 -> 26.1.3 ``                                                |
| [`a2626d58`](https://github.com/NixOS/nixpkgs/commit/a2626d5886cdbee58c80e5d88e53599d48d3a5dc) | `` vscode-extensions.equinusocio.vsc-material-theme: remove at 34.7.5 ``        |
| [`b6fd406f`](https://github.com/NixOS/nixpkgs/commit/b6fd406ff4b92a1a1956c4fab68a39969974d213) | `` vscode-extensions.equinusocio.vsc-material-theme-icons: remove at 3.8.8 ``   |
| [`dfbc27d2`](https://github.com/NixOS/nixpkgs/commit/dfbc27d2ca148d4a7f0b673984c0d95977db3e98) | `` k3s_1_31: 1.31.5 -> 1.31.6 ``                                                |
| [`eb81b213`](https://github.com/NixOS/nixpkgs/commit/eb81b213a54ef25e260acb5e500ee29edc5b7001) | `` k3s_1_30: 1.30.9 -> 1.30.10 ``                                               |
| [`dfe9faa8`](https://github.com/NixOS/nixpkgs/commit/dfe9faa864100ab97b902071480abc8d548d0f87) | `` k3s_1_29: 1.29.13 -> 1.29.14 ``                                              |
| [`45101201`](https://github.com/NixOS/nixpkgs/commit/45101201b1c9945275851dd82f800468837a2fa0) | `` fedifetcher: 7.1.14 -> 7.1.15 ``                                             |
| [`824e88d2`](https://github.com/NixOS/nixpkgs/commit/824e88d2ec1e2937a7eac4a8ef0aad98096bb2ea) | `` efibootmgr: fetch patch to allow reordering boot entries ``                  |
| [`74d7b56a`](https://github.com/NixOS/nixpkgs/commit/74d7b56adbd2f209a77f00603da1a34557a8d03b) | `` matrix-synapse: 1.124.0 -> 1.125 ``                                          |
| [`24f6d934`](https://github.com/NixOS/nixpkgs/commit/24f6d9346d3a6ce01d1be807d2260c4b2523d72f) | `` matrix-synapse-unwrapped: add update script ``                               |
| [`7e50ce1b`](https://github.com/NixOS/nixpkgs/commit/7e50ce1bc0223a218d88bf3ffae5162a578182f3) | `` matrix-synapse.tools: fix the eval (delete) ``                               |
| [`9de80d3f`](https://github.com/NixOS/nixpkgs/commit/9de80d3f3ac048b816c0c9effbbe0b91ca03130a) | `` [Backport release-24.11] k3s_1_30: 1.30.8+k3s1 -> 1.30.9+k3s1 ``             |
| [`15d91046`](https://github.com/NixOS/nixpkgs/commit/15d910464645b77481d8991fda8ab50437e5dc24) | `` [Backport release-24.11] k3s_1_29: 1.29.12+k3s1 -> 1.29.13+k3s1 ``           |