### PR TITLE
chore(flake/seanime): `b1471b4b` -> `26064309`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -947,11 +947,11 @@
         "nixpkgs": "nixpkgs_6"
       },
       "locked": {
-        "lastModified": 1742354599,
-        "narHash": "sha256-fWagf16gKQBrCWRGheHwSH5ha9BPl1yY3IU2F87rF4Y=",
+        "lastModified": 1742364448,
+        "narHash": "sha256-OvdAqPZzfBZ37K6iz1zN4vuQiD2R2epVtjRwcefzI6M=",
         "owner": "rishabh5321",
         "repo": "seanime-flake",
-        "rev": "b1471b4b2e50e86a16322482f17caf2453d26625",
+        "rev": "2606430995178eb427c5b8df1c18ad703747c3db",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                     | Message                                                                      |
| ---------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------- |
| [`26064309`](https://github.com/Rishabh5321/seanime-flake/commit/2606430995178eb427c5b8df1c18ad703747c3db) | `` fix(flake): add missing semicolon in configuration for seanime package `` |
| [`15703eba`](https://github.com/Rishabh5321/seanime-flake/commit/15703eba22042fcec0725ae72aede34b677a2439) | `` Checking errors ``                                                        |
| [`9f4e0207`](https://github.com/Rishabh5321/seanime-flake/commit/9f4e0207dfa3dc83047a7bcb17d5861ee5dfba4a) | `` correcting flake check ``                                                 |
| [`ff1371e4`](https://github.com/Rishabh5321/seanime-flake/commit/ff1371e4d54b7facf3fdee10b34a7aa4d777930f) | `` checking flake check ``                                                   |