### PR TITLE
chore(flake/better-control): `e5d465c8` -> `c592c739`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -124,11 +124,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1742987543,
-        "narHash": "sha256-zusuM+jQAKV4Np/k1X+5FLWADBe7aWfZa04ButC/gCU=",
+        "lastModified": 1743000737,
+        "narHash": "sha256-hLpW1ULJFHLrqxYu5lFHwYeLuW0yyneqjfn+B0It++4=",
         "owner": "rishabh5321",
         "repo": "better-control-flake",
-        "rev": "e5d465c8dde639d833706e0faa76601fa9764d13",
+        "rev": "c592c739644f4a154a2b7d7aa397b308278f828d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                            | Message                                                                       |
| ----------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------- |
| [`b2cf5d2c`](https://github.com/Rishabh5321/better-control-flake/commit/b2cf5d2c05c0e8293e911d985dc073be76049afa) | `` Update SHA256 hash for better-control version 5.3 in flake.nix ``          |
| [`032f35ff`](https://github.com/Rishabh5321/better-control-flake/commit/032f35ff410231512257406947f9f0ad476b9a8b) | `` Update better-control version to 5.3 and change source URL in flake.nix `` |