### PR TITLE
chore(flake/home-manager): `b5976017` -> `eb0f617a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -391,11 +391,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1742413527,
-        "narHash": "sha256-kx+mXJ+Z4nonuICPe6i6CguSGibYNlvHYYEerHp1wM0=",
+        "lastModified": 1742416832,
+        "narHash": "sha256-ycok0eJJcoknqaibdv/TEEEOUqovC42XCqbfLDYmnoQ=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "b5976017741653251258112f7e6ee5d8b9e3a832",
+        "rev": "eb0f617aecbaf1eff5bacec789891e775af2f5a3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                     |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------- |
| [`eb0f617a`](https://github.com/nix-community/home-manager/commit/eb0f617aecbaf1eff5bacec789891e775af2f5a3) | `` tex-fmt: add null package support ``     |
| [`9556d3c2`](https://github.com/nix-community/home-manager/commit/9556d3c2b48c0ec9a5cf4aa444b368cfb85fa60e) | `` tex-fmt: add module ``                   |
| [`8b629b54`](https://github.com/nix-community/home-manager/commit/8b629b5424dd2b10ff5cbca7fa52fa66ef33a196) | `` firefox: migrate search config to v12 `` |
| [`b44d79a5`](https://github.com/nix-community/home-manager/commit/b44d79a5b2d63ec1286fd4cb6d347df2b90679cb) | `` firefox: migrate search config to v11 `` |
| [`c1dc900a`](https://github.com/nix-community/home-manager/commit/c1dc900a1ac0b2688115508c7b3c2a70a990ff8d) | `` firefox: migrate search config to v7 ``  |