### PR TITLE
chore(flake/thorium): `a0e68f9c` -> `f86ec07f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1068,11 +1068,11 @@
         "nixpkgs": "nixpkgs_7"
       },
       "locked": {
-        "lastModified": 1742120384,
-        "narHash": "sha256-FQfxVrd0fm+n44zLx15RC20pYefB/6xGM1v1EU60JEg=",
+        "lastModified": 1742212563,
+        "narHash": "sha256-bgeHCo7ViBUVNrZXhM86EDUUdrtVqBm86ElG0r1i0hY=",
         "owner": "Rishabh5321",
         "repo": "thorium_flake",
-        "rev": "a0e68f9c55f5ecfd4a3d9d3b76ea411b72b9a874",
+        "rev": "f86ec07f64e39f735a0879101214d5045e36c7ef",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                     | Message                                                                                                       |
| ---------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------- |
| [`f86ec07f`](https://github.com/Rishabh5321/thorium_flake/commit/f86ec07f64e39f735a0879101214d5045e36c7ef) | `` fix(flake_check): specify flake output for installation to ensure correct package usage ``                 |
| [`c052e007`](https://github.com/Rishabh5321/thorium_flake/commit/c052e007c7135bdc258a2329dee98a253cd2223c) | `` fix(flake_check): update flake installation command and improve log handling for Telegram notifications `` |