### PR TITLE
chore(flake/grayjay): `4a9a2a61` -> `b4e485d8`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -431,11 +431,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1741258338,
-        "narHash": "sha256-odXMC65RySHmUN+DLIi+So+GyA0mzq/S/+fVrrjlGtU=",
+        "lastModified": 1741260077,
+        "narHash": "sha256-wPMMpvqbn8/N4IM55PzTEvuaSJTbbYcCdZ8h8Q3OvtQ=",
         "owner": "rishabh5321",
         "repo": "grayjay-flake",
-        "rev": "4a9a2a612142b69e2bc6ea8766c13065dfc215b5",
+        "rev": "b4e485d86628bd0792b9672e8ccf32932c70dd8d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                     | Message                                                             |
| ---------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------- |
| [`8a41aacb`](https://github.com/Rishabh5321/grayjay-flake/commit/8a41aacb0448dd3fde810df7c68b5359319b9941) | `` chore: auto lint and format ``                                   |
| [`9e647dd5`](https://github.com/Rishabh5321/grayjay-flake/commit/9e647dd51fce18bf4d32a159a5ee1b8fa024da6a) | `` chore: Remove default package configuration in flake.nix ``      |
| [`2c02c4ec`](https://github.com/Rishabh5321/grayjay-flake/commit/2c02c4ec041e08d5b503e4a8a4952fc433ea0787) | `` chore: auto lint and format ``                                   |
| [`921918ec`](https://github.com/Rishabh5321/grayjay-flake/commit/921918eca2c7164a7fa3466fc6ba35e8a94495fb) | `` chore: Add metadata for Grayjay app in flake.nix ``              |
| [`ecd0f61c`](https://github.com/Rishabh5321/grayjay-flake/commit/ecd0f61c73f52591e92df49008114f003e3da68e) | `` docs: Simplify README structure and remove redundant sections `` |