### PR TITLE
chore(flake/better-control): `581eb029` -> `0983ea8f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -124,11 +124,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1743203446,
-        "narHash": "sha256-oxamVAhyDY2Yd31HQiJG/byYFzqW/BQhhBOWfjt9EUk=",
+        "lastModified": 1743382333,
+        "narHash": "sha256-/DY/OfxGO/3Bf5bmKPrJsarIBizAAMAqMOLJaq78Z5Q=",
         "owner": "rishabh5321",
         "repo": "better-control-flake",
-        "rev": "581eb029676b47993ad63362cf30b88efe9dbbb1",
+        "rev": "0983ea8f821303026049fdbaaad4197f8da3fc3e",
         "type": "github"
       },
       "original": {
@@ -805,11 +805,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1743095683,
-        "narHash": "sha256-gWd4urRoLRe8GLVC/3rYRae1h+xfQzt09xOfb0PaHSk=",
+        "lastModified": 1743315132,
+        "narHash": "sha256-6hl6L/tRnwubHcA4pfUUtk542wn2Om+D4UnDhlDW9BE=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "5e5402ecbcb27af32284d4a62553c019a3a49ea6",
+        "rev": "52faf482a3889b7619003c0daec593a1912fddc1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                            | Message                                          |
| ----------------------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
| [`0983ea8f`](https://github.com/Rishabh5321/better-control-flake/commit/0983ea8f821303026049fdbaaad4197f8da3fc3e) | `` chore(flake/nixpkgs): 5e5402ec -> 52faf482 `` |