### PR TITLE
chore(flake/home-manager): `5ff90f09` -> `0e75a404`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -391,11 +391,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1742744903,
-        "narHash": "sha256-qd2uiGol/kb9Dk0vgOOLBl9VsycG0VfteM78OduFl2Y=",
+        "lastModified": 1742756669,
+        "narHash": "sha256-55QHo/lETkGO4lUfxhJ6TUs5OLOz5Ks7JDNAKDzpt4I=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "5ff90f09d1bd189b722e60798513724cdd3580b6",
+        "rev": "0e75a40458d065d1e5c6a10d0b74b9e35b550ae6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                                |
| ----------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------- |
| [`0e75a404`](https://github.com/nix-community/home-manager/commit/0e75a40458d065d1e5c6a10d0b74b9e35b550ae6) | `` firefox: fix assertion when missing force for extensions (#6688) `` |
| [`ecbcd792`](https://github.com/nix-community/home-manager/commit/ecbcd792e1f6cd018b0858b5b3d11733cd19c46f) | `` firefox: check if bookmarks attrset is of correct type ``           |
| [`d7f451d7`](https://github.com/nix-community/home-manager/commit/d7f451d7b13bbe075abecfd345f8b149a000216a) | `` firefox: replace with-lib-expression with inherit-expression ``     |
| [`62d6a893`](https://github.com/nix-community/home-manager/commit/62d6a8931eb03b8bcaca425dbbe5b327c794ec37) | `` firefox: fix bookmarks backwards compatibility ``                   |