### PR TITLE
chore(flake/zen-browser): `165ee672` -> `3c4f98e9`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1300,11 +1300,11 @@
         "nixpkgs": "nixpkgs_9"
       },
       "locked": {
-        "lastModified": 1743216975,
-        "narHash": "sha256-29xgm8F3DCcTNrQZ9V3Pwj6BkjalkKvGyjd+sF9/+3k=",
+        "lastModified": 1743463070,
+        "narHash": "sha256-x+A6Es0VkGyhp4ixhqg1Qi9iusLl7ioymqoe107L/Dg=",
         "owner": "0xc000022070",
         "repo": "zen-browser-flake",
-        "rev": "165ee672e6b17a8bcc0a3fb51fab3f79715cc1f3",
+        "rev": "3c4f98e9504d3f94bbd303d428162665a0ade8d6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                          | Message                                                                     |
| --------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------- |
| [`3c4f98e9`](https://github.com/0xc000022070/zen-browser-flake/commit/3c4f98e9504d3f94bbd303d428162665a0ade8d6) | `` Update Zen Browser twilight @ x86_64 && aarch64 to 1.10.3t#1743460319 `` |