### PR TITLE
chore(flake/home-manager): `938e802b` -> `5ee44bc7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -428,11 +428,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1743553103,
-        "narHash": "sha256-mfqG5NEa1APkqiGT2arkBDHUeDm+1afFpTcwyE+Szbo=",
+        "lastModified": 1743556466,
+        "narHash": "sha256-rvU79DJ6rPDxiH0sTp686Vlm+JewwAZPGcwt8OfHJbM=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "938e802b70ee7700141b18ef8dca05ad89917a37",
+        "rev": "5ee44bc7c2e853f144390a12ebe5174ad7e3b9e0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------------ |
| [`5ee44bc7`](https://github.com/nix-community/home-manager/commit/5ee44bc7c2e853f144390a12ebe5174ad7e3b9e0) | `` news: add services.home-manager.autoExpire entry `` |
| [`28242a60`](https://github.com/nix-community/home-manager/commit/28242a60d3cdcb6675dfe68ebbb64bf43c7be4e0) | `` home-manager-auto-expire: init ``                   |