### PR TITLE
chore(flake/better-control): `cc82f51c` -> `87013056`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -124,11 +124,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1742825191,
-        "narHash": "sha256-ZEiqIuADu29LpP1jplV2NmccXA+flzdiEKUUJ+3C1k8=",
+        "lastModified": 1742829198,
+        "narHash": "sha256-2owwmmwx0wUh9qmQ4BxrZluxYeHpbFBeoGUw520h91E=",
         "owner": "rishabh5321",
         "repo": "better-control-flake",
-        "rev": "cc82f51cbccf06ec1b648f8eacfa55427ca8a7f8",
+        "rev": "870130567c911b479303cff2977e3fc1e3956a9f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                            | Message                                                                    |
| ----------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------- |
| [`87013056`](https://github.com/Rishabh5321/better-control-flake/commit/870130567c911b479303cff2977e3fc1e3956a9f) | `` Update GitHub revision and SHA256 hash for better-control repository `` |
| [`ddb699f9`](https://github.com/Rishabh5321/better-control-flake/commit/ddb699f92aca438e8bc9e92ed06fbb82d8b2ca6c) | `` Update SHA256 hash for better-control repository ``                     |
| [`5886b35c`](https://github.com/Rishabh5321/better-control-flake/commit/5886b35cd8a393956841eccba1bfa3159ae86476) | `` Update GitHub revision ``                                               |