### PR TITLE
chore(flake/home-manager): `171915bf` -> `b14a70c4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -428,11 +428,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1743082807,
-        "narHash": "sha256-qmrCYHVqE6j0TQApfxGx8aRYNdNsqtOrZuH09A+cjTU=",
+        "lastModified": 1743097780,
+        "narHash": "sha256-5tUbaMBKYbfTe/4aXACxmiXG22TgwPBNcfZ8Kg3rt+g=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "171915bfce41018528fda9960211e81946d999b7",
+        "rev": "b14a70c40f4fd0b73d095ab04a7c6e31fbc18e52",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                       |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------- |
| [`b14a70c4`](https://github.com/nix-community/home-manager/commit/b14a70c40f4fd0b73d095ab04a7c6e31fbc18e52) | `` fzf: update zsh integration to be after plugins (#6716) `` |