### PR TITLE
chore(flake/better-control): `7d9a0376` -> `02955ad2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -124,11 +124,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1742806765,
-        "narHash": "sha256-U+BeOq0dHhx42CE7CCqmQPQDqu4wiNCFPyaGkyymX4A=",
+        "lastModified": 1742809729,
+        "narHash": "sha256-abmvPlr737gBHMTuJq0RRFGimwZk0eabO4WQPLIGPI8=",
         "owner": "rishabh5321",
         "repo": "better-control-flake",
-        "rev": "7d9a03761d058198519abd8740b7a25a77288fa9",
+        "rev": "02955ad208d0620cc8ba3b72b70bc892fc522974",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                            | Message                                                                                                   |
| ----------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------- |
| [`02955ad2`](https://github.com/Rishabh5321/better-control-flake/commit/02955ad208d0620cc8ba3b72b70bc892fc522974) | `` Update README.md: Improve formatting of Better-control link by removing unnecessary text ``            |
| [`1ee1de84`](https://github.com/Rishabh5321/better-control-flake/commit/1ee1de848318d2c3066c952d0774f755827453e2) | `` Add scheduled workflow to flake_check.yml for hourly execution ``                                      |
| [`14d05215`](https://github.com/Rishabh5321/better-control-flake/commit/14d05215552aeb5274418aeb9a95fcf61d27e137) | `` Update flake.nix: Change sha256 hash for better-control repository ``                                  |
| [`11d631fb`](https://github.com/Rishabh5321/better-control-flake/commit/11d631fb5b8326f4033452a85c17be247496e97e) | `` Update README.md: Adjust installation instructions to include better-control in systemPackages ``      |
| [`fdf5c4a9`](https://github.com/Rishabh5321/better-control-flake/commit/fdf5c4a9cbedd5c216f497fcde94f402148e0ab7) | `` Update README.md: Modify installation command to reference better-control package directly ``          |
| [`959d5706`](https://github.com/Rishabh5321/better-control-flake/commit/959d5706ea6527aa15309787ff5e779a99781457) | `` Update README.md: Change installation command to use better-control flake reference ``                 |
| [`c6be2bb6`](https://github.com/Rishabh5321/better-control-flake/commit/c6be2bb69a9c6a9eb1572724b8b91dda3eff7b27) | `` Fix flake.nix: Correct license declaration formatting ``                                               |
| [`827a147a`](https://github.com/Rishabh5321/better-control-flake/commit/827a147a04d88daa8fef8baa5f32c3c332054a56) | `` Update flake.nix: Change license from MIT to GPL-3.0 and remove contributing section from README.md `` |
| [`8629a0c7`](https://github.com/Rishabh5321/better-control-flake/commit/8629a0c73b827f2b93f4c34d790e3b062af38643) | `` Fix README.md: Add space in Better-control link for improved formatting ``                             |
| [`e937ad11`](https://github.com/Rishabh5321/better-control-flake/commit/e937ad11d4401f764e8ac2baaa941dee381df197) | `` Update flake.nix: Change sha256 hash for better-control repository ``                                  |
| [`2cc04dd9`](https://github.com/Rishabh5321/better-control-flake/commit/2cc04dd977efdfc1e050ef1537cf07d3cca02f69) | `` Update README.md: Remove outdated installation instructions for flake usage ``                         |