### PR TITLE
chore(flake/hyprland): `cec084c1` -> `9e9fda67`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -536,11 +536,11 @@
         "xdph": "xdph"
       },
       "locked": {
-        "lastModified": 1742989624,
-        "narHash": "sha256-qDyLM9A+dzG6ZRI4QjTL50+LPXQ2c9eLdzxcjgEgjzM=",
+        "lastModified": 1743001879,
+        "narHash": "sha256-8+MbNh31nQ9NtcakI3ssf6MSSEVeclq9e3PszIHEu0I=",
         "owner": "hyprwm",
         "repo": "Hyprland",
-        "rev": "cec084c178de979621cb520aa4f74a40c96567f2",
+        "rev": "9e9fda6711230d8292d20da3fd8f803c7ca24079",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                                              |
| ------------------------------------------------------------------------------------------------ | ---------------------------------------------------- |
| [`9e9fda67`](https://github.com/hyprwm/Hyprland/commit/9e9fda6711230d8292d20da3fd8f803c7ca24079) | `` surfacestate: track and apply updated state ``    |
| [`1c2b9a9c`](https://github.com/hyprwm/Hyprland/commit/1c2b9a9ce3a58c76632834774a4716af1de45fe6) | `` opengl: don't attempt to compile cm on gles3.0 `` |