### PR TITLE
chore(flake/grayjay): `c3f64486` -> `bd47282b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -431,11 +431,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1741279268,
-        "narHash": "sha256-tkFe+A5EK53n55e7HOMaH/G6Kvl7wLNqPxq5PDR6eAI=",
+        "lastModified": 1741321432,
+        "narHash": "sha256-CW2yNjCUqBnX6/J0mcS/fz3nNseJOhojAGR1F3MaM9A=",
         "owner": "rishabh5321",
         "repo": "grayjay-flake",
-        "rev": "c3f6448601f6d77a9cec454867a08071d88624b8",
+        "rev": "bd47282b622e807a16029750716cbf1067e1d790",
         "type": "github"
       },
       "original": {
@@ -825,11 +825,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1741173522,
-        "narHash": "sha256-k7VSqvv0r1r53nUI/IfPHCppkUAddeXn843YlAC5DR0=",
+        "lastModified": 1741246872,
+        "narHash": "sha256-Q6pMP4a9ed636qilcYX8XUguvKl/0/LGXhHcRI91p0U=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "d69ab0d71b22fa1ce3dbeff666e6deb4917db049",
+        "rev": "10069ef4cf863633f57238f179a0297de84bd8d3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                     | Message                                                                 |
| ---------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------- |
| [`bd47282b`](https://github.com/Rishabh5321/grayjay-flake/commit/bd47282b622e807a16029750716cbf1067e1d790) | `` chore(flake/nixpkgs): d69ab0d7 -> 10069ef4 ``                        |
| [`eec0afb8`](https://github.com/Rishabh5321/grayjay-flake/commit/eec0afb889ac2f859671b326beb28b84ffd47987) | `` refactor: Improve Grayjay directory copy and permissions handling `` |