### PR TITLE
chore(flake/akuse-flake): `f86db528` -> `38ca0f23`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -5,11 +5,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1742521496,
-        "narHash": "sha256-WAJz58zJbMNiTs0WOE9xiT228UXBKrldYcAxmRqHJBA=",
+        "lastModified": 1742761335,
+        "narHash": "sha256-WqaFLiOUklDC/1zjIIIaxPNyeBBM3mYcLAENGMrjeas=",
         "owner": "Rishabh5321",
         "repo": "akuse-flake",
-        "rev": "f86db528d1af5e26eae5622fc201c1dc5950d843",
+        "rev": "38ca0f23aedf982a3875209190a9d9182cce4ce8",
         "type": "github"
       },
       "original": {
@@ -721,11 +721,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1742422364,
-        "narHash": "sha256-mNqIplmEohk5jRkqYqG19GA8MbQ/D4gQSK0Mu4LvfRQ=",
+        "lastModified": 1742669843,
+        "narHash": "sha256-G5n+FOXLXcRx+3hCJ6Rt6ZQyF1zqQ0DL0sWAMn2Nk0w=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "a84ebe20c6bc2ecbcfb000a50776219f48d134cc",
+        "rev": "1e5b653dff12029333a6546c11e108ede13052eb",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                   | Message                                          |
| -------------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
| [`38ca0f23`](https://github.com/Rishabh5321/akuse-flake/commit/38ca0f23aedf982a3875209190a9d9182cce4ce8) | `` chore(flake/nixpkgs): a84ebe20 -> 1e5b653d `` |