### PR TITLE
chore(flake/hyprland): `f7ba86d1` -> `3fc3521a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -536,11 +536,11 @@
         "xdph": "xdph"
       },
       "locked": {
-        "lastModified": 1742860753,
-        "narHash": "sha256-ItOsU1v6CZNe6spfKtJ+cpVr0S87jq69PYe3lpOLzjI=",
+        "lastModified": 1742952129,
+        "narHash": "sha256-gNprNetigjuKqlV0EaoEN/XHNhfGM1tRmYO88Ov77vg=",
         "owner": "hyprwm",
         "repo": "Hyprland",
-        "rev": "f7ba86d1f335112ae0d13548947ddbd76b1477b6",
+        "rev": "3fc3521a97eba0fa67da80f17ae7872b1073f08d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                                                |
| ------------------------------------------------------------------------------------------------ | ------------------------------------------------------ |
| [`3fc3521a`](https://github.com/hyprwm/Hyprland/commit/3fc3521a97eba0fa67da80f17ae7872b1073f08d) | `` pass: remove unusued timeline in texpass (#9734) `` |
| [`9a67354f`](https://github.com/hyprwm/Hyprland/commit/9a67354fa24b66dc35f2c702be085122d110c38a) | `` Groupbar: apply scaling factor to text (#9731) ``   |