### PR TITLE
chore(flake/seanime): `fd6ceb52` -> `0ba7cb4d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -947,11 +947,11 @@
         "nixpkgs": "nixpkgs_6"
       },
       "locked": {
-        "lastModified": 1742119755,
-        "narHash": "sha256-4bjijrkEWfklsVjvzuBmmsZADpeboRrKpzVHIOPSL7g=",
+        "lastModified": 1742211935,
+        "narHash": "sha256-xDd5wZKj99jRcY8g7li6bfCeAJHP9EMYsesiiEFbahA=",
         "owner": "rishabh5321",
         "repo": "seanime-flake",
-        "rev": "fd6ceb527a0cdd5f9c10c7f49ca45e4a41689fe0",
+        "rev": "0ba7cb4dad816c11d80df42c25ff9a1988d8d71c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                     | Message                                                                                                    |
| ---------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------- |
| [`0ba7cb4d`](https://github.com/Rishabh5321/seanime-flake/commit/0ba7cb4dad816c11d80df42c25ff9a1988d8d71c) | `` fix(github): streamline environment variable usage and enhance log messaging in flake_check workflow `` |
| [`d8935e1a`](https://github.com/Rishabh5321/seanime-flake/commit/d8935e1ab9eb15b461e0be023d53dfaff3d726f5) | `` fix(github): improve log formatting and message structure in flake_check workflow ``                    |