### PR TITLE
chore(flake/akuse-flake): `5182e66c` -> `246ef88f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -5,11 +5,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1742212279,
-        "narHash": "sha256-1miIsFseosZXp0h2OgQjl6BQVg04w5CDaQ2MF4e0WyU=",
+        "lastModified": 1742355345,
+        "narHash": "sha256-LkU6LGOzUPrpeRoFFMRb8MHyka17k24v7hebVPuPLbI=",
         "owner": "Rishabh5321",
         "repo": "akuse-flake",
-        "rev": "5182e66c4a2e855667f7a37c71664fad21504f05",
+        "rev": "246ef88f55bf7b67fb371430851e5923481e6e21",
         "type": "github"
       },
       "original": {
@@ -721,11 +721,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1742069588,
-        "narHash": "sha256-C7jVfohcGzdZRF6DO+ybyG/sqpo1h6bZi9T56sxLy+k=",
+        "lastModified": 1742288794,
+        "narHash": "sha256-Txwa5uO+qpQXrNG4eumPSD+hHzzYi/CdaM80M9XRLCo=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "c80f6a7e10b39afcc1894e02ef785b1ad0b0d7e5",
+        "rev": "b6eaf97c6960d97350c584de1b6dcff03c9daf42",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                   | Message                                          |
| -------------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
| [`246ef88f`](https://github.com/Rishabh5321/akuse-flake/commit/246ef88f55bf7b67fb371430851e5923481e6e21) | `` chore(flake/nixpkgs): c80f6a7e -> b6eaf97c `` |