### PR TITLE
chore(flake/home-manager): `744f749d` -> `7fb86787`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -451,11 +451,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1741579508,
-        "narHash": "sha256-skRbH+UF2ES+msEa+KWi7AQFX73S+QsGlPsyCU6XyE0=",
+        "lastModified": 1741635347,
+        "narHash": "sha256-2aYfV44h18alHXopyfL4D9GsnpE5XlSVkp4MGe586VU=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "744f749dd6fbc1489591ea370b95156858629cb9",
+        "rev": "7fb8678716c158642ac42f9ff7a18c0800fea551",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                       |
| ----------------------------------------------------------------------------------------------------------- | --------------------------------------------- |
| [`7fb86787`](https://github.com/nix-community/home-manager/commit/7fb8678716c158642ac42f9ff7a18c0800fea551) | `` Fix missing styleName for kde6 (#6597) ``  |
| [`3593ee59`](https://github.com/nix-community/home-manager/commit/3593ee59a44974b8518829a5239b2f77222e3c81) | `` xdg-mime: Fix cross compilation (#6500) `` |