### PR TITLE
chore(flake/nix-gaming): `1491461d` -> `0fcdd01d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -743,11 +743,11 @@
         "nixpkgs": "nixpkgs_5"
       },
       "locked": {
-        "lastModified": 1742694749,
-        "narHash": "sha256-hH/Wofw+RKBbcTMuzCvvgPrnTkmEZd54bOsT0QR7EJM=",
+        "lastModified": 1742915889,
+        "narHash": "sha256-D8yfb9lOmTpXTZDYLTNY/+qgkhEtipJuguvBl62B+rg=",
         "owner": "fufexan",
         "repo": "nix-gaming",
-        "rev": "1491461d4a47f61264df62863ed163a00192b2f1",
+        "rev": "0fcdd01dc26ba63be2a1464b51410c5653810888",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                              | Message              |
| --------------------------------------------------------------------------------------------------- | -------------------- |
| [`0fcdd01d`](https://github.com/fufexan/nix-gaming/commit/0fcdd01dc26ba63be2a1464b51410c5653810888) | `` npins: upgrade `` |