### PR TITLE
chore(flake/zen-browser): `6dceddfe` -> `a4408170`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1274,11 +1274,11 @@
         "nixpkgs": "nixpkgs_7"
       },
       "locked": {
-        "lastModified": 1741450391,
-        "narHash": "sha256-zEFEI2RWmxYS5EZTlA8VnX5X7AueDKpXF2IjJx+dyKE=",
+        "lastModified": 1741554872,
+        "narHash": "sha256-A/Iim9o0hHJjDJVynwtLzkox7NquvPc8CsJ/8OB4dDw=",
         "owner": "0xc000022070",
         "repo": "zen-browser-flake",
-        "rev": "6dceddfe8e1691607eaa8d9f12f33ab6a5acea82",
+        "rev": "a4408170c5a2168bb79abcf587c5072e2ee5fb90",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                          | Message                                                                     |
| --------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------- |
| [`a4408170`](https://github.com/0xc000022070/zen-browser-flake/commit/a4408170c5a2168bb79abcf587c5072e2ee5fb90) | `` Update Zen Browser twilight @ x86_64 && aarch64 to 1.9.1t#1a293fc ``     |
| [`e3654e1d`](https://github.com/0xc000022070/zen-browser-flake/commit/e3654e1d95b22c1f8ddd2dda6c9e3ae42bbf41d3) | `` ci(update): using correct version var to create twilight release name `` |