### PR TITLE
chore(flake/spicetify-nix): `f8d3757d` -> `a06e502c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1026,11 +1026,11 @@
         "systems": "systems_2"
       },
       "locked": {
-        "lastModified": 1740889006,
-        "narHash": "sha256-A1iyKVvZrLdLwqWPC9OvPjC85ADQn2R1EGfCzJBl+wI=",
+        "lastModified": 1741493656,
+        "narHash": "sha256-1M2mf5pZTlhZXkSI8wKs9GfNb1hllND58zQUYSAe8EA=",
         "owner": "Gerg-L",
         "repo": "spicetify-nix",
-        "rev": "f8d3757d4ae3af2175a631fb9598a42d30ee75fc",
+        "rev": "a06e502c884307c33dbdf2017fd50ab3592ad868",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                    |
| ----------------------------------------------------------------------------------------------------- | -------------------------- |
| [`a06e502c`](https://github.com/Gerg-L/spicetify-nix/commit/a06e502c884307c33dbdf2017fd50ab3592ad868) | `` CI update 2025-03-09 `` |