### PR TITLE
chore(flake/stylix): `d732a614` -> `6b5afdbb`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1066,11 +1066,11 @@
         "tinted-zed": "tinted-zed"
       },
       "locked": {
-        "lastModified": 1741609301,
-        "narHash": "sha256-4KcrXB1DTopQ1kUsPqucvcITUJyfO4mIHNpkIG3dd60=",
+        "lastModified": 1741635390,
+        "narHash": "sha256-wuYjYWjePERWKmr/8TZ7rRnYPjOTVMRouiT6gOxH8WM=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "d732a61453e2cf322cb1f8801fcb7af8fc67dd73",
+        "rev": "6b5afdbb3e9e06de68d7c44dfe78a1359d422a45",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                        | Message                                                              |
| --------------------------------------------------------------------------------------------- | -------------------------------------------------------------------- |
| [`6b5afdbb`](https://github.com/danth/stylix/commit/6b5afdbb3e9e06de68d7c44dfe78a1359d422a45) | `` {firefox,floorp,librewolf}: add profile warning (#963) ``         |
| [`9388f64e`](https://github.com/danth/stylix/commit/9388f64ebe5d6bf99f35b67146f2aa0d765a12d0) | `` river: add cursor size and background color (#968) ``             |
| [`a742ba73`](https://github.com/danth/stylix/commit/a742ba739b61ac8ed344886e5c5e59cc8b0c7e1a) | `` waybar: add font option and change default to monospace (#972) `` |
| [`fc5acae5`](https://github.com/danth/stylix/commit/fc5acae54b03d9282f68d0f392cfffefbfade649) | `` stylix: add version checks (#924) ``                              |
| [`6c42dc31`](https://github.com/danth/stylix/commit/6c42dc31ef80f41d8b201ff79a3788a02d7f1834) | `` mpv: init (#949) ``                                               |
| [`6a7d5633`](https://github.com/danth/stylix/commit/6a7d563370269237f6a83f5d184e4f25233056b2) | `` vim: fix incorrect input path (#976) ``                           |
| [`2c20aed3`](https://github.com/danth/stylix/commit/2c20aed3b39a87b8ab7c0d1fef44987f8a69b2d3) | `` qt: autoenable hm module only on NixOS (#942) ``                  |