### PR TITLE
chore(flake/stylix): `f122d709` -> `64b4369b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1005,11 +1005,11 @@
         "tinted-zed": "tinted-zed"
       },
       "locked": {
-        "lastModified": 1742422444,
-        "narHash": "sha256-Djg5uMhIDPdFOZ7kTrqNlHaAqcx/4rp7BofZLsUHkLY=",
+        "lastModified": 1742486736,
+        "narHash": "sha256-yiNlCmfeT9G0NX3ogM3AQUACfoat04AlztKRnR3Kt6c=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "f122d70925ca44e5ee4216661769437ab36a6a3f",
+        "rev": "64b4369b6b24751c555d5bf887b52d6dbc419c6f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                        | Message                                       |
| --------------------------------------------------------------------------------------------- | --------------------------------------------- |
| [`64b4369b`](https://github.com/danth/stylix/commit/64b4369b6b24751c555d5bf887b52d6dbc419c6f) | `` doc: display module maintainers (#1010) `` |
| [`07c4f39b`](https://github.com/danth/stylix/commit/07c4f39b5b8d19930235cacbc05600fdcf1a2551) | `` halloy: add copyright notice (#1035) ``    |