### PR TITLE
chore(flake/zen-browser): `21e96d1d` -> `63ef58b3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1231,11 +1231,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1742368748,
-        "narHash": "sha256-UoMiFy+6wxEcDKcseTK+9rTdyX1Gt3rDUedzVEHlGzw=",
+        "lastModified": 1742439356,
+        "narHash": "sha256-iAQ/Ekh+YpRuVtctBB8wx6PbyJARVeWMKCiwv3vih68=",
         "owner": "0xc000022070",
         "repo": "zen-browser-flake",
-        "rev": "21e96d1d6ceb208eb2da1d57e54a4cf7dc6d3a04",
+        "rev": "63ef58b3e6fdf57a8449964cbeb35534dca2a5b7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                          | Message                                                                   |
| --------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------- |
| [`63ef58b3`](https://github.com/0xc000022070/zen-browser-flake/commit/63ef58b3e6fdf57a8449964cbeb35534dca2a5b7) | `` Update Zen Browser twilight @ x86_64 && aarch64 to 1.10t#1742438728 `` |