### PR TITLE
chore(flake/hyprland): `10a33563` -> `79b526a0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -536,11 +536,11 @@
         "xdph": "xdph"
       },
       "locked": {
-        "lastModified": 1743359379,
-        "narHash": "sha256-dbERoYlGsU0BGIutidZ1K3gQQGVUf/N/g0uXIvqVGzE=",
+        "lastModified": 1743370710,
+        "narHash": "sha256-xJMdf5S9JKP1OHz+be3P6JgN9ssA4cMo9krYCYghIpM=",
         "owner": "hyprwm",
         "repo": "Hyprland",
-        "rev": "10a335631e71f5bdbd8f311a3aaeeef89debae11",
+        "rev": "79b526a04199a05d1e9b0bbb035ba20b652a7a2b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                                               |
| ------------------------------------------------------------------------------------------------ | ----------------------------------------------------- |
| [`79b526a0`](https://github.com/hyprwm/Hyprland/commit/79b526a04199a05d1e9b0bbb035ba20b652a7a2b) | `` socket2: add minimized event for foreign-wlr ``    |
| [`075bbeca`](https://github.com/hyprwm/Hyprland/commit/075bbecabd6d41c02ebb823d91774a95cc9d50da) | `` core: fix artifacts when fullscreening (#9778) ``  |
| [`8aaffda9`](https://github.com/hyprwm/Hyprland/commit/8aaffda969bcff6708b47fab776ea45979ea7d9f) | `` core: fix null ref when resuming system (#9794) `` |