### PR TITLE
chore(flake/nixpkgs-stable): `6af28b83` -> `48913d8f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -809,11 +809,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1741048562,
-        "narHash": "sha256-W4YZ3fvWZiFYYyd900kh8P8wU6DHSiwaH0j4+fai1Sk=",
+        "lastModified": 1741196730,
+        "narHash": "sha256-0Sj6ZKjCpQMfWnN0NURqRCQn2ob7YtXTAOTwCuz7fkA=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "6af28b834daca767a7ef99f8a7defa957d0ade6f",
+        "rev": "48913d8f9127ea6530a2a2f1bd4daa1b8685d8a3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                         |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------- |
| [`89658bdd`](https://github.com/NixOS/nixpkgs/commit/89658bdd422297c3920cddce71de07c8204fb6ae) | `` checkpolicy: remove meta.name and add main program ``                        |
| [`1a48e30b`](https://github.com/NixOS/nixpkgs/commit/1a48e30b2889fe93ce7d33f4dd7de334fb77fe35) | `` vscode-extensions.eamodio.gitlens: 16.0.5 -> 16.3.2 ``                       |
| [`933137e0`](https://github.com/NixOS/nixpkgs/commit/933137e052b2cd9cd8bc7004580a698cc805477f) | `` todesk: bind tmpfs on /opt/todesk ``                                         |
| [`bc6ee30e`](https://github.com/NixOS/nixpkgs/commit/bc6ee30e1823221570ec895b9e4ac94c62d747de) | `` firefox-esr-128-unwrapped: 128.7.0esr -> 128.8.0esr ``                       |
| [`a9c40768`](https://github.com/NixOS/nixpkgs/commit/a9c40768fbb52b7db336c1f59a5a2607acc1eac2) | `` firefox-bin-unwrapped: 135.0.1 -> 136.0 ``                                   |
| [`f6eac4d3`](https://github.com/NixOS/nixpkgs/commit/f6eac4d3868ef38ebcc4e82b79e4ab070ab722e8) | `` firefox-unwrapped: 135.0.1 -> 136.0 ``                                       |
| [`a8d33ac8`](https://github.com/NixOS/nixpkgs/commit/a8d33ac8cb47708fab8060bb29280b82dc82900d) | `` vscode-extensions.eamodio.gitlens: 15.6.0 -> 16.0.5 ``                       |
| [`813059b1`](https://github.com/NixOS/nixpkgs/commit/813059b1f911fb9c61c6301007927d40b9aabbeb) | `` signal-desktop(darwin): 7.42.0 -> 7.44.0 ``                                  |
| [`5cb15df8`](https://github.com/NixOS/nixpkgs/commit/5cb15df875192e54e1dca65707257361700b0ecd) | `` signal-desktop: 7.42.0 -> 7.44.0 ``                                          |
| [`32909485`](https://github.com/NixOS/nixpkgs/commit/3290948518c5fe07a76acdff7d24e4d6a6114a30) | `` monado: set VIT_SYSTEM_LIBRARY_PATH so that libbasalt.so can be found ``     |
| [`7e5da789`](https://github.com/NixOS/nixpkgs/commit/7e5da78944abdc0bad7f8c784d5e00d1d92fd6fd) | `` brave: 1.75.180 -> 1.75.181 ``                                               |
| [`8a98039a`](https://github.com/NixOS/nixpkgs/commit/8a98039a28c3dcf084612dd26f7600309f8672c1) | `` percona-server_8_0: 8.0.40-31 -> 8.0.41-32 ``                                |
| [`f5ef9877`](https://github.com/NixOS/nixpkgs/commit/f5ef987744876d31466de72048c6b9b0c91b9a4e) | `` lightningstream: init at 0.4.3 ``                                            |
| [`b5fe0daa`](https://github.com/NixOS/nixpkgs/commit/b5fe0daa8f14771fb784a640fdc4906b55b10bad) | `` firefox-beta-unwrapped: 135.0b3 -> 135.0b9 ``                                |
| [`1560334a`](https://github.com/NixOS/nixpkgs/commit/1560334a1b19f114614b0478c56606a168f08c17) | `` ofono: 2.3 -> 2.14 ``                                                        |
| [`5cf91713`](https://github.com/NixOS/nixpkgs/commit/5cf9171388e7368e2ceb6365a57fbff1ab72aed0) | `` gnomeExtensions.gtk4-desktop-icons-ding-ng: update the patch ``              |
| [`9baccf87`](https://github.com/NixOS/nixpkgs/commit/9baccf87eb9816f4122a8765f540186bc4ba75fa) | `` gnomeExtensions: auto-update ``                                              |
| [`be3c15b9`](https://github.com/NixOS/nixpkgs/commit/be3c15b9dc769393eacdf0a9ffce31f6dce60640) | `` teleport_17: init at 17.2.1 ``                                               |
| [`0cf933a3`](https://github.com/NixOS/nixpkgs/commit/0cf933a3e6956f499f23e398d1a775c3d4abfd2f) | `` teleport_15, teleport_16: Use fetchCargoVendor ``                            |
| [`64ad9e6c`](https://github.com/NixOS/nixpkgs/commit/64ad9e6c57222ddcae6b9e64bf7ce635a32cdb59) | `` linuxPackages.rtl8821ce: remove hhm from maintainers ``                      |
| [`aff5d303`](https://github.com/NixOS/nixpkgs/commit/aff5d3033f6d428339686fb01a93bfbfd494416a) | `` linuxPackages.rtl8821ce: refactor ``                                         |
| [`371c8b0c`](https://github.com/NixOS/nixpkgs/commit/371c8b0cce669912cfe0195ebaf890e788d0e580) | `` linuxPackages.rtl8821ce: unstable-2024-03-26 -> unstable-2025-02-08 ``       |
| [`175fb12c`](https://github.com/NixOS/nixpkgs/commit/175fb12cbb7ba453a3ca585f546f58defe5af5bf) | `` prowlarr: reformat with nixfmt ``                                            |
| [`5151af3e`](https://github.com/NixOS/nixpkgs/commit/5151af3ed27639c89f032d8c9f52b001cf195e58) | `` prowlarr: move to pkgs/by-name ``                                            |
| [`ad130ca9`](https://github.com/NixOS/nixpkgs/commit/ad130ca99847b80957a5aa523c9931aa6eeef687) | `` skypeforlinux: 8.136.0.203 -> 8.137.0.425 ``                                 |
| [`0276ab0c`](https://github.com/NixOS/nixpkgs/commit/0276ab0cfe2907a933ee2c118dc8d6754485ff60) | `` jetbrains.plugins: update ``                                                 |
| [`6ffbb1bd`](https://github.com/NixOS/nixpkgs/commit/6ffbb1bdf29f7670084ec0a6e7237bf7e884395c) | `` jetbrains: 2024.3.2 -> 2024.3.5 ``                                           |
| [`dc4b2995`](https://github.com/NixOS/nixpkgs/commit/dc4b299564389f168dff43ced614e5c46b1bac0b) | `` vscode-extensions.llvm-vs-code-extensions.vscode-clangd: 0.1.24 -> 0.1.33 `` |
| [`64eb35ff`](https://github.com/NixOS/nixpkgs/commit/64eb35ffa28ac514a8673a70c2c1e3797fd55e2e) | `` vscode-extensions.streetsidesoftware.code-spell-checker: 4.0.21 -> 4.0.41 `` |
| [`8ed6004b`](https://github.com/NixOS/nixpkgs/commit/8ed6004bd265526ae4d147e656eeff2b207981d2) | `` jetbrains.plugins: init minecraft-development at 1.8.2 ``                    |
| [`8f8c1768`](https://github.com/NixOS/nixpkgs/commit/8f8c17680bd6244ddefc06d107bf2b4d7c368b96) | `` vscode-extensions.vscodevim.vim: 1.26.1 -> 1.29.0 ``                         |
| [`a987ef69`](https://github.com/NixOS/nixpkgs/commit/a987ef6943523ff4373e08b9f259059c9a5654fe) | `` vscode-extensions.asciidoctor.asciidoctor-vscode: 2.8.9 -> 3.4.2 ``          |
| [`2b572905`](https://github.com/NixOS/nixpkgs/commit/2b572905a2f864bb29d11b88c5ea0fa871d7e807) | `` vscode-extensions.jnoortheen.nix-ide: 0.3.5 -> 0.4.12 ``                     |
| [`336e1d56`](https://github.com/NixOS/nixpkgs/commit/336e1d56c564e5e905933c3f545f5a0073197c08) | `` vscode-extensions.arrterian.nix-env-selector: 1.0.10 -> 1.0.12 ``            |
| [`a1d54dbc`](https://github.com/NixOS/nixpkgs/commit/a1d54dbc884e13e61d7094df55826bebb4410122) | `` vscode-extensions.jnoortheen.nix-ide: 0.3.1 -> 0.3.5 ``                      |
| [`74285508`](https://github.com/NixOS/nixpkgs/commit/74285508ea0d7238ac11d2258905bbe5bf111ceb) | `` vscode-extensions.haskell.haskell: 2.2.2 -> 2.4.4 ``                         |
| [`242edc09`](https://github.com/NixOS/nixpkgs/commit/242edc0962dd3b94ad23348134fd9a3f74541156) | `` virt-manager: add StartupWMClass= to desktop file ``                         |
| [`b7131ec2`](https://github.com/NixOS/nixpkgs/commit/b7131ec2aae833dea7b357815c70f9ffff7081ee) | `` notmuch: fix build with emacs30 ``                                           |
| [`56ea807f`](https://github.com/NixOS/nixpkgs/commit/56ea807f2cf6e0602cd6e2f07026cf440aa0e852) | `` jetbrains.plugins: add several ``                                            |
| [`06ca4b67`](https://github.com/NixOS/nixpkgs/commit/06ca4b6794001033f60bdf0e0de891994af337a3) | `` kime: fix build ``                                                           |
| [`8be5f8f3`](https://github.com/NixOS/nixpkgs/commit/8be5f8f3709c1be2d737fdf421639bc6583548ef) | `` nixosTests.dependency-track: increase memorySize to fix test ``              |
| [`f0b2c33e`](https://github.com/NixOS/nixpkgs/commit/f0b2c33eff20e403968d8e650706b43ca44e9f55) | `` opencomposite: 0-unstable-2025-02-08 -> 1.0.1473 ``                          |
| [`93a58bbf`](https://github.com/NixOS/nixpkgs/commit/93a58bbfed265fa08be1b529111b18a5fdd98ba6) | `` grafana-image-renderer: 3.12.0 -> 3.12.1 ``                                  |
| [`09f3201f`](https://github.com/NixOS/nixpkgs/commit/09f3201f97fc39123b47b3391ae14be1e9098d07) | `` xrgears: 1.0.1-unstable-2024-07-09 -> 1.0.1-unstable-2025-03-03 ``           |
| [`519ee63b`](https://github.com/NixOS/nixpkgs/commit/519ee63b403cd82d5f73243362888566490e09f4) | `` electron-chromedriver_34: 34.2.0 -> 34.3.0 ``                                |
| [`4b64c0ec`](https://github.com/NixOS/nixpkgs/commit/4b64c0ec0561798b32cd1060f439ed90bfea5602) | `` electron_34-bin: 34.2.0 -> 34.3.0 ``                                         |
| [`bac6ac90`](https://github.com/NixOS/nixpkgs/commit/bac6ac90091f3e732a21195e77bc26de83b7b612) | `` electron-chromedriver_33: 33.4.1 -> 33.4.2 ``                                |
| [`16919a51`](https://github.com/NixOS/nixpkgs/commit/16919a51356e9777c74a105529bd9fa80cac9168) | `` electron-source.electron_33: 33.4.1 -> 33.4.2 ``                             |
| [`f3c1c729`](https://github.com/NixOS/nixpkgs/commit/f3c1c7291063dbbe9cc7cd46791b7cf88c6aa66e) | `` electron_33-bin: 33.4.1 -> 33.4.2 ``                                         |
| [`85cc0322`](https://github.com/NixOS/nixpkgs/commit/85cc03222bc375fd5dfe10c6f9519b17f818318e) | `` electron-chromedriver_32: 32.3.1 -> 32.3.2 ``                                |
| [`030a1667`](https://github.com/NixOS/nixpkgs/commit/030a166726e16e6c6232c746700837497bc08b46) | `` electron-source.electron_32: 32.3.1 -> 32.3.2 ``                             |
| [`e2b51479`](https://github.com/NixOS/nixpkgs/commit/e2b5147917f550fbecc262fa9048c37583a0b0a8) | `` electron_32-bin: 32.3.1 -> 32.3.2 ``                                         |
| [`68f8c6a6`](https://github.com/NixOS/nixpkgs/commit/68f8c6a689761256cbb25ae0a25c162ab5c52536) | `` element-call: 0.6.3 -> 0.7.1 ``                                              |
| [`06a515e1`](https://github.com/NixOS/nixpkgs/commit/06a515e144c3c3d1d92dc2c5181485600bc2e3df) | `` protonplus: 0.4.23 -> 0.4.24 ``                                              |
| [`668987ae`](https://github.com/NixOS/nixpkgs/commit/668987aee90e56958f17ee87d59ac669ed1919b2) | `` otb: init at 9.0.0 ``                                                        |
| [`1a9a4949`](https://github.com/NixOS/nixpkgs/commit/1a9a49498d73ff7809b2b5a7a5ab4c8629c86635) | `` shark: init at 4.0-unstable-2024-05-25 ``                                    |
| [`fd477d2d`](https://github.com/NixOS/nixpkgs/commit/fd477d2d7785b0c11a13063a0fd1cf3be96f6d51) | `` itk_4_13: init at 4.13.3 ``                                                  |
| [`c9c5a68e`](https://github.com/NixOS/nixpkgs/commit/c9c5a68ecc0bc3bae1f9a62b982c3060f75854f0) | `` nixos-anywhere: 1.7.0 -> 1.8.0 ``                                            |
| [`609b4f76`](https://github.com/NixOS/nixpkgs/commit/609b4f76c1655cdcdd1438997caad2fcd6b27ab4) | `` nixos-anywhere: add myself as a maintainer ``                                |
| [`28f605ff`](https://github.com/NixOS/nixpkgs/commit/28f605ff6f8b63234fc0f3cad9741405044229e1) | `` maintainers: add @daspk04 ``                                                 |
| [`930b8b90`](https://github.com/NixOS/nixpkgs/commit/930b8b90c9f48019eaaabe483d1fefd4929ab946) | `` nodejs_23: 23.8.0 -> 23.9.0 ``                                               |