### PR TITLE
chore(flake/hyprland): `d30cc19d` -> `b21edb1a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -559,11 +559,11 @@
         "xdph": "xdph"
       },
       "locked": {
-        "lastModified": 1741461862,
-        "narHash": "sha256-TNTtpDHoNB+wOEfypkGTu2zC0wHUwbabQo4HyU53Yok=",
+        "lastModified": 1741654302,
+        "narHash": "sha256-4AtygtWyIRXmBLdfWMSNJJNLvyp35NqFwq1UxK4IRQM=",
         "owner": "hyprwm",
         "repo": "Hyprland",
-        "rev": "d30cc19d253a3db784ad10c3084f58cbb52d325a",
+        "rev": "b21edb1a9753ba8c236302c1d6dba9ea2418b1d3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                                              |
| ------------------------------------------------------------------------------------------------ | ---------------------------------------------------- |
| [`b21edb1a`](https://github.com/hyprwm/Hyprland/commit/b21edb1a9753ba8c236302c1d6dba9ea2418b1d3) | `` input: fix touch calibration matrix overriding `` |
| [`e4af4b5e`](https://github.com/hyprwm/Hyprland/commit/e4af4b5e2e3566a5fa95505b0d0ef5e5c9e174b8) | `` core: update decorations on lockgroups (#9573) `` |