### PR TITLE
chore(flake/nix-gaming): `9818734e` -> `1491461d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -706,11 +706,11 @@
         "nixpkgs": "nixpkgs_4"
       },
       "locked": {
-        "lastModified": 1742607855,
-        "narHash": "sha256-lUF/tpSON29qNIqhECX/Ue4qVmI3FOvMaW4iUnK49C4=",
+        "lastModified": 1742694749,
+        "narHash": "sha256-hH/Wofw+RKBbcTMuzCvvgPrnTkmEZd54bOsT0QR7EJM=",
         "owner": "fufexan",
         "repo": "nix-gaming",
-        "rev": "9818734e2117dac703767585d48b805fad3e7a5e",
+        "rev": "1491461d4a47f61264df62863ed163a00192b2f1",
         "type": "github"
       },
       "original": {
@@ -800,11 +800,11 @@
     },
     "nixpkgs_4": {
       "locked": {
-        "lastModified": 1741865919,
-        "narHash": "sha256-4thdbnP6dlbdq+qZWTsm4ffAwoS8Tiq1YResB+RP6WE=",
+        "lastModified": 1742578646,
+        "narHash": "sha256-GiQ40ndXRnmmbDZvuv762vS+gew1uDpFwOfgJ8tLiEs=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "573c650e8a14b2faa0041645ab18aed7e60f0c9a",
+        "rev": "94c4dbe77c0740ebba36c173672ca15a7926c993",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                              | Message               |
| --------------------------------------------------------------------------------------------------- | --------------------- |
| [`1491461d`](https://github.com/fufexan/nix-gaming/commit/1491461d4a47f61264df62863ed163a00192b2f1) | `` Update packages `` |
| [`f45dd223`](https://github.com/fufexan/nix-gaming/commit/f45dd2233734b3b582cb99f4b732cc8251d8dc86) | `` Update flake ``    |