### PR TITLE
chore(flake/hyprland): `b21edb1a` -> `4b25fbe5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -559,11 +559,11 @@
         "xdph": "xdph"
       },
       "locked": {
-        "lastModified": 1741654302,
-        "narHash": "sha256-4AtygtWyIRXmBLdfWMSNJJNLvyp35NqFwq1UxK4IRQM=",
+        "lastModified": 1741714321,
+        "narHash": "sha256-MLsVJ2LrHJzPErd3ImRYuQJuhiKyKAUSHta5ZptH3wE=",
         "owner": "hyprwm",
         "repo": "Hyprland",
-        "rev": "b21edb1a9753ba8c236302c1d6dba9ea2418b1d3",
+        "rev": "4b25fbe5fda3bf7f0e561f400fb8f300b002eab3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                                                              |
| ------------------------------------------------------------------------------------------------ | -------------------------------------------------------------------- |
| [`4b25fbe5`](https://github.com/hyprwm/Hyprland/commit/4b25fbe5fda3bf7f0e561f400fb8f300b002eab3) | `` windows: respect noinitialfocus with workspace changes (#9586) `` |
| [`81e93acb`](https://github.com/hyprwm/Hyprland/commit/81e93acba4a4da6060192bc18147bf18dbd4ac8d) | `` groupbar: pass alpha to title tex render pass ``                  |