### PR TITLE
chore(flake/seanime): `c0aea485` -> `1b16056d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -832,11 +832,11 @@
     },
     "nixpkgs_6": {
       "locked": {
-        "lastModified": 1742422364,
-        "narHash": "sha256-mNqIplmEohk5jRkqYqG19GA8MbQ/D4gQSK0Mu4LvfRQ=",
+        "lastModified": 1742669843,
+        "narHash": "sha256-G5n+FOXLXcRx+3hCJ6Rt6ZQyF1zqQ0DL0sWAMn2Nk0w=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "a84ebe20c6bc2ecbcfb000a50776219f48d134cc",
+        "rev": "1e5b653dff12029333a6546c11e108ede13052eb",
         "type": "github"
       },
       "original": {
@@ -947,11 +947,11 @@
         "nixpkgs": "nixpkgs_6"
       },
       "locked": {
-        "lastModified": 1742517798,
-        "narHash": "sha256-+jc7WhBu9PO0abItYEMOQWbVzITcSXcajwFLkeRzBRo=",
+        "lastModified": 1742760603,
+        "narHash": "sha256-rFRb/DZqz52ObBRmWQkmgl78cZasTZfQSiJj9N6RbOQ=",
         "owner": "rishabh5321",
         "repo": "seanime-flake",
-        "rev": "c0aea4857a489f3b414bd919ca5efc596f806180",
+        "rev": "1b16056dbdd8d8bb6ca67f5d23d11b0421fbb3cd",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                     | Message                                          |
| ---------------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
| [`1b16056d`](https://github.com/Rishabh5321/seanime-flake/commit/1b16056dbdd8d8bb6ca67f5d23d11b0421fbb3cd) | `` chore(flake/nixpkgs): a84ebe20 -> 1e5b653d `` |