### PR TITLE
chore(flake/home-manager): `20ec3c10` -> `da018181`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -391,11 +391,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1742508709,
-        "narHash": "sha256-tz2qX+ZBOFFrbm+vt4aI5pmowfFBPPbtdpFXoUVQ9jM=",
+        "lastModified": 1742508854,
+        "narHash": "sha256-vQQTIl4+slrcu7ftVKNBql9ngBdY0dcYGujdT7zIVp0=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "20ec3c10498938c3ff78075b5fae94fe1cd4a715",
+        "rev": "da0181819479ddc034a3db9a77ed21ea3bcc0668",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                       |
| ----------------------------------------------------------------------------------------------------------- | --------------------------------------------- |
| [`da018181`](https://github.com/nix-community/home-manager/commit/da0181819479ddc034a3db9a77ed21ea3bcc0668) | `` tests: scrub lazy{docker,git} on darwin `` |
| [`2e9981ca`](https://github.com/nix-community/home-manager/commit/2e9981ca0d6cee56f54a5e265b5edcd4dfc1b554) | `` lazydocker: null package support ``        |
| [`65413f29`](https://github.com/nix-community/home-manager/commit/65413f297f8c4c42a99270c15bce7bda1bfea724) | `` lazydocker: remove with lib ``             |
| [`46efc3b2`](https://github.com/nix-community/home-manager/commit/46efc3b2e14783d39f595cb0e5954a3a1edb0217) | `` lazydocker: add module ``                  |