### PR TITLE
chore(flake/stylix): `5053a63c` -> `08e0c91d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1083,11 +1083,11 @@
         "tinted-zed": "tinted-zed"
       },
       "locked": {
-        "lastModified": 1741880767,
-        "narHash": "sha256-tXtop1zIJMyRt1LDERIWwMAMVKdfDtFp/g37YKy2Ke4=",
+        "lastModified": 1741951718,
+        "narHash": "sha256-5MfCjwlU6TXlrr8Nkg1TK+gExVPz8/aU8ofbidK2Nlc=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "5053a63c87fea3508439b7e9c1a66fa6979a4694",
+        "rev": "08e0c91d76e05a61ffe15bcd17ef7fa3160c5bd8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                        | Message                                           |
| --------------------------------------------------------------------------------------------- | ------------------------------------------------- |
| [`08e0c91d`](https://github.com/danth/stylix/commit/08e0c91d76e05a61ffe15bcd17ef7fa3160c5bd8) | `` ci: bump cachix/cachix-action from 15 to 16 `` |