### PR TITLE
chore(flake/home-manager): `eae06a96` -> `b870fb2d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -391,11 +391,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1742241223,
-        "narHash": "sha256-GyFiAxF1ou3lxdCFlLQJh2JdPpj7B+9mXQzieKSYo7g=",
+        "lastModified": 1742243099,
+        "narHash": "sha256-23Jja3FSzRkfJpCVfYxIxurEvLlaJFtJgodjD3+efzM=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "eae06a96af1903655f06cb401907555ea4048357",
+        "rev": "b870fb2d62ee0deb657951f83e8689143dce98c8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                                        |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------ |
| [`b870fb2d`](https://github.com/nix-community/home-manager/commit/b870fb2d62ee0deb657951f83e8689143dce98c8) | `` zsh: update zsh initContent example to use lib.literalExpression (#6637) `` |
| [`18e7d548`](https://github.com/nix-community/home-manager/commit/18e7d548992eb1900fdaad5f1a3eb8fd849b0cdd) | `` ci: bump cachix/cachix-action from 15 to 16 (#6644) ``                      |