### PR TITLE
chore(flake/hyprland): `2a6d0707` -> `f7ba86d1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -536,11 +536,11 @@
         "xdph": "xdph"
       },
       "locked": {
-        "lastModified": 1742841187,
-        "narHash": "sha256-lFc9UfoIXzw35R+mIQMX5q18ANiV6D04A2IxVjTUXVI=",
+        "lastModified": 1742860753,
+        "narHash": "sha256-ItOsU1v6CZNe6spfKtJ+cpVr0S87jq69PYe3lpOLzjI=",
         "owner": "hyprwm",
         "repo": "Hyprland",
-        "rev": "2a6d070774df4c17ca7d7d427065b04d0c77250a",
+        "rev": "f7ba86d1f335112ae0d13548947ddbd76b1477b6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                                             |
| ------------------------------------------------------------------------------------------------ | --------------------------------------------------- |
| [`f7ba86d1`](https://github.com/hyprwm/Hyprland/commit/f7ba86d1f335112ae0d13548947ddbd76b1477b6) | `` keybinds: add sendkeystate dispatcher (#9599) `` |
| [`f3db1b17`](https://github.com/hyprwm/Hyprland/commit/f3db1b172c6c61df7d5b8c960feccf3c19eb8e23) | `` decoration: bring back border_part_of_window ``  |