### PR TITLE
chore(flake/home-manager): `7f4c60a3` -> `1fd39a10`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -451,11 +451,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1741461731,
-        "narHash": "sha256-BBQfGvO3GWOV+5tmqH14gNcZrRaQ7Q3tQx31Frzoip8=",
+        "lastModified": 1741502651,
+        "narHash": "sha256-7u8FF20WRvQsmfTuNuCerRzstuZ0XgkwWPkq+GoRfiA=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "7f4c60a3d6e548dbc13666565c22cb3f8dcdad44",
+        "rev": "1fd39a105575ea997b32a043a0dd2c49294add5b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                                  |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------ |
| [`1fd39a10`](https://github.com/nix-community/home-manager/commit/1fd39a105575ea997b32a043a0dd2c49294add5b) | `` tests/vscode: fix darwin snippets test ``                             |
| [`8d2a0581`](https://github.com/nix-community/home-manager/commit/8d2a05810834119b96531745de7943cc8ba5bb79) | `` tests/thunderbird: fix darwin test ``                                 |
| [`4f2c4612`](https://github.com/nix-community/home-manager/commit/4f2c4612861405d40bc81fa8a8575d15bee6e8d2) | `` tests/yubikey-agent-darwin: fix test ``                               |
| [`4c964336`](https://github.com/nix-community/home-manager/commit/4c9643363a0f218a3d473149f6a024c8a66d0f62) | `` tests/ollama: fix darwin test ``                                      |
| [`68540fb7`](https://github.com/nix-community/home-manager/commit/68540fb7755d3be96c71cfc5a6f43a3d615d9de7) | `` tests/syncthing: syncthing wrapper stubbing for darwin ``             |
| [`15498b94`](https://github.com/nix-community/home-manager/commit/15498b94ec2c7aa857864af105b72cb41def0b00) | `` tests/syncthing: fix extra-options on darwin ``                       |
| [`1909541f`](https://github.com/nix-community/home-manager/commit/1909541fc7e844266df393a25c386cb4ca14f6e3) | `` tests/targets-darwin: fix user-defaults test ``                       |
| [`91f88408`](https://github.com/nix-community/home-manager/commit/91f88408ccb7649dc6feec5ba565aee4e2097510) | `` .github/workflows/test.yml: enable darwin tests ``                    |
| [`b3e11ed4`](https://github.com/nix-community/home-manager/commit/b3e11ed4a99bca48e47d7d7df6535c80dc73c79e) | `` tests: central darwin stubbing ``                                     |
| [`b74402e4`](https://github.com/nix-community/home-manager/commit/b74402e4e8f8cebbec860f0ba8fef2f703ad79f0) | `` tests: expose scrubDerivation ``                                      |
| [`72580374`](https://github.com/nix-community/home-manager/commit/72580374c81ad8803675ee0dc829a60773d24401) | `` Translate using Weblate (Chinese (Traditional Han script)) (#6581) `` |
| [`b23c4d4c`](https://github.com/nix-community/home-manager/commit/b23c4d4cbe931240fad25bba01509edc03c3aac6) | `` flake.lock: Update (#6591) ``                                         |