### PR TITLE
chore(flake/hyprland): `fc7223ed` -> `da2d7c39`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -536,11 +536,11 @@
         "xdph": "xdph"
       },
       "locked": {
-        "lastModified": 1743296003,
-        "narHash": "sha256-pnaFuxu72sXxytYYWr9CSX1bCYcOTMatWFMDeqCrtlI=",
+        "lastModified": 1743297135,
+        "narHash": "sha256-nkbX1N0UxFIQTq794UxffLUg3a/wFy/Zf6goUtzmEug=",
         "owner": "hyprwm",
         "repo": "Hyprland",
-        "rev": "fc7223edc08a2e330052e699e91ba35402aa088b",
+        "rev": "da2d7c3971d40f841f2afd7def8e4bad9a351e41",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                                                                         |
| ------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------- |
| [`da2d7c39`](https://github.com/hyprwm/Hyprland/commit/da2d7c3971d40f841f2afd7def8e4bad9a351e41) | `` config: Fix matching monitor by description to allow space prefix (#9788) `` |
| [`05eb0aa4`](https://github.com/hyprwm/Hyprland/commit/05eb0aa43ded10f008be3cfcde33fe0bfe6e45b1) | `` workspaces: Add binds:hide_special_on_workspace_change (#9728) ``            |