### PR TITLE
chore(flake/nixpkgs-stable): `5ef6c425` -> `1546c45c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -771,11 +771,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1740865531,
-        "narHash": "sha256-h00vGIh/jxcGl8aWdfnVRD74KuLpyY3mZgMFMy7iKIc=",
+        "lastModified": 1740932899,
+        "narHash": "sha256-F0qDu2egq18M3edJwEOAE+D+VQ+yESK6YWPRQBfOqq8=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "5ef6c425980847c78a80d759abc476e941a9bf42",
+        "rev": "1546c45c538633ae40b93e2d14e0bb6fd8f13347",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                  |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------ |
| [`b1c4852e`](https://github.com/NixOS/nixpkgs/commit/b1c4852e9f61a79281dfc03039dcbc0625ca997d) | `` alt-tab-macos: 7.20.0 -> 7.21.1 ``                                    |
| [`79020a75`](https://github.com/NixOS/nixpkgs/commit/79020a75765711b086b8d016f6d7db742f2bf31b) | `` brave: 1.75.175 -> 1.75.178 ``                                        |
| [`2b588bf4`](https://github.com/NixOS/nixpkgs/commit/2b588bf4805be39c836cd56095ebd65a158e8465) | `` python3Packages.asyncpg: disable a test broken by python ``           |
| [`534647d9`](https://github.com/NixOS/nixpkgs/commit/534647d9a94f6befb4720b21d7c5b5cf43bc330b) | `` python312Packages.pyqt6: fix build with Qt 6.8.2 ``                   |
| [`f6d1d84e`](https://github.com/NixOS/nixpkgs/commit/f6d1d84e2f76846fdd3995884c8342ef8feb98d0) | `` victoriametrics: 1.111.0 -> 1.112.0 ``                                |
| [`5b97c679`](https://github.com/NixOS/nixpkgs/commit/5b97c67982d9573dfb2214ca450a9068aac4f980) | `` xorg.xorgserver: 21.1.15 -> 21.1.16 (security) ``                     |
| [`cf33f99d`](https://github.com/NixOS/nixpkgs/commit/cf33f99dd163f0269d4e39afafb22dc56051d159) | `` xorg.xorgserver: 21.1.14 -> 21.1.15 ``                                |
| [`4f232dbd`](https://github.com/NixOS/nixpkgs/commit/4f232dbdd98d4fd2d9ced96cf274cf021fd0279f) | `` qt6: disable xcode version check on Darwin ``                         |
| [`fa70fc2b`](https://github.com/NixOS/nixpkgs/commit/fa70fc2b612a6a1da5d032941d6d16690135a4b2) | `` openh264: 2.4.1 -> 2.6.0 ``                                           |
| [`98ce341c`](https://github.com/NixOS/nixpkgs/commit/98ce341c1689bd26def7e950770c8db1e5b8ecc1) | `` vim: 9.1.1006 -> 9.1.1046 ``                                          |
| [`87b13770`](https://github.com/NixOS/nixpkgs/commit/87b1377047ce68a275a13480cb1b1f25daaa4bcd) | `` vim: 9.1.0990 -> 9.1.1006 ``                                          |
| [`51dd724f`](https://github.com/NixOS/nixpkgs/commit/51dd724f2257df8069ce4ecfcc50d37064fad7ac) | `` vim: 9.1.0905 -> 9.1.0990 ``                                          |
| [`56140e7e`](https://github.com/NixOS/nixpkgs/commit/56140e7e616a49878e4d50ededb40ddd99e2e02b) | `` vim: 9.1.0787 -> 9.1.0905 ``                                          |
| [`9043f382`](https://github.com/NixOS/nixpkgs/commit/9043f38269db94801a397aa88dcb56e54bba692a) | `` {postgresql*,libpq}: replace rev with tag ``                          |
| [`f770af18`](https://github.com/NixOS/nixpkgs/commit/f770af18836bdc5857aa92231e6c088f8ef0fe0d) | `` postgresql_17: 17.2 -> 17.4 ``                                        |
| [`3cf736af`](https://github.com/NixOS/nixpkgs/commit/3cf736af2c9b0126ed2d416849907852c2feff85) | `` postgresql_16: 16.6 -> 16.8 ``                                        |
| [`6461e872`](https://github.com/NixOS/nixpkgs/commit/6461e8724ce55566e38113a534b295bee8e263ae) | `` postgresql_15: 15.10 -> 15.12 ``                                      |
| [`9d178e53`](https://github.com/NixOS/nixpkgs/commit/9d178e532eb69255382c8d140d9f379d16eb5d74) | `` postgresql_14: 14.15 -> 14.17 ``                                      |
| [`59af478e`](https://github.com/NixOS/nixpkgs/commit/59af478e1af485f8af3d2f534eb7bba2443df15d) | `` postgresql_13: 13.18 -> 13.20 ``                                      |
| [`e6cf4b25`](https://github.com/NixOS/nixpkgs/commit/e6cf4b25a562059dce4424a4f0c28bcf8dbb2c93) | `` postgresql: fetch from GitHub instead of tarball ``                   |
| [`869428e2`](https://github.com/NixOS/nixpkgs/commit/869428e2c8dcaa92174553e5742a2ea4b85855b1) | `` libxml: 2.13.5 -> 2.13.6 ``                                           |
| [`f88c85e1`](https://github.com/NixOS/nixpkgs/commit/f88c85e17eac1acb0de8046a293005b85160145e) | `` curl: 8.12.0 -> 8.12.1 ``                                             |
| [`695729fb`](https://github.com/NixOS/nixpkgs/commit/695729fbf54ee9882636b2b853d6fa47e1528664) | `` ell: 0.69 -> 0.70 ``                                                  |
| [`24ba2749`](https://github.com/NixOS/nixpkgs/commit/24ba27492396a4bc779914021317fb2ce8cd08dc) | `` glib-networking: 2.80.0 → 2.80.1 ``                                   |
| [`12d33297`](https://github.com/NixOS/nixpkgs/commit/12d33297f8b99ebe3c0a79c462f8a82cb3c57ca0) | `` at-spi2-core: 2.54.0 → 2.54.1 ``                                      |
| [`e6d8f0d9`](https://github.com/NixOS/nixpkgs/commit/e6d8f0d95e36ddeed5edf605ca371a95f3fbaa82) | `` gtk4: 4.16.7 → 4.16.12 ``                                             |
| [`d200e09e`](https://github.com/NixOS/nixpkgs/commit/d200e09e30a714bb2973248426ed1da75904cc77) | `` libsecret: 0.21.4 → 0.21.6 ``                                         |
| [`8f2f6fea`](https://github.com/NixOS/nixpkgs/commit/8f2f6fea927604f211a767c3fc9b199cb039c845) | `` qemu: 9.1.2 -> 9.1.3 ``                                               |
| [`8be86f29`](https://github.com/NixOS/nixpkgs/commit/8be86f292264767ced0b47dd3ac23191c6d8d43b) | `` darwin.top: 139 -> 139.40.2 ``                                        |
| [`0868e9eb`](https://github.com/NixOS/nixpkgs/commit/0868e9ebecc964ab39fc03707707a6a91e47ab8e) | `` darwin.system_cmds: 1012 -> 1012.60.2 ``                              |
| [`f26fef28`](https://github.com/NixOS/nixpkgs/commit/f26fef287d6a4a25ab709e948a4851fb2eabea92) | `` darwin.network_cmds: 696 -> 698.60.4 ``                               |
| [`6d749dca`](https://github.com/NixOS/nixpkgs/commit/6d749dcab6b02f246721bfc0d3bd73e8bf2ce36f) | `` darwin.libpcap: 135 -> 137 ``                                         |
| [`a2d38959`](https://github.com/NixOS/nixpkgs/commit/a2d38959d2dee7953ad8d9a7ca617f1182ab0ee3) | `` darwin.libiconv: 107 -> 109 ``                                        |
| [`bff3bfd7`](https://github.com/NixOS/nixpkgs/commit/bff3bfd79203f5c738012d5ce0f1e1265c313175) | `` darwin.libffi: 35 -> 39 ``                                            |
| [`0e38def9`](https://github.com/NixOS/nixpkgs/commit/0e38def958e0e2cc65e9bcde2b20ecddbd3fcd22) | `` darwin.diskdev_cmds: 735 -> 737.60.1 ``                               |
| [`2ab30b03`](https://github.com/NixOS/nixpkgs/commit/2ab30b0318c2d7e40cb21429cdd1d5720d26a4bb) | `` darwin.developer_cmds: 79 -> 83 ``                                    |
| [`42bafd24`](https://github.com/NixOS/nixpkgs/commit/42bafd2434feb6cffe85683d93cade86a042763c) | `` darwin.copyfile: 213 -> 213.40.2 ``                                   |
| [`f150d7c4`](https://github.com/NixOS/nixpkgs/commit/f150d7c4ab88db802a348ef788ebde5b351e719f) | `` darwin.PowerManagement: 1740.0.7 -> 1740.60.27 ``                     |
| [`c56d5e2c`](https://github.com/NixOS/nixpkgs/commit/c56d5e2c64e1676416e1f0ff1b0e448978e622b7) | `` darwin.ICU: 74221 -> 74222.203 ``                                     |
| [`a6bb8359`](https://github.com/NixOS/nixpkgs/commit/a6bb8359b4754b3aefc37b9b2d914c5c1f6ac5f1) | `` darwin.AvailabilityVersions: 143.3 -> 143.6 ``                        |
| [`3bd94b80`](https://github.com/NixOS/nixpkgs/commit/3bd94b80c92c9a3c1129aa609ce079540312cb83) | `` apple-sdk_15: 15.0 -> 15.2 ``                                         |
| [`291eaff2`](https://github.com/NixOS/nixpkgs/commit/291eaff2f4f9683949a24b0b0238d5d70361c21d) | `` apple-sdk_{10_{12,13,14,15},11,12,13,14}: use Wayback Machine URLs `` |
| [`f64140e8`](https://github.com/NixOS/nixpkgs/commit/f64140e82e66ea63be5364bb0aeb61e47c63384d) | `` openssl_3_3: 3.3.2 -> 3.3.3 ``                                        |
| [`cf81911d`](https://github.com/NixOS/nixpkgs/commit/cf81911d662fa7642e328ca9c61cd1cd76c5ef46) | `` openssl_3: 3.0.15 -> 3.0.16 ``                                        |
| [`b17808cb`](https://github.com/NixOS/nixpkgs/commit/b17808cbebf3a6883ed3588f54a97e13b8752867) | `` nodejs_20: 20.18.2 -> 20.18.3 ``                                      |
| [`d39cb7e6`](https://github.com/NixOS/nixpkgs/commit/d39cb7e6cc305dd9692edd88f32439e1e37f284f) | `` curlMinimal: allow local networking on Darwin ``                      |
| [`b1c69a85`](https://github.com/NixOS/nixpkgs/commit/b1c69a858f75e1eb3706361d88967fd49ec7f489) | `` curl: add Scrumplex to maintainers ``                                 |
| [`64baf304`](https://github.com/NixOS/nixpkgs/commit/64baf30466e31a2d82f0e186354add4531bd5035) | `` curl: 8.11.1 -> 8.12.0 ``                                             |
| [`251d6a3f`](https://github.com/NixOS/nixpkgs/commit/251d6a3f84e69eaf2a5b8796757f0da7672bdb2d) | `` python312Packages.pyunbound: fix build ``                             |
| [`057f17db`](https://github.com/NixOS/nixpkgs/commit/057f17db15ddcc3304c517e92b9527aadfbbaba8) | `` unbound: bison is required when cross-compiling ``                    |
| [`fab2289e`](https://github.com/NixOS/nixpkgs/commit/fab2289e118025e14a84f0886e107309f75f8822) | `` unbound: support dynlib module (#333301) ``                           |
| [`49f36465`](https://github.com/NixOS/nixpkgs/commit/49f36465ae5e41b46d0084a8a6e88bf695ccfb5a) | `` unbound: fetch source from GitHub ``                                  |
| [`fefd49b2`](https://github.com/NixOS/nixpkgs/commit/fefd49b2f11a5c29cb627af5248df8b4c89964a8) | `` unbound: 1.21.1 -> 1.22.0 ``                                          |
| [`cfa91d48`](https://github.com/NixOS/nixpkgs/commit/cfa91d48cb343753a40278e6aef928d466397e06) | `` tcl: fix on static architectures ``                                   |
| [`d150aa3b`](https://github.com/NixOS/nixpkgs/commit/d150aa3bec8a4fd0ed850abde003a66f2074748c) | `` libtasn1: 4.19.0 -> 4.20.0 ``                                         |
| [`7d762711`](https://github.com/NixOS/nixpkgs/commit/7d76271122b8760fbdc9cc5ed1b9a9121b4d277b) | `` python313Packages.django_4: 4.2.18 -> 4.2.19 ``                       |
| [`5f4f5a6c`](https://github.com/NixOS/nixpkgs/commit/5f4f5a6c4cce6156e5a90d53fc840f5964a5bd32) | `` cacert: 3.107 -> 3.108 ``                                             |
| [`d2274755`](https://github.com/NixOS/nixpkgs/commit/d2274755d785233550c34ec20b0f03a553d3387a) | `` qt6: backport patches recommended by KDE folks ``                     |
| [`ee662996`](https://github.com/NixOS/nixpkgs/commit/ee662996019e6c63d66ea1d87cb955663736305b) | `` go_1_23: 1.23.5 -> 1.23.6 ``                                          |
| [`06aecd36`](https://github.com/NixOS/nixpkgs/commit/06aecd366c674fa29b44b867f69108a2b29001d8) | `` cpython: patch CVE-2025-0938 ``                                       |
| [`86c09812`](https://github.com/NixOS/nixpkgs/commit/86c0981230fd186dcefe317db93963c0bcdd1810) | `` qt6: 6.8.1 -> 6.8.2 ``                                                |
| [`338dc372`](https://github.com/NixOS/nixpkgs/commit/338dc372dd4a5b5516025ce9469b8c7c6b136eb1) | `` nodejs_20: 20.18.1 -> 20.18.2 ``                                      |
| [`a4c7d013`](https://github.com/NixOS/nixpkgs/commit/a4c7d01329ce83b35437c3029910a9da678baeb9) | `` libopenmpt: 0.7.12 -> 0.7.13 ``                                       |
| [`49f4abf4`](https://github.com/NixOS/nixpkgs/commit/49f4abf458f298bea17a5bf97aedc7da219e2369) | `` glibc: 2.40-36 -> 2.40-66 ``                                          |