### PR TITLE
chore(flake/zen-browser): `09269be6` -> `30fdea24`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1231,11 +1231,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1742065992,
-        "narHash": "sha256-G0/hK4Khox9O8cNF2wEO1sh16i9LioyRIj51ZJWh7WY=",
+        "lastModified": 1742076998,
+        "narHash": "sha256-EuqbZFwam8dXNiuytI67rIUrF4ogy62OF2nGxWk8GGI=",
         "owner": "0xc000022070",
         "repo": "zen-browser-flake",
-        "rev": "09269be63797cd668ca41bd13fc8a2d29f3e6afc",
+        "rev": "30fdea2435aeeb961acba896b9b65bab4fd17003",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                          | Message                                                                   |
| --------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------- |
| [`30fdea24`](https://github.com/0xc000022070/zen-browser-flake/commit/30fdea2435aeeb961acba896b9b65bab4fd17003) | `` Update Zen Browser twilight @ x86_64 && aarch64 to 1.10t#1742075633 `` |