### PR TITLE
chore(flake/zen-browser): `9a6a8b54` -> `b6b61a5d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1309,11 +1309,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1742018660,
-        "narHash": "sha256-xF766iA8/UNEY7/uw7AV7twnw/uji9SBonDX0BHOfcA=",
+        "lastModified": 1742020525,
+        "narHash": "sha256-UMRzJNmCkl3zqwdaJm+G8z9z1M5Pk5KyLk9wvvggOks=",
         "owner": "0xc000022070",
         "repo": "zen-browser-flake",
-        "rev": "9a6a8b54fdac8bf1a761624b50ed66d9982403c7",
+        "rev": "b6b61a5d3671313c8d19e577f60f0d42ff64fc15",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                          | Message                                                                              |
| --------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------ |
| [`b6b61a5d`](https://github.com/0xc000022070/zen-browser-flake/commit/b6b61a5d3671313c8d19e577f60f0d42ff64fc15) | `` ci(update/twilight): using updated at epoch for commit, release name and notes `` |
| [`6ea0a3e9`](https://github.com/0xc000022070/zen-browser-flake/commit/6ea0a3e914ffaec03c2b36adb585f8817853c2f6) | `` Update Zen Browser twilight @ x86_64 && aarch64 to 1.10t#null ``                  |
| [`cd9be7ef`](https://github.com/0xc000022070/zen-browser-flake/commit/cd9be7eff96cbde072e4bef696416dc401a46c45) | `` ci(update): removing invalid control characters from gh response ``               |