### PR TITLE
chore(flake/grayjay): `ccc0e40b` -> `8e17c270`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -371,11 +371,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1742212131,
-        "narHash": "sha256-5XlZDhUwVqWSbqtJgHokq3Ep5qiEY2YmSbo0AbspSPc=",
+        "lastModified": 1742355230,
+        "narHash": "sha256-tl+HTy4n6LhKbz/tBMtxhXGHpfPlctyLh6afSbHgnk8=",
         "owner": "rishabh5321",
         "repo": "grayjay-flake",
-        "rev": "ccc0e40bd95f3deba956c893cf63d593bd066cd7",
+        "rev": "8e17c27024d4b4823c2928b9a16da28fcf83dfb4",
         "type": "github"
       },
       "original": {
@@ -768,11 +768,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1742069588,
-        "narHash": "sha256-C7jVfohcGzdZRF6DO+ybyG/sqpo1h6bZi9T56sxLy+k=",
+        "lastModified": 1742288794,
+        "narHash": "sha256-Txwa5uO+qpQXrNG4eumPSD+hHzzYi/CdaM80M9XRLCo=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "c80f6a7e10b39afcc1894e02ef785b1ad0b0d7e5",
+        "rev": "b6eaf97c6960d97350c584de1b6dcff03c9daf42",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                     | Message                                          |
| ---------------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
| [`8e17c270`](https://github.com/Rishabh5321/grayjay-flake/commit/8e17c27024d4b4823c2928b9a16da28fcf83dfb4) | `` chore(flake/nixpkgs): c80f6a7e -> b6eaf97c `` |