### PR TITLE
chore(flake/stylix): `113643f3` -> `a55488c2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1005,11 +1005,11 @@
         "tinted-zed": "tinted-zed"
       },
       "locked": {
-        "lastModified": 1742591463,
-        "narHash": "sha256-CguaHULcm4RuIGN+i4u80dYZujFgZaeOTiShFxCwFhw=",
+        "lastModified": 1742736315,
+        "narHash": "sha256-XO+dWWoWer/YyczQeff3Onr3P0q7SxoKltndBrzRdTg=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "113643f332e1f70d90991722f8c4e5a0ace6fd06",
+        "rev": "a55488c247928380ee6a18c0a3a56a2d52fe06bc",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                        | Message                                                  |
| --------------------------------------------------------------------------------------------- | -------------------------------------------------------- |
| [`a55488c2`](https://github.com/danth/stylix/commit/a55488c247928380ee6a18c0a3a56a2d52fe06bc) | `` doc: reduce overuse of alerts (#1041) ``              |
| [`f537d507`](https://github.com/danth/stylix/commit/f537d507c3ac287ee0cbf36b7e514c403daed0f8) | `` doc: add subheading before module metadata (#1042) `` |