### PR TITLE
chore(flake/better-control): `323971c0` -> `d3161298`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -124,11 +124,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1742893048,
-        "narHash": "sha256-koT50Cwja6H5ASBmDPc+7FTtWcZ8b0/EfrmhpqZikuY=",
+        "lastModified": 1742965397,
+        "narHash": "sha256-Us3BO1OXLXp+F3XnuENi2sqavTHReamVJ4Oz9LmLOvg=",
         "owner": "rishabh5321",
         "repo": "better-control-flake",
-        "rev": "323971c0bc4bdb8bdd951e6a0a25bae9754509f8",
+        "rev": "d316129806420bf1d20f0f0f8e8adaff35d3372e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                            | Message                                                                            |
| ----------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------- |
| [`d3161298`](https://github.com/Rishabh5321/better-control-flake/commit/d316129806420bf1d20f0f0f8e8adaff35d3372e) | `` Update SHA256 hash for better-control repository in flake.nix ``                |
| [`f1b03193`](https://github.com/Rishabh5321/better-control-flake/commit/f1b03193abcb876e9ee89e30278e9fb6aaa86b6f) | `` Update better-control version to 5.2 and revise GitHub revision in flake.nix `` |