### PR TITLE
chore(flake/stylix): `41a773fb` -> `f122d709`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1005,11 +1005,11 @@
         "tinted-zed": "tinted-zed"
       },
       "locked": {
-        "lastModified": 1742422077,
-        "narHash": "sha256-CvI6JCs4VAmuiYtVFOTLX9xO08Oo6dGPQeBguJ3zRD8=",
+        "lastModified": 1742422444,
+        "narHash": "sha256-Djg5uMhIDPdFOZ7kTrqNlHaAqcx/4rp7BofZLsUHkLY=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "41a773fb0fe47c8652e7c7fd6971c8d0d2ac15ba",
+        "rev": "f122d70925ca44e5ee4216661769437ab36a6a3f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                        | Message                                        |
| --------------------------------------------------------------------------------------------- | ---------------------------------------------- |
| [`f122d709`](https://github.com/danth/stylix/commit/f122d70925ca44e5ee4216661769437ab36a6a3f) | `` avizo: hotfix aviOpcaity missing (#1023) `` |