### PR TITLE
chore(flake/hyprland): `03385fc0` -> `c8d80a29`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -499,11 +499,11 @@
         "xdph": "xdph"
       },
       "locked": {
-        "lastModified": 1742326985,
-        "narHash": "sha256-jC+nvjIdWQnvi7qmraIqAv6pcUzJpE89ug6BSbKhIkA=",
+        "lastModified": 1742341588,
+        "narHash": "sha256-IlkAyfErpnTEUpjGhECfGp3t3HgF8KHBrJquOCdjp3M=",
         "owner": "hyprwm",
         "repo": "Hyprland",
-        "rev": "03385fc07f82bb891ded33db464397d867eb503d",
+        "rev": "c8d80a292012f036e1a1d3eb3b0501e3e3917872",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                            |
| ------------------------------------------------------------------------------------------------ | ---------------------------------- |
| [`c8d80a29`](https://github.com/hyprwm/Hyprland/commit/c8d80a292012f036e1a1d3eb3b0501e3e3917872) | `` ci: Fail on warnings (#9668) `` |