### PR TITLE
chore(flake/grayjay): `094fd84a` -> `0a5db874`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -371,11 +371,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1742019701,
-        "narHash": "sha256-SkUSN/IDCgciXEKsHfoDap//zr38bSARbH39qZCoIyo=",
+        "lastModified": 1742116708,
+        "narHash": "sha256-K3pansltKkBavW7ur6Qa/wAoOUt8fW5w0DlZuR5WoYs=",
         "owner": "rishabh5321",
         "repo": "grayjay-flake",
-        "rev": "094fd84a261e9740de6ef5febba41714f421c818",
+        "rev": "0a5db874089c64913f58050eddbefed74793cbcf",
         "type": "github"
       },
       "original": {
@@ -768,11 +768,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1741851582,
-        "narHash": "sha256-cPfs8qMccim2RBgtKGF+x9IBCduRvd/N5F4nYpU0TVE=",
+        "lastModified": 1741985373,
+        "narHash": "sha256-ErKa5qzdqAWqb0OPDYD8+/+YleTSu8xHP9ldKkr7Opo=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "6607cf789e541e7873d40d3a8f7815ea92204f32",
+        "rev": "bd9298af7fc8f144ff834d6dad746e6fb4e227d3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                     | Message                                          |
| ---------------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
| [`0a5db874`](https://github.com/Rishabh5321/grayjay-flake/commit/0a5db874089c64913f58050eddbefed74793cbcf) | `` chore(flake/nixpkgs): 6607cf78 -> bd9298af `` |