### PR TITLE
chore(flake/home-manager): `144f13f5` -> `18780912`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -451,11 +451,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1741785612,
-        "narHash": "sha256-3NFLoC7AdenUJQHzPiHDYVBEgEIH6mGSbdx7GFbRURA=",
+        "lastModified": 1741791118,
+        "narHash": "sha256-4Y427uj0eql4yRU5rely3EcOlB9q457UDbG9omPtXiA=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "144f13f535be35c906241043f6bfcf21c1c419a0",
+        "rev": "18780912345970e5b546b1b085385789b6935a83",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                       |
| ----------------------------------------------------------------------------------------------------------- | --------------------------------------------- |
| [`18780912`](https://github.com/nix-community/home-manager/commit/18780912345970e5b546b1b085385789b6935a83) | `` home-cursor: louder deprecation ``         |
| [`74f2ed6a`](https://github.com/nix-community/home-manager/commit/74f2ed6a64a087fadb39a4af84c5ecc8083b686d) | `` test/home-cursor: add new .enable check `` |
| [`dcc20acf`](https://github.com/nix-community/home-manager/commit/dcc20acf93f338a47468996a0055cda1112c051c) | `` home-cursor: add doticons option ``        |
| [`00712ac0`](https://github.com/nix-community/home-manager/commit/00712ac0fb87bbfa13e892603863469ac4fd96a0) | `` home-cursor: use .enable pattern ``        |
| [`32531e45`](https://github.com/nix-community/home-manager/commit/32531e457215000b739da6cd40acfb080823f396) | `` home-cursor: explicit lib usage ``         |