### PR TITLE
chore(flake/hyprland): `b80b64cd` -> `d30cc19d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -559,11 +559,11 @@
         "xdph": "xdph"
       },
       "locked": {
-        "lastModified": 1741396322,
-        "narHash": "sha256-nD6EvpTNQ97C0Uk60JcyNUM4u4OFxIiwHPSExay+Y3E=",
+        "lastModified": 1741461862,
+        "narHash": "sha256-TNTtpDHoNB+wOEfypkGTu2zC0wHUwbabQo4HyU53Yok=",
         "owner": "hyprwm",
         "repo": "Hyprland",
-        "rev": "b80b64cd6c913f8c8ac820a1e4ca615a62ff958f",
+        "rev": "d30cc19d253a3db784ad10c3084f58cbb52d325a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                                                                   |
| ------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------- |
| [`d30cc19d`](https://github.com/hyprwm/Hyprland/commit/d30cc19d253a3db784ad10c3084f58cbb52d325a) | `` renderer: skip ds commits if buffer didn't change (#9556) ``           |
| [`f15b49e0`](https://github.com/hyprwm/Hyprland/commit/f15b49e0fd54d2cecc77f7eedbf7cd8f22215707) | `` core: prevent crash when monitor list is empty (#9572) ``              |
| [`c544c511`](https://github.com/hyprwm/Hyprland/commit/c544c5115c8d35a2212b3dcb93ae90cf8a9f8f0c) | `` windowrules: store floating size on close instead of resize (#9569) `` |