### PR TITLE
chore(flake/better-control): `d03e4774` -> `b51e4377`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -124,11 +124,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1743430256,
-        "narHash": "sha256-zxDvRn2VshYuNxWLzQ9WEA8aKdxl8IpojA2kOQ3D/10=",
+        "lastModified": 1743431943,
+        "narHash": "sha256-RJLSjVj7JokIWeV5Yc8kd0DYOuxOtc5Wkn5Qo4z3xmg=",
         "owner": "rishabh5321",
         "repo": "better-control-flake",
-        "rev": "d03e4774e778676281695fe7f9f27caa8872ca4d",
+        "rev": "b51e43772d60d908c1c1bf5d512903d77b1a44cc",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                            | Message                                |
| ----------------------------------------------------------------------------------------------------------------- | -------------------------------------- |
| [`52cdc370`](https://github.com/Rishabh5321/better-control-flake/commit/52cdc370e0319bf7dcfae6cb6e387860b7fa3535) | `` Fixed the desktop file handling: `` |