### PR TITLE
chore(flake/zen-browser): `25c78297` -> `e95cfe2e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1231,11 +1231,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1742325290,
-        "narHash": "sha256-CZG9MlQ8JRmeZb9tH1PwaHPsyFOnL/TW2aprOVZn+MM=",
+        "lastModified": 1742339828,
+        "narHash": "sha256-a3SN+mjAYzbuor/K60cUIrf4qz014dBHEjEBqf1dvpo=",
         "owner": "0xc000022070",
         "repo": "zen-browser-flake",
-        "rev": "25c7829770779a45c833aa590241693b3c6f0f8f",
+        "rev": "e95cfe2e14a7c7167ec7f2bf202d5d6d8b34f910",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                          | Message                                                    |
| --------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------- |
| [`e95cfe2e`](https://github.com/0xc000022070/zen-browser-flake/commit/e95cfe2e14a7c7167ec7f2bf202d5d6d8b34f910) | `` Update Zen Browser beta @ x86_64 && aarch64 to 1.10b `` |