### PR TITLE
chore(flake/akuse-flake): `1d974ec5` -> `cafd2bdf`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -5,11 +5,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1741235232,
-        "narHash": "sha256-HVdVKTxUZmIUuXXBNVl9p/xiwdMX/iBTBf9szkyAGKY=",
+        "lastModified": 1741321585,
+        "narHash": "sha256-RtJeYmXC+yAxJGDC5Ih6QWAZtqLgnqXLJaaQVFW1kgs=",
         "owner": "Rishabh5321",
         "repo": "akuse-flake",
-        "rev": "1d974ec51c4c088dea95d3e80464f2944077de8a",
+        "rev": "cafd2bdf399462f7c9c344bf45336d7728bd28a9",
         "type": "github"
       },
       "original": {
@@ -781,11 +781,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1741173522,
-        "narHash": "sha256-k7VSqvv0r1r53nUI/IfPHCppkUAddeXn843YlAC5DR0=",
+        "lastModified": 1741246872,
+        "narHash": "sha256-Q6pMP4a9ed636qilcYX8XUguvKl/0/LGXhHcRI91p0U=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "d69ab0d71b22fa1ce3dbeff666e6deb4917db049",
+        "rev": "10069ef4cf863633f57238f179a0297de84bd8d3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                   | Message                                          |
| -------------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
| [`cafd2bdf`](https://github.com/Rishabh5321/akuse-flake/commit/cafd2bdf399462f7c9c344bf45336d7728bd28a9) | `` chore(flake/nixpkgs): d69ab0d7 -> 10069ef4 `` |