### PR TITLE
chore(flake/zen-browser): `30fdea24` -> `d6a8c613`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1231,11 +1231,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1742076998,
-        "narHash": "sha256-EuqbZFwam8dXNiuytI67rIUrF4ogy62OF2nGxWk8GGI=",
+        "lastModified": 1742152409,
+        "narHash": "sha256-4SzEgAF/kPwReFVVHmXIAyTjjVmEj9bn0yPixXPvF4k=",
         "owner": "0xc000022070",
         "repo": "zen-browser-flake",
-        "rev": "30fdea2435aeeb961acba896b9b65bab4fd17003",
+        "rev": "d6a8c61396f9e010f0799574ea67c01a211cbf41",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                          | Message                                                                   |
| --------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------- |
| [`d6a8c613`](https://github.com/0xc000022070/zen-browser-flake/commit/d6a8c61396f9e010f0799574ea67c01a211cbf41) | `` Update Zen Browser twilight @ x86_64 && aarch64 to 1.10t#1742150064 `` |