### PR TITLE
chore(flake/home-manager): `b1b964ea` -> `def0dbbc`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -433,11 +433,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1741128660,
-        "narHash": "sha256-GWaZ+KGxWYbOB15CSqktwngq0ccA1l2Ov3aUfl9jeY4=",
+        "lastModified": 1741174782,
+        "narHash": "sha256-dYRebJk58/d5Ej1G6xTOadTfG6tU5zFgXYrLsRJlrgw=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "b1b964ea9348aef08cab514fa88e9c99def6fd63",
+        "rev": "def0dbbcea715d4514ca343ab4d6d7f3a1742da0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                 |
| ----------------------------------------------------------------------------------------------------------- | --------------------------------------- |
| [`def0dbbc`](https://github.com/nix-community/home-manager/commit/def0dbbcea715d4514ca343ab4d6d7f3a1742da0) | `` vscode: Support Cursor AI (#6417) `` |