### PR TITLE
chore(flake/spicetify-nix): `610654a0` -> `d86aca85`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -968,11 +968,11 @@
         "systems": "systems_2"
       },
       "locked": {
-        "lastModified": 1742512598,
-        "narHash": "sha256-nFPhSSxrPrpkmFR6vQq8OpUS+lGIAxDCUKg+5/qcnR8=",
+        "lastModified": 1742703429,
+        "narHash": "sha256-/07c78WpRta925dyZEhwQi+D+rd+zVoDPApur+907p4=",
         "owner": "Gerg-L",
         "repo": "spicetify-nix",
-        "rev": "610654a0afe56766e639077d9d267148667a25e8",
+        "rev": "d86aca850354c8db834c20feb170356e3d28a5c6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                    |
| ----------------------------------------------------------------------------------------------------- | -------------------------- |
| [`d86aca85`](https://github.com/Gerg-L/spicetify-nix/commit/d86aca850354c8db834c20feb170356e3d28a5c6) | `` CI update 2025-03-23 `` |