### PR TITLE
chore(flake/nixpkgs-stable): `b75693fb` -> `7105ae39`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -752,11 +752,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1742388435,
-        "narHash": "sha256-GheQGRNYAhHsvPxWVOhAmg9lZKkis22UPbEHlmZMthg=",
+        "lastModified": 1742512142,
+        "narHash": "sha256-8XfURTDxOm6+33swQJu/hx6xw1Tznl8vJJN5HwVqckg=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "b75693fb46bfaf09e662d09ec076c5a162efa9f6",
+        "rev": "7105ae3957700a9646cc4b766f5815b23ed0c682",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                          |
| ---------------------------------------------------------------------------------------------- | ---------------------------------------------------------------- |
| [`6d19b6fb`](https://github.com/NixOS/nixpkgs/commit/6d19b6fbdace9db0b3b98ff74703a623ea9f59d5) | `` bashly: 1.2.6 -> 1.2.10 ``                                    |
| [`792718e9`](https://github.com/NixOS/nixpkgs/commit/792718e9a5a061e5d5699580ab44fedd28e5282d) | `` paretosecurity: 0.0.87 -> 0.0.88 ``                           |
| [`086ac8a5`](https://github.com/NixOS/nixpkgs/commit/086ac8a51d89341a32be265ed5fc641e40040f7b) | `` paretosecurity: 0.0.86 -> 0.0.87 ``                           |
| [`ac9f1e44`](https://github.com/NixOS/nixpkgs/commit/ac9f1e449a862bf95b54f749bb2a29c6b5430ec1) | `` nextcloud30: 30.0.7 -> 30.0.8 ``                              |
| [`abe3fd71`](https://github.com/NixOS/nixpkgs/commit/abe3fd712964090ca9fd93a5b33cd04cbce073da) | `` nextcloud29: 29.0.13 -> 29.0.14 ``                            |
| [`7524c5e5`](https://github.com/NixOS/nixpkgs/commit/7524c5e5e332941f6868769eede725a7220065b4) | `` thunderbird-bin-unwrapped: 128.8.0esr -> 128.8.1esr ``        |
| [`c4b3c8ef`](https://github.com/NixOS/nixpkgs/commit/c4b3c8efc7a2309b98a9303dd853680b9147a58e) | `` linuxKernel.packages.kvmfr: fix for looking glass B7 ``       |
| [`f2986e68`](https://github.com/NixOS/nixpkgs/commit/f2986e68e375540d7025d9a3af7918c364c306f2) | `` looking-glass-client: B7-rc1 -> B7 ``                         |
| [`e066851f`](https://github.com/NixOS/nixpkgs/commit/e066851f0d52a5b7c79ec26b56c2c8c0b45fde6a) | `` looking-glass-client: use nanosvg from nixpkgs ``             |
| [`d2759cc1`](https://github.com/NixOS/nixpkgs/commit/d2759cc1408a5d64705899101c9510d841f98c0d) | `` build-support/rust/sysroot: remove ``                         |
| [`3b6dca7c`](https://github.com/NixOS/nixpkgs/commit/3b6dca7c5bba5670de80a6cfc3b22c453175d53b) | `` forgejo-lts: 7.0.13 -> 7.0.14 ``                              |
| [`507bf203`](https://github.com/NixOS/nixpkgs/commit/507bf2030aee898b027ce1100ef5eba9d7704391) | `` paretosecurity: init at 0.0.86, nixos/paretosecurity: init `` |
| [`61c5c8b1`](https://github.com/NixOS/nixpkgs/commit/61c5c8b1b5882dc3e93119e85148f0e3f797b264) | `` eza: 0.20.18 -> 0.20.24 ``                                    |
| [`598f1796`](https://github.com/NixOS/nixpkgs/commit/598f1796a4934d175e7c96ab88823ff7e35f0a1d) | `` electron-source.electron_34: 34.3.2 -> 34.3.3 ``              |
| [`3d71b58a`](https://github.com/NixOS/nixpkgs/commit/3d71b58a634da22eb6c78f124291ebd256e0b85c) | `` electron-chromedriver_34: 34.3.2 -> 34.3.3 ``                 |
| [`0d910d14`](https://github.com/NixOS/nixpkgs/commit/0d910d14947e9c70ad7af972a70dd10ce27f4e0a) | `` electron_34-bin: 34.3.2 -> 34.3.3 ``                          |
| [`9c14456d`](https://github.com/NixOS/nixpkgs/commit/9c14456d467de3fe470fcd60647fc52582272208) | `` electron-source.electron_33: 33.4.3 -> 33.4.5 ``              |
| [`d0a63cb7`](https://github.com/NixOS/nixpkgs/commit/d0a63cb7c8188adc6327f6c0257ca804bc5f6625) | `` electron-chromedriver_33: 33.4.3 -> 33.4.5 ``                 |
| [`db9e4ef9`](https://github.com/NixOS/nixpkgs/commit/db9e4ef9a4791e611d089e88b14867dbd5d423d6) | `` electron_33-bin: 33.4.3 -> 33.4.5 ``                          |