### PR TITLE
chore(flake/better-control): `d3161298` -> `b6e7a26d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -124,11 +124,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1742965397,
-        "narHash": "sha256-Us3BO1OXLXp+F3XnuENi2sqavTHReamVJ4Oz9LmLOvg=",
+        "lastModified": 1742975766,
+        "narHash": "sha256-koT50Cwja6H5ASBmDPc+7FTtWcZ8b0/EfrmhpqZikuY=",
         "owner": "rishabh5321",
         "repo": "better-control-flake",
-        "rev": "d316129806420bf1d20f0f0f8e8adaff35d3372e",
+        "rev": "b6e7a26d89a6505ae854e78d46ae3aba8c03a294",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                            | Message                                  |
| ----------------------------------------------------------------------------------------------------------------- | ---------------------------------------- |
| [`161a44f5`](https://github.com/Rishabh5321/better-control-flake/commit/161a44f57d56a25be04bf9e45718da665217bc5c) | `` chore: auto lint and format ``        |
| [`3915179f`](https://github.com/Rishabh5321/better-control-flake/commit/3915179f58b9085d7c9d1b3068d231cee49e8864) | `` Falling back to last working build `` |