### PR TITLE
chore(flake/hyprland): `c93140a5` -> `a46576af`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -536,11 +536,11 @@
         "xdph": "xdph"
       },
       "locked": {
-        "lastModified": 1743165127,
-        "narHash": "sha256-3tqo7xha/WDZN/WhjCM/hVRp9V8ROH3EvUYJhib4uc4=",
+        "lastModified": 1743178345,
+        "narHash": "sha256-H8rLWTN900NiGIuV2d1QkyDmyryjP/HLwuuOpUePHG8=",
         "owner": "hyprwm",
         "repo": "Hyprland",
-        "rev": "c93140a5f12a25f0a08b162caf31fe68fec62290",
+        "rev": "a46576afc32d7fbad6c358cc72ead7f4489d8ea8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                                                         |
| ------------------------------------------------------------------------------------------------ | --------------------------------------------------------------- |
| [`a46576af`](https://github.com/hyprwm/Hyprland/commit/a46576afc32d7fbad6c358cc72ead7f4489d8ea8) | `` xwayland: Cleanup server startup and FDs (#9769) ``          |
| [`10035a85`](https://github.com/hyprwm/Hyprland/commit/10035a85cc05f4ee572efb13e62aa1a1cfec6c8b) | `` core: Don't damage the entire surface every frame (#9763) `` |