### PR TITLE
chore(flake/akuse-flake): `f4d59051` -> `b857dbfd`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -5,11 +5,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1741631335,
-        "narHash": "sha256-pT7W9/SaWnzm/SxPN71zy295ALryb3lIaB8WRdrBdZI=",
+        "lastModified": 1741745621,
+        "narHash": "sha256-2s6XvsCYKYQhcgisdv8Fk8CTVL3qrbz6E+W1HpRZ3/s=",
         "owner": "Rishabh5321",
         "repo": "akuse-flake",
-        "rev": "f4d59051944deb42f2602b64a1d63ee271dc8317",
+        "rev": "b857dbfd2b3c4143efdb38d7c1c53b57b89d43fc",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                   | Message                                                      |
| -------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------ |
| [`89e1612b`](https://github.com/Rishabh5321/akuse-flake/commit/89e1612b9174427c3c41e48046f13dad17510e68) | `` chore(github): bump cachix/cachix-action from 15 to 16 `` |