### PR TITLE
chore(flake/seanime): `3aebc3d3` -> `84b76b07`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -927,11 +927,11 @@
         "nixpkgs": "nixpkgs_5"
       },
       "locked": {
-        "lastModified": 1741071887,
-        "narHash": "sha256-DfQZH8RWjI+wNixbx0fTcwrcpL0mIe/PZt+CkAGcbl4=",
+        "lastModified": 1741098487,
+        "narHash": "sha256-UkJUbHJfQVFf8xyPdai7lwnNwQWRR6JzzBcTJF1tITU=",
         "owner": "rishabh5321",
         "repo": "seanime-flake",
-        "rev": "3aebc3d3c9948b1f8d1149f237cfd569c197aa41",
+        "rev": "84b76b07321cbc3253b72e43f2003a39106d4a6b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                     | Message                                                                         |
| ---------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------- |
| [`04d51184`](https://github.com/Rishabh5321/seanime-flake/commit/04d51184d33cd6d9072960405703cf758dadbaa5) | `` chore: auto lint and format ``                                               |
| [`7efe9868`](https://github.com/Rishabh5321/seanime-flake/commit/7efe986861767d6a7cec8a94eadce4d5ab4ac546) | `` feat(systemd): Add startup delay as was noticing some issues with seanime `` |