### PR TITLE
chore(flake/hyprland): `9e9fda67` -> `9ea76428`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -536,11 +536,11 @@
         "xdph": "xdph"
       },
       "locked": {
-        "lastModified": 1743001879,
-        "narHash": "sha256-8+MbNh31nQ9NtcakI3ssf6MSSEVeclq9e3PszIHEu0I=",
+        "lastModified": 1743009764,
+        "narHash": "sha256-ySdBBDjPGTzvca/0Cnuz3+EswXn33thVqYksMR+93M8=",
         "owner": "hyprwm",
         "repo": "Hyprland",
-        "rev": "9e9fda6711230d8292d20da3fd8f803c7ca24079",
+        "rev": "9ea76428b68fad5a68e9153bcb246547ac2e5d6c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                                           |
| ------------------------------------------------------------------------------------------------ | ------------------------------------------------- |
| [`9ea76428`](https://github.com/hyprwm/Hyprland/commit/9ea76428b68fad5a68e9153bcb246547ac2e5d6c) | `` internal: fix minor ubsan errors (#9743) ``    |
| [`0cd04bd6`](https://github.com/hyprwm/Hyprland/commit/0cd04bd666665bfdeafc0f55a93e532cd8978827) | `` surfacestate: track and apply updated state `` |