### PR TITLE
chore(flake/nixpkgs-stable): `f0946fa5` -> `d02d88f8`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -789,11 +789,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1742751704,
-        "narHash": "sha256-rBfc+H1dDBUQ2mgVITMGBPI1PGuCznf9rcWX/XIULyE=",
+        "lastModified": 1742937945,
+        "narHash": "sha256-lWc+79eZRyvHp/SqMhHTMzZVhpxkRvthsP1Qx6UCq0E=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "f0946fa5f1fb876a9dc2e1850d9d3a4e3f914092",
+        "rev": "d02d88f8de5b882ccdde0465d8fa2db3aa1169f7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                              |
| ---------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------- |
| [`3bb45b04`](https://github.com/NixOS/nixpkgs/commit/3bb45b041e7147e2fd2daf689e26a1f970a55d65) | `` forgejo: 10.0.2 -> 10.0.3 ``                                                                      |
| [`17ef9241`](https://github.com/NixOS/nixpkgs/commit/17ef924123e4b92926d73198107a12d3f190481c) | `` Discord updates ``                                                                                |
| [`a0e6c381`](https://github.com/NixOS/nixpkgs/commit/a0e6c381de0e24a2898a6f5f45912a614ead39f4) | `` linux/hardened/patches/6.6: v6.6.80-hardened1 -> v6.6.83-hardened1 ``                             |
| [`0bc58a23`](https://github.com/NixOS/nixpkgs/commit/0bc58a2313f46630a8802bfba45e9b439287d346) | `` linux/hardened/patches/6.13: v6.13.5-hardened1 -> v6.13.7-hardened1 ``                            |
| [`544014f9`](https://github.com/NixOS/nixpkgs/commit/544014f9ff91d63d868c91e32ce7882ca29bad08) | `` linux/hardened/patches/6.12: v6.12.17-hardened1 -> v6.12.19-hardened1 ``                          |
| [`f301bf33`](https://github.com/NixOS/nixpkgs/commit/f301bf33720f574f146ff8a769a4f76f3053eb84) | `` linux/hardened/patches/6.1: v6.1.129-hardened1 -> v6.1.131-hardened1 ``                           |
| [`6ce72e17`](https://github.com/NixOS/nixpkgs/commit/6ce72e1769b706bb95899a73fa23df9610ffeb08) | `` linux/hardened/patches/5.4: v5.4.290-hardened1 -> v5.4.291-hardened1 ``                           |
| [`fbe90c24`](https://github.com/NixOS/nixpkgs/commit/fbe90c247f2bd98ef60faf964faf9d4deb9d9e02) | `` linux/hardened/patches/5.15: v5.15.178-hardened1 -> v5.15.179-hardened1 ``                        |
| [`5e3e2008`](https://github.com/NixOS/nixpkgs/commit/5e3e2008249ee85453df2872038ec60ec8b157bf) | `` linux/hardened/patches/5.10: v5.10.234-hardened1 -> v5.10.235-hardened1 ``                        |
| [`1fd16802`](https://github.com/NixOS/nixpkgs/commit/1fd16802c8e0098195558932192714a3820f0b78) | `` linux/hardened/patches/6.13: init at v6.13.5-hardened1 ``                                         |
| [`ed31760c`](https://github.com/NixOS/nixpkgs/commit/ed31760c68a3abb77972b1da406f095ddd82ceac) | `` linux/hardened/patches/6.12: v6.12.12-hardened1 -> v6.12.17-hardened1 ``                          |
| [`54ac08cf`](https://github.com/NixOS/nixpkgs/commit/54ac08cfa0899e4d4d25b48ef43ce5d5e04329fa) | `` linux/hardened/patches/6.6: v6.6.75-hardened1 -> v6.6.80-hardened1 ``                             |
| [`7a7d8910`](https://github.com/NixOS/nixpkgs/commit/7a7d891086c34fadbbe87e4e768271896998b49e) | `` linux/hardened/patches/6.1: v6.1.128-hardened1 -> v6.1.129-hardened1 ``                           |
| [`1d328297`](https://github.com/NixOS/nixpkgs/commit/1d328297ab4a84937df8d465d0b90273b993c6fb) | `` linux/hardened/patches/6.6: v6.6.73-hardened1 -> v6.6.75-hardened1 ``                             |
| [`9d3518b6`](https://github.com/NixOS/nixpkgs/commit/9d3518b6bf6bae00e068858e7db4c27660442aea) | `` linux/hardened/patches/6.12: v6.12.10-hardened1 -> v6.12.12-hardened1 ``                          |
| [`be147cb4`](https://github.com/NixOS/nixpkgs/commit/be147cb44504802f9b826809b0ae8a9b8bb15af1) | `` linux/hardened/patches/6.1: v6.1.126-hardened1 -> v6.1.128-hardened1 ``                           |
| [`366f2291`](https://github.com/NixOS/nixpkgs/commit/366f2291beb7a80861186aef3ca8ad5ed8bdd73a) | `` linux/hardened/patches/5.4: v5.4.289-hardened1 -> v5.4.290-hardened1 ``                           |
| [`433deff3`](https://github.com/NixOS/nixpkgs/commit/433deff315848a3afac742d3b40c9f7368386eff) | `` linux/hardened/patches/5.15: v5.15.176-hardened1 -> v5.15.178-hardened1 ``                        |
| [`eb41a833`](https://github.com/NixOS/nixpkgs/commit/eb41a833bcc590b0ee19f2707e87a9f0ecf64384) | `` linux/hardened/patches/5.10: v5.10.233-hardened1 -> v5.10.234-hardened1 ``                        |
| [`bc0ada7b`](https://github.com/NixOS/nixpkgs/commit/bc0ada7b00259da3b75d18839df876ca2ec88973) | `` ddnet-server: set correct mainProgram ``                                                          |
| [`fd773343`](https://github.com/NixOS/nixpkgs/commit/fd7733431852e867f6c69909d79a8786497ffaf9) | `` ddnet-server: fix Darwin build ``                                                                 |
| [`ce8afc3d`](https://github.com/NixOS/nixpkgs/commit/ce8afc3de6a4bd4a0f6944ac11c68bc488804e63) | `` inv-sig-helper: 0-unstable-2025-02-26 -> 0-unstable-2025-03-24 ``                                 |
| [`e1fb884b`](https://github.com/NixOS/nixpkgs/commit/e1fb884b31592cd9ccb7c82addfcc062289a9687) | `` phpPackages.castor: add `versionCheckHook` ``                                                     |
| [`2fe36659`](https://github.com/NixOS/nixpkgs/commit/2fe3665994ff7892ad549e1fa2ce61e37a9216ea) | `` snipe-it: reformat, cleanup ``                                                                    |
| [`c1ca9be2`](https://github.com/NixOS/nixpkgs/commit/c1ca9be2ea0159d55ac61eae972ae20cf4fb42f3) | `` snipe-it: use `php84`, remove custom override ``                                                  |
| [`9c4daa25`](https://github.com/NixOS/nixpkgs/commit/9c4daa258d0acdf58ce6d7efa7cf22ef893b7b48) | `` snipe-it: 7.1.16 -> 8.0.4 ``                                                                      |
| [`ee183768`](https://github.com/NixOS/nixpkgs/commit/ee1837682d69ccc68ac268d715b391765e04c128) | `` snipe-it: 7.1.15 -> 7.1.16 ``                                                                     |
| [`f656c715`](https://github.com/NixOS/nixpkgs/commit/f656c7151e7301d4189d5d583744323d05fc4401) | `` phpactor: add `versionCheckHook` ``                                                               |
| [`4ceeea63`](https://github.com/NixOS/nixpkgs/commit/4ceeea63b8bb28fcef557a7923a483ca3c1d3dbe) | `` phpPackages.php-codesniffer: 3.11.3 -> 3.12.0 ``                                                  |
| [`69d5a1eb`](https://github.com/NixOS/nixpkgs/commit/69d5a1eb93bd01cb79d641af584d76ac578443f6) | `` phpPackages.php-codesniffer: 3.11.2 -> 3.11.3 ``                                                  |
| [`77d046e0`](https://github.com/NixOS/nixpkgs/commit/77d046e079e498d6298829bfc29af1683bf15650) | `` composer-require-checker: add `versionCheckHook` ``                                               |
| [`6059c181`](https://github.com/NixOS/nixpkgs/commit/6059c18138115ec897afb0be1c18a630d8eb4e18) | `` phpPackages.castor: 0.22.1 -> 0.23.0 ``                                                           |
| [`331a5e80`](https://github.com/NixOS/nixpkgs/commit/331a5e80a77b3b83d927bb89d64030a948815c5e) | `` n98-magerun2: 7.5.0 -> 8.0.0 ``                                                                   |
| [`b247b03f`](https://github.com/NixOS/nixpkgs/commit/b247b03fd0d0df12d6441e71d587703e694b070e) | `` phpactor: 2024.11.28.1 -> 2025.02.21.0 ``                                                         |
| [`e2034b56`](https://github.com/NixOS/nixpkgs/commit/e2034b56fedff658383cd9e542dd8e9ec1a49b56) | `` eartag: 0.6.4 -> 0.6.5 ``                                                                         |
| [`3d6102ae`](https://github.com/NixOS/nixpkgs/commit/3d6102ae4e32972715bd8bf0f2d79a36574d17c5) | `` prometheus-knot-exporter: 3.4.4 -> 3.4.5 ``                                                       |
| [`1cc45af2`](https://github.com/NixOS/nixpkgs/commit/1cc45af24535c4523571761a24399c9696266167) | `` python312Packages.libknot: 3.4.4 -> 3.4.5 ``                                                      |
| [`5d385e6c`](https://github.com/NixOS/nixpkgs/commit/5d385e6c3a8b82c4510ac832293c0c17c710f295) | `` ghostty: 1.1.2 -> 1.1.3 ``                                                                        |
| [`2c95cb23`](https://github.com/NixOS/nixpkgs/commit/2c95cb23559ba8a86fe8de532069af924bcfc719) | `` phpPackages.psysh: fix `versionCheckHook` syntax ``                                               |
| [`d4e87ab5`](https://github.com/NixOS/nixpkgs/commit/d4e87ab57fd1895c590c2f244a8bc44e8650a12a) | `` phpPackages.php-cs-fixer: 3.70.1 -> 3.73.1 ``                                                     |
| [`a78fb3dd`](https://github.com/NixOS/nixpkgs/commit/a78fb3ddca45060b539720924c9d4fd3185a2313) | `` phpunit: add `versionCheckHook` ``                                                                |
| [`869818e6`](https://github.com/NixOS/nixpkgs/commit/869818e6664e5b07649615f629a5543e372c7a7a) | `` phel: fix `versionCheckHook` syntax ``                                                            |
| [`7ee1e9e9`](https://github.com/NixOS/nixpkgs/commit/7ee1e9e9f30f2d0cd6076d90ca080db6a75d30a3) | `` phpPackages.box: fix `versionCheckHook` syntax ``                                                 |
| [`902367f0`](https://github.com/NixOS/nixpkgs/commit/902367f038bf29bece7b01074cce4a50b67d9230) | `` phpPackages.grumphp: add `versionCheckHook` ``                                                    |
| [`9213f38b`](https://github.com/NixOS/nixpkgs/commit/9213f38b5c5e7bdddb55fb8adbec3ab89f854ec7) | `` phpPackages.phpstan: add `versionCheckHook` ``                                                    |
| [`aacdcb01`](https://github.com/NixOS/nixpkgs/commit/aacdcb01b561d7f0be606c5cc9378884d5f8687e) | `` phpPackages.psalm: fix `versionCheckHook` syntax ``                                               |
| [`98a95032`](https://github.com/NixOS/nixpkgs/commit/98a950326c21906a81533142a55a382d0ed322d6) | `` phpPackages.composer: add `versionCheckHook` ``                                                   |
| [`fc96533a`](https://github.com/NixOS/nixpkgs/commit/fc96533ac9473746267bd52df66ece27cdc3d677) | `` typst: fix `versionCheckHook` syntax ``                                                           |
| [`a7b42a9b`](https://github.com/NixOS/nixpkgs/commit/a7b42a9b3f82020da774fbffbbe5634bde1cdbaf) | `` cartridges: 2.11.1 -> 2.12.1 ``                                                                   |
| [`ae8cd8ff`](https://github.com/NixOS/nixpkgs/commit/ae8cd8ffa02cd18c4e08c0416ce181e648508b78) | `` sydbox: 3.32.3 -> 3.32.6 ``                                                                       |
| [`f88a886f`](https://github.com/NixOS/nixpkgs/commit/f88a886f3d3550e1312ea29d3d116cec46e4cee2) | `` ungoogled-chromium: 134.0.6998.117-1 -> 134.0.6998.165-1 ``                                       |
| [`84cdb8df`](https://github.com/NixOS/nixpkgs/commit/84cdb8df3cd1f498e64ed4d33cc0a6f4d61a8ed9) | `` google-chrome: 134.0.6998.88 -> 134.0.6998.165 ``                                                 |
| [`bbf49dea`](https://github.com/NixOS/nixpkgs/commit/bbf49deaef9bd9decdf9c87c2e822d0e72cbf350) | `` google-chrome: 134.0.6998.35 -> 134.0.6998.88 ``                                                  |
| [`dbc4e3a3`](https://github.com/NixOS/nixpkgs/commit/dbc4e3a308eae36cf6eeeb1458c96be77bb11612) | `` google-chrome: add libuuid to update script path ``                                               |
| [`abade403`](https://github.com/NixOS/nixpkgs/commit/abade403b686e926df9759b47385410b5857d35d) | `` libblake3: fix build on x86_64-darwin ``                                                          |
| [`1221774c`](https://github.com/NixOS/nixpkgs/commit/1221774c88bd9c52cedc34e5030e691bc2d40c83) | `` tail-tray: 0.2.16 -> 0.2.18 ``                                                                    |
| [`dd9f7c49`](https://github.com/NixOS/nixpkgs/commit/dd9f7c492b55220696e658e2c30af7b62070927a) | `` oo7: 0.4.0 -> 0.4.3 ``                                                                            |
| [`b4fa33f3`](https://github.com/NixOS/nixpkgs/commit/b4fa33f35cd5a8e7a930f96bb45742e2aa470159) | `` phpunit: 12.0.7 -> 12.0.10 ``                                                                     |
| [`88e5b5b9`](https://github.com/NixOS/nixpkgs/commit/88e5b5b921bd519acd3caaa149c154c48eec07f9) | `` build(deps): bump actions/upload-artifact from 4.6.1 to 4.6.2 ``                                  |
| [`d1b6af4b`](https://github.com/NixOS/nixpkgs/commit/d1b6af4b4514c6ab2a3efd4bd536a4eb368b76b3) | `` libblake3: 1.5.5 -> 1.7.0 ``                                                                      |
| [`b93d31e6`](https://github.com/NixOS/nixpkgs/commit/b93d31e6c24435cfc052d85c51adbe27ca4ecf21) | `` libblake3: add silvanshade to maintainers ``                                                      |
| [`6e5965d2`](https://github.com/NixOS/nixpkgs/commit/6e5965d23482af54cbf1ba0ceef42a55e5da7bfa) | `` maintainers: add silvanshade ``                                                                   |
| [`b03e18ed`](https://github.com/NixOS/nixpkgs/commit/b03e18ed5073917303d3bccdb56ed9c6db5477b3) | `` pixelfed: fix passthru test inheritance ``                                                        |
| [`29ede033`](https://github.com/NixOS/nixpkgs/commit/29ede0337842c7552a582ad1343e3a5183f8b7da) | `` pixelfed: 0.12.4 -> 0.12.5 ``                                                                     |
| [`bdb5b17b`](https://github.com/NixOS/nixpkgs/commit/bdb5b17b0604278e180edac1f87607fd87ebc526) | `` tbb_2022_0: init at 2022.0.0 ``                                                                   |
| [`35760d5f`](https://github.com/NixOS/nixpkgs/commit/35760d5ff21d7fe150a70fcf12198368a8c4d26c) | `` nixos/pixelfed: bump php version ``                                                               |
| [`f0373715`](https://github.com/NixOS/nixpkgs/commit/f03737158aa69f411bf0373f11df77cbc167d243) | `` pixelfed: 0.12.3 -> 0.12.4 ``                                                                     |
| [`b5a90431`](https://github.com/NixOS/nixpkgs/commit/b5a904311e4957e860491176057a364d08262757) | `` phpPackages.grumphp: 2.11.0 -> 2.12.0 ``                                                          |
| [`f3284cf7`](https://github.com/NixOS/nixpkgs/commit/f3284cf74ebc9eb7dc2bd72931c3acb21eeb562b) | `` linux_6_14: init at 6.14 ``                                                                       |
| [`7dab59ba`](https://github.com/NixOS/nixpkgs/commit/7dab59baa1053672a63f1e492ab6312fcca9b765) | `` linux_6_11{,_hardened}: drop ``                                                                   |
| [`92a39d41`](https://github.com/NixOS/nixpkgs/commit/92a39d41b13a9e94ec64fc89c991618015c133b5) | `` linux_latest-libre: 19729 -> 19746 ``                                                             |
| [`c6e1c637`](https://github.com/NixOS/nixpkgs/commit/c6e1c637de9714886303570ee68784c536ad26dc) | `` linux-rt_5_4: 5.4.288-rt94 -> 5.4.290-rt96 ``                                                     |
| [`ebd8e3b7`](https://github.com/NixOS/nixpkgs/commit/ebd8e3b7eaaf8ee87fbd7811c1fa8e3297f40e71) | `` linux-rt_5_10: 5.10.233-rt125 -> 5.10.234-rt127 ``                                                |
| [`bca9e9b9`](https://github.com/NixOS/nixpkgs/commit/bca9e9b9bd0ad2cfefbeee1d374fd5cc0876bd1c) | `` linux_6_6: 6.6.83 -> 6.6.84 ``                                                                    |
| [`c18f2e56`](https://github.com/NixOS/nixpkgs/commit/c18f2e56af38a8be21f57ad3340e7fb500b5c9a7) | `` linux_6_12: 6.12.19 -> 6.12.20 ``                                                                 |
| [`59ff06e0`](https://github.com/NixOS/nixpkgs/commit/59ff06e098d174803443bc45f837f8cffcde6158) | `` linux_6_13: 6.13.7 -> 6.13.8 ``                                                                   |
| [`8a1dcb8b`](https://github.com/NixOS/nixpkgs/commit/8a1dcb8b00f13af09ce07eb293b8aa693a0be9d9) | `` electron-source: try to avoid log spam ``                                                         |
| [`409e33ab`](https://github.com/NixOS/nixpkgs/commit/409e33ab7303c59f4ef3c7f53150ade65a1056d6) | `` electron: node_module_version should be int ``                                                    |
| [`f3ae0659`](https://github.com/NixOS/nixpkgs/commit/f3ae06598d00e03576c5d74f76840810a6eb9eaf) | `` chromium: move gnChromium to nativeBuildInputs, ``                                                |
| [`9e97b2b0`](https://github.com/NixOS/nixpkgs/commit/9e97b2b0652f86ab42a8ddfb86612a1eb00413b0) | `` electron: 35+ header generation needs ELECTRON_OUT_DIR ``                                         |
| [`e6a858cc`](https://github.com/NixOS/nixpkgs/commit/e6a858ccf44797be910cce2fb026c316a83ae1b5) | `` electron: remove duplicate use_qt flag ``                                                         |
| [`7997fd90`](https://github.com/NixOS/nixpkgs/commit/7997fd90e2d692e445bf695c063e9790a7247cd6) | `` electron-source.electron_35: init at 35.0.3 ``                                                    |
| [`af3b9303`](https://github.com/NixOS/nixpkgs/commit/af3b93032a6d786a81a31ad1fe6a530caf8cc7e4) | `` electron-chromedriver_35: init at 35.0.3 ``                                                       |
| [`63c9da60`](https://github.com/NixOS/nixpkgs/commit/63c9da60e17a4aaff7cb55200085644f7c1b5677) | `` electron_35-bin: init at 35.0.3 ``                                                                |
| [`f3d4feda`](https://github.com/NixOS/nixpkgs/commit/f3d4feda5a8a1d9efffa209d2f454fd451cebbac) | `` build(deps): bump actions/create-github-app-token from 1.11.6 to 1.11.7 ``                        |
| [`6c12376b`](https://github.com/NixOS/nixpkgs/commit/6c12376b22b5d2edfe37ead67b910dadc2975a85) | `` python-packages: sort with keep-sorted ``                                                         |
| [`88c4da24`](https://github.com/NixOS/nixpkgs/commit/88c4da247629a2cc29974e196dda22fd831f649c) | `` python-packages: configure keep-sorted ``                                                         |
| [`3fac6030`](https://github.com/NixOS/nixpkgs/commit/3fac603051eccb062afc0583308d1334f0caae9f) | `` ci: add keep-sorted workflow ``                                                                   |
| [`93b553da`](https://github.com/NixOS/nixpkgs/commit/93b553daad74f9fd7a6b8d75aaf284bf3399786b) | `` python-packages: format ``                                                                        |
| [`c8c06a2c`](https://github.com/NixOS/nixpkgs/commit/c8c06a2c149ee9b0baf232f4a73542609d04f65c) | `` duplicity: disable test_black due to Black version conflict ``                                    |
| [`b75bf237`](https://github.com/NixOS/nixpkgs/commit/b75bf237971c2e9727dfc84fe3fa510b9d581b9e) | `` frida-tools: fix missing websockets dependency ``                                                 |
| [`67731aa5`](https://github.com/NixOS/nixpkgs/commit/67731aa5dfb869fe201824e4353ab06d1654f469) | `` pythonPackages.frida-python: 16.0.19 -> 16.5.7 ``                                                 |
| [`583bcb9a`](https://github.com/NixOS/nixpkgs/commit/583bcb9af2ed4adff2a041510d9c9f00d304014f) | `` cargo-tauri: 2.3.1 -> 2.4.0 ``                                                                    |
| [`7ff29b3e`](https://github.com/NixOS/nixpkgs/commit/7ff29b3edf279e34703025e7feec174e5470128a) | `` prowlarr: 1.30.2.4939 -> 1.31.2.4975 ``                                                           |
| [`dddff755`](https://github.com/NixOS/nixpkgs/commit/dddff755204a49ca25db65e45f6fbdf53075cb0a) | `` nextcloud31: 31.0.1 -> 31.0.2 ``                                                                  |
| [`1165f75b`](https://github.com/NixOS/nixpkgs/commit/1165f75b64753c0523189780e504e60bdbe63895) | `` nextcloud31: 31.0.0 -> 31.0.1 ``                                                                  |
| [`4ec5bdf7`](https://github.com/NixOS/nixpkgs/commit/4ec5bdf713db3b3611eaf4178e70c9c60bdbac18) | `` nextcloud31: init at 31.0.0 ``                                                                    |
| [`6d41f30c`](https://github.com/NixOS/nixpkgs/commit/6d41f30cd4688cd40df8f5c6e6fafe588a3d9a07) | `` vencord: 1.11.6 -> 1.11.7 ``                                                                      |
| [`1ca55ea2`](https://github.com/NixOS/nixpkgs/commit/1ca55ea2eea4c47f9617be8acffc50e98eed445a) | `` sdl3: 3.2.6 -> 3.2.8 ``                                                                           |
| [`92bceadb`](https://github.com/NixOS/nixpkgs/commit/92bceadbe1be22e00fd7f8ecffd19eec0d18bcb0) | `` terraspace: Update ruby gems to fix vulnerability ``                                              |
| [`92f0c8a7`](https://github.com/NixOS/nixpkgs/commit/92f0c8a79ba43bd8fac409a30071d76d542976e6) | `` mailcatcher: 0.9.0 -> 0.10.0 ``                                                                   |
| [`0b6f0a1b`](https://github.com/NixOS/nixpkgs/commit/0b6f0a1b012bb07c8a737769bf869ad5d6aaafdd) | `` pyfa: 2.61.3 -> 2.62.1 ``                                                                         |
| [`df767808`](https://github.com/NixOS/nixpkgs/commit/df767808cce5237b15c4cb70b58ad4b1fe7cec14) | `` ceph: sync with master ``                                                                         |
| [`9bc80670`](https://github.com/NixOS/nixpkgs/commit/9bc8067086b51bd9a0c73cf8527271678c6d24ee) | `` ceph: 19.2.0 -> 19.2.1 ``                                                                         |
| [`42879adf`](https://github.com/NixOS/nixpkgs/commit/42879adf2c0e54d5efa1a08f3c23cc02b959fb20) | `` ceph: disable more pyopenssl tests ``                                                             |
| [`b54de544`](https://github.com/NixOS/nixpkgs/commit/b54de544e60a2b1bf09261fcc2aa6cbae0c0611c) | `` ceph: hack-fix build ``                                                                           |
| [`6af3ee3b`](https://github.com/NixOS/nixpkgs/commit/6af3ee3b500b650e03b12e575ed09e223f27969a) | `` ceph: pin boost186 ``                                                                             |
| [`300a86f4`](https://github.com/NixOS/nixpkgs/commit/300a86f4440e30ce08fe76c880e32d12e20d9030) | `` ceph: add patches for Boost 1.86 ``                                                               |
| [`7eb146d0`](https://github.com/NixOS/nixpkgs/commit/7eb146d08c65cb11206c4ecff29f16ee89d6478f) | `` ceph: add upstream patch for GCC 14 ``                                                            |
| [`5b488749`](https://github.com/NixOS/nixpkgs/commit/5b488749b854e5bb6ed12fbc47dbe16504a16508) | `` ceph: Add benaryorg as co-maintainer ``                                                           |
| [`8145c838`](https://github.com/NixOS/nixpkgs/commit/8145c838df88b54c622c7d63feb7038948da8391) | `` phpPackages.phpstan: 2.1.8 -> 2.1.10 ``                                                           |
| [`5a176115`](https://github.com/NixOS/nixpkgs/commit/5a1761150222c82b4198cafdbf7001aaf093f4ff) | `` spotifyd: fix build on darwin ``                                                                  |
| [`48258f99`](https://github.com/NixOS/nixpkgs/commit/48258f999796240de5567be7e74e7400ba13f9b8) | `` skim: 0.16.0 -> 0.16.1 ``                                                                         |
| [`b48eaa06`](https://github.com/NixOS/nixpkgs/commit/b48eaa06ae39f5ae42d7ed5fff9225bea774ab5e) | `` bign-handheld-thumbnailer: 1.1.1 -> 1.1.2 ``                                                      |
| [`81d44c10`](https://github.com/NixOS/nixpkgs/commit/81d44c100a46c2bca16ee79c57c9aad9fd410eee) | `` dotnetCorePackages.dotnet_10.sdk: fix fallback packages evaluation ``                             |
| [`604e688d`](https://github.com/NixOS/nixpkgs/commit/604e688dc45eef535b0a6f8c94de366d9652afff) | `` playonlinux: add python dependency pyasyncore ``                                                  |
| [`979e1fdc`](https://github.com/NixOS/nixpkgs/commit/979e1fdca2031c60272f69459ddbb0d771ec959a) | `` valkey: remove rucadi from maintainers ``                                                         |
| [`96984306`](https://github.com/NixOS/nixpkgs/commit/969843061be42d5c4249a17d3c624a1686850245) | `` zabbix50: 5.0.41 -> 5.0.46 ``                                                                     |
| [`d44d65ff`](https://github.com/NixOS/nixpkgs/commit/d44d65ff245a4ba52bb239a1eef9cc67e6152566) | `` phpPackages.psalm: 5.26.1 -> 6.8.6 ``                                                             |
| [`86b1b6eb`](https://github.com/NixOS/nixpkgs/commit/86b1b6ebab8b9e2baceee4a2e51c416a139835e2) | `` phpPackages.phpstan: 2.1.1 -> 2.1.8 ``                                                            |
| [`dcf92d18`](https://github.com/NixOS/nixpkgs/commit/dcf92d186cb9131d689d377bafa45912c994499c) | `` phpPackages.phing: 3.0.0 -> 3.0.1 ``                                                              |
| [`f541d222`](https://github.com/NixOS/nixpkgs/commit/f541d2225a7361212858400d318b92fe709e0fe8) | `` phel: 0.13.0 -> 0.16.1 ``                                                                         |
| [`2e6e4dbf`](https://github.com/NixOS/nixpkgs/commit/2e6e4dbf3f483cf01f26bfcc6e22795468bd54f1) | `` paratest: unbreak ``                                                                              |
| [`4c27ba17`](https://github.com/NixOS/nixpkgs/commit/4c27ba17aa6a6dad58938c7da337a9b0a84fc504) | `` signal-desktop(aarch64-linux): 7.36.0 -> 7.46.0-1 from COPR (#384032) ``                          |
| [`974f5821`](https://github.com/NixOS/nixpkgs/commit/974f5821645b33fb137dc7cf743be788cb2b1211) | `` signal-desktop: remove absolute path in desktop entry ``                                          |
| [`38c0d5b0`](https://github.com/NixOS/nixpkgs/commit/38c0d5b0e2f1419c1c155b2d34f3fafecb7502ec) | `` microsoft-edge: 134.0.3124.51 -> 134.0.3124.68 ``                                                 |
| [`f1cf0f32`](https://github.com/NixOS/nixpkgs/commit/f1cf0f321177944eda90d4839426daa4d18269fd) | `` xmedcon: 0.25.0 -> 0.25.1 ``                                                                      |
| [`06a1c6e4`](https://github.com/NixOS/nixpkgs/commit/06a1c6e46a4ee462a4967b90c3dba8c907c470ae) | `` xmedcon: 0.24.1 -> 0.25.0 ``                                                                      |
| [`034fd232`](https://github.com/NixOS/nixpkgs/commit/034fd2322791257a2e8ed3bab9006b042fb44a18) | `` dotnetCorePackages.dotnet_10.vmr: 10.0.0-preview.1 -> 10.0.0-preview.2 ``                         |
| [`921bde71`](https://github.com/NixOS/nixpkgs/commit/921bde71ac48e45e95caff8568094b3ddbca3fef) | `` dotnetCorePackages.sdk_10_0-bin: 10.0.100-preview.1.25120.13 -> 10.0.100-preview.2.25164.34 ``    |
| [`65fb24d6`](https://github.com/NixOS/nixpkgs/commit/65fb24d68ee68f08d348b8270e2c77f860ab482c) | `` dotnet: clear $HOME when calling --info or --version ``                                           |
| [`5fe09b44`](https://github.com/NixOS/nixpkgs/commit/5fe09b442ddf92ebf81c252c934c1d8f3c8ece44) | `` dotnet-sdk_8: fix AOT on darwin ``                                                                |
| [`6bcf98d2`](https://github.com/NixOS/nixpkgs/commit/6bcf98d2b38c03db6c61a2673650754f9be87eef) | `` dotnetCorePackages.combinePackages: propagate darwin sandbox profile ``                           |
| [`2b678b49`](https://github.com/NixOS/nixpkgs/commit/2b678b496ac76319af8ab53bad2ede2f64de11b4) | `` dotnet: disable prerelease updates for dotnet 9 ``                                                |
| [`a260d14c`](https://github.com/NixOS/nixpkgs/commit/a260d14c7f06f67567d0a4a935218de0b94a46ab) | `` dotnet: improve jq error handling in update scripts ``                                            |
| [`910d44cf`](https://github.com/NixOS/nixpkgs/commit/910d44cf61afb661de18b1852db2d9f2c90a9827) | `` jetbrains: 2024.3.4 -> 2024.3.6 ``                                                                |
| [`abb35e3d`](https://github.com/NixOS/nixpkgs/commit/abb35e3d7ff2d8270906bb848db93f263d286115) | `` Fix rust-rover build ``                                                                           |
| [`892ffa0e`](https://github.com/NixOS/nixpkgs/commit/892ffa0eab2e40081f7fe73269598672b8471cb7) | `` jetbrains: 2024.3 -> 2024.3.6 ``                                                                  |
| [`aa699040`](https://github.com/NixOS/nixpkgs/commit/aa699040d84ba99ad1afd07f55626bd1b04aac62) | `` jetbrains.plugins: update ``                                                                      |
| [`a6c7ea1c`](https://github.com/NixOS/nixpkgs/commit/a6c7ea1cf23ec738bd455be9eaa163e947a04334) | `` elasticsearch: 7.17.16 -> 7.17.27 ``                                                              |
| [`42bfec7a`](https://github.com/NixOS/nixpkgs/commit/42bfec7a735d563b000669ff637c1acb8b040de5) | `` elasticsearchPlugins.analysis-smartcn: inline reference to lib since there is only one in meta `` |
| [`a2b59919`](https://github.com/NixOS/nixpkgs/commit/a2b59919750951565a440be4294f036ee47023c7) | `` elasticsearchPlugins.analysis-smartcn: init at 7.17.16 ``                                         |
| [`58f89480`](https://github.com/NixOS/nixpkgs/commit/58f8948058d618195766c753bd753635b1e1ab49) | `` gotosocial: 0.18.2 -> 0.18.3 ``                                                                   |
| [`c880b762`](https://github.com/NixOS/nixpkgs/commit/c880b762a6e992332815b8ffb4626d13c1761b45) | `` knot-dns: 3.4.4 -> 3.4.5 ``                                                                       |
| [`5e382b1e`](https://github.com/NixOS/nixpkgs/commit/5e382b1ea13ddfa6c322195cdfc8545dce723cb4) | `` xcpretty: 0.3.0 -> 0.4.0 ``                                                                       |
| [`1302003f`](https://github.com/NixOS/nixpkgs/commit/1302003f8d684a15e89ba2707591d654f7d389bc) | `` xcode-install: 2.6.8 -> 2.8.1 ``                                                                  |
| [`db04fdda`](https://github.com/NixOS/nixpkgs/commit/db04fdda99a1efb211271e9362ceb90a8ec5bc10) | `` fastlane: 2.220.0 -> 2.227.0 ``                                                                   |
| [`d7bb3cf7`](https://github.com/NixOS/nixpkgs/commit/d7bb3cf7c1a4431d039b73d514fcc9ecc28d9cd0) | `` factorio, factorio-experimental: 2.0.32 -> 2.0.41 ``                                              |
| [`84f6d378`](https://github.com/NixOS/nixpkgs/commit/84f6d37838ba29cb5606192b843e7051b6f4ee7f) | `` factorio, factorio-experimental: 2.0.28 -> 2.0.32 ``                                              |
| [`36821ce7`](https://github.com/NixOS/nixpkgs/commit/36821ce7d949de99e545842c3858a401da1e2e8d) | `` factorio, factorio-experimental: 2.0.23 -> 2.0.28 ``                                              |
| [`bfde20f4`](https://github.com/NixOS/nixpkgs/commit/bfde20f4e3a63a4b32267cefb17170ec40b219da) | `` factorio: 2.0.22 -> 2.0.23 ``                                                                     |
| [`104f48be`](https://github.com/NixOS/nixpkgs/commit/104f48beccd9d32d375a826d647b06d65de426e6) | `` factorio: 2.0.20 → 2.0.21, factorio-experimental: 2.0.20 → 2.0.22 (#359574) ``                    |
| [`376cba6b`](https://github.com/NixOS/nixpkgs/commit/376cba6b9a10b7ebdd6e4dd005225ecd7df822a6) | `` factorio: 2.0.15 -> 2.0.20 (#357306) ``                                                           |
| [`f80cb757`](https://github.com/NixOS/nixpkgs/commit/f80cb757c23ca884486bdf6e4f89dbd9faadeae6) | `` python3Packages.pyexpect: init at 1.0.22 (#388026) ``                                             |
| [`69256e89`](https://github.com/NixOS/nixpkgs/commit/69256e895fe96252869f960b05182743b7ec0c94) | `` spotifyd: 0.3.5-unstable-2024-12-27 -> 0.4.0 ``                                                   |
| [`ff608ba5`](https://github.com/NixOS/nixpkgs/commit/ff608ba5ea3199d64e811957d100c017afa66096) | `` nix-forecast: 0.2.0 -> 0.3.0 ``                                                                   |
| [`51afa418`](https://github.com/NixOS/nixpkgs/commit/51afa418d54fbb3352199a797ec23666aed2359f) | `` sdl3: don't propagate build inputs ``                                                             |
| [`6839ef78`](https://github.com/NixOS/nixpkgs/commit/6839ef7859d06b3ee930ad473343d73eeb9153f4) | `` heroic: 2.16.0 -> 2.16.1 ``                                                                       |
| [`37943a97`](https://github.com/NixOS/nixpkgs/commit/37943a97a616a936e88460d256d82a313e03113e) | `` cryptomator: 1.15.0 -> 1.15.1 ``                                                                  |
| [`4a4ee444`](https://github.com/NixOS/nixpkgs/commit/4a4ee444c5aaf559e312bae47e23329ff31478d4) | `` cryptomator: 1.14.2 -> 1.15.0 ``                                                                  |
| [`69ed9de0`](https://github.com/NixOS/nixpkgs/commit/69ed9de0cec45be4acec549bbaa6fbc1440a2e63) | `` cryptomator: add maintainer gepbird ``                                                            |
| [`73c3eb4d`](https://github.com/NixOS/nixpkgs/commit/73c3eb4dcaefff1d2bae91c05ab552c5aa61a8d3) | `` cryptomator: 1.14.1 -> 1.14.2, unbreak ``                                                         |
| [`46c57119`](https://github.com/NixOS/nixpkgs/commit/46c571191094616eb46e5fb453b9f2c466a0c99e) | `` cryptomator: remove `with lib;`, order attrs ``                                                   |
| [`4b8033ef`](https://github.com/NixOS/nixpkgs/commit/4b8033efc1100f2b727fe921f3731c09a78f18d4) | `` cryptomator: migrate to by-name ``                                                                |
| [`93fd38b9`](https://github.com/NixOS/nixpkgs/commit/93fd38b9ec8b41bc12abfdbe7fd2c1a25c2a24e1) | `` zfs_{2_3,unstable}: 2.3.0 -> 2.3.1 ``                                                             |
| [`f5a29a6e`](https://github.com/NixOS/nixpkgs/commit/f5a29a6e814ef4e218b3c67284f9b3043f920515) | `` nixos/tests/velocity: init ``                                                                     |
| [`99ab02bb`](https://github.com/NixOS/nixpkgs/commit/99ab02bbd61a5cec987477f8e4304035c9dd0c91) | `` velocity: fix dependencies for release-24.11 ``                                                   |
| [`9ea2c457`](https://github.com/NixOS/nixpkgs/commit/9ea2c457ac31702fc1e807caabef402ff2eb3d67) | `` velocity: init at 3.4.0-unstable-2025-02-28 ``                                                    |