### PR TITLE
chore(flake/hyprland): `4082e876` -> `b80b64cd`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -559,11 +559,11 @@
         "xdph": "xdph"
       },
       "locked": {
-        "lastModified": 1741388183,
-        "narHash": "sha256-7Pu1rH3YJpWLUrgQBSbeR+e5TVtEN1IwLLk1soOCalE=",
+        "lastModified": 1741396322,
+        "narHash": "sha256-nD6EvpTNQ97C0Uk60JcyNUM4u4OFxIiwHPSExay+Y3E=",
         "owner": "hyprwm",
         "repo": "Hyprland",
-        "rev": "4082e876d522dc6ed7118d62cdaa729f84c1b755",
+        "rev": "b80b64cd6c913f8c8ac820a1e4ca615a62ff958f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                                                                              |
| ------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------ |
| [`b80b64cd`](https://github.com/hyprwm/Hyprland/commit/b80b64cd6c913f8c8ac820a1e4ca615a62ff958f) | `` windowrules: add option to allow size persistence between app launches (#9422) `` |