### PR TITLE
chore(flake/grayjay): `5b8d99d7` -> `f57a3ea0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -371,11 +371,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1742536494,
-        "narHash": "sha256-e/hVQrJYW5+jRv7b5WFuphhFYVLR/AxZUX1O4Wk+sOE=",
+        "lastModified": 1742761191,
+        "narHash": "sha256-g+eQnk4ADxVqRjYsN5gy2fHEeo4C4a+Vh73um4+LK6M=",
         "owner": "rishabh5321",
         "repo": "grayjay-flake",
-        "rev": "5b8d99d706aa7fb6ae01754f052731ca03fcd429",
+        "rev": "f57a3ea0270f348b86b040173bd29811714d1076",
         "type": "github"
       },
       "original": {
@@ -768,11 +768,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1742422364,
-        "narHash": "sha256-mNqIplmEohk5jRkqYqG19GA8MbQ/D4gQSK0Mu4LvfRQ=",
+        "lastModified": 1742669843,
+        "narHash": "sha256-G5n+FOXLXcRx+3hCJ6Rt6ZQyF1zqQ0DL0sWAMn2Nk0w=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "a84ebe20c6bc2ecbcfb000a50776219f48d134cc",
+        "rev": "1e5b653dff12029333a6546c11e108ede13052eb",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                     | Message                                          |
| ---------------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
| [`f57a3ea0`](https://github.com/Rishabh5321/grayjay-flake/commit/f57a3ea0270f348b86b040173bd29811714d1076) | `` chore(flake/nixpkgs): a84ebe20 -> 1e5b653d `` |