### PR TITLE
chore(flake/hyprland): `5f60fc7d` -> `ec4bea79`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -499,11 +499,11 @@
         "xdph": "xdph"
       },
       "locked": {
-        "lastModified": 1742245601,
-        "narHash": "sha256-02OZCZPy6J2dFpKNnWlWkpZHwV8iyi5rPSIWmB0YMvY=",
+        "lastModified": 1742261820,
+        "narHash": "sha256-KYriCbjqEh+NWJOuRFEut4hIdIVtqPIhYWSGRKRooOU=",
         "owner": "hyprwm",
         "repo": "Hyprland",
-        "rev": "5f60fc7d00eb08ee39cac1f5eceeb97ffbea0e7f",
+        "rev": "ec4bea7901bdb1f36d33354c02e36d7e03b1ac1e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                                             |
| ------------------------------------------------------------------------------------------------ | --------------------------------------------------- |
| [`ec4bea79`](https://github.com/hyprwm/Hyprland/commit/ec4bea7901bdb1f36d33354c02e36d7e03b1ac1e) | `` config: nuke windowrule v1 syntax ``             |
| [`9171db19`](https://github.com/hyprwm/Hyprland/commit/9171db1984415a8553ee707bc2f558eb1ae06e7e) | `` renderer: delete now redundant ifdefs (#9651) `` |