### PR TITLE
chore(flake/grayjay): `0dc8f5cb` -> `798b83c2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -408,11 +408,11 @@
         "nixpkgs": "nixpkgs_3"
       },
       "locked": {
-        "lastModified": 1742885894,
-        "narHash": "sha256-sTw/r0cfs1DZTIEXusOeZ5Ut4Pe6o6crDcYCWfWXX20=",
+        "lastModified": 1742984519,
+        "narHash": "sha256-Vk9PkC/d3kyikJbOW8skUCqGWmUkQ5SrAcGqapvWyGo=",
         "owner": "rishabh5321",
         "repo": "grayjay-flake",
-        "rev": "0dc8f5cb68b376879bd98551df0d479fc369e505",
+        "rev": "798b83c2aa452004d955ba0a39a495773570710a",
         "type": "github"
       },
       "original": {
@@ -821,11 +821,11 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1742669843,
-        "narHash": "sha256-G5n+FOXLXcRx+3hCJ6Rt6ZQyF1zqQ0DL0sWAMn2Nk0w=",
+        "lastModified": 1742889210,
+        "narHash": "sha256-hw63HnwnqU3ZQfsMclLhMvOezpM7RSB0dMAtD5/sOiw=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "1e5b653dff12029333a6546c11e108ede13052eb",
+        "rev": "698214a32beb4f4c8e3942372c694f40848b360d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                     | Message                                          |
| ---------------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
| [`798b83c2`](https://github.com/Rishabh5321/grayjay-flake/commit/798b83c2aa452004d955ba0a39a495773570710a) | `` chore(flake/nixpkgs): 1e5b653d -> 698214a3 `` |