### PR TITLE
chore(flake/hyprland): `6ab5a0be` -> `fdb7ca6c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -499,11 +499,11 @@
         "xdph": "xdph"
       },
       "locked": {
-        "lastModified": 1742664841,
-        "narHash": "sha256-I9cprYu92u8PatjTGyM3Bp6XvAmznYiY88AjAr14tUw=",
+        "lastModified": 1742681162,
+        "narHash": "sha256-kkWvzXU/w48eKqvKVvcE7rWAOH+MeT1ErIgqB7h0Eas=",
         "owner": "hyprwm",
         "repo": "Hyprland",
-        "rev": "6ab5a0befb45e90eb45b8d6582e68d13147297dc",
+        "rev": "fdb7ca6c8fa3611ab04eccf129a515efd9852c73",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                                                              |
| ------------------------------------------------------------------------------------------------ | -------------------------------------------------------------------- |
| [`fdb7ca6c`](https://github.com/hyprwm/Hyprland/commit/fdb7ca6c8fa3611ab04eccf129a515efd9852c73) | `` core/compositor: Fix dropping cursor buffer data early (#9700) `` |