### PR TITLE
chore(flake/akuse-flake): `de1a9c2e` -> `36599058`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -5,11 +5,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1742984670,
-        "narHash": "sha256-Y655QJcNsK8z04LHtig08vN+KZbrC8vz44vBbCcfGik=",
+        "lastModified": 1743200491,
+        "narHash": "sha256-2rIFW9mF78GjIklh2gP0bzgLGg/2ZEnaPpwT6+MMFS8=",
         "owner": "Rishabh5321",
         "repo": "akuse-flake",
-        "rev": "de1a9c2ed8f5bf07dcd67fda15a5da7445f9507f",
+        "rev": "365990588ddfbe01e33810df6105df8acb759ddd",
         "type": "github"
       },
       "original": {
@@ -758,11 +758,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1742889210,
-        "narHash": "sha256-hw63HnwnqU3ZQfsMclLhMvOezpM7RSB0dMAtD5/sOiw=",
+        "lastModified": 1743095683,
+        "narHash": "sha256-gWd4urRoLRe8GLVC/3rYRae1h+xfQzt09xOfb0PaHSk=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "698214a32beb4f4c8e3942372c694f40848b360d",
+        "rev": "5e5402ecbcb27af32284d4a62553c019a3a49ea6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                   | Message                                          |
| -------------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
| [`36599058`](https://github.com/Rishabh5321/akuse-flake/commit/365990588ddfbe01e33810df6105df8acb759ddd) | `` chore(flake/nixpkgs): 698214a3 -> 5e5402ec `` |