### PR TITLE
chore(flake/akuse-flake): `e760509b` -> `f4d59051`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -5,11 +5,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1741472226,
-        "narHash": "sha256-C1mu04t4i6YXytxUcxbqxEHvdXbVEhUvjWa+a65vtho=",
+        "lastModified": 1741631335,
+        "narHash": "sha256-pT7W9/SaWnzm/SxPN71zy295ALryb3lIaB8WRdrBdZI=",
         "owner": "Rishabh5321",
         "repo": "akuse-flake",
-        "rev": "e760509be83a6e439dba07c2ee82f28c1e064769",
+        "rev": "f4d59051944deb42f2602b64a1d63ee271dc8317",
         "type": "github"
       },
       "original": {
@@ -781,11 +781,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1741379970,
-        "narHash": "sha256-Wh7esNh7G24qYleLvgOSY/7HlDUzWaL/n4qzlBePpiw=",
+        "lastModified": 1741513245,
+        "narHash": "sha256-7rTAMNTY1xoBwz0h7ZMtEcd8LELk9R5TzBPoHuhNSCk=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "36fd87baa9083f34f7f5027900b62ee6d09b1f2f",
+        "rev": "e3e32b642a31e6714ec1b712de8c91a3352ce7e1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                   | Message                                                           |
| -------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------- |
| [`f4d59051`](https://github.com/Rishabh5321/akuse-flake/commit/f4d59051944deb42f2602b64a1d63ee271dc8317) | `` chore(flake/nixpkgs): 36fd87ba -> e3e32b64 ``                  |
| [`0ee0811e`](https://github.com/Rishabh5321/akuse-flake/commit/0ee0811ec3bfa9d1d4ef585fc4cb7f86c795870e) | `` chore(github): bump cachix/install-nix-action from 30 to 31 `` |