### PR TITLE
chore(flake/hyprland): `9ea76428` -> `5380cbcd`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -536,11 +536,11 @@
         "xdph": "xdph"
       },
       "locked": {
-        "lastModified": 1743009764,
-        "narHash": "sha256-ySdBBDjPGTzvca/0Cnuz3+EswXn33thVqYksMR+93M8=",
+        "lastModified": 1743084029,
+        "narHash": "sha256-BxdTLD9OYtP+QSkyW3KaUmvNa63uyGMpZ/rhr16Dcws=",
         "owner": "hyprwm",
         "repo": "Hyprland",
-        "rev": "9ea76428b68fad5a68e9153bcb246547ac2e5d6c",
+        "rev": "5380cbcddac97ab037317532bd9efd1f56ba7bf9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                                      |
| ------------------------------------------------------------------------------------------------ | -------------------------------------------- |
| [`5380cbcd`](https://github.com/hyprwm/Hyprland/commit/5380cbcddac97ab037317532bd9efd1f56ba7bf9) | `` workspaces: minor fixes to persistence `` |