### PR TITLE
chore(flake/stylix): `6fada03c` -> `6eea250b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1063,11 +1063,11 @@
         "tinted-zed": "tinted-zed"
       },
       "locked": {
-        "lastModified": 1741335745,
-        "narHash": "sha256-jsYqEZ/gll40Jgl8BhzEAYz4E86uwUm99RkaVY38chk=",
+        "lastModified": 1741392477,
+        "narHash": "sha256-6ySHuduGhlZBv1uxEOlOeHWDEkKuLQ/O63DI+ZRfAmg=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "6fada03cd5e223aa9c111e7073118692065a7ee1",
+        "rev": "6eea250b10386be0fc23496d1039d76b3147680e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                        | Message                                    |
| --------------------------------------------------------------------------------------------- | ------------------------------------------ |
| [`6eea250b`](https://github.com/danth/stylix/commit/6eea250b10386be0fc23496d1039d76b3147680e) | `` dunst: fix opacity rounding (#965) ``   |
| [`4891f147`](https://github.com/danth/stylix/commit/4891f1471b682af073574dc51fa4810f1470ef8f) | `` stylix: simplify dummy values (#959) `` |
| [`74f1ac55`](https://github.com/danth/stylix/commit/74f1ac55d3b09fb3be23563d398b430e756a6e83) | `` fnott: init (#948) ``                   |
| [`7fc0a871`](https://github.com/danth/stylix/commit/7fc0a8716e753f0341300ebe34cda5f8a90527f8) | `` stylix: add editorconfig (#945) ``      |