### PR TITLE
chore(flake/hyprland): `c754d796` -> `e5968048`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -559,11 +559,11 @@
         "xdph": "xdph"
       },
       "locked": {
-        "lastModified": 1741936499,
-        "narHash": "sha256-R/3zI3t8xUyT55nPtzpB8Xw9Tc55nZ/Tgl7gAddcv+A=",
+        "lastModified": 1741998159,
+        "narHash": "sha256-mf3SzoEPxphBb5Ed5TS34BBbBKEZmQPFkrlZ8Bu4+dc=",
         "owner": "hyprwm",
         "repo": "Hyprland",
-        "rev": "c754d7963f769e4ee272fda4301c87ac644b0dd5",
+        "rev": "e59680481d74fdfcc432bb9640ba2c979022c4c2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                                                          |
| ------------------------------------------------------------------------------------------------ | ---------------------------------------------------------------- |
| [`e5968048`](https://github.com/hyprwm/Hyprland/commit/e59680481d74fdfcc432bb9640ba2c979022c4c2) | `` input: Fix clicking through groupbar tabs (#9606) ``          |
| [`f4315db5`](https://github.com/hyprwm/Hyprland/commit/f4315db50f058df3620b1e03a75aa2192aa08c81) | `` nix: mesa -> libgbm (#9612) ``                                |
| [`3cc8e8c6`](https://github.com/hyprwm/Hyprland/commit/3cc8e8c6be897ce19d9d1798a5fa7f0a8c6221aa) | `` renderer: don't crash if cm fails to compile ``               |
| [`b3794460`](https://github.com/hyprwm/Hyprland/commit/b37944605f0e3285781082de28c7434b8d6293bf) | `` protocols: fix include ``                                     |
| [`f4995c18`](https://github.com/hyprwm/Hyprland/commit/f4995c1837b433f77241075ee9a1597f80a59b89) | `` descriptions: remove allow_early_buffer_release ``            |
| [`6ffde364`](https://github.com/hyprwm/Hyprland/commit/6ffde3646688cee448683f95a858fc1754c0c35a) | `` syncobj: use eventfd instead of stalling fd checks (#9437) `` |