### PR TITLE
chore(flake/hyprland): `011d7ccb` -> `5f60fc7d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -499,11 +499,11 @@
         "xdph": "xdph"
       },
       "locked": {
-        "lastModified": 1742223160,
-        "narHash": "sha256-lExsJAtqhTITVBRuRoWklddFekm5CO+nrS2sxG4rsIA=",
+        "lastModified": 1742245601,
+        "narHash": "sha256-02OZCZPy6J2dFpKNnWlWkpZHwV8iyi5rPSIWmB0YMvY=",
         "owner": "hyprwm",
         "repo": "Hyprland",
-        "rev": "011d7ccb91081ff99f184564ea38d1b9e543a99c",
+        "rev": "5f60fc7d00eb08ee39cac1f5eceeb97ffbea0e7f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                                                       |
| ------------------------------------------------------------------------------------------------ | ------------------------------------------------------------- |
| [`5f60fc7d`](https://github.com/hyprwm/Hyprland/commit/5f60fc7d00eb08ee39cac1f5eceeb97ffbea0e7f) | `` renderer: only commit hw cursor stuff if needed (#9654) `` |
| [`c4f46473`](https://github.com/hyprwm/Hyprland/commit/c4f46473df0cbfcc822e3158db717c6b7f809760) | `` monitor: Optimize direct scanout damage (#9653) ``         |