### PR TITLE
chore(flake/better-control): `02955ad2` -> `cc82f51c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -124,11 +124,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1742809729,
-        "narHash": "sha256-abmvPlr737gBHMTuJq0RRFGimwZk0eabO4WQPLIGPI8=",
+        "lastModified": 1742825191,
+        "narHash": "sha256-ZEiqIuADu29LpP1jplV2NmccXA+flzdiEKUUJ+3C1k8=",
         "owner": "rishabh5321",
         "repo": "better-control-flake",
-        "rev": "02955ad208d0620cc8ba3b72b70bc892fc522974",
+        "rev": "cc82f51cbccf06ec1b648f8eacfa55427ca8a7f8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                            | Message                                                   |
| ----------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------- |
| [`4ae5c6de`](https://github.com/Rishabh5321/better-control-flake/commit/4ae5c6dead319655faaf2f7e0a42835bbf492ea0) | `` Changed version to 5.0 according to control.desktop `` |
| [`28e07f5a`](https://github.com/Rishabh5321/better-control-flake/commit/28e07f5a205e13a02c1acef549a30c23c2e1d67f) | `` Use with pkgs to avoid repetition ``                   |
| [`2ed54397`](https://github.com/Rishabh5321/better-control-flake/commit/2ed54397547ff4aa4feee3c36e4e90b407bf3737) | `` Use --replace-fail and remove outdated --replace's ``  |
| [`993c7b8a`](https://github.com/Rishabh5321/better-control-flake/commit/993c7b8a199b792e315b3e6c1dabbff428d5d48b) | `` Drop no longer necessary condition ``                  |
| [`7879879f`](https://github.com/Rishabh5321/better-control-flake/commit/7879879f86d494a21734ad03d2a30c8865907791) | `` Track rev to not break on next commit ``               |
| [`55d32098`](https://github.com/Rishabh5321/better-control-flake/commit/55d320988f4db744ed56b86e1e5627132b1cce57) | `` Fix version ``                                         |
| [`3328f883`](https://github.com/Rishabh5321/better-control-flake/commit/3328f883eca9742651d4d05cee0b4f90044f581a) | `` Add default package to fix nix build .# ``             |