### PR TITLE
chore(flake/home-manager): `09280e17` -> `b6fd653e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -428,11 +428,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1743351736,
-        "narHash": "sha256-bpPX3E8EG4tGuMlu3+fFUfRYlNRCmQk2PFfnZDpgroM=",
+        "lastModified": 1743360001,
+        "narHash": "sha256-HtpS/ZdgWXw0y+aFdORcX5RuBGTyz3WskThspNR70SM=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "09280e17bbd29536efd1549751038fa155489bd4",
+        "rev": "b6fd653ef8fbeccfd4958650757e91767a65506d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                    |
| ----------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------- |
| [`b6fd653e`](https://github.com/nix-community/home-manager/commit/b6fd653ef8fbeccfd4958650757e91767a65506d) | `` newsboat: add a package option to the module (#6717) `` |