### PR TITLE
chore(flake/home-manager): `27a72d99` -> `b5976017`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -391,11 +391,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1742411397,
-        "narHash": "sha256-qsFtK4H/IxBHoUD7aWDL+emAfh++E42gRMaGskT3irs=",
+        "lastModified": 1742413527,
+        "narHash": "sha256-kx+mXJ+Z4nonuICPe6i6CguSGibYNlvHYYEerHp1wM0=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "27a72d991305cfd9b15018a6e7eb3db93a32bc60",
+        "rev": "b5976017741653251258112f7e6ee5d8b9e3a832",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                         |
| ----------------------------------------------------------------------------------------------------------- | ----------------------------------------------- |
| [`b5976017`](https://github.com/nix-community/home-manager/commit/b5976017741653251258112f7e6ee5d8b9e3a832) | `` easyeffects: remove with lib ``              |
| [`e278f46a`](https://github.com/nix-community/home-manager/commit/e278f46a0990344b3186d09a35350fbcb6fa4dbd) | `` easyeffects: add hausken as maintainer ``    |
| [`6b8cea64`](https://github.com/nix-community/home-manager/commit/6b8cea647349f53f2d57399535478001bebed053) | `` easyeffects: add option to import presets `` |
| [`e4a40b44`](https://github.com/nix-community/home-manager/commit/e4a40b441e49443ffd25c05614ad9c134a12e53c) | `` waylogout: add path support ``               |
| [`16a2a802`](https://github.com/nix-community/home-manager/commit/16a2a802de24a122800ec744639976cb457dde23) | `` waylogout: nullable package support ``       |
| [`e0be70bc`](https://github.com/nix-community/home-manager/commit/e0be70bcf94be20f8f0f6d215d909b614ab6ebeb) | `` waylogout: remove with lib ``                |
| [`1e0c64b6`](https://github.com/nix-community/home-manager/commit/1e0c64b6a23f2b7cd02106b0083069476c7fab61) | `` waylogout: added configuration module ``     |
| [`0d616edb`](https://github.com/nix-community/home-manager/commit/0d616edbacaa4e6a8cf794e573244f3d948f4150) | `` maintainers: add noodlez ``                  |