### PR TITLE
chore(flake/stylix): `11780517` -> `6fada03c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1063,11 +1063,11 @@
         "tinted-zed": "tinted-zed"
       },
       "locked": {
-        "lastModified": 1741112087,
-        "narHash": "sha256-dBGwN4aHmX2QUXolZDhV+p06+WM5ZykL4wd9BD6bT7k=",
+        "lastModified": 1741335745,
+        "narHash": "sha256-jsYqEZ/gll40Jgl8BhzEAYz4E86uwUm99RkaVY38chk=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "11780517948f214b9f93d1bf5a2d29bc181d3a33",
+        "rev": "6fada03cd5e223aa9c111e7073118692065a7ee1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                        | Message                                         |
| --------------------------------------------------------------------------------------------- | ----------------------------------------------- |
| [`6fada03c`](https://github.com/danth/stylix/commit/6fada03cd5e223aa9c111e7073118692065a7ee1) | `` nvf: init (#939) ``                          |
| [`48538792`](https://github.com/danth/stylix/commit/4853879264376ae7d20dea2a7af58490f179bc7a) | `` vscode: support arbitrary profiles (#914) `` |