### PR TITLE
chore(flake/home-manager): `869f2ec2` -> `8bef8b7a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -428,11 +428,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1742871411,
-        "narHash": "sha256-F3xBdOs5m0SE6Gq3jz+JxDOPvsLs22vbGfD05uF6xEc=",
+        "lastModified": 1742926508,
+        "narHash": "sha256-wgfY302ZaOsBCXb8aZDTG3Zt2kg3jDDaRrmtUw8nz00=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "869f2ec2add75ce2a70a6dbbf585b8399abec625",
+        "rev": "8bef8b7a0a95d347018f09b291e2fa0a77abd23f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                                            |
| ----------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------- |
| [`8bef8b7a`](https://github.com/nix-community/home-manager/commit/8bef8b7a0a95d347018f09b291e2fa0a77abd23f) | `` direnv: fix typo ``                                                             |
| [`529906d6`](https://github.com/nix-community/home-manager/commit/529906d6a2ef020130110f4f8214a4513aa7996f) | `` podman: fix typo ``                                                             |
| [`5abb21dc`](https://github.com/nix-community/home-manager/commit/5abb21dc10e4a9aaee5874c36e800a2609eceaef) | `` distrobox: fix typo ``                                                          |
| [`e3dded7a`](https://github.com/nix-community/home-manager/commit/e3dded7a85c68f8445a735d70920fc00a808621b) | `` fish: Fix manpage completion generation with paths containing spaces (#6703) `` |
| [`29806065`](https://github.com/nix-community/home-manager/commit/298060655681ec239491252da9b295d854ff51fe) | `` distrobox: replace hardcoded path with config package's path (#6701) ``         |