### PR TITLE
chore(flake/zen-browser): `b166ec44` -> `6dceddfe`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1271,11 +1271,11 @@
         "nixpkgs": "nixpkgs_7"
       },
       "locked": {
-        "lastModified": 1741428924,
-        "narHash": "sha256-Ivq8Ih3glwhdtSmVYBveL1eioyvUAIP1ZX/lgZEHcCM=",
+        "lastModified": 1741450391,
+        "narHash": "sha256-zEFEI2RWmxYS5EZTlA8VnX5X7AueDKpXF2IjJx+dyKE=",
         "owner": "0xc000022070",
         "repo": "zen-browser-flake",
-        "rev": "b166ec443ea9ede1891f6291b17b97772e8c392b",
+        "rev": "6dceddfe8e1691607eaa8d9f12f33ab6a5acea82",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                          | Message                                                                                |
| --------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------- |
| [`6dceddfe`](https://github.com/0xc000022070/zen-browser-flake/commit/6dceddfe8e1691607eaa8d9f12f33ab6a5acea82) | `` ci(update): support for twilight releases based on the same tag with same commit `` |