### PR TITLE
chore(flake/nixpkgs-stable): `c570c1f5` -> `7ffe0edc`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -789,11 +789,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1743231893,
-        "narHash": "sha256-tpJsHMUPEhEnzySoQxx7+kA+KUtgWqvlcUBqROYNNt0=",
+        "lastModified": 1743367904,
+        "narHash": "sha256-sOos1jZGKmT6xxPvxGQyPTApOunXvScV4lNjBCXd/CI=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "c570c1f5304493cafe133b8d843c7c1c4a10d3a6",
+        "rev": "7ffe0edc685f14b8c635e3d6591b0bbb97365e6c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                 |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------- |
| [`5a992d0c`](https://github.com/NixOS/nixpkgs/commit/5a992d0c0bc17ed12c62a2140cb3b752f601c732) | `` shortwave: 4.0.1 -> 5.0.0 ``                         |
| [`d92ed67c`](https://github.com/NixOS/nixpkgs/commit/d92ed67ce20e994f2dcda9f0fd0d5227c2fde01c) | `` sydbox: use finalAttrs pattern ``                    |
| [`47d6fd35`](https://github.com/NixOS/nixpkgs/commit/47d6fd35d221f4a8fe8d45cbaec844d59c7dd6c2) | `` element-desktop: 1.11.95 -> 1.11.96 ``               |
| [`6fce1ac5`](https://github.com/NixOS/nixpkgs/commit/6fce1ac501f3c1e0851ec2b53026dc92825f2c16) | `` element-web-unwrapped: 1.11.95 -> 1.11.96 ``         |
| [`88679d2f`](https://github.com/NixOS/nixpkgs/commit/88679d2f5eae6f474acf4536857f8c3dda0f3876) | `` python3Packages.pyotb: init at 2.1.0 ``              |
| [`05fd254b`](https://github.com/NixOS/nixpkgs/commit/05fd254b8948fbc041c0b8bf32f8fb09cb2f8e2c) | `` ci/keep-sorted: friendlier error message ``          |
| [`f1d91da1`](https://github.com/NixOS/nixpkgs/commit/f1d91da1323c684f8f214ecf612c3a06bd17a692) | `` globalplatform: init at 2.4.0-unstable-2025-03-23 `` |
| [`b5da3af8`](https://github.com/NixOS/nixpkgs/commit/b5da3af8b8962d26585446da92f93c157b3f525e) | `` atop: 2.11.0 -> 2.11.1 ``                            |
| [`6286adae`](https://github.com/NixOS/nixpkgs/commit/6286adae92d55fdf57a82764f38653142e07d4d8) | `` freetube: 0.23.2 -> 0.23.3 ``                        |
| [`8aa54835`](https://github.com/NixOS/nixpkgs/commit/8aa548355abd5382dae95dabe66fb756ee91412f) | `` immich: 1.129.0 -> 1.130.3 ``                        |
| [`72454680`](https://github.com/NixOS/nixpkgs/commit/72454680b54b196a632b2ec4f87d35f829b0dbba) | `` immich: fix npmDeps build failure ``                 |
| [`806e567e`](https://github.com/NixOS/nixpkgs/commit/806e567e567e35eb80ad882c15ba4512c2ced4ea) | `` mpd: 0.23.17 -> 0.24.2 ``                            |
| [`00ffdb4a`](https://github.com/NixOS/nixpkgs/commit/00ffdb4ae3ea1f44e9cee9835666457da1473c6d) | `` lakectl: init at 1.53.0 ``                           |
| [`c972fbed`](https://github.com/NixOS/nixpkgs/commit/c972fbed0206110662ea7b19b4c2c02e59d72e60) | `` wabt: 1.0.36 -> 1.0.37 ``                            |
| [`ecfd27e1`](https://github.com/NixOS/nixpkgs/commit/ecfd27e15582d03d3c5c8b12612a528a014cb7b0) | `` parallel-disk-usage: 0.10.0 -> 0.11.0 ``             |
| [`e45ba490`](https://github.com/NixOS/nixpkgs/commit/e45ba49043a8c283d96fe659870bb0fb976d7812) | `` python312Packages.xonsh: 0.19.3 -> 0.19.4 ``         |
| [`3b9bb27f`](https://github.com/NixOS/nixpkgs/commit/3b9bb27fcf9b5128ff10e5a0a7d589a64f9097c5) | `` lock: 1.4.2 -> 1.5.1 ``                              |
| [`0fd6e813`](https://github.com/NixOS/nixpkgs/commit/0fd6e813fccc55ede941fd7bf87da7ed09405243) | `` diesel-cli: 2.2.7 -> 2.2.8 ``                        |
| [`4ab9a71b`](https://github.com/NixOS/nixpkgs/commit/4ab9a71b3f6cc4b17d43f4f337febc015e5b3423) | `` tarsnap: 1.0.40 -> 1.0.41 ``                         |
| [`c9d0e61d`](https://github.com/NixOS/nixpkgs/commit/c9d0e61d4690e1c27d664c42439f6b5b27757a38) | `` floorp: 11.24.0 -> 11.25.0 ``                        |
| [`016b8175`](https://github.com/NixOS/nixpkgs/commit/016b81755c08014028bdfc7ccc36f98f94fb3a17) | `` pyfa: 2.62.1 -> 2.62.2 ``                            |
| [`de3c7c5e`](https://github.com/NixOS/nixpkgs/commit/de3c7c5e99d28811dafaeb7772a44ce81d976436) | `` librewolf-unwrapped: 136.0.1-1 -> 136.0.4-1 ``       |
| [`8555ecf6`](https://github.com/NixOS/nixpkgs/commit/8555ecf6f177a2a1e0be311565fee85e0be51b68) | `` grafana: 11.3.4 -> 11.3.5 ``                         |
| [`81db2289`](https://github.com/NixOS/nixpkgs/commit/81db2289650d5d89525cde03980de32d5e0cb29c) | `` signal-desktop(darwin): 7.46.0 -> 7.47.0 ``          |
| [`d599c444`](https://github.com/NixOS/nixpkgs/commit/d599c444fe8496121893e4e55893945e00b22d75) | `` signal-desktop(aarch64): 7.46.0-1 -> 7.47.0-1 ``     |
| [`54145f40`](https://github.com/NixOS/nixpkgs/commit/54145f40eba057dbe2523ed4c3713818cb1853aa) | `` signal-desktop: 7.46.0 -> 7.47.0 ``                  |
| [`f0c77fd6`](https://github.com/NixOS/nixpkgs/commit/f0c77fd66e526f10ca7d6bd850e27cab2142c6e6) | `` yt-dlp: 2025.03.25 -> 2025.03.26 ``                  |
| [`1a90895b`](https://github.com/NixOS/nixpkgs/commit/1a90895be0fdc9b58d108a249229b8a544f82aa8) | `` mattermost: 9.11.9 -> 9.11.11 ``                     |