### PR TITLE
chore(flake/akuse-flake): `8f75288d` -> `de1a9c2e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -5,11 +5,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1742886930,
-        "narHash": "sha256-Dj2McYNnV9EExYQegqS0zTHUfRvq/9CbNisZIEjZb7M=",
+        "lastModified": 1742984670,
+        "narHash": "sha256-Y655QJcNsK8z04LHtig08vN+KZbrC8vz44vBbCcfGik=",
         "owner": "Rishabh5321",
         "repo": "akuse-flake",
-        "rev": "8f75288ddc4d943d013545e77ca2727fdcb6b5e8",
+        "rev": "de1a9c2ed8f5bf07dcd67fda15a5da7445f9507f",
         "type": "github"
       },
       "original": {
@@ -758,11 +758,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1742669843,
-        "narHash": "sha256-G5n+FOXLXcRx+3hCJ6Rt6ZQyF1zqQ0DL0sWAMn2Nk0w=",
+        "lastModified": 1742889210,
+        "narHash": "sha256-hw63HnwnqU3ZQfsMclLhMvOezpM7RSB0dMAtD5/sOiw=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "1e5b653dff12029333a6546c11e108ede13052eb",
+        "rev": "698214a32beb4f4c8e3942372c694f40848b360d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                   | Message                                          |
| -------------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
| [`de1a9c2e`](https://github.com/Rishabh5321/akuse-flake/commit/de1a9c2ed8f5bf07dcd67fda15a5da7445f9507f) | `` chore(flake/nixpkgs): 1e5b653d -> 698214a3 `` |