### PR TITLE
chore(flake/home-manager): `c657142e` -> `fb74bb76`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -391,11 +391,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1742246081,
-        "narHash": "sha256-1e4oFbtdOOb6NqauHevWWjEUXZnfZ6RUAJJjn9i4YBc=",
+        "lastModified": 1742305478,
+        "narHash": "sha256-iYCinzZnnUeCkZ031qGRwPdwRsqW6o9Y0MgGpA7Zva4=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "c657142e24a43ea1035889f0b0a7c24598e0e18a",
+        "rev": "fb74bb76d94a6c55632376c931fc108131260ee9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                 |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------------- |
| [`fb74bb76`](https://github.com/nix-community/home-manager/commit/fb74bb76d94a6c55632376c931fc108131260ee9) | `` vscode: fix creation of storage.json file (#6650) `` |