### PR TITLE
chore(flake/better-control): `b6e7a26d` -> `e5d465c8`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -124,11 +124,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1742975766,
-        "narHash": "sha256-koT50Cwja6H5ASBmDPc+7FTtWcZ8b0/EfrmhpqZikuY=",
+        "lastModified": 1742987543,
+        "narHash": "sha256-zusuM+jQAKV4Np/k1X+5FLWADBe7aWfZa04ButC/gCU=",
         "owner": "rishabh5321",
         "repo": "better-control-flake",
-        "rev": "b6e7a26d89a6505ae854e78d46ae3aba8c03a294",
+        "rev": "e5d465c8dde639d833706e0faa76601fa9764d13",
         "type": "github"
       },
       "original": {
@@ -805,11 +805,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1742669843,
-        "narHash": "sha256-G5n+FOXLXcRx+3hCJ6Rt6ZQyF1zqQ0DL0sWAMn2Nk0w=",
+        "lastModified": 1742889210,
+        "narHash": "sha256-hw63HnwnqU3ZQfsMclLhMvOezpM7RSB0dMAtD5/sOiw=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "1e5b653dff12029333a6546c11e108ede13052eb",
+        "rev": "698214a32beb4f4c8e3942372c694f40848b360d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                            | Message                                                                                            |
| ----------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------- |
| [`e5d465c8`](https://github.com/Rishabh5321/better-control-flake/commit/e5d465c8dde639d833706e0faa76601fa9764d13) | `` chore(flake/nixpkgs): 1e5b653d -> 698214a3 ``                                                   |
| [`970aa924`](https://github.com/Rishabh5321/better-control-flake/commit/970aa924a1fa38cb2bd42f22740ad7fdc0af930c) | `` Refine installation process in flake.nix by removing unnecessary binaries after installation `` |
| [`fb2eadfa`](https://github.com/Rishabh5321/better-control-flake/commit/fb2eadfa44a0f7d975e0880940b9b442fd950355) | `` Update better-control version to 5.2 and change source fetching method in flake.nix ``          |