### PR TITLE
chore(flake/nix-gaming): `d8f2ee44` -> `5a240f91`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -728,11 +728,11 @@
         "nixpkgs": "nixpkgs_3"
       },
       "locked": {
-        "lastModified": 1740879783,
-        "narHash": "sha256-qcev0BeRGEKHJ9KoKnVyZVIgGhnhLSbSjKVXPoFOyFg=",
+        "lastModified": 1740981963,
+        "narHash": "sha256-UVI1Nn5rHFLX5p3Bym/7u+LdZEnBr3pclprcUPkslvw=",
         "owner": "fufexan",
         "repo": "nix-gaming",
-        "rev": "d8f2ee44e0038a1b90f4dd381e9f31fe1c112f1a",
+        "rev": "5a240f9176826c61afc664e58e55256428a5be93",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                              | Message                                    |
| --------------------------------------------------------------------------------------------------- | ------------------------------------------ |
| [`5a240f91`](https://github.com/fufexan/nix-gaming/commit/5a240f9176826c61afc664e58e55256428a5be93) | `` Revert "osu-lazer-bin: SDL2 -> sdl3" `` |