### PR TITLE
chore(flake/hyprland): `ccbdba7e` -> `6384f4ac`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -499,11 +499,11 @@
         "xdph": "xdph"
       },
       "locked": {
-        "lastModified": 1742584793,
-        "narHash": "sha256-Zhau0ocCNRDg/+MTIutjPkN1+pYjYzgyW3P7eqL/LkQ=",
+        "lastModified": 1742660024,
+        "narHash": "sha256-CwKcL78ltCooEVNakUzDXG91nHB0hLNE0Tz3FqXjPss=",
         "owner": "hyprwm",
         "repo": "Hyprland",
-        "rev": "ccbdba7ee2ccb835306de89a6023134fa6b8006f",
+        "rev": "6384f4acf4e2988bcb35d3dfc5821f07867a34d0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                                                            |
| ------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------ |
| [`6384f4ac`](https://github.com/hyprwm/Hyprland/commit/6384f4acf4e2988bcb35d3dfc5821f07867a34d0) | `` core/compositor: Correctly track SHM buffer damage (#9678) ``   |
| [`4600043a`](https://github.com/hyprwm/Hyprland/commit/4600043a498b015360a0f2b6f682ae82aff1b198) | `` hyprpm: return 1 when plugins are outdated (#9694) ``           |
| [`279b0604`](https://github.com/hyprwm/Hyprland/commit/279b06044c583bfaa207d6fbd373c752967a4a2e) | `` screencopy, render: Use explicit sync for screencopy (#9697) `` |