### PR TITLE
chore(flake/hyprland): `79b526a0` -> `4c987b20`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -536,11 +536,11 @@
         "xdph": "xdph"
       },
       "locked": {
-        "lastModified": 1743370710,
-        "narHash": "sha256-xJMdf5S9JKP1OHz+be3P6JgN9ssA4cMo9krYCYghIpM=",
+        "lastModified": 1743437607,
+        "narHash": "sha256-EEUFIq/btzh8RZ/dv69PXvC5c7ythmCYlDOzH7vriAk=",
         "owner": "hyprwm",
         "repo": "Hyprland",
-        "rev": "79b526a04199a05d1e9b0bbb035ba20b652a7a2b",
+        "rev": "4c987b20e28362410d0c9f9a37bafd6f128b0a2c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                                                             |
| ------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------- |
| [`4c987b20`](https://github.com/hyprwm/Hyprland/commit/4c987b20e28362410d0c9f9a37bafd6f128b0a2c) | `` makefile: fix find command in installheaders ``                  |
| [`23092707`](https://github.com/hyprwm/Hyprland/commit/2309270752383be30857d9c15cd3e259c4e6ed58) | `` anr: add config for ping number before popup shows up (#9782) `` |