### PR TITLE
chore(flake/nixpkgs-stable): `20755fa0` -> `52e3095f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -812,11 +812,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1741332913,
-        "narHash": "sha256-ri1e8ZliWS3Jnp9yqpKApHaOo7KBN33W8ECAKA4teAQ=",
+        "lastModified": 1741445498,
+        "narHash": "sha256-F5Em0iv/CxkN5mZ9hRn3vPknpoWdcdCyR0e4WklHwiE=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "20755fa05115c84be00b04690630cb38f0a203ad",
+        "rev": "52e3095f6d812b91b22fb7ad0bfc1ab416453634",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                     |
| ---------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------- |
| [`904f1ea2`](https://github.com/NixOS/nixpkgs/commit/904f1ea203247e69d6564a84e411bcfdd4998f84) | `` librewolf-bin: use librewolf-bin-unwrapped ``                            |
| [`4f2cf52e`](https://github.com/NixOS/nixpkgs/commit/4f2cf52e8792a30e1a8579ea9237d4a0c98c1b0f) | `` librewolf-bin-unwrapped: init at 136.0-2 ``                              |
| [`c8649f64`](https://github.com/NixOS/nixpkgs/commit/c8649f64bb47461da93181d86f9959088a79fb74) | `` osu-lazer-bin: 2025.225.0 -> 2025.306.0 ``                               |
| [`1e8a295b`](https://github.com/NixOS/nixpkgs/commit/1e8a295b23353797b546a1dd742c6ea4e0f3a835) | `` osu-lazer: 2025.225.0 -> 2025.306.0 ``                                   |
| [`a3f28d5a`](https://github.com/NixOS/nixpkgs/commit/a3f28d5aaf2b3e2b4243cc2e522f1f3538a51fb6) | `` python313Packages.django_5: 5.1.6 -> 5.1.7 ``                            |
| [`2d36aeab`](https://github.com/NixOS/nixpkgs/commit/2d36aeab56a81a9bcbb3b3e1668d7befb59d76b9) | `` rust-synapse-compress-state: rename from rust-synapse-state-compress ``  |
| [`493e44f4`](https://github.com/NixOS/nixpkgs/commit/493e44f480a658a5fa9c582bf53712b2f7b30362) | `` qt6ct: use CMake ``                                                      |
| [`82b19541`](https://github.com/NixOS/nixpkgs/commit/82b195418450ffe8af980447700961240c4355b8) | `` qt6ct: switch to new upstream ``                                         |
| [`c817095a`](https://github.com/NixOS/nixpkgs/commit/c817095aa0e1bebcdae928c3d625448b54b0f43b) | `` linux_6_1: 6.1.129 -> 6.1.130 ``                                         |
| [`f7495494`](https://github.com/NixOS/nixpkgs/commit/f74954946cfa0330264ecabb70922e6faa2bfd65) | `` linux_6_6: 6.6.80 -> 6.6.81 ``                                           |
| [`ad7008ff`](https://github.com/NixOS/nixpkgs/commit/ad7008ff415e27b98375a78da8824eae378215be) | `` linux_6_12: 6.12.17 -> 6.12.18 ``                                        |
| [`a8f0b92a`](https://github.com/NixOS/nixpkgs/commit/a8f0b92aa696eb4bb53f3d002a96849c1e97009e) | `` linux_6_13: 6.13.5 -> 6.13.6 ``                                          |
| [`9cc1001c`](https://github.com/NixOS/nixpkgs/commit/9cc1001c78474f5802bfa5f0ba3f99cf27e8c8b5) | `` mullvad-browser: 14.0.5 -> 14.0.7 ``                                     |
| [`279fa4ef`](https://github.com/NixOS/nixpkgs/commit/279fa4ef8b6491156db78d201e3763826f6c58ad) | `` tor-browser: 14.0.6 -> 14.0.7 ``                                         |
| [`2fbe4939`](https://github.com/NixOS/nixpkgs/commit/2fbe493988a300ca33937afa5167d1900786b271) | `` apache-directory-studio: remove redundant parenthesis ``                 |
| [`d3c73a3b`](https://github.com/NixOS/nixpkgs/commit/d3c73a3bcb4837025a54a495d65187e0f743ecef) | `` apache-directory-studio: fix startup by creating /tmp/SWT-GDBusServer `` |
| [`eef362c2`](https://github.com/NixOS/nixpkgs/commit/eef362c25df5572b7f72bb6a6797a5b24c474c7f) | `` apache-directory-studio: add missing glib ``                             |
| [`dc6275ab`](https://github.com/NixOS/nixpkgs/commit/dc6275ab4dd5b523f45e2891d943cba7de09d763) | `` jenkins: 2.492.1 -> 2.492.2 ``                                           |
| [`2d19a273`](https://github.com/NixOS/nixpkgs/commit/2d19a2732a52ff86e4e9c2eada8729091c379a33) | `` otb: 9.0.0 -> 9.1.0 ``                                                   |
| [`42c7d146`](https://github.com/NixOS/nixpkgs/commit/42c7d14675a9d380cd721b1ffe25b664de1709a3) | `` linux_latest-libre: 19712 -> 19729 ``                                    |
| [`44184e54`](https://github.com/NixOS/nixpkgs/commit/44184e54bdce673bb9bc0e004b69bcc6e1ec0070) | `` python312Packages.coiled: init at 1.79.2 ``                              |
| [`8f3b7aff`](https://github.com/NixOS/nixpkgs/commit/8f3b7aff5000b6bd63936e65ccbb1ec31f779c50) | `` python312Packages.gilknocker: init at 0.4.1.post6 ``                     |
| [`7d6fe798`](https://github.com/NixOS/nixpkgs/commit/7d6fe79833587e886e1d68cb3e149d3fb3ee5324) | `` libsForQt5.qtstyleplugin-kvantum: 1.1.3 -> 1.1.4 ``                      |
| [`434f49a5`](https://github.com/NixOS/nixpkgs/commit/434f49a5e17a1ba14865f18345f446ab9a66db76) | `` electron-chromedriver_32: 32.3.2 -> 32.3.3 ``                            |
| [`926649ce`](https://github.com/NixOS/nixpkgs/commit/926649ce3269ec0bd4aa10504ae9dd5f7e78d4f1) | `` electron_32-bin: 32.3.2 -> 32.3.3 ``                                     |
| [`7b97e72d`](https://github.com/NixOS/nixpkgs/commit/7b97e72d4a1f69656bce87b32c2ae3b659e7f16c) | `` cartridges: 2.11 -> 2.11.1 ``                                            |
| [`37ef36e6`](https://github.com/NixOS/nixpkgs/commit/37ef36e6cd5ee72e60b2ebe8ba105805cffdec9b) | `` electron-source.electron_32: remove as it's EOL ``                       |
| [`451de5d7`](https://github.com/NixOS/nixpkgs/commit/451de5d72418c828fad749ef118881f5b84aed7d) | `` netdata: 1.47.4 -> 1.47.5 ``                                             |
| [`7270697c`](https://github.com/NixOS/nixpkgs/commit/7270697ca1b79bc692b4c63e44092ac524057fb5) | `` electron_32-bin: mark as insecure because it's EOL ``                    |
| [`ca7725c6`](https://github.com/NixOS/nixpkgs/commit/ca7725c665dadacbfcaa2892d365bf832b1a7ad3) | `` vencord: refactor `meta` ``                                              |
| [`97adc67c`](https://github.com/NixOS/nixpkgs/commit/97adc67cd7f3a9aaecd3fd279531270c082ce9d2) | `` vencord: 1.11.5 -> 1.11.6 ``                                             |
| [`5f8081f5`](https://github.com/NixOS/nixpkgs/commit/5f8081f5d321b69cb8b2127c0a9bfa0b69170be5) | `` drum-machine: init at 1.0.0 ``                                           |
| [`88fecd6d`](https://github.com/NixOS/nixpkgs/commit/88fecd6d94e9e54d20db0912a56c7f1914723fc5) | `` oo7-server: init at 0.4.0 ``                                             |
| [`61815445`](https://github.com/NixOS/nixpkgs/commit/61815445acbcbad26f1c7965753d5abe1eab5604) | `` oo7-portal: init at 0.4.0 ``                                             |
| [`5c6e56eb`](https://github.com/NixOS/nixpkgs/commit/5c6e56eb113186598367f2996d640d41489a5fd9) | `` oo7: 0.3.3 -> 0.4.0 ``                                                   |
| [`c7b5b4c5`](https://github.com/NixOS/nixpkgs/commit/c7b5b4c5e33ad4e7b93a76485880253b7a39e02d) | `` oo7: re-add updateScript ``                                              |
| [`2d8a8df5`](https://github.com/NixOS/nixpkgs/commit/2d8a8df5fb9cd86138c813ad6223cafb56af2349) | `` tuba: 0.9.1 -> 0.9.2 ``                                                  |
| [`0103e7b2`](https://github.com/NixOS/nixpkgs/commit/0103e7b281dbd7ac25de82cb0b4920f495c2f97a) | `` tetris: init at 0.1.6 ``                                                 |