### PR TITLE
chore(flake/better-control): `6b85375e` -> `55b11984`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -124,11 +124,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1743482196,
-        "narHash": "sha256-NML9zmxPd710ZS/jsLfLF6vTVR0PNJ8NktwxJn97U/A=",
+        "lastModified": 1743526441,
+        "narHash": "sha256-wbFeOVOl7c64gimc9HYBQpAFzu4qz4cXnbNZSdgljQg=",
         "owner": "rishabh5321",
         "repo": "better-control-flake",
-        "rev": "6b85375e8dd9f8e02491a7e8ababbe88b4212413",
+        "rev": "55b11984bca9bd2193002fa9d57418057c30d75b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                            | Message                                                                    |
| ----------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------- |
| [`3f8ab2ec`](https://github.com/Rishabh5321/better-control-flake/commit/3f8ab2ec36a6382037e3fdd2f827d9c015386f42) | `` Qr code generation works will have fix for startup apps ``              |
| [`024407c8`](https://github.com/Rishabh5321/better-control-flake/commit/024407c8024db983be8ef403767057063f681b81) | `` Add python3Packages.qrcode and python3Packages.requests to flake.nix `` |
| [`4c032559`](https://github.com/Rishabh5321/better-control-flake/commit/4c03255926acb3f4196866ff2fa202b19a6a2c5d) | `` Update better-control to 5.8 ``                                         |