### PR TITLE
chore(flake/nixpkgs-stable): `52e3095f` -> `ebe2788e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -812,11 +812,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1741445498,
-        "narHash": "sha256-F5Em0iv/CxkN5mZ9hRn3vPknpoWdcdCyR0e4WklHwiE=",
+        "lastModified": 1741600792,
+        "narHash": "sha256-yfDy6chHcM7pXpMF4wycuuV+ILSTG486Z/vLx/Bdi6Y=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "52e3095f6d812b91b22fb7ad0bfc1ab416453634",
+        "rev": "ebe2788eafd539477f83775ef93c3c7e244421d3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                               |
| ---------------------------------------------------------------------------------------------- | --------------------------------------------------------------------- |
| [`fa6bb1f2`](https://github.com/NixOS/nixpkgs/commit/fa6bb1f2d68a69de7a54453f4aef6e6f5e0dc0b1) | `` pnpm_10: 10.6.1 -> 10.6.2 ``                                       |
| [`a76a965e`](https://github.com/NixOS/nixpkgs/commit/a76a965e646a71c9e6baf211bcb57da717adbc15) | `` google-chrome: 133.0.6943.141 -> 134.0.6998.35 ``                  |
| [`7bc51d34`](https://github.com/NixOS/nixpkgs/commit/7bc51d3463f789480f5fa2066c2e973f29038645) | `` linux_6_6: 6.6.81 -> 6.6.82 ``                                     |
| [`ecb78797`](https://github.com/NixOS/nixpkgs/commit/ecb78797723f9754ec9555d45d027b6c44b4b0eb) | `` linux_testing: 6.14-rc5 -> 6.14-rc6 ``                             |
| [`6c713aed`](https://github.com/NixOS/nixpkgs/commit/6c713aed738db5e91b7e2f5535f345f6090a9cd6) | `` raycast: 1.93.0 -> 1.93.2 ``                                       |
| [`5f30dc85`](https://github.com/NixOS/nixpkgs/commit/5f30dc85946066641b0520641c5fb807af6a7c03) | `` [Backport 24.11] vscodium: 1.94.2.24284 -> 1.97.2.25045 #388513 `` |
| [`25beabde`](https://github.com/NixOS/nixpkgs/commit/25beabde5b0c0fb8464974ff5757a07d365d7763) | `` matrix-authentication-service: 0.13.0 -> 0.14.1 ``                 |
| [`105058a6`](https://github.com/NixOS/nixpkgs/commit/105058a6c802668c28d903a6acef47c66e716e88) | `` matrix-authentication-service: fix vendor hash ``                  |
| [`3e021696`](https://github.com/NixOS/nixpkgs/commit/3e0216968f702a0e90f3e56693b6b9132e71c890) | `` matrix-authentication-service: 0.12.0 -> 0.13.0 ``                 |
| [`1d121463`](https://github.com/NixOS/nixpkgs/commit/1d12146318bd5e7390619c7e599182abcd59c2de) | `` open-policy-agent: 0.70.0 -> 1.1.0 ``                              |
| [`cb94994b`](https://github.com/NixOS/nixpkgs/commit/cb94994bdbd2349e2ac920bd1ada31ba8185f82d) | `` pnpm: 10.5.2 -> 10.6.1 ``                                          |
| [`b32b7e7f`](https://github.com/NixOS/nixpkgs/commit/b32b7e7f4fff01d0a153fcdebb0e922b679cea5c) | `` pnpm: 10.4.1 -> 10.5.2 ``                                          |
| [`9da24b6d`](https://github.com/NixOS/nixpkgs/commit/9da24b6d2d971a7b042314170bb25ecfb1856bab) | `` pnpm: 10.4.0 -> 10.4.1 ``                                          |
| [`3f1dbe48`](https://github.com/NixOS/nixpkgs/commit/3f1dbe48410e12084ab0fd2683c977c5e8546a19) | `` pnpm_10: 10.2.1 -> 10.4.0 ``                                       |
| [`97058e41`](https://github.com/NixOS/nixpkgs/commit/97058e41eb65ff30936552960507536c48bd0c16) | `` pnpm_10: 10.2.0 -> 10.2.1 ``                                       |
| [`ace784b3`](https://github.com/NixOS/nixpkgs/commit/ace784b32bfb25fdfdae96655f0bb3b34efc4350) | `` pnpm_10: 10.1.0 -> 10.2.0 ``                                       |
| [`a0dec22a`](https://github.com/NixOS/nixpkgs/commit/a0dec22aed75f9d1a312fbdc4d58238358f708fc) | `` qpwgraph: 0.8.1 -> 0.8.2 ``                                        |
| [`c237f167`](https://github.com/NixOS/nixpkgs/commit/c237f167e39c39d097c61501d1ee6022d53d1d09) | `` mpd: 0.23.16 -> 0.23.17 ``                                         |
| [`ee16269b`](https://github.com/NixOS/nixpkgs/commit/ee16269b477129e65aed2a2db55ff7c45c77fe96) | `` mpd: 0.23.15 -> 0.23.16 ``                                         |
| [`c1bdc0ea`](https://github.com/NixOS/nixpkgs/commit/c1bdc0ead70f08fc3259fb04c81935eb9897c961) | `` vencord: use latest pnpm_10 ``                                     |
| [`3ded32d7`](https://github.com/NixOS/nixpkgs/commit/3ded32d70534e7f6616723d2684e0e98b586ccc0) | `` pnpm.fetchDeps: ignore packageManager field in package.json ``     |
| [`1934ac9d`](https://github.com/NixOS/nixpkgs/commit/1934ac9dfdd1bae237a2b2f67aff423f17adb5d8) | `` pnpm_9: 9.15.5 -> 9.15.7 ``                                        |
| [`110bd369`](https://github.com/NixOS/nixpkgs/commit/110bd3693eb1a8a0152cfe92a71cbb15ac9eb2e5) | `` thunderbird-bin-unwrapped: 128.7.1esr -> 128.8.0esr ``             |
| [`38098da1`](https://github.com/NixOS/nixpkgs/commit/38098da15f4824918397cb34eaaa3be490690ef2) | `` brave: 1.75.181 -> 1.76.73 ``                                      |
| [`8d6d3347`](https://github.com/NixOS/nixpkgs/commit/8d6d33471d79f4f3fb1f84a6fb02262288c01bd4) | `` librewolf: 136.0-1 -> 136.0-2 ``                                   |
| [`26ccf9b0`](https://github.com/NixOS/nixpkgs/commit/26ccf9b0aae53cd3b35b3fc47cbb768df2a7156a) | `` librewolf: add fpletz to maintainers ``                            |
| [`57eb639e`](https://github.com/NixOS/nixpkgs/commit/57eb639e84665e05e7b693209590f24ce98c7830) | `` librewolf-unwrapped: sync build patching with upstream ``          |
| [`cb398b88`](https://github.com/NixOS/nixpkgs/commit/cb398b888c3d4d72ae0d640813465a5797a22752) | `` librewolf-unwrapped: restore patch application ``                  |
| [`6cda4529`](https://github.com/NixOS/nixpkgs/commit/6cda4529f0c5c2674728b1c5cae899fbc7ef97ae) | `` neatvnc: 0.9.3 -> 0.9.4 ``                                         |
| [`f0c87344`](https://github.com/NixOS/nixpkgs/commit/f0c8734476374697e2a4de24dd78fa72f982b28c) | `` prusa-slicer: patch curl version checks ``                         |
| [`65956b23`](https://github.com/NixOS/nixpkgs/commit/65956b234273ef1763b8d25d6c213e78c8d22e31) | `` syn2mas: 0.13.0 -> 0.14.0 ``                                       |
| [`299cc9af`](https://github.com/NixOS/nixpkgs/commit/299cc9afd8ac1bbdb56edd5ea76bd821161bdf1d) | `` git-wait: init at 0.4.0-unstable-2024-12-01 ``                     |
| [`ca2d4431`](https://github.com/NixOS/nixpkgs/commit/ca2d4431f3abb91ade917eefb395eb4f348cc3cb) | `` microsoft-edge: 133.0.3065.69 -> 134.0.3124.51 ``                  |
| [`24152259`](https://github.com/NixOS/nixpkgs/commit/241522594d2359a8be722cd71aff8f2791a18643) | `` erlang_27: 27.2.4 -> 27.3 ``                                       |
| [`8da0ccfc`](https://github.com/NixOS/nixpkgs/commit/8da0ccfcdc52d3ae04fac6dbdffc2d5beb49ab7c) | `` erlang_27: 27.2 -> 27.2.4 ``                                       |
| [`28205f98`](https://github.com/NixOS/nixpkgs/commit/28205f989728c6aaed26911fd48c2312fe147437) | `` erlang_nox: 27.2.1 -> 27.2.2 ``                                    |
| [`08d1b290`](https://github.com/NixOS/nixpkgs/commit/08d1b2904c844cc902915a11358dbb1fec033ed3) | `` erlang_nox: 27.2 -> 27.2.1 ``                                      |
| [`d9e73547`](https://github.com/NixOS/nixpkgs/commit/d9e73547939b87f4de34f1301ac6273d5c5f2ee0) | `` erlang_26: 26.2.5.6 -> 26.2.5.9 ``                                 |
| [`feba9359`](https://github.com/NixOS/nixpkgs/commit/feba9359f648e215d628bff95986cdd8dee9144e) | `` erlang_26: 26.2.5.6 -> 26.2.5.7 ``                                 |
| [`1dccb226`](https://github.com/NixOS/nixpkgs/commit/1dccb2260ffb29fb85505ce1dbe7d38391dc1c67) | `` erlang_25: 25.3.2.16 -> 25.3.2.18 ``                               |
| [`53ead050`](https://github.com/NixOS/nixpkgs/commit/53ead050f6ac1973311183fb5bd0d16ee7400aeb) | `` platformio: 6.1.16 -> 6.1.17 ``                                    |