### PR TITLE
chore(flake/stylix): `b45eb498` -> `711bd28a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1059,11 +1059,11 @@
         "tinted-zed": "tinted-zed"
       },
       "locked": {
-        "lastModified": 1743451752,
-        "narHash": "sha256-PXHHMhGea0b4CNKXkcAPHT9AlFOrptaVwlcMjPE/MVk=",
+        "lastModified": 1743464673,
+        "narHash": "sha256-XQXrK7o2c/5VgiyaSbaIeKhtfhSiF5ykppITYzPnXtk=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "b45eb498944ffeae47aba8d1e42b8449fd07ca08",
+        "rev": "711bd28ac96dec8c9187f8db4a297677eef2e654",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                        | Message                                                      |
| --------------------------------------------------------------------------------------------- | ------------------------------------------------------------ |
| [`711bd28a`](https://github.com/danth/stylix/commit/711bd28ac96dec8c9187f8db4a297677eef2e654) | `` stylix: add missing parentheses around mkMerge (#1078) `` |