### PR TITLE
chore(flake/home-manager): `63e77d09` -> `7853236f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -391,11 +391,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1742670145,
-        "narHash": "sha256-xQ2F9f+ICAGBp/nNv3ddD2U4ZvzuLOci0u/5lyMXPvk=",
+        "lastModified": 1742698343,
+        "narHash": "sha256-ODQxVgw9pbwdAYuN3jwZ1HntDHEH44rd3XPexum+UE8=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "63e77d09a133ac641a0c204e7cfb0c97e133706d",
+        "rev": "7853236fae80bb625c319df8d730cad2a5584f26",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                              |
| ----------------------------------------------------------------------------------------------------------- | ---------------------------------------------------- |
| [`7853236f`](https://github.com/nix-community/home-manager/commit/7853236fae80bb625c319df8d730cad2a5584f26) | `` rclone: ensure remotes have a type field ``       |
| [`7a08b8c8`](https://github.com/nix-community/home-manager/commit/7a08b8c898bb594f271bbabd3972af2c89d68b11) | `` rclone: correctly escape whitespace in secrets `` |