### PR TITLE
chore(flake/akuse-flake): `638702ff` -> `a2f6c702`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -5,11 +5,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1742019802,
-        "narHash": "sha256-k4E/A2+Fx0ZDc0Kcj+YVPveh3eKBNeu/032mSP9UUiQ=",
+        "lastModified": 1742116844,
+        "narHash": "sha256-gjSbq9M0Vi8bo26QJkX05QP3eyy5awefinrfveNG11k=",
         "owner": "Rishabh5321",
         "repo": "akuse-flake",
-        "rev": "638702ff6021fe7c8c296dce97d4cf967689fe3b",
+        "rev": "a2f6c702511ded7bdbc799a3eb34558a190a8f6d",
         "type": "github"
       },
       "original": {
@@ -721,11 +721,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1741851582,
-        "narHash": "sha256-cPfs8qMccim2RBgtKGF+x9IBCduRvd/N5F4nYpU0TVE=",
+        "lastModified": 1741985373,
+        "narHash": "sha256-ErKa5qzdqAWqb0OPDYD8+/+YleTSu8xHP9ldKkr7Opo=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "6607cf789e541e7873d40d3a8f7815ea92204f32",
+        "rev": "bd9298af7fc8f144ff834d6dad746e6fb4e227d3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                   | Message                                          |
| -------------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
| [`a2f6c702`](https://github.com/Rishabh5321/akuse-flake/commit/a2f6c702511ded7bdbc799a3eb34558a190a8f6d) | `` chore(flake/nixpkgs): 6607cf78 -> bd9298af `` |