### PR TITLE
chore(flake/hyprland): `d7e7a292` -> `24337607`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -541,11 +541,11 @@
         "xdph": "xdph"
       },
       "locked": {
-        "lastModified": 1741035361,
-        "narHash": "sha256-WSfqkzWUY8FMFnaGm0n9QcoO0cgqJbYcv3ccfkFv7Qw=",
+        "lastModified": 1741218628,
+        "narHash": "sha256-Z+jPT8nijCV1EzCZ5XkLr8x82WPCX/GKk8OKg8Kr+s4=",
         "owner": "hyprwm",
         "repo": "Hyprland",
-        "rev": "d7e7a292613a4f20218074ff8299dff099a80098",
+        "rev": "243376078655f304b01e5097c59108745bbb9da9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                                                            |
| ------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------ |
| [`24337607`](https://github.com/hyprwm/Hyprland/commit/243376078655f304b01e5097c59108745bbb9da9) | `` hyprctl: Error handling improvements, minor cleanups (#9536) `` |
| [`b51ab182`](https://github.com/hyprwm/Hyprland/commit/b51ab182ae3e8d88426af856b59dd28c6a9722ef) | `` socket2: add activespecialv2 (#9530) ``                         |