### PR TITLE
chore(flake/akuse-flake): `246ef88f` -> `1eb8f97c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -5,11 +5,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1742355345,
-        "narHash": "sha256-LkU6LGOzUPrpeRoFFMRb8MHyka17k24v7hebVPuPLbI=",
+        "lastModified": 1742365495,
+        "narHash": "sha256-IPReZRmRroOaaA2O/7mV4kuKQhjPJICQ57WSBkLtGJ4=",
         "owner": "Rishabh5321",
         "repo": "akuse-flake",
-        "rev": "246ef88f55bf7b67fb371430851e5923481e6e21",
+        "rev": "1eb8f97c66ea32822fc46c35f4b86729565c579b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                   | Message                                                                                                                                                                                              |
| -------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
| [`2f51d2c4`](https://github.com/Rishabh5321/akuse-flake/commit/2f51d2c4f398af3053b72132ffed056807934c97) | `` Enhance flake_check workflow by adding Cachix setup, improving error handling, and refining Telegram notification messages with detailed status updates for flake check and install processes. `` |