### PR TITLE
chore(flake/spicetify-nix): `5979517f` -> `32663bb5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1022,11 +1022,11 @@
         "systems": "systems_3"
       },
       "locked": {
-        "lastModified": 1742816943,
-        "narHash": "sha256-BMQg7gJmbMbm0HkaMr7n+pmLJRsy/+JxQkjg8SS5iLk=",
+        "lastModified": 1742854930,
+        "narHash": "sha256-yry0JTKn3TotaCIgBjIl8rSsnqqxqT01rtJQUc0PeOA=",
         "owner": "Gerg-L",
         "repo": "spicetify-nix",
-        "rev": "5979517ff68c1ae011503d5027d98d0472d392e8",
+        "rev": "32663bb5e4dce31d252b1ba02deb3631d220d74e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                         |
| ----------------------------------------------------------------------------------------------------- | ------------------------------- |
| [`32663bb5`](https://github.com/Gerg-L/spicetify-nix/commit/32663bb5e4dce31d252b1ba02deb3631d220d74e) | `` CI update 2025-03-24 ``      |
| [`dde1e683`](https://github.com/Gerg-L/spicetify-nix/commit/dde1e683128105133e90ca8c189a7a17f2a72a1c) | `` fix: Update npins version `` |