### PR TITLE
chore(flake/stylix): `fa288c0d` -> `ff9ae322`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1005,11 +1005,11 @@
         "tinted-zed": "tinted-zed"
       },
       "locked": {
-        "lastModified": 1742234510,
-        "narHash": "sha256-dQoo4XivjZuJiSi8ePv9CuP0ncE64RLyz2vb46blRx0=",
+        "lastModified": 1742299802,
+        "narHash": "sha256-enlpX8hwrfmjv/dHTKWzAB5Cwt1Kr6+ptikjX3Ob+FY=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "fa288c0dc695b49c9af38614af8da981371fe92a",
+        "rev": "ff9ae322bcaeccabc65812390000276455331123",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                        | Message                                          |
| --------------------------------------------------------------------------------------------- | ------------------------------------------------ |
| [`ff9ae322`](https://github.com/danth/stylix/commit/ff9ae322bcaeccabc65812390000276455331123) | `` treewide: clean up `with` and stuff (#975) `` |