### PR TITLE
chore(flake/home-manager): `04c915bc` -> `d2c014e1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -451,11 +451,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1741345870,
-        "narHash": "sha256-KTpoO4oaucdFr3oJJBYpGK+aWVVrLvtiT17EQE7Cf4Y=",
+        "lastModified": 1741393072,
+        "narHash": "sha256-+Su28oU1FBvptj1AO0geJP+BcIJghSVxaNFagvW5K2M=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "04c915bcf1a1eac3519372ff3185beef053fba7c",
+        "rev": "d2c014e1c73195d1958abec0c5ca6112b07b79da",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                               |
| ----------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------- |
| [`d2c014e1`](https://github.com/nix-community/home-manager/commit/d2c014e1c73195d1958abec0c5ca6112b07b79da) | `` treewide: null package support (#6582) ``                          |
| [`6c2b7940`](https://github.com/nix-community/home-manager/commit/6c2b79403e9ae852fbf1d55b29f2ea4d2aa43255) | `` treewide: use graphical-session.target for GUI services (#5785) `` |
| [`95711f92`](https://github.com/nix-community/home-manager/commit/95711f926676018d279ba09fe7530d03b5d5b3e2) | `` treewide: remove with lib (#6512) ``                               |
| [`83f46293`](https://github.com/nix-community/home-manager/commit/83f4629364b6e627ce25d7d246058e48ffa4b111) | `` granted: support fish shell (#6549) ``                             |