### PR TITLE
chore(flake/stylix): `0323253b` -> `8fce9170`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1059,11 +1059,11 @@
         "tinted-zed": "tinted-zed"
       },
       "locked": {
-        "lastModified": 1743272504,
-        "narHash": "sha256-ZC2BpHQTyg3ZuozBqRDwhCC/b+LiO4BreEbJaeVYyLQ=",
+        "lastModified": 1743289743,
+        "narHash": "sha256-N+6FE5K9yHJWBrk9RRXnLg5xPVoz/wgIDbfw5KmLeiI=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "0323253b3ee48ba132071fe626eddfcb5cbb8b6b",
+        "rev": "8fce91704d59dbe5bf0d76b166866ed33f2359c9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                        | Message                                                         |
| --------------------------------------------------------------------------------------------- | --------------------------------------------------------------- |
| [`8fce9170`](https://github.com/danth/stylix/commit/8fce91704d59dbe5bf0d76b166866ed33f2359c9) | `` doc: add license check to PR template (#1072) ``             |
| [`21b90991`](https://github.com/danth/stylix/commit/21b90991afd366f7bf9d2c7fd51095c7015907eb) | `` doc: improve maintainer subheading in PR template (#1071) `` |