### PR TITLE
chore(flake/akuse-flake): `087df4fc` -> `f86db528`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -5,11 +5,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1742398682,
-        "narHash": "sha256-xdZlz70yb+4jNsEcE9p3mhaNfQLrFkIYUJSnGPT+lQw=",
+        "lastModified": 1742521496,
+        "narHash": "sha256-WAJz58zJbMNiTs0WOE9xiT228UXBKrldYcAxmRqHJBA=",
         "owner": "Rishabh5321",
         "repo": "akuse-flake",
-        "rev": "087df4fc613857211808c9e44d72d0501f535488",
+        "rev": "f86db528d1af5e26eae5622fc201c1dc5950d843",
         "type": "github"
       },
       "original": {
@@ -721,11 +721,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1742288794,
-        "narHash": "sha256-Txwa5uO+qpQXrNG4eumPSD+hHzzYi/CdaM80M9XRLCo=",
+        "lastModified": 1742422364,
+        "narHash": "sha256-mNqIplmEohk5jRkqYqG19GA8MbQ/D4gQSK0Mu4LvfRQ=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "b6eaf97c6960d97350c584de1b6dcff03c9daf42",
+        "rev": "a84ebe20c6bc2ecbcfb000a50776219f48d134cc",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                   | Message                                          |
| -------------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
| [`f86db528`](https://github.com/Rishabh5321/akuse-flake/commit/f86db528d1af5e26eae5622fc201c1dc5950d843) | `` chore(flake/nixpkgs): b6eaf97c -> a84ebe20 `` |