### PR TITLE
chore(flake/nixpkgs-stable): `48913d8f` -> `20755fa0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -809,11 +809,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1741196730,
-        "narHash": "sha256-0Sj6ZKjCpQMfWnN0NURqRCQn2ob7YtXTAOTwCuz7fkA=",
+        "lastModified": 1741332913,
+        "narHash": "sha256-ri1e8ZliWS3Jnp9yqpKApHaOo7KBN33W8ECAKA4teAQ=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "48913d8f9127ea6530a2a2f1bd4daa1b8685d8a3",
+        "rev": "20755fa05115c84be00b04690630cb38f0a203ad",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                    |
| ---------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------- |
| [`20755fa0`](https://github.com/NixOS/nixpkgs/commit/20755fa05115c84be00b04690630cb38f0a203ad) | `` emacs: add a patch to fix upstream bug#63288 and bug#76523 ``           |
| [`dba30f04`](https://github.com/NixOS/nixpkgs/commit/dba30f04e056720749356dc3136869ea61d64517) | `` julia-bin: autoPatchelf manually to avoid mangling cache ``             |
| [`ba922183`](https://github.com/NixOS/nixpkgs/commit/ba922183e59a2e1aa4a000dbbd9edb6f1557098c) | `` mangojuice: use vkbasalt ``                                             |
| [`1e054d2b`](https://github.com/NixOS/nixpkgs/commit/1e054d2b53cd2f52d01c47ce8e688c14980c5641) | `` dosage-tracker: 1.9.1 -> 1.9.3 ``                                       |
| [`8b054c58`](https://github.com/NixOS/nixpkgs/commit/8b054c58bd5ba429a36481f50bccd54c567fffcd) | `` dolibarr: 20.0.4 -> 21.0.0 ``                                           |
| [`565117f6`](https://github.com/NixOS/nixpkgs/commit/565117f60e7e9790d91f5f87f65eeceb17db99a3) | `` keepassxc: 2.7.9 -> 2.7.10 ``                                           |
| [`8610c509`](https://github.com/NixOS/nixpkgs/commit/8610c509ff89f980d6ba5645095885af901f1f67) | `` garnet: 1.0.57 -> 1.0.58 ``                                             |
| [`d6b2c333`](https://github.com/NixOS/nixpkgs/commit/d6b2c333fa89b184315120a7cf8393e9ed2d642a) | `` lock: 1.4.1 -> 1.4.2 ``                                                 |
| [`b6f45962`](https://github.com/NixOS/nixpkgs/commit/b6f4596294d851f7a333ee66f169fab2d36f7d16) | `` garage: 1.0.1 -> 1.1.0 ``                                               |
| [`fd2d7317`](https://github.com/NixOS/nixpkgs/commit/fd2d7317188d4006061cb08b1ffff23dcf145a86) | `` protonplus: 0.4.24 -> 0.4.25 ``                                         |
| [`3d11ac2f`](https://github.com/NixOS/nixpkgs/commit/3d11ac2ff0e1ad6baed53a479867e09d2d581c5c) | `` firmware-manager: use fetchCargoVendor ``                               |
| [`1907ea1e`](https://github.com/NixOS/nixpkgs/commit/1907ea1e8f63d206c8bf7991552a539f8a4baeaa) | `` vscode-extensions.illixion.vscode-vibrancy-continued: init at 1.1.44 `` |
| [`54d9f930`](https://github.com/NixOS/nixpkgs/commit/54d9f9306de888dba7c9bcd8e8a5af6dabbc9a92) | `` maintainers: add _2hexed ``                                             |
| [`dd666ecd`](https://github.com/NixOS/nixpkgs/commit/dd666ecd3f90cbf115be71aac13b3a6f2383fb48) | `` emacs: patch mailcap.el to find pkgs.mailcap ``                         |
| [`ae402133`](https://github.com/NixOS/nixpkgs/commit/ae40213396fd6703095767c8364c7d8489ca8f22) | `` edukai: 4.0 -> 5.0 ``                                                   |
| [`74428df6`](https://github.com/NixOS/nixpkgs/commit/74428df6a6c07a681f7cc75725f7d601bc099e3d) | `` librewolf: 135.0.1-1 -> 136.0-1 ``                                      |
| [`7329b644`](https://github.com/NixOS/nixpkgs/commit/7329b644e22eca658d30182bb3323997639f194e) | `` librewolf: 135.0-1 -> 135.0.1-1 ``                                      |
| [`c04d01fb`](https://github.com/NixOS/nixpkgs/commit/c04d01fb910f5c75f4958c187e5aa8a9a9caabd3) | `` librewolf: 134.0.1-1 -> 135.0-1 ``                                      |
| [`6b2b74aa`](https://github.com/NixOS/nixpkgs/commit/6b2b74aaa7688fa467822d44e998065fec841923) | `` librewolf: 134.0 -> 134.0.1 ``                                          |
| [`a460ab30`](https://github.com/NixOS/nixpkgs/commit/a460ab30fd58e9b723b14cd5fa124e03d4a903c6) | `` [24.11] python312Packages.ariadne: 0.23.0 -> 0.24 (#387249) ``          |
| [`d5b271c3`](https://github.com/NixOS/nixpkgs/commit/d5b271c3c212139805cc21fc52e48cdef735c3cc) | `` chromium,chromedriver: 133.0.6943.141 -> 134.0.6998.35 ``               |
| [`b7110349`](https://github.com/NixOS/nixpkgs/commit/b71103495d1955882bebb51d606b8cfb085169e1) | `` chromium: prepare for M134 ``                                           |
| [`e9ef8fd7`](https://github.com/NixOS/nixpkgs/commit/e9ef8fd7c2db8984bf82e59a1ae87f3e37612d28) | `` nixos/osquery: revert test for database_path ``                         |
| [`3698efdb`](https://github.com/NixOS/nixpkgs/commit/3698efdb9afaa79fb0eae7195dd1d698053a2fe1) | `` nixos/osquery: set default database_path and logger_path ``             |
| [`7143119e`](https://github.com/NixOS/nixpkgs/commit/7143119e504c06f8c125ceacd374273bc414c60a) | `` nixos/osquery: fix database_path + logger_path opts per systemd docs `` |
| [`fdd0b663`](https://github.com/NixOS/nixpkgs/commit/fdd0b663299e40126a0c433537157cae5f67ca88) | `` floorp: 11.23.1 -> 11.24.0 ``                                           |
| [`680356a3`](https://github.com/NixOS/nixpkgs/commit/680356a3d98993b68adcd0059e88b4bfa603727f) | `` dotnetCorePackages.dotnet_10.vmr: init at 10.0.0-preview.1 ``           |
| [`d5053a34`](https://github.com/NixOS/nixpkgs/commit/d5053a343e70c1be15cd4f96369e7561fc3b9abb) | `` dotnet-{sdk,runtime,aspnetcore}_10: init at 10.0.0-preview.1.25080.5 `` |
| [`42088350`](https://github.com/NixOS/nixpkgs/commit/42088350c3a17a251c392411ec4d52827658b569) | `` sdl3: 3.2.2 -> 3.2.6, fix version regex ``                              |
| [`d4a177b7`](https://github.com/NixOS/nixpkgs/commit/d4a177b741f523f6f4798f544db3692dc2db709d) | `` patroni: 4.0.4 -> 4.0.5 ``                                              |
| [`b8de9b49`](https://github.com/NixOS/nixpkgs/commit/b8de9b49fe8ac3b92105c353c331fdaf39550d1a) | `` mangojuice: 0.8.1 -> 0.8.2 ``                                           |
| [`358b3691`](https://github.com/NixOS/nixpkgs/commit/358b369157182147f46234a41a0dfe348c31da1f) | `` mangojuice: add pciutils to $PATH ``                                    |
| [`bb496f45`](https://github.com/NixOS/nixpkgs/commit/bb496f45d443d261f1b5ce5dca61accecb7f9d04) | `` sydbox: 3.32.2 -> 3.32.3 ``                                             |
| [`2142df6d`](https://github.com/NixOS/nixpkgs/commit/2142df6d552b77f45e4cf94e4eeb72359dda6db7) | `` sydbox: 3.30.1 -> 3.32.2 ``                                             |
| [`eac2c1c4`](https://github.com/NixOS/nixpkgs/commit/eac2c1c47eafc091f5cdcf9bb64d8e304917477b) | `` sydbox: 3.30.0 -> 3.30.1 ``                                             |
| [`174a4a42`](https://github.com/NixOS/nixpkgs/commit/174a4a42d31703f5a3883d7b830fc13a72b9b182) | `` nss_latest: 3.108 -> 3.109 ``                                           |
| [`6e1569c2`](https://github.com/NixOS/nixpkgs/commit/6e1569c2730930e84014ff5a06c7665f892d9f28) | `` dosage-tracker: 1.8.3 -> 1.9.1 ``                                       |