### PR TITLE
chore(flake/hyprland): `4a79eea6` -> `fc7223ed`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -536,11 +536,11 @@
         "xdph": "xdph"
       },
       "locked": {
-        "lastModified": 1743281547,
-        "narHash": "sha256-2f/43KCxmTyci4i2VjsRuRGfy62lfa8P81oiD2UeJtQ=",
+        "lastModified": 1743296003,
+        "narHash": "sha256-pnaFuxu72sXxytYYWr9CSX1bCYcOTMatWFMDeqCrtlI=",
         "owner": "hyprwm",
         "repo": "Hyprland",
-        "rev": "4a79eea6dc7a2b121fc9ce9a3c9ecd0a89666dd8",
+        "rev": "fc7223edc08a2e330052e699e91ba35402aa088b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                                                                              |
| ------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------ |
| [`fc7223ed`](https://github.com/hyprwm/Hyprland/commit/fc7223edc08a2e330052e699e91ba35402aa088b) | `` synctimeline: check if fd is readable before wait (#9789) ``                      |
| [`86c279d7`](https://github.com/hyprwm/Hyprland/commit/86c279d7d0df9a6f2a78b47f3ca966272a9b9ee0) | `` protocols: Don't update hdr metadata if image description is unchanged (#9776) `` |
| [`46b00a4a`](https://github.com/hyprwm/Hyprland/commit/46b00a4a861370e2ba560732df6f0783cf5cf9b5) | `` makefile: add new shaders to `make installheaders` (#9783) ``                     |