### PR TITLE
chore(flake/better-control): `c205dcf9` -> `80e94451`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -124,11 +124,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1743088981,
-        "narHash": "sha256-qpr7csHe5u3y9Gd92A9izw26SnyoxK+AVtOLL03Geko=",
+        "lastModified": 1743135212,
+        "narHash": "sha256-ehWvnbVYJLJverwPJ/1xmXJscDgrYOL3GAR7nPhNsA8=",
         "owner": "rishabh5321",
         "repo": "better-control-flake",
-        "rev": "c205dcf9be12d8934e197e0f8a833de6a8c49bc8",
+        "rev": "80e944516dbef598fdfc5d8f2b5256804ef4bdfa",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                            | Message                           |
| ----------------------------------------------------------------------------------------------------------------- | --------------------------------- |
| [`80e94451`](https://github.com/Rishabh5321/better-control-flake/commit/80e944516dbef598fdfc5d8f2b5256804ef4bdfa) | `` Hadling PR ``                  |
| [`f5b6546e`](https://github.com/Rishabh5321/better-control-flake/commit/f5b6546e77b440836e94ec9bd1a1c1120fd929bb) | `` Error Handling for workflow `` |
| [`d64f9f7b`](https://github.com/Rishabh5321/better-control-flake/commit/d64f9f7b892f5513a3f186a9ad7e6b134983a201) | `` Error Handling ``              |