### PR TITLE
chore(flake/home-manager): `94605dca` -> `fc189507`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -391,11 +391,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1742447757,
-        "narHash": "sha256-Q0KXcHQmum8L6IzGhhkVhjFMKY6BvYa/rhmLP26Ws8o=",
+        "lastModified": 1742489436,
+        "narHash": "sha256-891PjWxlkKMEn4dK9rrqTV6py/lf7xFD0d5B2bM0A18=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "94605dcadefeaff6b35c8931c9f38e4f4dc7ad0a",
+        "rev": "fc189507bc0bc74b3794ee6912a5b80de8dfcc0c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                                |
| ----------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------- |
| [`fc189507`](https://github.com/nix-community/home-manager/commit/fc189507bc0bc74b3794ee6912a5b80de8dfcc0c) | `` docs: nixos module declarative installation instructions (#6208) `` |
| [`c36cc49e`](https://github.com/nix-community/home-manager/commit/c36cc49e55aff5562b0ca924f34285de6d6273be) | `` onlyoffice: add module (#6667) ``                                   |