### PR TITLE
chore(flake/zen-browser): `cf99a16f` -> `1e799701`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1231,11 +1231,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1742347442,
-        "narHash": "sha256-CZG9MlQ8JRmeZb9tH1PwaHPsyFOnL/TW2aprOVZn+MM=",
+        "lastModified": 1742355096,
+        "narHash": "sha256-2E7xNeXk96kuPH+LgNYPdVsbK8NufxStm/gF0wDbiMo=",
         "owner": "0xc000022070",
         "repo": "zen-browser-flake",
-        "rev": "cf99a16f61bdc2352c8b2fbdeb4fd4a2701251f8",
+        "rev": "1e79970112733db7fc586cfc9213fc21931fb6bc",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                          | Message                                                                   |
| --------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------- |
| [`1e799701`](https://github.com/0xc000022070/zen-browser-flake/commit/1e79970112733db7fc586cfc9213fc21931fb6bc) | `` Update Zen Browser twilight @ x86_64 && aarch64 to 1.10t#1742353408 `` |