### PR TITLE
chore(flake/hyprland): `155eba57` -> `7ea4fbf0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -499,11 +499,11 @@
         "xdph": "xdph"
       },
       "locked": {
-        "lastModified": 1742422176,
-        "narHash": "sha256-zzRrkGQiVEPGNiU4pYTARzqFwVf3JxXxbz6UcEJkWIc=",
+        "lastModified": 1742468927,
+        "narHash": "sha256-3CBAs8OF0etCIaa4p+VyuXfLrL1cvD5E3Dmigqg2YOo=",
         "owner": "hyprwm",
         "repo": "Hyprland",
-        "rev": "155eba57d81fa2553f1eda8788bd9d1a16947a43",
+        "rev": "7ea4fbf0ba034d947339b3a94a10da022eca1988",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                                               |
| ------------------------------------------------------------------------------------------------ | ----------------------------------------------------- |
| [`7ea4fbf0`](https://github.com/hyprwm/Hyprland/commit/7ea4fbf0ba034d947339b3a94a10da022eca1988) | `` types: Upgrade buffer ref from WP to SP (#9677) `` |
| [`f6ca4bac`](https://github.com/hyprwm/Hyprland/commit/f6ca4bac51595555916f7403ae178680791f824c) | `` syncobj: restore SHM buffer reset (#9675) ``       |