### PR TITLE
chore(flake/nixpkgs-stable): `da044451` -> `b75693fb`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -752,11 +752,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1742268799,
-        "narHash": "sha256-IhnK4LhkBlf14/F8THvUy3xi/TxSQkp9hikfDZRD4Ic=",
+        "lastModified": 1742388435,
+        "narHash": "sha256-GheQGRNYAhHsvPxWVOhAmg9lZKkis22UPbEHlmZMthg=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "da044451c6a70518db5b730fe277b70f494188f1",
+        "rev": "b75693fb46bfaf09e662d09ec076c5a162efa9f6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                              |
| ---------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------- |
| [`e33b5bea`](https://github.com/NixOS/nixpkgs/commit/e33b5bea6d82d6eeeec932764da9ddd843f70f6a) | `` [24.11] xpra: add a few missing dependencies ``                                                   |
| [`b914fa7a`](https://github.com/NixOS/nixpkgs/commit/b914fa7a9a2a2b00a2c5c43b7b6a5f49bbb1fdd0) | `` [24.11] xpra 6.1.3 -> xpra 6.2.5 ``                                                               |
| [`7fc6da26`](https://github.com/NixOS/nixpkgs/commit/7fc6da2600da4464ca35c7a2c293b69cfaf8829d) | `` benzene: init at 0-unstable-2022-12-18 ``                                                         |
| [`625c9439`](https://github.com/NixOS/nixpkgs/commit/625c943960fb0fd76db1158f59cec3cc9f6b8229) | `` maintainers: add eilvelia ``                                                                      |
| [`fa7bc5b3`](https://github.com/NixOS/nixpkgs/commit/fa7bc5b3893a17981d76084a02b308bebcdc7a2d) | `` dotnetCorePackages.dotnet_9.vmr: 9.0.2 -> 9.0.3 ``                                                |
| [`e6b912eb`](https://github.com/NixOS/nixpkgs/commit/e6b912ebc843763accd10d40ed02f30d41e83960) | `` dotnetCorePackages.dotnet_8.vmr: 8.0.13 -> 8.0.14 ``                                              |
| [`ed9357c4`](https://github.com/NixOS/nixpkgs/commit/ed9357c48ffcde08cdb744c680c333595a0130c9) | `` dotnet: stop logging nuget-to-json to deps.out ``                                                 |
| [`c5901414`](https://github.com/NixOS/nixpkgs/commit/c5901414e0339f93a54971333006a293d11e784c) | `` dotnetCorePackages.sdk_9_0-bin: 9.0.200 -> 9.0.201 ``                                             |
| [`d295fc66`](https://github.com/NixOS/nixpkgs/commit/d295fc66d32e697828674735a2c4bef1b9fa5fc3) | `` dotnetCorePackages.sdk_8_0-bin: 8.0.406 -> 8.0.407 ``                                             |
| [`6e15bd5d`](https://github.com/NixOS/nixpkgs/commit/6e15bd5d44bf2cf44c8f3a3b63c4232978625c47) | `` helix: 25.01 -> 25.01.1 ``                                                                        |
| [`d2f49dfc`](https://github.com/NixOS/nixpkgs/commit/d2f49dfc4c79c041a43c78b5078816da5050013e) | `` helix: 24.07 -> 25.01 ``                                                                          |
| [`c34801c6`](https://github.com/NixOS/nixpkgs/commit/c34801c665cead25670abe2fa3f30814e50b9655) | `` buildNpmPackage: nixfmt ``                                                                        |
| [`e82ac2e7`](https://github.com/NixOS/nixpkgs/commit/e82ac2e71454df6d25b68e135040c125b7320084) | `` buildNpmPackage: restructure with lib.extendMkDerivation ``                                       |
| [`613f645f`](https://github.com/NixOS/nixpkgs/commit/613f645f308385a0e204b399686b0e280d06c8ec) | `` phpPackages.box: 4.6.2 -> 4.6.6, fix `installCheck` ``                                            |
| [`152749ea`](https://github.com/NixOS/nixpkgs/commit/152749ea6b8024c116ce678c9b4d687e98735a10) | `` phpdocumentor: 3.6.0 -> 3.7.1 ``                                                                  |
| [`cdcd9fc8`](https://github.com/NixOS/nixpkgs/commit/cdcd9fc8da6d2c9f4d658ba1dabc7b200f442ca6) | `` build-support/php: enable support for `dontCheckForBrokenSymlinks` set to `true` by default ``    |
| [`d7f61d6e`](https://github.com/NixOS/nixpkgs/commit/d7f61d6e7c0caf36aaf39617df024d02108ee025) | `` build-support/php: refactor build scripts ``                                                      |
| [`aa2914ed`](https://github.com/NixOS/nixpkgs/commit/aa2914ed0c8893501257c140b17bd6fe6831a097) | `` laravel: update hash ``                                                                           |
| [`63482fb9`](https://github.com/NixOS/nixpkgs/commit/63482fb9537a86933d0f1c4d37d2f030ff8f5a34) | `` robo: update hash, add `installCheck` ``                                                          |
| [`c6e86108`](https://github.com/NixOS/nixpkgs/commit/c6e86108c37ae05c70f499e7c6f4a823430f4715) | `` phel: update hash, add `installCheck` ``                                                          |
| [`7f435cc2`](https://github.com/NixOS/nixpkgs/commit/7f435cc297a304031cf21a013756b0429a7f7bba) | `` paratest: 7.6.0 -> 7.8.2 ``                                                                       |
| [`a7d520c0`](https://github.com/NixOS/nixpkgs/commit/a7d520c03e2a6be7ada77eeee43c93c17b8c6932) | `` phpPackages.phpinsights: update hash, add `installCheck` ``                                       |
| [`6063ba40`](https://github.com/NixOS/nixpkgs/commit/6063ba401fcf755768cfd0b2fcf9af50d91b7abd) | `` phpPackages.psysh: update hash, add `installCheck` ``                                             |
| [`52b76d29`](https://github.com/NixOS/nixpkgs/commit/52b76d29983c6880bb87eb919fdd0cc1b33e34fb) | `` phpPackages.phing: update hash, add `installCheck` ``                                             |
| [`4623bea9`](https://github.com/NixOS/nixpkgs/commit/4623bea9c8b3ceecaed2a6d8277079294420d432) | `` deployer: 7.4.0 -> 7.5.12-unstable-2025-03-02 ``                                                  |
| [`9a909ec1`](https://github.com/NixOS/nixpkgs/commit/9a909ec11c2b77f9658321758d01ba0a215df6e6) | `` pest: 3.3.1 -> 3.7.4 ``                                                                           |
| [`22185244`](https://github.com/NixOS/nixpkgs/commit/22185244de85af75822022d81ff86d099775d2f8) | `` phpPackages.php-cs-fixer: 3.67.0 -> 3.70.1 ``                                                     |
| [`b2ed58ea`](https://github.com/NixOS/nixpkgs/commit/b2ed58ead2c3646a63fe5fc79128de4f43571c35) | `` build-support/php: support `lib.extendMkDerivation` for `php.mkComposerVendor` ``                 |
| [`da850677`](https://github.com/NixOS/nixpkgs/commit/da8506773cb7893a47ce255cfc70e49a80490afd) | `` build-support/php: support `lib.extendMkDerivation` for `php.buildComposerProject2` ``            |
| [`abb0983e`](https://github.com/NixOS/nixpkgs/commit/abb0983ee9883691cbefe0c40031453dacc4be2c) | `` CI: fix nixos manual should rebuild on 'lib/**' changes ``                                        |
| [`ba60a577`](https://github.com/NixOS/nixpkgs/commit/ba60a577e34074bd5ba015117f72ed1b8cd185f3) | `` duplicity: 3.0.3.2 -> 3.0.4 ``                                                                    |
| [`d514f62a`](https://github.com/NixOS/nixpkgs/commit/d514f62af5fea22c1aa26f8d1da43bf9c730ccad) | `` radarr: 5.18.4.9674 -> 5.19.3.9730 ``                                                             |
| [`921fb1ec`](https://github.com/NixOS/nixpkgs/commit/921fb1ecc8f4b60dc08ba33518754e0a036b2aca) | `` nixd: 2.6.0 -> 2.6.1 ``                                                                           |
| [`e36bc998`](https://github.com/NixOS/nixpkgs/commit/e36bc998bc06767287a29b8c70ab35b989ad8f91) | `` firefox-bin-unwrapped: 136.0.1 -> 136.0.2 ``                                                      |
| [`8f9ba8ee`](https://github.com/NixOS/nixpkgs/commit/8f9ba8ee5b34f545f60ca77544518e4c14ffe914) | `` firefox-unwrapped: 136.0.1 -> 136.0.2 ``                                                          |
| [`0fe53bed`](https://github.com/NixOS/nixpkgs/commit/0fe53bed551fdb51a46e8fc7d88c2ff451fa9e0e) | `` bambu-studio: 01.10.01.50 -> 01.10.02.76 ``                                                       |
| [`9c13a534`](https://github.com/NixOS/nixpkgs/commit/9c13a534e28fd5e67f880343bca1cf43cda7ede8) | `` doc: add chapter Fixed-point arguments of build helpers ``                                        |
| [`8d75d86a`](https://github.com/NixOS/nixpkgs/commit/8d75d86a11c29f3dc27388ed83a458442385b55a) | `` lib.extendMkDerivation: init ``                                                                   |
| [`81533410`](https://github.com/NixOS/nixpkgs/commit/815334105413dda5aea8960a16906b2884ff11a2) | `` nuget-to-json: use --netrc-optional for curl ``                                                   |
| [`25feb49c`](https://github.com/NixOS/nixpkgs/commit/25feb49cdd07385e17a377cf71decdc315475f8d) | `` nuget-to-json: stop hiding curl errors ``                                                         |
| [`da15c936`](https://github.com/NixOS/nixpkgs/commit/da15c9369bffe0a1dd8256dac35cec61a8e8bcdd) | `` nixt: 2.5.1 -> 2.6.0 ``                                                                           |
| [`f67f8642`](https://github.com/NixOS/nixpkgs/commit/f67f8642bc6cedc75b3ecbe16c5b339f58ce2a37) | `` vrcadvert: 1.0.0 -> 1.0.1 ``                                                                      |
| [`f134fdd4`](https://github.com/NixOS/nixpkgs/commit/f134fdd4726960369b62056302a983af4a927e1b) | `` build(deps): bump cachix/cachix-action from 15 to 16 ``                                           |
| [`2935fe68`](https://github.com/NixOS/nixpkgs/commit/2935fe68b9acbdb3dd0017051729a8c643d27f8f) | `` apple-sdk: add multiple URLs for fetching SDK, prioritizing apple CDN ``                          |
| [`dbb19a63`](https://github.com/NixOS/nixpkgs/commit/dbb19a63f7e0ad002ec30cd85a6578918e9a9775) | `` default-crate-overrides: proc-macro-crate: fix build for 3.3.0 ``                                 |
| [`606602b3`](https://github.com/NixOS/nixpkgs/commit/606602b3282a1152e1f0448055e3da50ced01e12) | `` default-crate-overrides: proc-macro-crate: don't break potential patches ``                       |
| [`e2d8af3d`](https://github.com/NixOS/nixpkgs/commit/e2d8af3dfef30ddaa3fec56a75d95d2beceddff2) | `` thunderbird-latest-unwrapped: 133.0 -> 136.0 ``                                                   |
| [`07d1876a`](https://github.com/NixOS/nixpkgs/commit/07d1876ae3b3b8f94a4350ab041f1f1ae33986cc) | `` thunderbird-128-unwrapped: 128.7.1esr -> 128.8.0esr ``                                            |
| [`13bebbbe`](https://github.com/NixOS/nixpkgs/commit/13bebbbe0249fd5575022af83d1e56c8586e3f9e) | `` network: make network-setup service do not depend on udevd directly; fix typo with GRE tunnels `` |
| [`59f85325`](https://github.com/NixOS/nixpkgs/commit/59f85325e59e868bc260d05fbcfca3177bd198b4) | `` cinelerra: 2.3-unstable-2024-03-20 -> 2.3-unstable-2025-01-25 ``                                  |