### PR TITLE
chore(flake/nixpkgs-stable): `7105ae39` -> `f0946fa5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -752,11 +752,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1742512142,
-        "narHash": "sha256-8XfURTDxOm6+33swQJu/hx6xw1Tznl8vJJN5HwVqckg=",
+        "lastModified": 1742751704,
+        "narHash": "sha256-rBfc+H1dDBUQ2mgVITMGBPI1PGuCznf9rcWX/XIULyE=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "7105ae3957700a9646cc4b766f5815b23ed0c682",
+        "rev": "f0946fa5f1fb876a9dc2e1850d9d3a4e3f914092",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                      |
| ---------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------- |
| [`0ab4a35e`](https://github.com/NixOS/nixpkgs/commit/0ab4a35ea3f79f11018702be57548589170f93f6) | `` workflows/manual-nixos-v2: use a matrix to build on different systems ``                  |
| [`f0b47287`](https://github.com/NixOS/nixpkgs/commit/f0b472873c43a20df51872565d00504e1ac72bf7) | `` workflows/manual-nixos-v2: split platforms into separate artifacts ``                     |
| [`9c116e50`](https://github.com/NixOS/nixpkgs/commit/9c116e502c3269a958497253bc293d9bb8205fd1) | `` workflows/manual-nixos-v2: fix upload action ``                                           |
| [`736f182d`](https://github.com/NixOS/nixpkgs/commit/736f182d1bec4747796b4f935abcb0db295ed04b) | `` workflows/build-nixos-manual: upload result ``                                            |
| [`a103a4c0`](https://github.com/NixOS/nixpkgs/commit/a103a4c02a5667faaaef237e21b1b23e0550c076) | `` workflows/build-nixos-manual: run it on aarch64-linux too ``                              |
| [`b1c6b3a6`](https://github.com/NixOS/nixpkgs/commit/b1c6b3a611e1d31f7dfd3ba376314f591e2aba80) | `` teleport: mark broken on x86_64-darwin ``                                                 |
| [`7a4ab0aa`](https://github.com/NixOS/nixpkgs/commit/7a4ab0aa78c910c43ed4de0f1befcd12b55d35f1) | `` dxvk_2: 2.5.3 -> 2.6 ``                                                                   |
| [`25a0fd83`](https://github.com/NixOS/nixpkgs/commit/25a0fd832d7fec05959c0429d3b0f5b4476fe063) | `` kanidm: don't log provisioned passwords via instrumentation ``                            |
| [`dda79599`](https://github.com/NixOS/nixpkgs/commit/dda7959917b4c93400428ac466e53c93f13862b7) | `` dxvk_2: 2.5.2 -> 2.5.3 ``                                                                 |
| [`15d15f60`](https://github.com/NixOS/nixpkgs/commit/15d15f60152e9da6c2443d6c2607a3aad8dd1f2f) | `` python3Packages.bump-my-version: init at 1.0.2 ``                                         |
| [`d6b17b0e`](https://github.com/NixOS/nixpkgs/commit/d6b17b0ee8059f99f87ed6cf050943128625f029) | `` teleport_17: 17.2.8 -> 17.2.9 ``                                                          |
| [`2788f5ee`](https://github.com/NixOS/nixpkgs/commit/2788f5ee542657a05236c1ba517943f3282cfa5e) | `` teleport_17: 17.2.1 -> 17.2.8 ``                                                          |
| [`89ba4830`](https://github.com/NixOS/nixpkgs/commit/89ba48302f7b453c075a6c9beec2e3331944e30e) | `` teleport_16: 16.4.14 -> 16.4.16 ``                                                        |
| [`7a7b19a2`](https://github.com/NixOS/nixpkgs/commit/7a7b19a2e25613a6126565afd98742f2f97e1e37) | `` teleport_15: 15.4.26 -> 15.4.29 ``                                                        |
| [`a710fd47`](https://github.com/NixOS/nixpkgs/commit/a710fd47aa63a7722644d77673db1d4049d3ca07) | `` pnpm_10: 10.6.3 -> 10.6.5 ``                                                              |
| [`20e1923b`](https://github.com/NixOS/nixpkgs/commit/20e1923b292d97135ce3c98221c00907194a04bf) | `` pnpm_{8,9,10}: add updateScript ``                                                        |
| [`3cb55acc`](https://github.com/NixOS/nixpkgs/commit/3cb55accd6d7ba25f24321c69c86eee539b2b316) | `` Revert "Backport of #389509 to release 24.11" ``                                          |
| [`38a642b0`](https://github.com/NixOS/nixpkgs/commit/38a642b03bcbe4708ca8a7f7ac237f2d441fc3bf) | `` [Backport release-24.11] mastodon: 4.3.4 -> 4.3.6 (#389693) ``                            |
| [`29a0fe74`](https://github.com/NixOS/nixpkgs/commit/29a0fe74ba57245e66636d07aa863e9257461fa5) | `` mautrix-whatsapp: 0.11.3 -> 0.11.4 ``                                                     |
| [`dbb787fd`](https://github.com/NixOS/nixpkgs/commit/dbb787fda0438b1fe0abbeec021e7fb2d26bdb3f) | `` microsoft-edge: fix aad sync ``                                                           |
| [`576e8f9a`](https://github.com/NixOS/nixpkgs/commit/576e8f9ae909614026e2c9345833f821c2ee4cfb) | `` chromium,chromedriver: 134.0.6998.117 -> 134.0.6998.165 ``                                |
| [`05ed9d67`](https://github.com/NixOS/nixpkgs/commit/05ed9d67cafbd2d0e990ca247375b4fb2ad772dd) | `` owntone: init at 28.11 ``                                                                 |
| [`57a78033`](https://github.com/NixOS/nixpkgs/commit/57a78033b9a6f09739435bad6e5901410bec784a) | `` yt-dlp: 2025.2.19 -> 2025.3.21 ``                                                         |
| [`cee5c13b`](https://github.com/NixOS/nixpkgs/commit/cee5c13bfbdddfc10ea4f7c0097d2377e3c2a80f) | `` xonsh: 0.19.2 -> 0.19.3 ``                                                                |
| [`dc0daf7b`](https://github.com/NixOS/nixpkgs/commit/dc0daf7b841ca641c3da5cd4b2152680007389f9) | `` editline: recognize `Alt-Left`/`Alt-Right` in more platforms ``                           |
| [`d0447137`](https://github.com/NixOS/nixpkgs/commit/d04471373fc736ea1cfbcdd4a5f64d694cd28644) | `` errands: fix src hash ``                                                                  |
| [`d9e30144`](https://github.com/NixOS/nixpkgs/commit/d9e30144ddb0e30ef71cd95952e251d482d94878) | `` forgejo: remove SSH DSA test skips ``                                                     |
| [`0c54d30f`](https://github.com/NixOS/nixpkgs/commit/0c54d30f9b492778f6248b770342ce13157df160) | `` forgejo: 10.0.1 -> 10.0.2 ``                                                              |
| [`474d8bd3`](https://github.com/NixOS/nixpkgs/commit/474d8bd3cf71f4cedf7e69e15c320f68c628ee25) | `` pyzstd: add pitkling as maintainer ``                                                     |
| [`02cd4487`](https://github.com/NixOS/nixpkgs/commit/02cd44872b73f955c20b6a7b4deb898e92de32d0) | `` py7zr: init at 0.22.0 ``                                                                  |
| [`5040f7fd`](https://github.com/NixOS/nixpkgs/commit/5040f7fd946a133d65f3d2202138b612a12f883f) | `` pyppmd: init at 1.1.1 ``                                                                  |
| [`4325cf1c`](https://github.com/NixOS/nixpkgs/commit/4325cf1cd53fbebd8834034d7bb66122f1f217a0) | `` pybcj: init at 1.0.3 ``                                                                   |
| [`a93e368f`](https://github.com/NixOS/nixpkgs/commit/a93e368fe9d5e0508c90e974d499c66f4d0792a2) | `` multivolumefile: init at 0.2.3 ``                                                         |
| [`f748c78b`](https://github.com/NixOS/nixpkgs/commit/f748c78b348254b93589704ab357931d63f58248) | `` inflate64: init at 1.0.1 ``                                                               |
| [`3e541fcf`](https://github.com/NixOS/nixpkgs/commit/3e541fcf6bde5a9f5f4f51626e4df5ba35fdae6c) | `` pyzstd: init at 0.16.2 ``                                                                 |
| [`7f634beb`](https://github.com/NixOS/nixpkgs/commit/7f634beba5ad87fd9670e0463b725ce878a35313) | `` cassandra_3_0: 3.0.28 -> 3.0.31 ``                                                        |
| [`0aab3dc0`](https://github.com/NixOS/nixpkgs/commit/0aab3dc0efac57fa2b90bac7e2e4fe5b149b26e9) | `` cassandra_3_11: 3.11.12 -> 3.11.18 ``                                                     |
| [`de36e226`](https://github.com/NixOS/nixpkgs/commit/de36e226439afad7adea86d160461349d4dd4ca1) | `` cassandra: 4.1.7 -> 4.1.8 ``                                                              |
| [`ec3e5764`](https://github.com/NixOS/nixpkgs/commit/ec3e5764b47457684f8dda5980daf9348ca2c3ab) | `` Reapply "build(deps): bump cachix/install-nix-action from 30 to 31" ``                    |
| [`c637e3b0`](https://github.com/NixOS/nixpkgs/commit/c637e3b0665d6ea7ef0bc6c0b82b752a896c9642) | `` ci/eval/compare: fix reading store paths from json file ``                                |
| [`448e806d`](https://github.com/NixOS/nixpkgs/commit/448e806d8a84263d645a973d73bca20eb25a2e9e) | `` OWNERS: set ZFS owners ``                                                                 |
| [`0ba0e054`](https://github.com/NixOS/nixpkgs/commit/0ba0e054478dbf6b3d439bfab07db3c119f4e04a) | `` buildVscodeExtension: remove unused parameter `src` ``                                    |
| [`84e251ad`](https://github.com/NixOS/nixpkgs/commit/84e251ad511e96e57a59996040268583a7424420) | `` buildVscodeMarketplaceExtension: support `finalAttrs` through `lib.extendMkDerivation` `` |
| [`e5c744c6`](https://github.com/NixOS/nixpkgs/commit/e5c744c68feb31c5927f58b49e6b20ad8eb8ab02) | `` buildVscodeExtension: support `finalAttrs` through `lib.extendMkDerivation` ``            |
| [`6db5a533`](https://github.com/NixOS/nixpkgs/commit/6db5a533dff331c201e81a9a8504e960acf50f86) | `` vscode-extensions: make `pname` optional ``                                               |
| [`e47edd6f`](https://github.com/NixOS/nixpkgs/commit/e47edd6f18752c5072e6bd8278cc125d75bb1f84) | `` vscode-extensions: set pname ``                                                           |
| [`fac6704b`](https://github.com/NixOS/nixpkgs/commit/fac6704b010b5df0cb523b12f4e21b572bcfa418) | `` nextcloud-whiteboard-server: add meta.mainProgram ``                                      |
| [`a7d01a8a`](https://github.com/NixOS/nixpkgs/commit/a7d01a8a4e5658c1d3192fadd51e009929e86b44) | `` dotnetCorePackages.sdk_9_0-bin: 9.0.201 -> 9.0.202 ``                                     |
| [`c580b8ff`](https://github.com/NixOS/nixpkgs/commit/c580b8ffe5713444886bfec838184abd36bea024) | `` ungoogled-chromium: 134.0.6998.88-1 -> 134.0.6998.117-1 ``                                |
| [`b8844144`](https://github.com/NixOS/nixpkgs/commit/b884414475a496124eb6f0d3902c3db9ae0afc97) | `` triforce-lv2: init at 0.2.0 ``                                                            |
| [`1507dd42`](https://github.com/NixOS/nixpkgs/commit/1507dd42e71340756e47cc74556ff4592766aa1e) | `` epson-escpr2: 1.2.27 -> 1.2.28 ``                                                         |
| [`5c398df3`](https://github.com/NixOS/nixpkgs/commit/5c398df315b0d8a026879298db853da558782b09) | `` buildRustPackage: reformat after refactoring ``                                           |
| [`ff616c0a`](https://github.com/NixOS/nixpkgs/commit/ff616c0a778fb636af97ac73042d6406d3afc91a) | `` buildRustPackage: restructure with lib.extendMkDerivation ``                              |
| [`84839fb3`](https://github.com/NixOS/nixpkgs/commit/84839fb3dbcbe306f60802b1d36b8590b341271c) | `` buildRustPackage: avoid global assertions ``                                              |
| [`22dae4e7`](https://github.com/NixOS/nixpkgs/commit/22dae4e7009a8ffad04377f390471ef3d0218e2d) | `` paretosecurity: 0.0.89 -> 0.0.91,, nixos/paretosecurity: add trayIcon option ``           |
| [`2e14a72f`](https://github.com/NixOS/nixpkgs/commit/2e14a72fa0de69db2b837e972c8ba36d1ed604de) | `` paretosecurity: 0.0.88 -> 0.0.89 ``                                                       |
| [`d6b7bf3c`](https://github.com/NixOS/nixpkgs/commit/d6b7bf3c6dc862cc7b862e23772b94e751149588) | `` golangci-lint-langserver: 0.0.9 -> 0.0.10 ``                                              |
| [`25dc08dd`](https://github.com/NixOS/nixpkgs/commit/25dc08dd6107b6a269316362f35f0c3df6d2360b) | `` raycast: 1.93.2 -> 1.94.0 ``                                                              |
| [`5edaa88a`](https://github.com/NixOS/nixpkgs/commit/5edaa88ae93395d2870d9c47a86bbddd1c636ed9) | `` chromium,chromedriver: 134.0.6998.88 -> 134.0.6998.117 ``                                 |
| [`ef6b59c2`](https://github.com/NixOS/nixpkgs/commit/ef6b59c27d738c1302bc191cb758dea8863c0ec0) | `` nextcloud30: 30.0.7 -> 30.0.8 ``                                                          |
| [`8145d65d`](https://github.com/NixOS/nixpkgs/commit/8145d65d5de5c6d1e48c3647938db4f59da6ef3a) | `` nextcloud29: 29.0.13 -> 29.0.14 ``                                                        |
| [`91154a95`](https://github.com/NixOS/nixpkgs/commit/91154a95646c550ed3c87b8e21ba2ef28b39d872) | `` showtime: 47.0 -> 48.0 ``                                                                 |
| [`38b57e28`](https://github.com/NixOS/nixpkgs/commit/38b57e280a570546d7bba9a2e20dc4886ecd9dc6) | `` dosage-tracker: 1.9.3 -> 1.9.4 ``                                                         |
| [`3ec4f1d2`](https://github.com/NixOS/nixpkgs/commit/3ec4f1d251294aeed334b61c38c40cb363c93bfa) | `` protonplus: 0.4.25 -> 0.4.27 ``                                                           |
| [`60b1c5ac`](https://github.com/NixOS/nixpkgs/commit/60b1c5acfabba6dfb89bea863ba525c3bf75c5d5) | `` refine: 0.5.2 -> 0.5.5 ``                                                                 |
| [`6b36952c`](https://github.com/NixOS/nixpkgs/commit/6b36952c94d799ba075f86de9ef6d0cf8bcac39e) | `` gancio: 1.24.0 -> 1.24.4 ``                                                               |
| [`1916f271`](https://github.com/NixOS/nixpkgs/commit/1916f27171b3ed092591a466485784061b00a762) | `` immich: fix cross build for FreeBSD ``                                                    |
| [`13e093c2`](https://github.com/NixOS/nixpkgs/commit/13e093c25a906dedda093e4d2b31c57782f9666a) | `` immich: 1.128.0 -> 1.129.0 ``                                                             |
| [`56fdc0eb`](https://github.com/NixOS/nixpkgs/commit/56fdc0eb8854447996a409091d2b03582e8b062a) | `` immich.geodata: fix hash ``                                                               |
| [`657ac740`](https://github.com/NixOS/nixpkgs/commit/657ac7404194273b827d385f2f65fd34a20dc15a) | `` immich: allow overriding of sourcesJSON ``                                                |
| [`7b31f3f6`](https://github.com/NixOS/nixpkgs/commit/7b31f3f616c44bc7859bd315112293b4cda50d44) | `` immich: update geonames hash ``                                                           |
| [`743f40ff`](https://github.com/NixOS/nixpkgs/commit/743f40ffc4e5163917aaa96745a5ed57d7ae3e8f) | `` immich: 1.127.0 -> 1.128.0 ``                                                             |
| [`061791e2`](https://github.com/NixOS/nixpkgs/commit/061791e25e1e88fd00ffd3e0e85904fba051b665) | `` perlPackages.CryptRandom: 1.54 -> 1.57 ``                                                 |
| [`0fe21cb0`](https://github.com/NixOS/nixpkgs/commit/0fe21cb0336598741a341d0a426917193c946a23) | `` errands: 46.2.7 -> 46.2.8 ``                                                              |
| [`6c5a5664`](https://github.com/NixOS/nixpkgs/commit/6c5a5664c0c1daf63af7052592d4a09b20938955) | `` errands: 46.2.6 -> 46.2.7 ``                                                              |
| [`8c6146b0`](https://github.com/NixOS/nixpkgs/commit/8c6146b0acf491733d63afa398622cbbe6104bc6) | `` nodejs_23: 23.9.0 -> 23.10.0 ``                                                           |
| [`db65b8a2`](https://github.com/NixOS/nixpkgs/commit/db65b8a2da3ece84622e781004859556ad0d5384) | `` webex: 44.10.2.31237 -> 45.2.0.31846 ``                                                   |
| [`89f462e6`](https://github.com/NixOS/nixpkgs/commit/89f462e665d4de870b847511467b77d31e2ac10f) | `` pyfa: 2.61.0 -> 2.61.3 ``                                                                 |
| [`4beb7a93`](https://github.com/NixOS/nixpkgs/commit/4beb7a93e395bca9073ce84829f02525ab26fbef) | `` pyfa: 2.60.2 -> 2.61.0 ``                                                                 |
| [`f581a0ad`](https://github.com/NixOS/nixpkgs/commit/f581a0addcc360cc99c593f086d204f858b32af3) | `` maintainers: add paschoal ``                                                              |