### PR TITLE
chore(flake/thorium): `c51e94cb` -> `d6ea5e4a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -848,11 +848,11 @@
     },
     "nixpkgs_7": {
       "locked": {
-        "lastModified": 1741851582,
-        "narHash": "sha256-cPfs8qMccim2RBgtKGF+x9IBCduRvd/N5F4nYpU0TVE=",
+        "lastModified": 1741985373,
+        "narHash": "sha256-ErKa5qzdqAWqb0OPDYD8+/+YleTSu8xHP9ldKkr7Opo=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "6607cf789e541e7873d40d3a8f7815ea92204f32",
+        "rev": "bd9298af7fc8f144ff834d6dad746e6fb4e227d3",
         "type": "github"
       },
       "original": {
@@ -1068,11 +1068,11 @@
         "nixpkgs": "nixpkgs_7"
       },
       "locked": {
-        "lastModified": 1742020055,
-        "narHash": "sha256-9LWo0MSFZkSAMqGdYC+3+4k2AIGFJ6lpJROyFhM4y5Y=",
+        "lastModified": 1742116747,
+        "narHash": "sha256-EqFih9h2eO4y3KHBTxeQTukZ5mmcip2yCMtgAtp03Jg=",
         "owner": "Rishabh5321",
         "repo": "thorium_flake",
-        "rev": "c51e94cb5b97ccaa730637bfaeaa1886841d81eb",
+        "rev": "d6ea5e4ae84ffe6f764acb8218f4ccb8368393dc",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                     | Message                                          |
| ---------------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
| [`d6ea5e4a`](https://github.com/Rishabh5321/thorium_flake/commit/d6ea5e4ae84ffe6f764acb8218f4ccb8368393dc) | `` chore(flake/nixpkgs): 6607cf78 -> bd9298af `` |