### PR TITLE
chore(flake/nixpkgs): `10069ef4` -> `36fd87ba`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -873,11 +873,11 @@
     },
     "nixpkgs_5": {
       "locked": {
-        "lastModified": 1741246872,
-        "narHash": "sha256-Q6pMP4a9ed636qilcYX8XUguvKl/0/LGXhHcRI91p0U=",
+        "lastModified": 1741379970,
+        "narHash": "sha256-Wh7esNh7G24qYleLvgOSY/7HlDUzWaL/n4qzlBePpiw=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "10069ef4cf863633f57238f179a0297de84bd8d3",
+        "rev": "36fd87baa9083f34f7f5027900b62ee6d09b1f2f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                     |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------- |
| [`f28e6aa5`](https://github.com/NixOS/nixpkgs/commit/f28e6aa5f322ab91cc8d987708c9b8ea6a1244bc) | `` python312Packages.netbox-routing: 0.2.3 -> 0.3.0 (#388019) ``                            |
| [`aded50da`](https://github.com/NixOS/nixpkgs/commit/aded50da108e87b305596709ddf92e319d18fa6a) | `` openssh_gssapi, openssh_hpn: remove self (aneeshusa) from maintainers ``                 |
| [`531b1c64`](https://github.com/NixOS/nixpkgs/commit/531b1c6489eab4990ed3b05d053102fa88899df8) | `` updatecli: 0.92.0 -> 0.94.1 ``                                                           |
| [`5deeee39`](https://github.com/NixOS/nixpkgs/commit/5deeee393a763d95c60e61a03ec2f92f0787977e) | `` nixos/wireshark: usbmon permissions ``                                                   |
| [`c8e3ade1`](https://github.com/NixOS/nixpkgs/commit/c8e3ade10926ee15d0a4bf886dea3f4ce2f63c32) | `` lk-jwt-service: 0.1.2 -> 0.2.0 ``                                                        |
| [`d95b40ed`](https://github.com/NixOS/nixpkgs/commit/d95b40ed108f0244313e89cbc5b6a39e1c58aa8c) | `` netbox-routing: init at 0.2.3 (#387430) ``                                               |
| [`9cb65c88`](https://github.com/NixOS/nixpkgs/commit/9cb65c88b8de397649775da6ffce75db7ade1ece) | `` cargo-bolero: 0.12.0 -> 0.13.0 (#387965) ``                                              |
| [`c2c4ce76`](https://github.com/NixOS/nixpkgs/commit/c2c4ce7631321d854fd87db97a01fe3cfcf96903) | `` python312Packages.lightning-utilities: 0.13.1 -> 0.14.0 ``                               |
| [`e8c9148f`](https://github.com/NixOS/nixpkgs/commit/e8c9148f5c6749744d78eb0b64dceff92cafa533) | `` curv: switch to openexr_3 ``                                                             |
| [`43d99641`](https://github.com/NixOS/nixpkgs/commit/43d9964161fa7485d3db96621bb06c2bc736f19f) | `` pdi: 1.8.2 -> 1.8.3 ``                                                                   |
| [`f6c39b92`](https://github.com/NixOS/nixpkgs/commit/f6c39b92c86f662875b47753fb0272324d3d7676) | `` organicmaps: 2025.02.17-3 -> 2025.03.02-7 ``                                             |
| [`1b69c31a`](https://github.com/NixOS/nixpkgs/commit/1b69c31a5b08797a943c06420d019921269e2d7c) | `` python313Packages.bc-detect-secrets: 1.5.36 -> 1.5.37 ``                                 |
| [`ccfd85de`](https://github.com/NixOS/nixpkgs/commit/ccfd85de5681b9370a37f8db41a64a4299e52214) | `` zed-editor: gitUpdater -> nix-update-script ``                                           |
| [`238d6cb8`](https://github.com/NixOS/nixpkgs/commit/238d6cb8993a2817097fabbc087d21a92c789542) | `` python313Packages.coinmetrics-api-client: 2025.2.26.16 -> 2025.3.3.16 ``                 |
| [`fe36d1e3`](https://github.com/NixOS/nixpkgs/commit/fe36d1e378384c29f94a8ad2925b9b5134d45fd3) | `` python313Packages.pysuezv2: 2.0.3 -> 2.0.4 ``                                            |
| [`f74aa077`](https://github.com/NixOS/nixpkgs/commit/f74aa0774010f2617d3e4901cc4265f53df031cd) | `` python313Packages.xkcdpass: 1.19.9 -> 1.20.0 ``                                          |
| [`ec1ec5b4`](https://github.com/NixOS/nixpkgs/commit/ec1ec5b4f89f9308122ae177732a3148b510f46b) | `` python313Packages.eufylife-ble-client: 0.1.8 -> 0.1.9 ``                                 |
| [`f2af639f`](https://github.com/NixOS/nixpkgs/commit/f2af639f1231e387c80cc5169e208c40a81005d9) | `` python313Packages.cyclopts: 3.9.0 -> 3.9.1 ``                                            |
| [`d5a56529`](https://github.com/NixOS/nixpkgs/commit/d5a56529176f713122584632e33f15d615caec15) | `` apache-directory-studio: remove redundant parenthesis ``                                 |
| [`b707af9a`](https://github.com/NixOS/nixpkgs/commit/b707af9ad1d2c12dd278bc2155c03100bc478785) | `` apache-directory-studio: fix startup by creating /tmp/SWT-GDBusServer ``                 |
| [`83d69521`](https://github.com/NixOS/nixpkgs/commit/83d69521caaf4710d035745d9805972e1d1ede13) | `` apache-directory-studio: add missing glib ``                                             |
| [`6fa5cb30`](https://github.com/NixOS/nixpkgs/commit/6fa5cb30e5ec7ca3ff4bdcb74705720987225cb6) | `` electron{,-bin}: add tomasajt as a maintainer ``                                         |
| [`1f465bbe`](https://github.com/NixOS/nixpkgs/commit/1f465bbe413c180ad2c22c590141d7b678343123) | `` jenkins: 2.492.1 -> 2.492.2 ``                                                           |
| [`2eebfbb8`](https://github.com/NixOS/nixpkgs/commit/2eebfbb886ad53effdbc721d75a7bea04395f83c) | `` vscode-extensions.mongodb.mongodb-vscode: 1.12.0 -> 1.12.1 ``                            |
| [`e548e395`](https://github.com/NixOS/nixpkgs/commit/e548e39566c2d5d913fea7aa6b496e695496c90e) | `` ruff: 0.9.9 -> 0.9.10 ``                                                                 |
| [`7c4cc944`](https://github.com/NixOS/nixpkgs/commit/7c4cc9449ed0973a5342ed1fe6d4154f689848c9) | `` bitcoin: modernize ``                                                                    |
| [`d43357b4`](https://github.com/NixOS/nixpkgs/commit/d43357b4aeb087db221837e4b12d1a76d8b3287a) | `` bitcoin: add __darwinAllowNetworking to fix build in sandbox ``                          |
| [`b890f62d`](https://github.com/NixOS/nixpkgs/commit/b890f62df9c62a3cabe442188ef7ca19ca03792f) | `` miniupnpc: modernize, add versionCheckHook ``                                            |
| [`5232aceb`](https://github.com/NixOS/nixpkgs/commit/5232aceb7b5025eac71b7ef2c6360c8af4c346d3) | `` miniupnpc: fix on darwin ``                                                              |
| [`cb9fc302`](https://github.com/NixOS/nixpkgs/commit/cb9fc30245352e9a76b2e8057e06e251ea17cf49) | `` hydrus: disable tests on darwin ``                                                       |
| [`64f84905`](https://github.com/NixOS/nixpkgs/commit/64f84905a5537b2e0beda2d7dff507173f1b3e49) | `` uv: 0.6.4 -> 0.6.5 ``                                                                    |
| [`132d8ac6`](https://github.com/NixOS/nixpkgs/commit/132d8ac65ccea9a5aeb29e245e218eb9713b412e) | `` python312Packages.spectral-cube: disable failing tests ``                                |
| [`b4ed4f95`](https://github.com/NixOS/nixpkgs/commit/b4ed4f95beb7c74505fd92bf7a6e9c0f12d95a9f) | `` python312Packages.pgcli: 4.1.0 -> 4.2.0 ``                                               |
| [`39deb90f`](https://github.com/NixOS/nixpkgs/commit/39deb90fa6ed0cffea95681ec3bf4664bf44c863) | `` hydrus: 609 -> 612 ``                                                                    |
| [`4ef36e6f`](https://github.com/NixOS/nixpkgs/commit/4ef36e6f218917fbf30f6dd668ed81b3a6652912) | `` hydrus: cleanup ``                                                                       |
| [`31d77f9e`](https://github.com/NixOS/nixpkgs/commit/31d77f9ef9cc87a6b6bd4f0a595f1d729808262d) | `` hydrus: move to by-name ``                                                               |
| [`c6e2327f`](https://github.com/NixOS/nixpkgs/commit/c6e2327f62e519fe3f3f18bb47ba46b76061d738) | `` seagoat: 0.50.1 -> 0.54.3 ``                                                             |
| [`decbece9`](https://github.com/NixOS/nixpkgs/commit/decbece9655793cb8af445c994f7a80023948df1) | `` llvmPackages_{12,13,14,15,16,17,18,19,20,git}.llvm: move patches out of common ``        |
| [`2b28900a`](https://github.com/NixOS/nixpkgs/commit/2b28900a1f6097c3bde0a53234f3b9bf0aff7fbc) | `` llvmPackages_{12,13,14,15,16,17,18,19,20,git}.lldb: move patches out of common ``        |
| [`394ef62f`](https://github.com/NixOS/nixpkgs/commit/394ef62fb0b6abfc7200625f5ed6ee472a5b7574) | `` llvmPackages_{12,13,14,15,16,17,18,19,20,git}.libcxx: move patches out of common ``      |
| [`c330ebeb`](https://github.com/NixOS/nixpkgs/commit/c330ebeb4fb445582f83c0d129c29060675e0570) | `` llvmPackages_{12,13,14,15,16,17,18,19,20,git}.compiler-rt: move patches out of common `` |
| [`946113bb`](https://github.com/NixOS/nixpkgs/commit/946113bbf7cc35df1b6c6a179d0f783e9db87ff4) | `` llvmPackages_{12,13,14,15,16,17,18,19,20,git}.openmp: move patches out of common ``      |
| [`1a148262`](https://github.com/NixOS/nixpkgs/commit/1a148262f409cd898d8afb4923368e01744ac6a8) | `` llvmPackages_{12,13,14,15,16,17,18,19,20,git}.libunwind: move patches out of common ``   |
| [`20e4f33f`](https://github.com/NixOS/nixpkgs/commit/20e4f33f16363de958f35da54814e5c085bcffaf) | `` llvmPackages_{12,13,14,15,16,17,18,19,20,git}.lld: move patches out of common ``         |
| [`e85abae0`](https://github.com/NixOS/nixpkgs/commit/e85abae0ae8226127494f935854056396891cb72) | `` llvmPackages_{12,13,14,15,16,17,18,19,20,git}.clang: move patches out of common ``       |
| [`41d68f67`](https://github.com/NixOS/nixpkgs/commit/41d68f672d7ca450a77a588693f40fb3375ae68b) | `` llvmPackages_{19,20,git}.bolt: move patches out of common ``                             |
| [`8079fb45`](https://github.com/NixOS/nixpkgs/commit/8079fb45d5a7c09cac1ef6541780c824e821a1e4) | `` postgresqlPackages.pg_tle: init at 1.4.0 (#387868) ``                                    |
| [`c11fb08f`](https://github.com/NixOS/nixpkgs/commit/c11fb08f6f47159eb54ed6c3a55b9c46082735d5) | `` pantheon.appcenter: 8.0.1 -> 8.1.0 ``                                                    |
| [`73caa97a`](https://github.com/NixOS/nixpkgs/commit/73caa97ac733e84dfbac446abfcc54c47a7329ff) | `` fcft: 3.1.10 -> 3.2.0 ``                                                                 |
| [`132a324a`](https://github.com/NixOS/nixpkgs/commit/132a324ab368dca5ff250fd6690f2200afe364c4) | `` linux_latest-libre: 19712 -> 19729 ``                                                    |
| [`92c50e93`](https://github.com/NixOS/nixpkgs/commit/92c50e9378ea84f00c3e12a047717d919f501657) | `` cpptrace: 0.8.1 -> 0.8.2 ``                                                              |
| [`9773a03a`](https://github.com/NixOS/nixpkgs/commit/9773a03aedf95fb31fc50e96229426693f4636f6) | `` typst: use finalAttrs ``                                                                 |
| [`a418f07b`](https://github.com/NixOS/nixpkgs/commit/a418f07be1a647723a33f30e5a45dffa64303f0b) | `` renode-dts2repl: 0-unstable-2025-02-19 -> 0-unstable-2025-03-05 ``                       |
| [`8f6fc1e6`](https://github.com/NixOS/nixpkgs/commit/8f6fc1e620c7432d64a318630c2b59fbfbbfa35b) | `` rabbit: fix build, relax dependencies ``                                                 |
| [`f72cd877`](https://github.com/NixOS/nixpkgs/commit/f72cd87737b9c467344d551b1e6506206fd153d2) | `` typst: 0.13.0 -> 0.13.1 ``                                                               |
| [`a85d1033`](https://github.com/NixOS/nixpkgs/commit/a85d10330ef191be65377f75f026129cfc976e6d) | `` aapt: disable on aarch64-linux ``                                                        |
| [`12328192`](https://github.com/NixOS/nixpkgs/commit/12328192c55aaa09f002217f19bbbe699d7e0710) | `` ospd-openvas: 22.8.0 -> 22.8.1 ``                                                        |
| [`6d67e850`](https://github.com/NixOS/nixpkgs/commit/6d67e8506218e2f4f086c422b16c345991b1a2f6) | `` python313Packages.tencentcloud-sdk-python: 3.0.1331 -> 3.0.1333 ``                       |
| [`97891783`](https://github.com/NixOS/nixpkgs/commit/97891783561c8245d2a75c96aa09cd7479846032) | `` zed-editor: use finalAttrs.finalPackage whenever possible ``                             |
| [`5aab3550`](https://github.com/NixOS/nixpkgs/commit/5aab35504452da13626059b1cafd461e3618f7f2) | `` zed-editor.fhs: add entrypoint zed-editor-fhs in all-packages ``                         |
| [`0dd025a7`](https://github.com/NixOS/nixpkgs/commit/0dd025a7fca607e56bb0939a956b08872fef0293) | `` python313Packages.nexia: 2.2.1 -> 2.2.3 ``                                               |
| [`e15c38b2`](https://github.com/NixOS/nixpkgs/commit/e15c38b2dbd631578e33a34a8704f8c8c7d19ed9) | `` python313Packages.pontos: 25.1.0 -> 25.3.1 ``                                            |
| [`286dca89`](https://github.com/NixOS/nixpkgs/commit/286dca893038d8dbdfbec3454acd1aae42dfb92c) | `` python313Packages.typst: 0.13.0 -> 0.13.1 ``                                             |
| [`69480c5f`](https://github.com/NixOS/nixpkgs/commit/69480c5f6dc20b11213ec67459400f0a9acbab65) | `` python313Packages.iterfzf: 1.4.0.60.2 -> 1.5.0.60.2 ``                                   |
| [`1fe8d8fd`](https://github.com/NixOS/nixpkgs/commit/1fe8d8fd87acdc77fd97d1238239695b74bffe94) | `` python313Packages.aiosseclient: 0.1.6 -> 0.1.7 ``                                        |
| [`ac1b915d`](https://github.com/NixOS/nixpkgs/commit/ac1b915d44a5d055a56e590eba1728ba952c96f3) | `` gancio: 1.23.1 -> 1.24.0 ``                                                              |
| [`2270999f`](https://github.com/NixOS/nixpkgs/commit/2270999fd0b5b4542b9e549bf25a188bf1540a0e) | `` go-graft: add changelog ``                                                               |
| [`b59729a0`](https://github.com/NixOS/nixpkgs/commit/b59729a0ae95c49ae352797acd166131df0225c2) | `` go-graft: clarify license to agpl3Only ``                                                |
| [`06773292`](https://github.com/NixOS/nixpkgs/commit/067732921fae5a44f91e47d7bb9e2b9596a9f053) | `` nixos/evcc: support passing secrets with envsubst ``                                     |
| [`095da00b`](https://github.com/NixOS/nixpkgs/commit/095da00b2d9701fa85828d4ad165760ea6d1f9d5) | `` nixos/umurmur: init ``                                                                   |
| [`e31a8ecf`](https://github.com/NixOS/nixpkgs/commit/e31a8ecf35dbf4bb1c8ca45100c79072f8a1e536) | `` papeer: 0.8.3 -> 0.8.4 ``                                                                |
| [`9ab684ef`](https://github.com/NixOS/nixpkgs/commit/9ab684efa85aebbd93b1257f54063720fbd4ebd6) | `` python312Packages.pymc: 5.21.0 -> 5.21.1 ``                                              |
| [`369eaeef`](https://github.com/NixOS/nixpkgs/commit/369eaeefa37aa40796fe402e8caa0b7834c31913) | `` evcc: set mainProgram ``                                                                 |
| [`70d6886d`](https://github.com/NixOS/nixpkgs/commit/70d6886ddfab2124308d0bd53b47d37e87bb6f48) | `` python312Packages.pyiceberg: 0.8.1 -> 0.9.0 ``                                           |
| [`cee01a7a`](https://github.com/NixOS/nixpkgs/commit/cee01a7a06c7b3ac6bf0055dd08e10aed275e6ba) | `` opensbi: 1.5.1 -> 1.6 ``                                                                 |
| [`7500cb18`](https://github.com/NixOS/nixpkgs/commit/7500cb1861202a8010bd51946a2f6b876687179d) | `` go-graft: alias to gg ``                                                                 |
| [`954cd004`](https://github.com/NixOS/nixpkgs/commit/954cd0049f7eedab46058ae21553f55e97f6e7d0) | `` aider-chat: add withPlaywright override ``                                               |
| [`b4a654aa`](https://github.com/NixOS/nixpkgs/commit/b4a654aaf72223b4726e8ef75ab0de8afc231a72) | `` python3Packages.aider-chat: 0.75.1 -> 0.75.2 ``                                          |
| [`56ef85ba`](https://github.com/NixOS/nixpkgs/commit/56ef85ba0c5caf58abbe6f94282d4943eabf18e9) | `` go-graft, gg: merge duplicated package ``                                                |
| [`b70ba4b5`](https://github.com/NixOS/nixpkgs/commit/b70ba4b58ea0bead6a38220159be915c222d0b37) | `` .git-blame-ignore-revs: add nixos/movim ``                                               |
| [`43c1654c`](https://github.com/NixOS/nixpkgs/commit/43c1654cae47cbf987cb63758c06245fa95c1e3b) | `` nixos/movim: run nixfmt on module ``                                                     |
| [`ba2b1307`](https://github.com/NixOS/nixpkgs/commit/ba2b130736b9c4a36f22dfcb90500d2e0eac796b) | `` vscode-extensions.github.copilot: 1.277.1411 -> 1.279.1416 ``                            |
| [`f8d1fdd4`](https://github.com/NixOS/nixpkgs/commit/f8d1fdd4689c75b12eb4a2e4a4d8a3ffccbd5ffe) | `` vscode-extensions.github.copilot-chat: 0.25.2025021201 -> 0.26.2025030506 ``             |
| [`fa7baffa`](https://github.com/NixOS/nixpkgs/commit/fa7baffa4e1c174c279cadc4688d00beec783bca) | `` kdePackages: Gear 24.12.2 -> 24.12.3 ``                                                  |
| [`5a9480f6`](https://github.com/NixOS/nixpkgs/commit/5a9480f65058e1c38df3542674b305d91f264736) | `` svtplay-dl: 4.101 -> 4.103 ``                                                            |
| [`187b7a1c`](https://github.com/NixOS/nixpkgs/commit/187b7a1c6507baa0711a648c426cb08b5d14d24d) | `` vscode-extensions.astro-build.astro-vscode: 2.10.2 -> 2.15.4 ``                          |
| [`1c0ceab1`](https://github.com/NixOS/nixpkgs/commit/1c0ceab1ab06ff21c46165669455900bbfb784dd) | `` vscode-extensions.redhat.vscode-yaml: 1.14.0 -> 1.16.0 ``                                |
| [`28891180`](https://github.com/NixOS/nixpkgs/commit/288911807b67e97eb494bbbb4410c0b80164c3f2) | `` vscode-extensions.editorconfig.editorconfig: 0.16.4 -> 0.17.0 ``                         |
| [`7454c3d1`](https://github.com/NixOS/nixpkgs/commit/7454c3d13d682f243797221ab4ebbb3eceecd076) | `` vscode-extensions.davidanson.vscode-markdownlint: 0.56.0 -> 0.58.2 ``                    |
| [`ac7dd1bf`](https://github.com/NixOS/nixpkgs/commit/ac7dd1bf305d6bad7a2e3ab94b8cfe3af0b81fbc) | `` vscode-extensions.continue.continue: 0.8.54 -> 0.8.68 ``                                 |
| [`5aa6f0aa`](https://github.com/NixOS/nixpkgs/commit/5aa6f0aa52a8de4acb80333dd3d40d6dbd6e4b25) | `` mold: 2.36.0 -> 2.37.0 ``                                                                |
| [`e3ec614d`](https://github.com/NixOS/nixpkgs/commit/e3ec614d7b3e910604b6a7db1a9c7e5c37ba1c47) | `` vscode-extension.johnpapa.winteriscoming: init at 1.4.4 ``                               |
| [`df1bbd4a`](https://github.com/NixOS/nixpkgs/commit/df1bbd4a666e350242e4c1606b0c2e8d694959e9) | `` vpl-gpu-rt: 25.1.2 -> 25.1.3 ``                                                          |
| [`55fbd4b3`](https://github.com/NixOS/nixpkgs/commit/55fbd4b35dee12b909f176e778c9e5372e857d98) | `` zed-editor: 0.176.2 -> 0.176.3 ``                                                        |
| [`b4f9c064`](https://github.com/NixOS/nixpkgs/commit/b4f9c06454758d9be8de48461800775beb5bcdb2) | `` readarr: 0.4.10.2734 -> 0.4.11.2747 ``                                                   |
| [`e97e847b`](https://github.com/NixOS/nixpkgs/commit/e97e847bc5f5fd98d0ba7f7ac56390ebc8c327b1) | `` above: 2.7 -> 2.8 ``                                                                     |
| [`3061e562`](https://github.com/NixOS/nixpkgs/commit/3061e5622ce7377ff8db7adb0be07fe53780a7c9) | `` meerk40t: 0.9.7010 -> 0.9.7020 ``                                                        |
| [`1246f9f5`](https://github.com/NixOS/nixpkgs/commit/1246f9f50fa3eb3eca816843b484da14e290b389) | `` netgen: init at 6.2.2501 ``                                                              |
| [`a4414731`](https://github.com/NixOS/nixpkgs/commit/a4414731640221444c64439eafc46134e6166677) | `` superlu_dist: init at 9.1.0 ``                                                           |
| [`50cedbb8`](https://github.com/NixOS/nixpkgs/commit/50cedbb8bf590315b0e30db325e2f2a205eda93c) | `` memray: 1.15.0 -> 1.16.0 ``                                                              |
| [`5ef3aea0`](https://github.com/NixOS/nixpkgs/commit/5ef3aea0ff033d2d80835f6ce43f894878239d53) | `` wit-bindgen: 0.39.0 -> 0.40.0 ``                                                         |
| [`a4c80aee`](https://github.com/NixOS/nixpkgs/commit/a4c80aee8e047f61964ae0b049ea04ee6bc5f3a0) | `` vyxal: update mill dependency to use fetchurl for version and URL locking ``             |
| [`62b0d310`](https://github.com/NixOS/nixpkgs/commit/62b0d310852311d388714711abe6ebc1efcde1fe) | `` readest: init at 0.9.19 ``                                                               |
| [`463de74a`](https://github.com/NixOS/nixpkgs/commit/463de74a35abde9b97bb02bd98ac72f5ae53858f) | `` terraform-providers.google: 6.21.0 -> 6.24.0 ``                                          |
| [`46f90d39`](https://github.com/NixOS/nixpkgs/commit/46f90d3931151b0da37fe88e7e7b8f9deba6ac31) | `` dracula-theme: 4.0.0-unstable-2025-02-14 -> 4.0.0-unstable-2025-03-04 ``                 |
| [`408f1f1a`](https://github.com/NixOS/nixpkgs/commit/408f1f1ac662c44c1f9a6c6788eeb6930fefc9d1) | `` beamPackages.ex_doc: add erlang builds to tests ``                                       |
| [`7276e3b2`](https://github.com/NixOS/nixpkgs/commit/7276e3b2c11451a7e312168304a2e1f236f099d3) | `` tigerbeetle: 0.16.28 -> 0.16.30 ``                                                       |
| [`232647a5`](https://github.com/NixOS/nixpkgs/commit/232647a5cf83374feb2dfd2a0e3b9ef3c8a921ac) | `` python312Packages.mandown: 1.11.1 -> 1.11.2 ``                                           |
| [`b215052b`](https://github.com/NixOS/nixpkgs/commit/b215052b0bce39ee6593db32232f089525093d12) | `` python312Packages.gitingest: 0.1.3 -> 0.1.4 ``                                           |
| [`9154158b`](https://github.com/NixOS/nixpkgs/commit/9154158bce496e92d6475285ee6914c1758f9c40) | `` python312Packages.google-genai: 1.4.0 -> 1.5.0 ``                                        |
| [`8c3eacc2`](https://github.com/NixOS/nixpkgs/commit/8c3eacc220bba912d65de5eabf231f472a66ca22) | `` mangohud: split gamescopeSupport into mangoapp & mangoctl support ``                     |
| [`190a9a09`](https://github.com/NixOS/nixpkgs/commit/190a9a09c973fc11fe12f51dd50900a0e354b23f) | `` mangohud: add option to disable waylandSupport ``                                        |
| [`d2c2b2c2`](https://github.com/NixOS/nixpkgs/commit/d2c2b2c2870c004845982facc7538336421596b3) | `` libdnf: 0.73.4 -> 0.74.0 ``                                                              |
| [`be4a2bec`](https://github.com/NixOS/nixpkgs/commit/be4a2bec60894018812640db0eb440ecab7f4bcd) | `` kargo: 1.3.0 -> 1.3.1 ``                                                                 |
| [`de0fe301`](https://github.com/NixOS/nixpkgs/commit/de0fe301211c267807afd11b12613f5511ff7433) | `` python312Packages.mplhep: 0.3.56 -> 0.3.57 ``                                            |
| [`1e41a945`](https://github.com/NixOS/nixpkgs/commit/1e41a945431b6918bdff1a869635a0ee8904c937) | `` mangohud: add option to disable x11 support ``                                           |
| [`c60fcad6`](https://github.com/NixOS/nixpkgs/commit/c60fcad63c6009671fc2c6352681ca5d04beb2be) | `` mangohud: add option to disable nvidia support ``                                        |
| [`7955a7cf`](https://github.com/NixOS/nixpkgs/commit/7955a7cf86d4320d9b964f1ce7aaa1d7a25dc2b1) | `` nvidia-modprobe: 570.86.16 -> 570.124.04 ``                                              |
| [`ce3a7247`](https://github.com/NixOS/nixpkgs/commit/ce3a7247918888b029e6606d6b98ce4a202c76cc) | `` clever-tools: 3.11.0 -> 3.12.0 ``                                                        |