### PR TITLE
chore(flake/home-manager): `b9da58d5` -> `0ff53f6d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -428,11 +428,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1742944004,
-        "narHash": "sha256-l9xKPl0kGHzMdh8FO0AXbPjc67gqzgPpF1WpRUQ7qGE=",
+        "lastModified": 1742946951,
+        "narHash": "sha256-us5DS0XGVpZBMbYs3TSQYn61bswEPmLpBOYITD4/bUE=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "b9da58d50551ebd74226fb8487b248a5a36c988f",
+        "rev": "0ff53f6d336edb3ad81647dc931ad1c9c7f890ca",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                          |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
| [`0ff53f6d`](https://github.com/nix-community/home-manager/commit/0ff53f6d336edb3ad81647dc931ad1c9c7f890ca) | `` helix: add extraConfig option (#6575) ``      |
| [`2321c688`](https://github.com/nix-community/home-manager/commit/2321c6889bd473d384b687c7d536d88fec3b3256) | `` ripgrep-all: Add module (#5459) ``            |
| [`338b2eab`](https://github.com/nix-community/home-manager/commit/338b2eabdfde14a79755341ea472e2c55d1064c4) | `` waybar: integrate with tray.target (#6675) `` |