### PR TITLE
chore(flake/zen-browser): `1e799701` -> `21e96d1d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1231,11 +1231,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1742355096,
-        "narHash": "sha256-2E7xNeXk96kuPH+LgNYPdVsbK8NufxStm/gF0wDbiMo=",
+        "lastModified": 1742368748,
+        "narHash": "sha256-UoMiFy+6wxEcDKcseTK+9rTdyX1Gt3rDUedzVEHlGzw=",
         "owner": "0xc000022070",
         "repo": "zen-browser-flake",
-        "rev": "1e79970112733db7fc586cfc9213fc21931fb6bc",
+        "rev": "21e96d1d6ceb208eb2da1d57e54a4cf7dc6d3a04",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                          | Message                                                    |
| --------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------- |
| [`21e96d1d`](https://github.com/0xc000022070/zen-browser-flake/commit/21e96d1d6ceb208eb2da1d57e54a4cf7dc6d3a04) | `` Update Zen Browser beta @ x86_64 && aarch64 to 1.10b `` |