### PR TITLE
chore(flake/nixpkgs-stable): `1546c45c` -> `6af28b83`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -791,11 +791,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1740932899,
-        "narHash": "sha256-F0qDu2egq18M3edJwEOAE+D+VQ+yESK6YWPRQBfOqq8=",
+        "lastModified": 1741048562,
+        "narHash": "sha256-W4YZ3fvWZiFYYyd900kh8P8wU6DHSiwaH0j4+fai1Sk=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "1546c45c538633ae40b93e2d14e0bb6fd8f13347",
+        "rev": "6af28b834daca767a7ef99f8a7defa957d0ade6f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                           |
| ---------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------- |
| [`6af28b83`](https://github.com/NixOS/nixpkgs/commit/6af28b834daca767a7ef99f8a7defa957d0ade6f) | `` xdp-tools: patch to allow building with Emacs 30 ``                            |
| [`2c13ab4e`](https://github.com/NixOS/nixpkgs/commit/2c13ab4e8d2387139564101e28298d97c57381bb) | `` sunshine: fix placeholder values in sunshine.desktop ``                        |
| [`5e4153df`](https://github.com/NixOS/nixpkgs/commit/5e4153dfb29fcd104a8041dfeecc094bd0b2792b) | `` gitlab: fix merge requests pages by running script of vue-demi ``              |
| [`5e9cd21e`](https://github.com/NixOS/nixpkgs/commit/5e9cd21ec1ad6b375808dd7cea2737af21a40cd7) | `` gitlab: update ruby and downgrade nodejs to meet upstreams recommendations ``  |
| [`7c7f936e`](https://github.com/NixOS/nixpkgs/commit/7c7f936e76ab21c0f3f669df2ab929a02d702a24) | `` linux_testing: 6.14-rc4 -> 6.14-rc5 ``                                         |
| [`8277b851`](https://github.com/NixOS/nixpkgs/commit/8277b85188dacdb66b0958bf2d2c8f614697ef7b) | `` build(deps): bump actions/create-github-app-token from 1.11.5 to 1.11.6 ``     |
| [`7550672e`](https://github.com/NixOS/nixpkgs/commit/7550672e52df252f04fa2dfd22095988a422d537) | `` sunshine: 2025.118.151840 -> 2025.122.141614 ``                                |
| [`4abe169b`](https://github.com/NixOS/nixpkgs/commit/4abe169bdaaa1783e948ca23246c8fb8ff41784a) | `` stm32cubemx: add StartupWMClass= to desktop file ``                            |
| [`62a38aa6`](https://github.com/NixOS/nixpkgs/commit/62a38aa64791b918f12b2e47fe3c97606f781018) | `` stm32cubemx: fix missing icon ``                                               |
| [`f2e9f1df`](https://github.com/NixOS/nixpkgs/commit/f2e9f1df5d481e41cd4aa9a09edb1ecf53ba8d33) | `` stm32cubemx: fix desktop file ``                                               |
| [`e198365a`](https://github.com/NixOS/nixpkgs/commit/e198365afac927a3c109b0ea144ddd55a132afcf) | `` virt-top: 1.1.1 -> 1.1.2 ``                                                    |
| [`fd06ef92`](https://github.com/NixOS/nixpkgs/commit/fd06ef92d9e70913a421563634c1b07f8cecc864) | `` komikku: 1.70.0 -> 1.71.0 ``                                                   |
| [`6729d229`](https://github.com/NixOS/nixpkgs/commit/6729d22933a35233d00fc3f58887582ef82d851b) | `` wlx-overlay-s: 25.2.0 -> 25.3.0 ``                                             |
| [`8d33ad42`](https://github.com/NixOS/nixpkgs/commit/8d33ad42cef48031d2f65808dc1b4ee765ed1b61) | `` linuxPackages.prl-tools: 20.2.1-55876 -> 20.2.2-55879 ``                       |
| [`0444a03e`](https://github.com/NixOS/nixpkgs/commit/0444a03e80db8f8aa37b6a0abe61f64e0cd14d74) | `` switch-to-configuration-ng: increase dbus timeout to 10s ``                    |
| [`b81dc13e`](https://github.com/NixOS/nixpkgs/commit/b81dc13e0e67e44e4a647ab4c78650241213091e) | `` dcmtk: update build flags, add patches ``                                      |
| [`2ed05307`](https://github.com/NixOS/nixpkgs/commit/2ed05307126868415c7a530f288e3bbcad186352) | `` nodejs_18: 18.20.6 -> 18.20.7 ``                                               |
| [`b03a73df`](https://github.com/NixOS/nixpkgs/commit/b03a73df34a5ce1b7c10d25e8f78b34ed879ce25) | `` emacs-pgtk: init at 30.1 ``                                                    |
| [`daac9d1a`](https://github.com/NixOS/nixpkgs/commit/daac9d1a2a630203e7ca181e544bdadfc2bf02ca) | `` emacs: bump default version to latest stable release 30.1 ``                   |
| [`c00b51e6`](https://github.com/NixOS/nixpkgs/commit/c00b51e6cc0c61221aa7df08a74129bcc5fc2ee9) | `` emacs: let hydra not build epkgs to speed up bumping default Emacs ``          |
| [`70f2c65e`](https://github.com/NixOS/nixpkgs/commit/70f2c65e235b3fdf81c9258d8d6f45cf62aff277) | `` emacs: mark version < 30 as insecure and tell users to use emacs30 ``          |
| [`c9c03c02`](https://github.com/NixOS/nixpkgs/commit/c9c03c025a7e94eef2d4a7f88d0b20d7bd77a3c7) | `` syn2mas: 0.12.0 -> 0.13.0 ``                                                   |
| [`a7e7c839`](https://github.com/NixOS/nixpkgs/commit/a7e7c839669a9b2a86f09c9f0e3ea24a2b6bb08b) | `` video2x: init at 6.4.0 ``                                                      |
| [`168242d0`](https://github.com/NixOS/nixpkgs/commit/168242d00959782b939752984ba64253cb2ec153) | `` linux_xanmod_latest: 6.13.4 -> 6.13.5 ``                                       |
| [`6d131b81`](https://github.com/NixOS/nixpkgs/commit/6d131b8181c3fb53ab9f8095b0312a1ec08212ba) | `` linux_xanmod: 6.12.16 -> 6.12.17 ``                                            |
| [`adc1e1a7`](https://github.com/NixOS/nixpkgs/commit/adc1e1a777774f0064f45b6b290fae47ba4f6d2d) | `` linux_xanmod_latest: 6.12.15 -> 6.13.4 ``                                      |
| [`c7c5f388`](https://github.com/NixOS/nixpkgs/commit/c7c5f38853d617984b7d0b74b83e604ef2890f5a) | `` linux_xanmod: 6.12.15 -> 6.12.16 ``                                            |
| [`60e221e4`](https://github.com/NixOS/nixpkgs/commit/60e221e43fe3ce2e03bd9d24166753c660fff6f9) | `` koboldcpp: 1.84.2 -> 1.85 ``                                                   |
| [`d427919e`](https://github.com/NixOS/nixpkgs/commit/d427919e1502b5f6f6dd2771a777f9a8c8cfcc47) | `` warp-terminal: 0.2025.02.19.08.02.stable_05 -> 0.2025.02.26.08.02.stable_02 `` |
| [`1f474e96`](https://github.com/NixOS/nixpkgs/commit/1f474e9644658f123a19fef87762a618ba57fda3) | `` brave: 1.75.178 -> 1.75.180 ``                                                 |
| [`606b2a3a`](https://github.com/NixOS/nixpkgs/commit/606b2a3a3fcf0543549afe14e456a3cf6f296247) | `` lib.derivations: add warnOnInstantiate ``                                      |