### PR TITLE
chore(flake/home-manager): `597f9c2f` -> `744f749d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -451,11 +451,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1741563526,
-        "narHash": "sha256-FAJ7jIwFq1gxbxS+cdhtTxFM8eLWgP0jQGaVIvA/bug=",
+        "lastModified": 1741579508,
+        "narHash": "sha256-skRbH+UF2ES+msEa+KWi7AQFX73S+QsGlPsyCU6XyE0=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "597f9c2f06af8791b31c48ad05471ac5afbd0f0a",
+        "rev": "744f749dd6fbc1489591ea370b95156858629cb9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                                           |
| ----------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------- |
| [`744f749d`](https://github.com/nix-community/home-manager/commit/744f749dd6fbc1489591ea370b95156858629cb9) | `` mods: add a mods module (#6339) ``                                             |
| [`ce9cb249`](https://github.com/nix-community/home-manager/commit/ce9cb2496c48ebb33e42ee0ab82267f67b82f71e) | `` podman: added volume, image, and build quadlets (#6137) ``                     |
| [`f8bb0ba6`](https://github.com/nix-community/home-manager/commit/f8bb0ba6de361c43c1c1e9756375f23ffadac1f9) | `` zoxide: update mkOrder to place bash configuration at end of bashrc (#6572) `` |