### PR TITLE
chore(flake/zen-browser): `4dd2f79d` -> `ee6e6d22`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1231,11 +1231,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1742180312,
-        "narHash": "sha256-67nyifSJu0TnXReokhA+pQhqswg0ZOp033k+QboSL8s=",
+        "lastModified": 1742235890,
+        "narHash": "sha256-sfdA0G2ZfNITslnvrCgP02yHPHZtroFR7QS+mPteLtQ=",
         "owner": "0xc000022070",
         "repo": "zen-browser-flake",
-        "rev": "4dd2f79d89dc0ebbb1b3ebf96776383cc6d6989a",
+        "rev": "ee6e6d22de1297b8cfa5b90b8fd7744ceb124df9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                          | Message                                                                   |
| --------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------- |
| [`ee6e6d22`](https://github.com/0xc000022070/zen-browser-flake/commit/ee6e6d22de1297b8cfa5b90b8fd7744ceb124df9) | `` Update Zen Browser twilight @ x86_64 && aarch64 to 1.10t#1742234037 `` |