### PR TITLE
chore(flake/akuse-flake): `cc17d8d0` -> `63c0bfdd`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -5,11 +5,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1741036897,
-        "narHash": "sha256-a4vpU6iNq5Us5qxU2psd21ywVqTBgMf5EuvkdS47n1c=",
+        "lastModified": 1741151515,
+        "narHash": "sha256-iq0rhJYfTCVZHupg5K6DMtZw28dzAriOR33Sf2WHNbs=",
         "owner": "Rishabh5321",
         "repo": "akuse-flake",
-        "rev": "cc17d8d039acfdd9c7dcb2720ce067def81d31a6",
+        "rev": "63c0bfdd7702475cf63248d950bad01323c4e341",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                   | Message                                                              |
| -------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------- |
| [`63c0bfdd`](https://github.com/Rishabh5321/akuse-flake/commit/63c0bfdd7702475cf63248d950bad01323c4e341) | `` fix(nix): Specify x86_64-linux package in README configuration `` |