### PR TITLE
chore(flake/hyprland): `1f0fd79b` -> `a4e6c5d6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -536,11 +536,11 @@
         "xdph": "xdph"
       },
       "locked": {
-        "lastModified": 1743517238,
-        "narHash": "sha256-yJaShaC/XQL4bevEB4KmvUav2fns8Ugh+UmB06AYOXE=",
+        "lastModified": 1743547897,
+        "narHash": "sha256-14VSGZy+0D/zVRxZl/0ZiAcTSd+R6Cw87TsmsdU1clM=",
         "owner": "hyprwm",
         "repo": "Hyprland",
-        "rev": "1f0fd79b910b798e650d6f0c546273bc83422526",
+        "rev": "a4e6c5d678e8dd27ab07a6d6eb4ba2834fab81d1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                                                                               |
| ------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------- |
| [`a4e6c5d6`](https://github.com/hyprwm/Hyprland/commit/a4e6c5d678e8dd27ab07a6d6eb4ba2834fab81d1) | `` window: don't deactivate unfocused xwayland windows in groups (#9781) ``           |
| [`3a47c73f`](https://github.com/hyprwm/Hyprland/commit/3a47c73f34d358c55e97927b0682dbdda19e24c1) | `` layout: center floating window at cursor when picked up from fullscreen (#9780) `` |