### PR TITLE
chore(flake/thorium): `ad2fb2e0` -> `89e4c0fa`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -901,11 +901,11 @@
     },
     "nixpkgs_8": {
       "locked": {
-        "lastModified": 1743095683,
-        "narHash": "sha256-gWd4urRoLRe8GLVC/3rYRae1h+xfQzt09xOfb0PaHSk=",
+        "lastModified": 1743315132,
+        "narHash": "sha256-6hl6L/tRnwubHcA4pfUUtk542wn2Om+D4UnDhlDW9BE=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "5e5402ecbcb27af32284d4a62553c019a3a49ea6",
+        "rev": "52faf482a3889b7619003c0daec593a1912fddc1",
         "type": "github"
       },
       "original": {
@@ -1137,11 +1137,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1743204066,
-        "narHash": "sha256-b/VyAuGXQOtfRqC4HG8I+XbvO+vSr8CtKO+mS6Q1K20=",
+        "lastModified": 1743385349,
+        "narHash": "sha256-3ULqBFgPWF08f9gIi2pK5ervD/eiZeSHIiarKhnKZKs=",
         "owner": "Rishabh5321",
         "repo": "thorium_flake",
-        "rev": "ad2fb2e0f4cbec0b83108b785a2c7d60de2b9819",
+        "rev": "89e4c0fa0175c395d72e7662ee9c391f22b10c01",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                     | Message                                          |
| ---------------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
| [`89e4c0fa`](https://github.com/Rishabh5321/thorium_flake/commit/89e4c0fa0175c395d72e7662ee9c391f22b10c01) | `` chore(flake/nixpkgs): 5e5402ec -> 52faf482 `` |