### PR TITLE
chore(flake/thorium): `29fb385b` -> `46552186`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -848,11 +848,11 @@
     },
     "nixpkgs_7": {
       "locked": {
-        "lastModified": 1742422364,
-        "narHash": "sha256-mNqIplmEohk5jRkqYqG19GA8MbQ/D4gQSK0Mu4LvfRQ=",
+        "lastModified": 1742669843,
+        "narHash": "sha256-G5n+FOXLXcRx+3hCJ6Rt6ZQyF1zqQ0DL0sWAMn2Nk0w=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "a84ebe20c6bc2ecbcfb000a50776219f48d134cc",
+        "rev": "1e5b653dff12029333a6546c11e108ede13052eb",
         "type": "github"
       },
       "original": {
@@ -1068,11 +1068,11 @@
         "nixpkgs": "nixpkgs_7"
       },
       "locked": {
-        "lastModified": 1742520594,
-        "narHash": "sha256-CPUxG1hM/4CuZTsXVocEoHh2uKTejXn2WarNRIanRTY=",
+        "lastModified": 1742761243,
+        "narHash": "sha256-tnMyfgrSOaxWnHqxGF8KDm9qhjuuO966KaNa9iWswBM=",
         "owner": "Rishabh5321",
         "repo": "thorium_flake",
-        "rev": "29fb385bcf48255bba8cba197392816616598891",
+        "rev": "46552186527a8217348e6d4ca1d3e8bb8ec158d9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                     | Message                                          |
| ---------------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
| [`46552186`](https://github.com/Rishabh5321/thorium_flake/commit/46552186527a8217348e6d4ca1d3e8bb8ec158d9) | `` chore(flake/nixpkgs): a84ebe20 -> 1e5b653d `` |