### PR TITLE
chore(flake/nixpkgs): `bd9298af` -> `c80f6a7e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -816,11 +816,11 @@
     },
     "nixpkgs_5": {
       "locked": {
-        "lastModified": 1741985373,
-        "narHash": "sha256-ErKa5qzdqAWqb0OPDYD8+/+YleTSu8xHP9ldKkr7Opo=",
+        "lastModified": 1742069588,
+        "narHash": "sha256-C7jVfohcGzdZRF6DO+ybyG/sqpo1h6bZi9T56sxLy+k=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "bd9298af7fc8f144ff834d6dad746e6fb4e227d3",
+        "rev": "c80f6a7e10b39afcc1894e02ef785b1ad0b0d7e5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                       |
| ---------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------- |
| [`63aef1cb`](https://github.com/NixOS/nixpkgs/commit/63aef1cb834e9693284e322e19f352e4b4b03ec3) | `` discord: update various ``                                                 |
| [`3fd5825a`](https://github.com/NixOS/nixpkgs/commit/3fd5825a52f985c401a052fd260c3a341ea53ac1) | `` flow-editor: rename to flow-control ``                                     |
| [`24c2ce0e`](https://github.com/NixOS/nixpkgs/commit/24c2ce0e33cef6b552baad7cdc3773e23012e3ab) | `` statping-ng: init at 0.92.0 ``                                             |
| [`91d223c1`](https://github.com/NixOS/nixpkgs/commit/91d223c194ab4bae373d566855bf3255806fd1fc) | `` aliases: fix oxygen-icons5 alias ``                                        |
| [`f961f717`](https://github.com/NixOS/nixpkgs/commit/f961f717e76a9024585b2f23fef0e09e9e56b83d) | `` nixos/minecraft-server: fix package example ``                             |
| [`6c12682c`](https://github.com/NixOS/nixpkgs/commit/6c12682c6d2e822dcabf3a016124de0a86214053) | `` kdePackages.plasma-workspace: wrap with --inherit-argv0 ``                 |
| [`e44f5a37`](https://github.com/NixOS/nixpkgs/commit/e44f5a37cff768682b2c9114fdaf9f52c55822b6) | `` nixosTests.php: migrate to runTest ``                                      |
| [`fbcd2ea3`](https://github.com/NixOS/nixpkgs/commit/fbcd2ea3b7da51c242aafe773dc5e7ba337f046a) | `` vscode-extensions.github.copilot: 1.279.1416 -> 1.284.0 ``                 |
| [`1d1b64cf`](https://github.com/NixOS/nixpkgs/commit/1d1b64cfb1412565f8ae811bea2bdce09742fd88) | `` home-assistant-custom-components.sleep_as_android: init at 2.3.2 ``        |
| [`2d3a45d0`](https://github.com/NixOS/nixpkgs/commit/2d3a45d000f67883e624fc5955f7431fc4734734) | `` ratman: 0.4.0 -> 0.7.0 ``                                                  |
| [`1bb3ddca`](https://github.com/NixOS/nixpkgs/commit/1bb3ddca1ad2d514707e759fe60b264c7c760798) | `` androidStudioPackages.canary: 2024.3.2.7 -> 2024.3.2.8 ``                  |
| [`8e698c3f`](https://github.com/NixOS/nixpkgs/commit/8e698c3f15a17e8a25ea42de9a75220b6f6d2824) | `` forgejo-lts: unbreak unit tests by downgrading go to 1.23 ``               |
| [`d1177847`](https://github.com/NixOS/nixpkgs/commit/d117784740552bb5b66a83ce9181732360ab755c) | `` lighthouse: 5.3.0 -> 6.0.1 ``                                              |
| [`684efdc4`](https://github.com/NixOS/nixpkgs/commit/684efdc40c524c4d4a7aaff59b3b014575253f7e) | `` python314: 3.14.0a5 -> 3.14.0a6 ``                                         |
| [`dbb97d9f`](https://github.com/NixOS/nixpkgs/commit/dbb97d9f1c74c80d4f2877154a9799a2e1ef1eb0) | `` nrr: 0.10.0 -> 0.10.1 ``                                                   |
| [`d4cab85c`](https://github.com/NixOS/nixpkgs/commit/d4cab85cf6089bfe7142c2fc9163c137d4f24e0c) | `` zed-editor: 0.177.7 -> 0.177.9 ``                                          |
| [`5df7f65f`](https://github.com/NixOS/nixpkgs/commit/5df7f65f86054534fa7c8537186682f55f8803fa) | `` calcmysky: 0.3.3 -> 0.3.4 ``                                               |
| [`84ef5573`](https://github.com/NixOS/nixpkgs/commit/84ef55739ce0e0b675da4988d9aea2f12006c0be) | `` extension-manager: init at 0.6.1 ``                                        |
| [`05bec881`](https://github.com/NixOS/nixpkgs/commit/05bec881e8a12eb4e9efaaf83c92fc05db36cd7c) | `` hedgewars: update meta ``                                                  |
| [`9e68af6f`](https://github.com/NixOS/nixpkgs/commit/9e68af6fab100f31e3d57ffc96d6c115e08786d7) | `` hedgewars: update to unstable and drop the pinned SDL2_image ``            |
| [`41876dc4`](https://github.com/NixOS/nixpkgs/commit/41876dc43246270ed7f68e74c3d56d6042b1dcf8) | `` cachix: 1.7.6 -> 1.7.7 ``                                                  |
| [`51904f22`](https://github.com/NixOS/nixpkgs/commit/51904f228cb9f685aae1ebf404fccb22e2f03103) | `` yeoman: unbreak package ``                                                 |
| [`f8b11e8a`](https://github.com/NixOS/nixpkgs/commit/f8b11e8a904814b84c1e03efdf4534d062d4056c) | `` python3Packages.sphinxcontrib-svg2pdfconverter: init at 1.3.0 ``           |
| [`0ede6e40`](https://github.com/NixOS/nixpkgs/commit/0ede6e400be2945bd1557846d846ca61911f26db) | `` hedgewars: fetch patch from github ``                                      |
| [`64131c2a`](https://github.com/NixOS/nixpkgs/commit/64131c2a6f40fdc1d2f751a3803dfbf94c35223e) | `` hedgewars: move to by-name tree ``                                         |
| [`efb76208`](https://github.com/NixOS/nixpkgs/commit/efb7620824a08e01063823eacd6019c756a42979) | `` openrw: remove unneeded sfml dependency ``                                 |
| [`61d3ef9c`](https://github.com/NixOS/nixpkgs/commit/61d3ef9c7c0363580a432b76717d4226b652a81b) | `` openrw: mark as broken on darwin ``                                        |
| [`952560f0`](https://github.com/NixOS/nixpkgs/commit/952560f0d94e929903f87f148470587d070e456b) | `` gitlab-container-registry: add leona to maintainers ``                     |
| [`12c9b599`](https://github.com/NixOS/nixpkgs/commit/12c9b5996b21b8cc50f6279676db3c39ad74a021) | `` python312Packages.symspellpy: update disabled ``                           |
| [`7c896a83`](https://github.com/NixOS/nixpkgs/commit/7c896a835f536ecb7aa04a099f6fedef007c4b1a) | `` maintainers/team-list: add leona to gitlab ``                              |
| [`f359ba1d`](https://github.com/NixOS/nixpkgs/commit/f359ba1df689868371bccbe781aef57c50193d7f) | `` materialgram: 5.11.1.1 -> 5.12.5.1 ``                                      |
| [`16a8c896`](https://github.com/NixOS/nixpkgs/commit/16a8c896a23103aa9b33411c0927d7f6c13b9f32) | `` python313Packages.surepy: refactor ``                                      |
| [`466d527f`](https://github.com/NixOS/nixpkgs/commit/466d527fdaf9739ef74f81e9f294b52b47d5b204) | `` python313Packages.surepy: remove postPatch section ``                      |
| [`1abc916c`](https://github.com/NixOS/nixpkgs/commit/1abc916c6385c08fafb082fefcfbefe32b530f4d) | `` firefox-devedition-bin-unwrapped: 137.0b1 -> 137.0b6 ``                    |
| [`8cb46a64`](https://github.com/NixOS/nixpkgs/commit/8cb46a64a0f49e9660c53726b0c49c661dbf6962) | `` terraform-providers.gridscale: 2.1.0 -> 2.1.1 ``                           |
| [`a04a4de6`](https://github.com/NixOS/nixpkgs/commit/a04a4de6e1e007e9477643d2fec168881386b13f) | `` terraform-providers.lxd: 2.4.0 -> 2.5.0 ``                                 |
| [`9579478b`](https://github.com/NixOS/nixpkgs/commit/9579478b3512eab450b5892b9fc6bed48499b303) | `` python313Packages.rubymarshal: 1.2.8 -> 1.2.9 ``                           |
| [`994c56c8`](https://github.com/NixOS/nixpkgs/commit/994c56c88148852a128e9830492a89d1c8d1f53f) | `` nixos/cloudflared: remove assertion for certificateFile ``                 |
| [`1e324ae3`](https://github.com/NixOS/nixpkgs/commit/1e324ae3f8e53919084372e158d3c8f5809b47e6) | `` errands: 46.2.7 -> 46.2.8 ``                                               |
| [`be0f033b`](https://github.com/NixOS/nixpkgs/commit/be0f033b8f9366d12f9d651b0ceeed79274baf23) | `` jjui: 0.5 -> 0.7 ``                                                        |
| [`154457c1`](https://github.com/NixOS/nixpkgs/commit/154457c1d9ff633f36ddce59087da7cff2044250) | `` thunderbird: use the monthly release version by default ``                 |
| [`85f15a27`](https://github.com/NixOS/nixpkgs/commit/85f15a27627da9d84036cde6fa853165f0c7068e) | `` vscode-extensions.continue.continue: 0.8.68 -> 1.1.11 ``                   |
| [`15aeace5`](https://github.com/NixOS/nixpkgs/commit/15aeace54e2f5da4b1477f5174424d7ef2a485dd) | `` terraform-providers.auth0: 1.13.1 -> 1.14.0 ``                             |
| [`38590f30`](https://github.com/NixOS/nixpkgs/commit/38590f303b54b358a2cfe788b238fff588e389f7) | `` nixos/changedetection-io: fix typo (#383539) ``                            |
| [`e4b08ccb`](https://github.com/NixOS/nixpkgs/commit/e4b08ccba762b30c5e1f93141e490922ff29bc33) | `` platformio-core: 6.1.17 -> 6.1.18 ``                                       |
| [`ac83b6bf`](https://github.com/NixOS/nixpkgs/commit/ac83b6bfcf12c6ace298b290834514afa9daeca1) | `` llama-cpp: 4798 -> 4889 ``                                                 |
| [`afb73c8c`](https://github.com/NixOS/nixpkgs/commit/afb73c8cf9a1f5336367edbe8627c9c9da981cc4) | `` php81: 8.1.31 -> 8.1.32 ``                                                 |
| [`f9c2f62a`](https://github.com/NixOS/nixpkgs/commit/f9c2f62ac04cc3334c05e66162d5fb792bfe6770) | `` snac2: 2.72 -> 2.73 ``                                                     |
| [`d8ba36e4`](https://github.com/NixOS/nixpkgs/commit/d8ba36e42dce3efb53806b0d9cbb00ff278c1192) | `` linuxPackages.r8125: cleanup ``                                            |
| [`c794e90e`](https://github.com/NixOS/nixpkgs/commit/c794e90ebba22dc6b6f7840702288dbdf2fceefe) | `` linuxPackages.r8125: 9.014.01 -> 9.015.00 ``                               |
| [`a0dc832b`](https://github.com/NixOS/nixpkgs/commit/a0dc832b2e1af62539c467841f086f3f78dcfaf7) | `` php82: 8.2.27 -> 8.2.28 ``                                                 |
| [`b5335251`](https://github.com/NixOS/nixpkgs/commit/b5335251ea1cf82b9719fed0972a363f8ffd77b6) | `` php84: 8.4.4 -> 8.4.5 ``                                                   |
| [`b6c8dc67`](https://github.com/NixOS/nixpkgs/commit/b6c8dc67b3de4ec16854915dbda19979844b0af3) | `` php: 8.3.17 -> 8.3.19 ``                                                   |
| [`29359fb7`](https://github.com/NixOS/nixpkgs/commit/29359fb77498f79f8e7f4fcc74556fa20406c521) | `` terraform-providers.ovh: 1.6.0 -> 2.0.0 ``                                 |
| [`7aeac03f`](https://github.com/NixOS/nixpkgs/commit/7aeac03f40021f4b213d460ef5813e52184368db) | `` SDL_compat: don't propagate build inputs ``                                |
| [`abaf2bd3`](https://github.com/NixOS/nixpkgs/commit/abaf2bd3823aae703289f3ccb25b13742a992499) | `` SDL_compat: use SDL3 through sdl2-compat ``                                |
| [`2371f38c`](https://github.com/NixOS/nixpkgs/commit/2371f38c394f10a830670ff230ed9de757413d6e) | `` typos: 1.30.0 -> 1.30.2 ``                                                 |
| [`f8eedc4f`](https://github.com/NixOS/nixpkgs/commit/f8eedc4f47f43ebb6b9c21e0a5c4a16ef14e031c) | `` rio: 0.2.8 -> 0.2.10 ``                                                    |
| [`dc5ddbfb`](https://github.com/NixOS/nixpkgs/commit/dc5ddbfb69a970a9b8f5d560b03b7950a486a04d) | `` python313Packages.flux-led: 1.1.3 -> 1.1.4 ``                              |
| [`d6405892`](https://github.com/NixOS/nixpkgs/commit/d6405892b667ecbae51653ae7fcde64c7da8864b) | `` python312Packages.awscrt: 0.23.10 -> 0.24.2 ``                             |
| [`a137efa7`](https://github.com/NixOS/nixpkgs/commit/a137efa7add785135e37404846ebf78997bfeb93) | `` python313Packages.ohme: 1.4.0 -> 1.4.1 ``                                  |
| [`fb6fcd4e`](https://github.com/NixOS/nixpkgs/commit/fb6fcd4e85d79f916eabaa0841cbdcb8e5619970) | `` sdl3: don't propagate build inputs ``                                      |
| [`a9e6a2fe`](https://github.com/NixOS/nixpkgs/commit/a9e6a2fe8fd78b86267ed177ef1591a3072fae10) | `` python313Packages.aioshelly: 13.2.0 -> 13.3.0 ``                           |
| [`1711da9b`](https://github.com/NixOS/nixpkgs/commit/1711da9b2f40a2dfae5a5d48ac934ee90917d2e1) | `` python313Packages.aioharmony: 0.4.1 -> 0.5.2 ``                            |
| [`b19d5610`](https://github.com/NixOS/nixpkgs/commit/b19d5610121efb30e99172b513c04c800163511d) | `` python313Packages.pyoverkiz: 1.16.2 -> 1.16.3 ``                           |
| [`728ec259`](https://github.com/NixOS/nixpkgs/commit/728ec2591fcb3dd941aeae33fb61bd16c846dcd2) | `` python313Packages.nexia: 2.3.0 -> 2.4.0 ``                                 |
| [`bdb364e0`](https://github.com/NixOS/nixpkgs/commit/bdb364e0e19406cf286fbf572066e8405830de42) | `` python313Packages.thinqconnect: 1.0.4 -> 1.0.5 ``                          |
| [`c45f2cda`](https://github.com/NixOS/nixpkgs/commit/c45f2cdacf06c3cbcdf37c5b6156c35970cd8e4a) | `` python313Packages.twilio: 9.4.6 -> 9.5.0 ``                                |
| [`4d1558ea`](https://github.com/NixOS/nixpkgs/commit/4d1558eab606b0a6c52b907658eca227a7908a18) | `` cnspec: 11.44.0 -> 11.45.1 ``                                              |
| [`4949101a`](https://github.com/NixOS/nixpkgs/commit/4949101a7c5cd829930e3d6b0f3026479cca38be) | `` python313Packages.tencentcloud-sdk-python: 3.0.1339 -> 3.0.1340 ``         |
| [`2b7d1881`](https://github.com/NixOS/nixpkgs/commit/2b7d18817b8822230abab22fe8fcd8213933f98d) | `` ldeep: relax ldap3-bleeding-edge ``                                        |
| [`45c19a48`](https://github.com/NixOS/nixpkgs/commit/45c19a484ad6d436fefd0e99a04bc2aaddd06d2c) | `` python312Packages.primer3: refactor ``                                     |
| [`464ba643`](https://github.com/NixOS/nixpkgs/commit/464ba64341494532ea703f50c0b1f1e3246834d7) | `` python312Packages.weblate-language-data: add changelog to meta ``          |
| [`ce57ceaf`](https://github.com/NixOS/nixpkgs/commit/ce57ceaf64cdd49cb312ff7c7bfa791edcaa2ae0) | `` ares-rs: 0.10.0 -> 0.11.0 ``                                               |
| [`a896fd01`](https://github.com/NixOS/nixpkgs/commit/a896fd0151ec8457524e486f76d52a34d5d241ab) | `` python313Packages.executor: disable on python 313 ``                       |
| [`707424f8`](https://github.com/NixOS/nixpkgs/commit/707424f8c16cb58ad0c1d089b3f2bc9448e681bd) | `` flet-client-flutter: 0.27.4 -> 0.27.6 ``                                   |
| [`bf5ace02`](https://github.com/NixOS/nixpkgs/commit/bf5ace02200790ddca65ee0f67ace63321cc0dbd) | `` linuxPackages.rtl8821ce: 0-unstable-2025-02-08 -> 0-unstable-2025-03-12 `` |
| [`b5d0d397`](https://github.com/NixOS/nixpkgs/commit/b5d0d397f6f30ebb032f5022393147c6cd30b9d9) | `` linuxPackages.rtl8821ce: add updateScript ``                               |
| [`7e757144`](https://github.com/NixOS/nixpkgs/commit/7e757144154ede07d5a1de322b846a7389026bd2) | `` release-plz: 0.3.120 -> 0.3.125 ``                                         |
| [`b3696b3b`](https://github.com/NixOS/nixpkgs/commit/b3696b3b304ea370694e1a41de67b91ecdc2f928) | `` google-chrome: 134.0.6998.35 -> 134.0.6998.88 ``                           |
| [`bd9ebda4`](https://github.com/NixOS/nixpkgs/commit/bd9ebda4bf20d7b53b76e1509aba7ceacfd9988e) | `` soundalike: init at 0.1.2 ``                                               |
| [`337181ea`](https://github.com/NixOS/nixpkgs/commit/337181ea2dd0a9fd81a532fdee510ae71a40956c) | `` python312Packages.instructor: 1.7.2 -> 1.7.4 ``                            |
| [`d3501a35`](https://github.com/NixOS/nixpkgs/commit/d3501a353916cf7303b2d55a8c0e645c374fd887) | `` quark-engine: 25.2.1 -> 25.3.1 ``                                          |
| [`91509a21`](https://github.com/NixOS/nixpkgs/commit/91509a21b820638bb730f85fb670a45d5e2c591c) | `` eksctl: 0.203.0 -> 0.205.0 ``                                              |
| [`ec1bc3d9`](https://github.com/NixOS/nixpkgs/commit/ec1bc3d99a49cb76d5cdb6d0afd81e9a39337b76) | `` petsc: add qbisi as maintainer ``                                          |
| [`68937e3e`](https://github.com/NixOS/nixpkgs/commit/68937e3e06ec6509f66193c3b680637f0c3611bf) | `` pshash: init at 0.1.14.6 ``                                                |
| [`c8110339`](https://github.com/NixOS/nixpkgs/commit/c8110339add878be660c37b6c4383e958b6b8a53) | `` hdr10plus_tool: remove use of with lib; ``                                 |
| [`691c6411`](https://github.com/NixOS/nixpkgs/commit/691c641159f9464be03fd94095f19bf578969d44) | `` hdr10plus_tool: point to concrete release changelog ``                     |
| [`2d6a37a2`](https://github.com/NixOS/nixpkgs/commit/2d6a37a2460a63606e5c5a03b457ea23e51b1353) | `` hdr10plus_tool: use finalAttrs pattern ``                                  |
| [`a6c939c5`](https://github.com/NixOS/nixpkgs/commit/a6c939c52ad47de444d0cbdd36da3dbb6593ea8a) | `` hdr10plus_tool: enable package tests ``                                    |
| [`f7a11220`](https://github.com/NixOS/nixpkgs/commit/f7a112205027ea066c90b7764ea888768a3794cf) | `` paru: correct shell completion file names ``                               |
| [`ba4f38c7`](https://github.com/NixOS/nixpkgs/commit/ba4f38c72e41f047924313b51b4092dd1a208498) | `` qownnotes: 25.2.9 -> 25.3.3 ``                                             |
| [`d98aba8b`](https://github.com/NixOS/nixpkgs/commit/d98aba8b68fea4ba6470aeaa7d5c475ed8c59998) | `` arpack-mpi: remove unnecessary __darwinAllowLocalNetworking ``             |
| [`4d1fad54`](https://github.com/NixOS/nixpkgs/commit/4d1fad5499e1a9ad312288ed775e9cfe1b9fc87a) | `` arpack-mpi: fix test failure on aarch64-linux ``                           |
| [`e2124e73`](https://github.com/NixOS/nixpkgs/commit/e2124e7359174c41d1a0011e10c0fd4865147631) | `` maa-assistant-arknights: 5.13.1 -> 5.14.0 ``                               |
| [`5e2ee121`](https://github.com/NixOS/nixpkgs/commit/5e2ee121c98eb5c3d51c2befea6062ddb6df9178) | `` python312Packages.cloudpathlib: 0.20.0 -> 0.21.0 ``                        |
| [`6fd0455e`](https://github.com/NixOS/nixpkgs/commit/6fd0455eb3328b6ed5d4c1cb75128a9bc302d727) | `` python312Packages.elasticsearch8: 8.17.1 -> 8.17.2 ``                      |
| [`f92b13c0`](https://github.com/NixOS/nixpkgs/commit/f92b13c0c4d77077aa9a79e18a73b39e1dc1397f) | `` rust-analyzer-unwrapped: 2025-02-24 -> 2025-03-10 ``                       |
| [`a11120f1`](https://github.com/NixOS/nixpkgs/commit/a11120f144c24f77d1759ef96f0bfeb1c6a5d2eb) | `` trilium-next-desktop: add arm64 distributions ``                           |
| [`967630a9`](https://github.com/NixOS/nixpkgs/commit/967630a93c63932bdb136ec0a60b27d7a59b16f0) | `` vdo: 8.3.0.73 -> 8.3.1.1 ``                                                |
| [`bf36e0bc`](https://github.com/NixOS/nixpkgs/commit/bf36e0bc1c2b95121ea4c20b6c4f2bc025ff406f) | `` t-rec: 0.7.8 -> 0.7.9 ``                                                   |
| [`b621de87`](https://github.com/NixOS/nixpkgs/commit/b621de872f44fbad4a2381dea189e4dbc55df5ad) | `` redpanda-client: 24.3.6 -> 24.3.7 ``                                       |
| [`c193a306`](https://github.com/NixOS/nixpkgs/commit/c193a306f8507d28a6b79ba2430b7298a0aeed55) | `` pyenv: 2.5.3 -> 2.5.4 ``                                                   |
| [`c83fceb7`](https://github.com/NixOS/nixpkgs/commit/c83fceb7868999a3241c3640e4741f6dc9fb3aeb) | `` system76-firmware: 1.0.69 -> 1.0.70 ``                                     |
| [`1d9ec8f2`](https://github.com/NixOS/nixpkgs/commit/1d9ec8f28679bf80aaae4e91c285507f491199bf) | `` kine: 0.13.10 -> 0.13.11 ``                                                |
| [`5f528389`](https://github.com/NixOS/nixpkgs/commit/5f5283898981176f73a1ce6f00a3215aa779bcf3) | `` Apply suggestions from code review ``                                      |
| [`9fe26b0a`](https://github.com/NixOS/nixpkgs/commit/9fe26b0a9a71980d2a96099d7e932c4b1ced60d8) | `` sequoia-chameleon-gnupg: 0.12.0 -> 0.13.0 ``                               |
| [`ea0d50f2`](https://github.com/NixOS/nixpkgs/commit/ea0d50f2e353772ee9bbbff59d9427507e6331a5) | `` iosevka: 33.0.0 -> 33.0.1 ``                                               |
| [`2ab618ae`](https://github.com/NixOS/nixpkgs/commit/2ab618ae4eabaceaa56997e5869dbb844cc90e2c) | `` mdsh: 0.9.0 -> 0.9.1 ``                                                    |
| [`3b3b0b47`](https://github.com/NixOS/nixpkgs/commit/3b3b0b47462aea443bce9edfcb08b86aa8045695) | `` python3.pkgs.pysls: Fix build on Darwin ``                                 |