### PR TITLE
chore(flake/nix-gaming): `b2a32ef8` -> `0894bfe2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -766,11 +766,11 @@
         "nixpkgs": "nixpkgs_4"
       },
       "locked": {
-        "lastModified": 1741916615,
-        "narHash": "sha256-SU6Q/IBGJ9a7u6WrVjZ+ShoIjK3To/lD3U37DgfX1Tw=",
+        "lastModified": 1742045780,
+        "narHash": "sha256-+DTq6s9QFutsc0NCKGARH3+J5MBkz91goh7/WHXI9Wo=",
         "owner": "fufexan",
         "repo": "nix-gaming",
-        "rev": "b2a32ef80ad0cc7f3dee928771791625ff9494c1",
+        "rev": "0894bfe2c7f48091c1f5100f39bdfa0e19d08ab4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                              | Message                                             |
| --------------------------------------------------------------------------------------------------- | --------------------------------------------------- |
| [`0894bfe2`](https://github.com/fufexan/nix-gaming/commit/0894bfe2c7f48091c1f5100f39bdfa0e19d08ab4) | `` star-citizen: Ensure all tricks are installed `` |
| [`829a5575`](https://github.com/fufexan/nix-gaming/commit/829a5575cfce4bb8619183e7de35b97a9b12720b) | `` star-citizen: 2.1.0 -> 2.3.1 ``                  |