### PR TITLE
chore(flake/zen-browser): `7de16ae3` -> `b166ec44`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1271,11 +1271,11 @@
         "nixpkgs": "nixpkgs_7"
       },
       "locked": {
-        "lastModified": 1740554227,
-        "narHash": "sha256-xpwZeMw2gGenixGQDyVv+ja+epcR+EJ1BPuGFdgFS18=",
+        "lastModified": 1741428924,
+        "narHash": "sha256-Ivq8Ih3glwhdtSmVYBveL1eioyvUAIP1ZX/lgZEHcCM=",
         "owner": "0xc000022070",
         "repo": "zen-browser-flake",
-        "rev": "7de16ae319e6f6852274fa90b0d41c00049767c9",
+        "rev": "b166ec443ea9ede1891f6291b17b97772e8c392b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                          | Message                                                   |
| --------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------- |
| [`b166ec44`](https://github.com/0xc000022070/zen-browser-flake/commit/b166ec443ea9ede1891f6291b17b97772e8c392b) | `` Update Zen Browser beta @ x86_64 && aarch64 to 1.9b `` |