### PR TITLE
chore(flake/hyprland): `3fc3521a` -> `cec084c1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -536,11 +536,11 @@
         "xdph": "xdph"
       },
       "locked": {
-        "lastModified": 1742952129,
-        "narHash": "sha256-gNprNetigjuKqlV0EaoEN/XHNhfGM1tRmYO88Ov77vg=",
+        "lastModified": 1742989624,
+        "narHash": "sha256-qDyLM9A+dzG6ZRI4QjTL50+LPXQ2c9eLdzxcjgEgjzM=",
         "owner": "hyprwm",
         "repo": "Hyprland",
-        "rev": "3fc3521a97eba0fa67da80f17ae7872b1073f08d",
+        "rev": "cec084c178de979621cb520aa4f74a40c96567f2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                                                 |
| ------------------------------------------------------------------------------------------------ | ------------------------------------------------------- |
| [`cec084c1`](https://github.com/hyprwm/Hyprland/commit/cec084c178de979621cb520aa4f74a40c96567f2) | `` pass/rect: include clipBox in opaque calculations `` |
| [`c2ef8fcc`](https://github.com/hyprwm/Hyprland/commit/c2ef8fcc0014cfed4e465b184572e6acad9f750f) | `` groupbar: round boxes ``                             |