### PR TITLE
chore(flake/home-manager): `ad0614a1` -> `908e055e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -428,11 +428,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1742771635,
-        "narHash": "sha256-HQHzQPrg+g22tb3/K/4tgJjPzM+/5jbaujCZd8s2Mls=",
+        "lastModified": 1742825959,
+        "narHash": "sha256-wgnQZMrLLQJlZ+htTXzoQtoz9EzL15Z2crH3+OnRmMk=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "ad0614a1ec9cce3b13169e20ceb7e55dfaf2a818",
+        "rev": "908e055e157a0b35466faf4125d7e7410ff56160",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                 |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------------- |
| [`908e055e`](https://github.com/nix-community/home-manager/commit/908e055e157a0b35466faf4125d7e7410ff56160) | `` git: option to use difftastic as difftool (#5335) `` |