### PR TITLE
chore(flake/akuse-flake): `1eb8f97c` -> `087df4fc`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -5,11 +5,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1742365495,
-        "narHash": "sha256-IPReZRmRroOaaA2O/7mV4kuKQhjPJICQ57WSBkLtGJ4=",
+        "lastModified": 1742398682,
+        "narHash": "sha256-xdZlz70yb+4jNsEcE9p3mhaNfQLrFkIYUJSnGPT+lQw=",
         "owner": "Rishabh5321",
         "repo": "akuse-flake",
-        "rev": "1eb8f97c66ea32822fc46c35f4b86729565c579b",
+        "rev": "087df4fc613857211808c9e44d72d0501f535488",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                   | Message                                                      |
| -------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------ |
| [`0940beff`](https://github.com/Rishabh5321/akuse-flake/commit/0940beffb5e0968fbff36c1fdb1e54b5657a3d8b) | `` chore(github): bump cachix/cachix-action from 14 to 16 `` |