### PR TITLE
chore(flake/akuse-flake): `b857dbfd` -> `bc24f53b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -5,11 +5,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1741745621,
-        "narHash": "sha256-2s6XvsCYKYQhcgisdv8Fk8CTVL3qrbz6E+W1HpRZ3/s=",
+        "lastModified": 1741890626,
+        "narHash": "sha256-EMohzzrYQQbWSXK30CeJtKVzwuCw4xUFfB4ccqNgMs4=",
         "owner": "Rishabh5321",
         "repo": "akuse-flake",
-        "rev": "b857dbfd2b3c4143efdb38d7c1c53b57b89d43fc",
+        "rev": "bc24f53bcde4c6d44e6344e4b753305d1ba8643c",
         "type": "github"
       },
       "original": {
@@ -781,11 +781,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1741513245,
-        "narHash": "sha256-7rTAMNTY1xoBwz0h7ZMtEcd8LELk9R5TzBPoHuhNSCk=",
+        "lastModified": 1741851582,
+        "narHash": "sha256-cPfs8qMccim2RBgtKGF+x9IBCduRvd/N5F4nYpU0TVE=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "e3e32b642a31e6714ec1b712de8c91a3352ce7e1",
+        "rev": "6607cf789e541e7873d40d3a8f7815ea92204f32",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                   | Message                                          |
| -------------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
| [`bc24f53b`](https://github.com/Rishabh5321/akuse-flake/commit/bc24f53bcde4c6d44e6344e4b753305d1ba8643c) | `` chore(flake/nixpkgs): e3e32b64 -> 6607cf78 `` |