### PR TITLE
chore(flake/stylix): `7e990667` -> `113643f3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1005,11 +1005,11 @@
         "tinted-zed": "tinted-zed"
       },
       "locked": {
-        "lastModified": 1742496983,
-        "narHash": "sha256-UpJrU0DEhNLVZwL/RPVOEUHCG6iDOVDoYelkmgS4V38=",
+        "lastModified": 1742591463,
+        "narHash": "sha256-CguaHULcm4RuIGN+i4u80dYZujFgZaeOTiShFxCwFhw=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "7e9906679d384472849272e5a5eef7adbdb1d87f",
+        "rev": "113643f332e1f70d90991722f8c4e5a0ace6fd06",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                        | Message                                               |
| --------------------------------------------------------------------------------------------- | ----------------------------------------------------- |
| [`113643f3`](https://github.com/danth/stylix/commit/113643f332e1f70d90991722f8c4e5a0ace6fd06) | `` doc: add note for user-imported modules (#1039) `` |