### PR TITLE
chore(flake/hyprland): `6f74d8d7` -> `cca0f48b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -499,11 +499,11 @@
         "xdph": "xdph"
       },
       "locked": {
-        "lastModified": 1742293483,
-        "narHash": "sha256-NvkYAtxTetNEOHdgeYlrXJALHetWSRMErfFVkXnuZHE=",
+        "lastModified": 1742297408,
+        "narHash": "sha256-Xn3vzG7dhQlK26B0vUeModxYC8UD/6OhOi+5vqYV6Y4=",
         "owner": "hyprwm",
         "repo": "Hyprland",
-        "rev": "6f74d8d7e998e96811fb22dfa33fd31de0e0c713",
+        "rev": "cca0f48b74e87f86244f5773c42d9ade84683f3b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                                                                       |
| ------------------------------------------------------------------------------------------------ | ----------------------------------------------------------------------------- |
| [`cca0f48b`](https://github.com/hyprwm/Hyprland/commit/cca0f48b74e87f86244f5773c42d9ade84683f3b) | `` renderer: add an option to disable cm and auto-skip cm if not necessary `` |
| [`60edb376`](https://github.com/hyprwm/Hyprland/commit/60edb376f29d89859072d90e9e4d8660a07caf88) | `` config/defaultConfig.hpp: windowrulev2 -> windowrule (#9663) ``            |