### PR TITLE
chore(flake/zen-browser): `47a0eba7` -> `0f396890`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1231,11 +1231,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1742512665,
-        "narHash": "sha256-6Ny7bh2Gl4afdqCLBZ/LQmPyvgcYKdltqPmT3IZYOUU=",
+        "lastModified": 1742527988,
+        "narHash": "sha256-t1i+0/dM4jkMUWMTcl7hlmCHFtwdGJdIIqKh0cLHlHU=",
         "owner": "0xc000022070",
         "repo": "zen-browser-flake",
-        "rev": "47a0eba73fef434d60eb658ac1464df4900548b8",
+        "rev": "0f396890cefee28c1e204f891a287bf33fba3fce",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                          | Message                                                                     |
| --------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------- |
| [`0f396890`](https://github.com/0xc000022070/zen-browser-flake/commit/0f396890cefee28c1e204f891a287bf33fba3fce) | `` Update Zen Browser twilight @ x86_64 && aarch64 to 1.10.1t#1742527213 `` |