### PR TITLE
chore(flake/akuse-flake): `36599058` -> `c81aead7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -5,11 +5,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1743200491,
-        "narHash": "sha256-2rIFW9mF78GjIklh2gP0bzgLGg/2ZEnaPpwT6+MMFS8=",
+        "lastModified": 1743385837,
+        "narHash": "sha256-f21HebD5zIrEzdQmN8iVHTrhBoxgugS1qhm3IDE34+8=",
         "owner": "Rishabh5321",
         "repo": "akuse-flake",
-        "rev": "365990588ddfbe01e33810df6105df8acb759ddd",
+        "rev": "c81aead7df1880839e142a2f7d9cd3020388deac",
         "type": "github"
       },
       "original": {
@@ -758,11 +758,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1743095683,
-        "narHash": "sha256-gWd4urRoLRe8GLVC/3rYRae1h+xfQzt09xOfb0PaHSk=",
+        "lastModified": 1743315132,
+        "narHash": "sha256-6hl6L/tRnwubHcA4pfUUtk542wn2Om+D4UnDhlDW9BE=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "5e5402ecbcb27af32284d4a62553c019a3a49ea6",
+        "rev": "52faf482a3889b7619003c0daec593a1912fddc1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                   | Message                                          |
| -------------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
| [`c81aead7`](https://github.com/Rishabh5321/akuse-flake/commit/c81aead7df1880839e142a2f7d9cd3020388deac) | `` chore(flake/nixpkgs): 5e5402ec -> 52faf482 `` |