### PR TITLE
chore(flake/nixpkgs-stable): `d02d88f8` -> `c570c1f5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -789,11 +789,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1742937945,
-        "narHash": "sha256-lWc+79eZRyvHp/SqMhHTMzZVhpxkRvthsP1Qx6UCq0E=",
+        "lastModified": 1743231893,
+        "narHash": "sha256-tpJsHMUPEhEnzySoQxx7+kA+KUtgWqvlcUBqROYNNt0=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "d02d88f8de5b882ccdde0465d8fa2db3aa1169f7",
+        "rev": "c570c1f5304493cafe133b8d843c7c1c4a10d3a6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                  |
| ---------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------- |
| [`0538ad05`](https://github.com/NixOS/nixpkgs/commit/0538ad05097ea228311ae242c3991c1ced0af145) | `` linux_6_1: 6.1.131 -> 6.1.132 ``                                                      |
| [`aa716452`](https://github.com/NixOS/nixpkgs/commit/aa71645286e14ef1d1b99a6194118a0689a8d4b2) | `` linux_6_6: 6.6.84 -> 6.6.85 ``                                                        |
| [`ffcec2aa`](https://github.com/NixOS/nixpkgs/commit/ffcec2aa249866d7612f016458602a4be5194c41) | `` linux_6_12: 6.12.20 -> 6.12.21 ``                                                     |
| [`3de2a17e`](https://github.com/NixOS/nixpkgs/commit/3de2a17efd3341f4865924c32fa90cbc99e0159a) | `` linux_6_13: 6.13.8 -> 6.13.9 ``                                                       |
| [`826921af`](https://github.com/NixOS/nixpkgs/commit/826921af7959a7b2247fb8ce8e7caeec071a12af) | `` restic: 0.17.3 -> 0.18.0 ``                                                           |
| [`5d2eb564`](https://github.com/NixOS/nixpkgs/commit/5d2eb5647f70206663db474d49dd8908d4e79363) | `` erlang_nox: 27.3 -> 27.3.1 ``                                                         |
| [`ea06c043`](https://github.com/NixOS/nixpkgs/commit/ea06c043c900f20743cd13bfbbe745f81e4a9a80) | `` inv-sig-helper: 0-unstable-2025-03-25 -> 0-unstable-2025-03-27 ``                     |
| [`40169ef9`](https://github.com/NixOS/nixpkgs/commit/40169ef9fc47e1038f21cb5b877ec3983e40a0ab) | `` linux_xanmod_latest: 6.13.7 -> 6.13.8 ``                                              |
| [`71fdc329`](https://github.com/NixOS/nixpkgs/commit/71fdc329e55804743f41031cf0f7d68754c36d7c) | `` linux_xanmod: 6.12.19 -> 6.12.20 ``                                                   |
| [`26816c26`](https://github.com/NixOS/nixpkgs/commit/26816c26409026da81985cc18227a0baf7bdd251) | `` k3s: 1.31.6+k3s1 -> 1.31.7+k3s1 ``                                                    |
| [`c5ded3fa`](https://github.com/NixOS/nixpkgs/commit/c5ded3fabdbc712dc7f90c5736b76d73de547b5e) | `` k3s: 1.30.10+k3s1 -> 1.30.11+k3s1 ``                                                  |
| [`5d1c9c10`](https://github.com/NixOS/nixpkgs/commit/5d1c9c103736c3c660f67e09dbfb9932d2159151) | `` k3s: 1.29.14+k3s1 -> 1.29.15+k3s1 ``                                                  |
| [`5dc7ba6f`](https://github.com/NixOS/nixpkgs/commit/5dc7ba6f9152a8819b1c27bb34dcdaaab3b60975) | `` python-packages: sort with keep-sorted ``                                             |
| [`dfb284a8`](https://github.com/NixOS/nixpkgs/commit/dfb284a898b4f273fc948f92b5e1838d49e3ff71) | `` python-packages: fix sorting of inherits ``                                           |
| [`e58d3983`](https://github.com/NixOS/nixpkgs/commit/e58d398355a9a8c3c668d5f60868ec0c3975c094) | `` meshcentral: 1.1.42 -> 1.1.43 ``                                                      |
| [`fb1a2a34`](https://github.com/NixOS/nixpkgs/commit/fb1a2a34be88984c60ad965c9ae916889b91c725) | `` wiki-js: 2.5.306 -> 2.5.307 ``                                                        |
| [`abd17c1f`](https://github.com/NixOS/nixpkgs/commit/abd17c1f5f33562ff89eace36588af89a327b123) | `` vscode-utils.buildVscodeExtension: support alternative installPhase and sourceRoot `` |
| [`1410e361`](https://github.com/NixOS/nixpkgs/commit/1410e361f5dd3d35aa844ab824487f630e2937ed) | `` nix: update nix-fallback-paths to 2.24.13 ``                                          |
| [`c1cba1e3`](https://github.com/NixOS/nixpkgs/commit/c1cba1e3e0683ed7d379cf24ecf6419ddcfe1884) | `` nixVersions.nix_2_24: 2.24.12 -> 2.24.13 ``                                           |
| [`4486a20f`](https://github.com/NixOS/nixpkgs/commit/4486a20f3989b090939b6c9b07120a8d27babeb2) | `` nix: fix update script to also update fallback paths ``                               |
| [`7c73302f`](https://github.com/NixOS/nixpkgs/commit/7c73302f7cfb5f8f83222010d237b8868e580b53) | `` gitlab: 17.9.2 -> 17.9.3 ``                                                           |
| [`1825b23f`](https://github.com/NixOS/nixpkgs/commit/1825b23f1d12598b3b26988ee2bbb7121b981280) | `` key: 2.12.2 -> 2.12.3 ``                                                              |
| [`3fcf8837`](https://github.com/NixOS/nixpkgs/commit/3fcf8837c2de24af23cedbc5f417922a2511efbf) | `` libreoffice-bin: 7.6.7 -> 25.2.1 ``                                                   |
| [`a5850401`](https://github.com/NixOS/nixpkgs/commit/a585040155a6710da6d30d5f7f6a8e6564ee144d) | `` nextcloud31Packages.apps.recognize: add hash for nextcloud 31 ``                      |
| [`17d56ed0`](https://github.com/NixOS/nixpkgs/commit/17d56ed0406bf3152a120e1cce574796497a3b4a) | `` kanidm: ensure matching versions for kanidm.withSecretProvisioning ``                 |
| [`f096dbfa`](https://github.com/NixOS/nixpkgs/commit/f096dbfae2406a442aff82b6521abe861bb6e0da) | `` rke2_testing: mark as vulnerable as the RKE2 channel no longer serves updates ``      |
| [`6e97ad4b`](https://github.com/NixOS/nixpkgs/commit/6e97ad4b37f597401cd9010cb7eb9624068063a4) | `` rke2_stable: 1.30.5+rke2r1 -> 1.31.7+rke2r1 ``                                        |
| [`b632336d`](https://github.com/NixOS/nixpkgs/commit/b632336d4939e4ccf7d9f08f673bcb2a28fe7ba7) | `` rke2_latest: 1.31.1+rke2r1 -> 1.32.3+rke2r1 ``                                        |
| [`8a0faf59`](https://github.com/NixOS/nixpkgs/commit/8a0faf597cc0b294c3d97a4d845ce9dbc85c6874) | `` libblake3: use older tbb ``                                                           |
| [`0f07bcba`](https://github.com/NixOS/nixpkgs/commit/0f07bcbaea1aacb1744dcecdfdc9569aba580819) | `` strace: split man pages off ``                                                        |
| [`25d2d8a6`](https://github.com/NixOS/nixpkgs/commit/25d2d8a6c2a4df798130c6b16968b92f86990d5b) | `` strace: 6.13 -> 6.14 ``                                                               |
| [`fa17c72e`](https://github.com/NixOS/nixpkgs/commit/fa17c72e57cfa6b65a923c057881c11fbee73a8b) | `` exim: 4.98.1 -> 4.98.2 ``                                                             |
| [`e0fb79cf`](https://github.com/NixOS/nixpkgs/commit/e0fb79cf269ea2b95fb0ed45afedc140b1ad6659) | `` zulip: 5.11.1 → 5.12.0 ``                                                             |
| [`c88d0fda`](https://github.com/NixOS/nixpkgs/commit/c88d0fdae5466499d1d8803f33d423b5c752cb1c) | `` calibre-web: don't overuse `with lib;` ``                                             |
| [`32308c1f`](https://github.com/NixOS/nixpkgs/commit/32308c1fca09a93ec7faec20ca073883906b84f9) | `` calibre-web: only use nixosTests on linux ``                                          |
| [`9319c3bb`](https://github.com/NixOS/nixpkgs/commit/9319c3bb296d535b856091a601b33190db5c4508) | `` calibre-web: 0.6.22 -> 0.6.24 ``                                                      |
| [`311b0e32`](https://github.com/NixOS/nixpkgs/commit/311b0e32487c4dddd4210f03ef0756b5b5b2148b) | `` calibre-web: format with nixfmt ``                                                    |
| [`9ec21461`](https://github.com/NixOS/nixpkgs/commit/9ec21461fbf102566e3a88614f6682315a4826bb) | `` python312Packages.netifaces-plus: init at 0.12.4 ``                                   |
| [`7be939c7`](https://github.com/NixOS/nixpkgs/commit/7be939c73e5181595eb36f01155eab90c4849060) | `` python312Packages.flask-dance: init at 7.1.0 ``                                       |
| [`e460b445`](https://github.com/NixOS/nixpkgs/commit/e460b445298daa61932aa4e61228f5e247dca92d) | `` python312Packages.urlobject: init at 2.4.3 ``                                         |
| [`f44c9b44`](https://github.com/NixOS/nixpkgs/commit/f44c9b44d818a287427c4fc4373ef6b70594ef5e) | `` python312Packages.scholarly: init at 1.7.11 ``                                        |
| [`58c27783`](https://github.com/NixOS/nixpkgs/commit/58c27783478043370d7674c5af2ee903af7c23fd) | `` python312Packages.comicapi: init at 3.2.0 ``                                          |
| [`52ca3255`](https://github.com/NixOS/nixpkgs/commit/52ca3255942ae033cf72a073fb3aa0ea8b68b90f) | `` python312Packages.text2digits: init at 0.1.0 ``                                       |
| [`bfb42d43`](https://github.com/NixOS/nixpkgs/commit/bfb42d4341a6e154cd49aac1b59bc6b960243a97) | `` python312Packages.wordninja: init at 2.0.0 ``                                         |
| [`72febdf4`](https://github.com/NixOS/nixpkgs/commit/72febdf4051a756f68bbe69bfc48db9d99e89eab) | `` reposilite: 3.5.21 -> 3.5.22 ``                                                       |
| [`5625c888`](https://github.com/NixOS/nixpkgs/commit/5625c888a58e6475df117bf4eaa348e614947475) | `` reposilite: add updateScript ``                                                       |
| [`b9c013a3`](https://github.com/NixOS/nixpkgs/commit/b9c013a340bc91219ecf6d3d55ce1b1a09066f9a) | `` sonarr: 4.0.13.2932 -> 4.0.14.2939 ``                                                 |
| [`f2befab0`](https://github.com/NixOS/nixpkgs/commit/f2befab0e8dceccf0006665ea2995fb5333a385c) | `` matrix-synapse: 1.126.0 -> 1.127.1 ``                                                 |
| [`c4ed82e8`](https://github.com/NixOS/nixpkgs/commit/c4ed82e8b5e69710f25eccb0f42cffe882a840e5) | `` `pkgs/tools/package-management/nix/default.nix`: Format ``                            |
| [`f4033775`](https://github.com/NixOS/nixpkgs/commit/f40337752acebed5bba3b3c538dcd20ff68888fa) | `` mic92: update my matrix handle and drop gpg ``                                        |
| [`6dd67017`](https://github.com/NixOS/nixpkgs/commit/6dd67017f086d9c8656c28246a294f3521976564) | `` nix: add nix team as maintainers for nix ``                                           |
| [`22f67cbb`](https://github.com/NixOS/nixpkgs/commit/22f67cbbb452b2c07bb12a0ca0f1af3537e031f5) | `` percona-server: 8.4.3-3 -> 8.4.4-4 ``                                                 |
| [`bf3f4494`](https://github.com/NixOS/nixpkgs/commit/bf3f4494bcaeff9bbf67934f3eee86eb629c5786) | `` pnpm_10: 10.6.5 -> 10.7.0 ``                                                          |
| [`a96910ac`](https://github.com/NixOS/nixpkgs/commit/a96910ac7c84d8afba1f53e374754d6ba689fa36) | `` firefox-bin-unwrapped: 136.0.2 -> 136.0.3 ``                                          |
| [`710bb7e8`](https://github.com/NixOS/nixpkgs/commit/710bb7e8f68de6718dd7b3c66d305317352097b0) | `` firefox-unwrapped: 136.0.2 -> 136.0.3 ``                                              |
| [`454aaed2`](https://github.com/NixOS/nixpkgs/commit/454aaed2c2957d5b55bde2dd7a64c720062a2a88) | `` owntone: 28.11 -> 28.12 ``                                                            |
| [`3bb25f86`](https://github.com/NixOS/nixpkgs/commit/3bb25f86c15f96c6a37789a6ecb16925d58bb853) | `` [backport release-24.11] systemtap-sdt: init ``                                       |
| [`6b08ad7e`](https://github.com/NixOS/nixpkgs/commit/6b08ad7ecc5d03c1b6d47465588821711a2c2602) | `` yt-dlp: 2025.3.21 -> 2025.3.25 ``                                                     |
| [`8aeb7ca8`](https://github.com/NixOS/nixpkgs/commit/8aeb7ca88375a474cf7ffcba969e55e9d04b8d5a) | `` veilid: 0.4.3 -> 0.4.4 ``                                                             |
| [`b963ea32`](https://github.com/NixOS/nixpkgs/commit/b963ea32a0ae5e4e72ba4bc2864166bbc66de846) | `` grub2: remove security patch causing segfault with `grub-mount` / NTFS ``             |
| [`67b3bd54`](https://github.com/NixOS/nixpkgs/commit/67b3bd549ab1a8cb8c6b7970f1447957d95c41ce) | `` extra-container: 0.12 -> 0.13 ``                                                      |
| [`f31fe521`](https://github.com/NixOS/nixpkgs/commit/f31fe52176e5265dec9bf01c14ae04251d16eaad) | `` turbo: fix building on rust 1.82 ``                                                   |
| [`d920dd3d`](https://github.com/NixOS/nixpkgs/commit/d920dd3d8764cbf270891f112cba46a5d4cecd20) | `` grub2: apply patches for security issues ``                                           |
| [`70497a9a`](https://github.com/NixOS/nixpkgs/commit/70497a9a9de0094e3026337a678b981ab71e78a4) | `` turbo: 2.3.4 -> 2.4.2 ``                                                              |
| [`543cfe18`](https://github.com/NixOS/nixpkgs/commit/543cfe187d4e7d5807a2cff2de4fec34e960707b) | `` turbo: 2.3.3 -> 2.3.4 ``                                                              |
| [`198c863e`](https://github.com/NixOS/nixpkgs/commit/198c863eee572384fb77b11d00b7fa3feb2d08e3) | `` terraform-providers.proxmox: 2.9.14 -> 3.0.1-rc6 ``                                   |