### PR TITLE
chore(flake/nixpkgs-stable): `a1185f40` -> `da044451`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -752,11 +752,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1742136038,
-        "narHash": "sha256-DDe16FJk18sadknQKKG/9FbwEro7A57tg9vB5kxZ8kY=",
+        "lastModified": 1742268799,
+        "narHash": "sha256-IhnK4LhkBlf14/F8THvUy3xi/TxSQkp9hikfDZRD4Ic=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "a1185f4064c18a5db37c5c84e5638c78b46e3341",
+        "rev": "da044451c6a70518db5b730fe277b70f494188f1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                        |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------ |
| [`ee27b9b7`](https://github.com/NixOS/nixpkgs/commit/ee27b9b71bfe44d268340e5c860c295e18b10c29) | `` recordbox: 0.9.2 -> 0.9.3 ``                                                |
| [`808b2ae2`](https://github.com/NixOS/nixpkgs/commit/808b2ae2329b0879a7e5343cccd8ad4af06a55d9) | `` Revert "build(deps): bump cachix/install-nix-action from 30 to 31" ``       |
| [`30c5c073`](https://github.com/NixOS/nixpkgs/commit/30c5c07320027e64b361dd0d68d57b49fb7e1182) | `` build(deps): bump cachix/install-nix-action from 30 to 31 ``                |
| [`a7dde5b9`](https://github.com/NixOS/nixpkgs/commit/a7dde5b9b988c515c11add8609e8d100f2c05b21) | `` gitlab-container-registry: disable flaky test ``                            |
| [`d5f6b4a4`](https://github.com/NixOS/nixpkgs/commit/d5f6b4a40310e0b1b26ab89daae8a0abc5683eaa) | `` consul: 1.20.4 -> 1.20.5 ``                                                 |
| [`e3740906`](https://github.com/NixOS/nixpkgs/commit/e374090668936491d8182ca97c562dcbfae1479a) | `` skypeforlinux: 8.137.0.425 -> 8.138.0.203 ``                                |
| [`ceb3583c`](https://github.com/NixOS/nixpkgs/commit/ceb3583c589b7b2f3446d6b9237d0a2a095e48e1) | `` linux_xanmod_latest: 6.13.6 -> 6.13.7 ``                                    |
| [`d3c356fb`](https://github.com/NixOS/nixpkgs/commit/d3c356fb84282c36a8602a1cecc2d187bcf641a7) | `` linux_xanmod: 6.12.18 -> 6.12.19 ``                                         |
| [`6153d5b5`](https://github.com/NixOS/nixpkgs/commit/6153d5b50dbe627683f0bc09387bdb483e6abadd) | `` nextcloud-talk-desktop: 1.0.1 -> 1.1.5 ``                                   |
| [`5085497b`](https://github.com/NixOS/nixpkgs/commit/5085497bc1a5ae86f847f74ffc8305edec26b616) | `` nextcloud-talk-desktop: 1.0.0 -> 1.0.1 ``                                   |
| [`9728ada1`](https://github.com/NixOS/nixpkgs/commit/9728ada1bd922101d1b8ec30f655cbb6df1000bb) | `` linux_testing: 6.14-rc6 -> 6.14-rc7 ``                                      |
| [`343790be`](https://github.com/NixOS/nixpkgs/commit/343790be0363b21f49c3f3d31654a12f77af963e) | `` qrcp: 0.11.4 -> 0.11.6 ``                                                   |
| [`a430022c`](https://github.com/NixOS/nixpkgs/commit/a430022c7cae7f0bb2237e8be129ae2dbbe7c941) | `` nixVersions.nix_2_26: Add maintainers to scope, use nix_2_24 maintainers `` |
| [`72f7256a`](https://github.com/NixOS/nixpkgs/commit/72f7256ad5b5093cd76f0a03097fdd7975b55895) | `` nixVersions.nix_2_26: Typo ``                                               |
| [`47a81db5`](https://github.com/NixOS/nixpkgs/commit/47a81db5e619e4271f105bb67e713f5d16e3e8a5) | `` nixVersions.nix_2_26: Apply nix#12557 use correct stdenv ``                 |
| [`3bb3367b`](https://github.com/NixOS/nixpkgs/commit/3bb3367baea8811b672b89b81f16724c8689c038) | `` nixVersions.nix_2_26: 2.26.1 -> 2.26.3 ``                                   |
| [`10123919`](https://github.com/NixOS/nixpkgs/commit/101239197c1c9b2bdcab0ff34a28849c5d833cb0) | `` Move nix/2_26 -> nix/vendor/2_26 ``                                         |
| [`fbe38e86`](https://github.com/NixOS/nixpkgs/commit/fbe38e860e3adc013d9966ff538adef9b41a4d34) | `` nixVersions.nix_2_26: Add libs to propagated-build-inputs ``                |
| [`4aabb849`](https://github.com/NixOS/nixpkgs/commit/4aabb849fd6f41e1ba2e73507c0f20e7d3cba692) | `` nixVersions.nix_2_26: Fix lndir calls on darwin ``                          |
| [`5cf73de7`](https://github.com/NixOS/nixpkgs/commit/5cf73de71729c104ed87ecf32fab9a1191bd78f8) | `` nixVersions.nix_2_26: Improve meta ``                                       |
| [`20201d8f`](https://github.com/NixOS/nixpkgs/commit/20201d8f62dd3b2ae7e55c96fc817a3caf6ce026) | `` nixVersions.nix_2_26: Refactor rename nixDefaultsLayer ``                   |
| [`bf9170e3`](https://github.com/NixOS/nixpkgs/commit/bf9170e345bb70ae87a9bfd439a7a2973f483ad7) | `` nixVersions.nix_2_26: Use a multi-output derivation ``                      |
| [`6435d054`](https://github.com/NixOS/nixpkgs/commit/6435d054f629148e8bac3c029f45db9b04d3009a) | `` Format ``                                                                   |
| [`0b47a5f6`](https://github.com/NixOS/nixpkgs/commit/0b47a5f6aa8bb61010c205b4277fe1580d802c92) | `` nixVersions.nix_2_26: Expose derivation system ``                           |
| [`9eebb5af`](https://github.com/NixOS/nixpkgs/commit/9eebb5af4aeb9cdeac2b7f21f305c3a06811e0d2) | `` nixVersions.nix_2_26: Update and improve packaging ``                       |
| [`31f17764`](https://github.com/NixOS/nixpkgs/commit/31f17764612ecf1433d465d8723ba832d11bd325) | `` palemoon-bin: 33.6.0.1 -> 33.6.1 ``                                         |
| [`cf7a072a`](https://github.com/NixOS/nixpkgs/commit/cf7a072acb2c53e34ca3d89c63df454cad8b845d) | `` osu-lazer: 2025.306.0 -> 2025.316.0 ``                                      |
| [`9c26651b`](https://github.com/NixOS/nixpkgs/commit/9c26651b85daab4e03320a45f7849aa525742e76) | `` osu-lazer-bin: 2025.306.0 -> 2025.316.0 ``                                  |
| [`e0e4b125`](https://github.com/NixOS/nixpkgs/commit/e0e4b12591b9b0c3f2f9deaf80eec0cad4bc515c) | `` discord: update various ``                                                  |
| [`373aac48`](https://github.com/NixOS/nixpkgs/commit/373aac489753e95b41ccacfda37e2aad80546a2d) | `` discord: 0.0.86 -> 0.0.87 ``                                                |
| [`3833d038`](https://github.com/NixOS/nixpkgs/commit/3833d03814b7823f49ed06f5e6bb08c37bc6e287) | `` firefox-devedition-unwrapped: 137.0b2 -> 137.0b6 ``                         |
| [`1395a43f`](https://github.com/NixOS/nixpkgs/commit/1395a43f6c5add8510cb919883addcf750cd7459) | `` firefox-beta-unwrapped: 137.0b2 -> 137.0b6 ``                               |
| [`30f15543`](https://github.com/NixOS/nixpkgs/commit/30f1554327f303d019968b08cd295b253821ff3e) | `` firefox-devedition-unwrapped: fix branding ``                               |
| [`3dfae1bf`](https://github.com/NixOS/nixpkgs/commit/3dfae1bf0bfa945a1c1a06d4bcc676672cb8cfe1) | `` firefox-devedition-bin-unwrapped: 137.0b1 -> 137.0b6 ``                     |
| [`8304c359`](https://github.com/NixOS/nixpkgs/commit/8304c359ea5914dc0ce4ff5713b354867ee40064) | `` nextcloud30Packages: updtae ``                                              |
| [`c21b2993`](https://github.com/NixOS/nixpkgs/commit/c21b299380fba5b72574414ca212293719e051b6) | `` nextcloud29Packages: updtae ``                                              |
| [`30fac29e`](https://github.com/NixOS/nixpkgs/commit/30fac29e690efa510c63860b8ec39f79ef8b7cd2) | `` nextcloud28Packages: update ``                                              |
| [`e44ff33d`](https://github.com/NixOS/nixpkgs/commit/e44ff33d024066d673d17468c40af811ff8e3d38) | `` nextcloud30: 30.0.6 -> 30.0.7 ``                                            |
| [`4aef37c4`](https://github.com/NixOS/nixpkgs/commit/4aef37c4d8d55d2d7b6a397190c11c91434f00e2) | `` nextcloud29: 29.0.12 -> 29.0.13 ``                                          |
| [`42b144ec`](https://github.com/NixOS/nixpkgs/commit/42b144ec7ece545a20813de5ea0c37caa0ea9f0a) | `` nixos/tests/akkoma: re‐write end‐to‐end test ``                             |
| [`fe1d20a1`](https://github.com/NixOS/nixpkgs/commit/fe1d20a160a0f39fb83062fe036a959d1ead516b) | `` meshcentral: 1.1.39 -> 1.1.42 ``                                            |
| [`b7c79d02`](https://github.com/NixOS/nixpkgs/commit/b7c79d02e77c2d70ed541d57a5c20280461a7060) | `` roslyn-ls: 4.14.0-1.25074.7 -> 4.14.0-2.25120.5 ``                          |
| [`b087a23c`](https://github.com/NixOS/nixpkgs/commit/b087a23ccb24b55abf6be09381ebc30d6e4ff909) | `` longcat: init at 0.0.12 ``                                                  |
| [`8eb682b0`](https://github.com/NixOS/nixpkgs/commit/8eb682b0f39ef9176b26665343d46e89cd837399) | `` opensc: 0.26.0 -> 0.26.1 ``                                                 |
| [`b84e1673`](https://github.com/NixOS/nixpkgs/commit/b84e1673bafcb381655788567ab03468a0cfe0ce) | `` system76-wallpapers: init at 0-unstable-2024-04-26 ``                       |
| [`f16fe69f`](https://github.com/NixOS/nixpkgs/commit/f16fe69f24e7a71027aeab442934570b01d57eec) | `` pop-hp-wallpapers: init at 0-unstable-2022-04-01 ``                         |
| [`22282c76`](https://github.com/NixOS/nixpkgs/commit/22282c7617d665e271e8ede540111e214b810077) | `` pop-wallpapers: init at 1.0.5 ``                                            |
| [`1c6a5800`](https://github.com/NixOS/nixpkgs/commit/1c6a5800787c267bfbb6149b857aa13646883550) | `` grass: 8.4.0 -> 8.4.1 ``                                                    |
| [`835612df`](https://github.com/NixOS/nixpkgs/commit/835612dfee079124ec3db70284ccb481d7e17470) | `` ppsspp-qt: Fix Qt wrapping ``                                               |
| [`5de41aa9`](https://github.com/NixOS/nixpkgs/commit/5de41aa9de735712454069998997ae266dbe10d3) | `` curv: switch to openexr_3 ``                                                |
| [`32e00251`](https://github.com/NixOS/nixpkgs/commit/32e002510614f5a6875423b9dbe908f144cd39d8) | `` gancio: 1.23.1 -> 1.24.0 ``                                                 |
| [`4c75cd42`](https://github.com/NixOS/nixpkgs/commit/4c75cd4298e43f90d36bf0660243dded4f4090c4) | `` beam: fix locale errors on darwin ``                                        |
| [`6ba23722`](https://github.com/NixOS/nixpkgs/commit/6ba2372288b707f2020de754b1e5a988af2da8f5) | `` python3Packages.mwxml: 0.3.4 -> 0.3.5 ``                                    |
| [`ded4016d`](https://github.com/NixOS/nixpkgs/commit/ded4016dde2e0315dcde74adbde768aaf2e47fec) | `` open-adventure: init at 1.20 ``                                             |
| [`edf3aa3c`](https://github.com/NixOS/nixpkgs/commit/edf3aa3c43390136d09c8bb41a24e14c3ffca16f) | `` maintainers: add EmanuelM153 ``                                             |
| [`8c7a5cfa`](https://github.com/NixOS/nixpkgs/commit/8c7a5cfac428e03cb45203b451ce1623763a00b3) | `` grafanaPlugins.victoriametrics-logs-datasource: init at 0.14.3 ``           |