### PR TITLE
chore(flake/stylix): `e43eb4e2` -> `bcc674f1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1083,11 +1083,11 @@
         "tinted-zed": "tinted-zed"
       },
       "locked": {
-        "lastModified": 1741976991,
-        "narHash": "sha256-74Q3Kpzde+S3pWaZihNFMjCn8lo4wmDVmg+Uvw8YLLQ=",
+        "lastModified": 1742040559,
+        "narHash": "sha256-Hb3aw00C1/5ORiTCASwMd8vcLAl/GNJfyjXZyl/EKpc=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "e43eb4e2a7dfbd96454df2b1c9418299b4373773",
+        "rev": "bcc674f1994396137438bac9d905971453d33b12",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                        | Message                                     |
| --------------------------------------------------------------------------------------------- | ------------------------------------------- |
| [`bcc674f1`](https://github.com/danth/stylix/commit/bcc674f1994396137438bac9d905971453d33b12) | `` stylix: simplify autoload.nix (#1001) `` |