### PR TITLE
chore(flake/home-manager): `7853236f` -> `9172a6f9`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -391,11 +391,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1742698343,
-        "narHash": "sha256-ODQxVgw9pbwdAYuN3jwZ1HntDHEH44rd3XPexum+UE8=",
+        "lastModified": 1742701794,
+        "narHash": "sha256-bJIFFa6/4vBGoNmCwjO5TCIbiveV2BRxVLqHcxk5jXw=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "7853236fae80bb625c319df8d730cad2a5584f26",
+        "rev": "9172a6f956f7e0f7810861b9b1146f1c43d9abcb",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                        |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------ |
| [`9172a6f9`](https://github.com/nix-community/home-manager/commit/9172a6f956f7e0f7810861b9b1146f1c43d9abcb) | `` skhd: add module (#6682) `` |