### PR TITLE
chore(flake/home-manager): `22a36aa7` -> `27a72d99`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -391,11 +391,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1742326330,
-        "narHash": "sha256-Tumt3tcMXJniSh7tw2gW+WAnVLeB3WWm+E+yYFnLBXo=",
+        "lastModified": 1742411397,
+        "narHash": "sha256-qsFtK4H/IxBHoUD7aWDL+emAfh++E42gRMaGskT3irs=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "22a36aa709de7dd42b562a433b9cefecf104a6ee",
+        "rev": "27a72d991305cfd9b15018a6e7eb3db93a32bc60",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                                    |
| ----------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------- |
| [`27a72d99`](https://github.com/nix-community/home-manager/commit/27a72d991305cfd9b15018a6e7eb3db93a32bc60) | `` podman: include systemd in quadlet service path ``                      |
| [`bb72d79f`](https://github.com/nix-community/home-manager/commit/bb72d79f5d319a11fd6226303ebf7a5dd1fd1913) | `` podman: use type in attr name of built quadlets ``                      |
| [`8bb07191`](https://github.com/nix-community/home-manager/commit/8bb071912b32e858cfc4daba1a5683d5c62f1955) | `` podman: warn if values match a quadlet only by name ``                  |
| [`81bf639d`](https://github.com/nix-community/home-manager/commit/81bf639da70763a844b79ffecd5de59b83f5ecb2) | `` podman: link dependent quadlets during build ``                         |
| [`4108ec3a`](https://github.com/nix-community/home-manager/commit/4108ec3aa80244948d86f95c82c1dfc22daeb35c) | `` podman: use dependency quadlets directly in build for generator ``      |
| [`eb5d59da`](https://github.com/nix-community/home-manager/commit/eb5d59dac9d77717135fdec1ef51c14a72e8c9f9) | `` rclone: add module ``                                                   |
| [`66f565db`](https://github.com/nix-community/home-manager/commit/66f565db48ebc9cef33f651c44151e7355400e10) | `` maintainers: add jess ``                                                |
| [`9d554281`](https://github.com/nix-community/home-manager/commit/9d554281e059196661f4dbb44e99f2eff9bfd381) | `` firefox: refactor bookmarks into a submodule & require force (#6402) `` |
| [`1727f417`](https://github.com/nix-community/home-manager/commit/1727f417b7774953fe081ebb3757b60dab8a2943) | `` flake.lock: Update (#6636) ``                                           |
| [`62dc8c30`](https://github.com/nix-community/home-manager/commit/62dc8c30ef292c003610ebae62ec5ec7544cdffe) | `` home-manager: add autocomplete for `--log-format` ``                    |
| [`229648c5`](https://github.com/nix-community/home-manager/commit/229648c51e732cb8e70de7e0af5223f3e8160304) | `` home-manager: support `--log-format` flag (#6093) ``                    |