### PR TITLE
chore(flake/nixpkgs-stable): `7ffe0edc` -> `02f2af8c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -789,11 +789,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1743367904,
-        "narHash": "sha256-sOos1jZGKmT6xxPvxGQyPTApOunXvScV4lNjBCXd/CI=",
+        "lastModified": 1743501102,
+        "narHash": "sha256-7PCBQ4aGVF8OrzMkzqtYSKyoQuU2jtpPi4lmABpe5X4=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "7ffe0edc685f14b8c635e3d6591b0bbb97365e6c",
+        "rev": "02f2af8c8a8c3b2c05028936a1e84daefa1171d4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                       |
| ---------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------- |
| [`3e6af10a`](https://github.com/NixOS/nixpkgs/commit/3e6af10a79f2abf4cc5681cdf0c504e13f7ecfeb) | `` linux_xanmod_latest: 6.13.8 -> 6.13.9 ``                                   |
| [`e606bd5d`](https://github.com/NixOS/nixpkgs/commit/e606bd5de760df289eb64c4e2a3504bc55e2caa3) | `` linux_xanmod: 6.12.20 -> 6.12.21 ``                                        |
| [`18003272`](https://github.com/NixOS/nixpkgs/commit/18003272f1a1f63292d131a31e833c15b794cdc3) | `` repart: Enable custom --empty flags in initrd ``                           |
| [`0c64ccbb`](https://github.com/NixOS/nixpkgs/commit/0c64ccbbaca82f6840882b060c488a01e6e30b70) | `` linuxPackages.rtl8821ce: 0-unstable-2025-03-12 -> 0-unstable-2025-03-31 `` |
| [`5c163939`](https://github.com/NixOS/nixpkgs/commit/5c16393923092977b31a906795ce2809560217f3) | `` reposilite: 3.5.22 -> 3.5.23 ``                                            |
| [`e4a74fd1`](https://github.com/NixOS/nixpkgs/commit/e4a74fd10b211a6d8f5575a85154aac0209a8e55) | `` qpwgraph: 0.8.2 -> 0.8.3 ``                                                |
| [`826bd56f`](https://github.com/NixOS/nixpkgs/commit/826bd56f674ef8c61bd738bc447a270f6f28e59f) | `` [Backport release-24.11] triforce-lv2: 0.2.0 -> 0.2.1 (#394958) ``         |
| [`16389cf4`](https://github.com/NixOS/nixpkgs/commit/16389cf4259e91235e6bdee4b6d185d6e1ae633e) | `` libblake3: 1.7.0 -> 1.8.0 ``                                               |
| [`dc2422cb`](https://github.com/NixOS/nixpkgs/commit/dc2422cb8918e2aa0c1133dfea406d5f37e36f92) | `` velocity: 3.4.0-unstable-2025-02-28 -> 3.4.0-unstable-2025-03-27 ``        |
| [`091d5d16`](https://github.com/NixOS/nixpkgs/commit/091d5d16e3acb159cfdfde0e15d15bafd30773ed) | `` sympa: Add missing UnicodeUTF8 dependency ``                               |
| [`d318bf65`](https://github.com/NixOS/nixpkgs/commit/d318bf654d2c879d611683ead56f0a4ca727ed85) | `` sympa: 6.2.74 -> 6.2.76 ``                                                 |
| [`3fa2584a`](https://github.com/NixOS/nixpkgs/commit/3fa2584a5c6dcc02d182387dc2d5b62e433972b6) | `` koboldcpp: 1.85 -> 1.86.2 ``                                               |
| [`3a129bf0`](https://github.com/NixOS/nixpkgs/commit/3a129bf0ce3b0a8f4899bcba2bafb748244ed0fc) | `` gitignore: ignore worktrees ``                                             |
| [`97188f53`](https://github.com/NixOS/nixpkgs/commit/97188f53352da26c10efa60611e5eb5782127755) | `` nodejs_18: 18.20.7 -> 18.20.8 ``                                           |
| [`db0007b9`](https://github.com/NixOS/nixpkgs/commit/db0007b98fbef1e0657849282f5fd21ab351a0bf) | `` linuxPackages.rtl8821ce: fix build on 6.14 ``                              |
| [`a5139bc8`](https://github.com/NixOS/nixpkgs/commit/a5139bc8e5e3a75af094fb33ab86871a2b8a7a6c) | `` nss_latest: 3.109 -> 3.110 ``                                              |
| [`f9625662`](https://github.com/NixOS/nixpkgs/commit/f96256622a6bf355b174dcf89d50beddda4e4818) | `` erlang_26: 26.2.5.9 -> 26.2.5.10 ``                                        |
| [`8e6ce9fc`](https://github.com/NixOS/nixpkgs/commit/8e6ce9fc693128820b8a2c672f0dc6fa614c06b0) | `` erlang_25: 25.3.2.18 -> 25.3.2.19 ``                                       |
| [`e1995166`](https://github.com/NixOS/nixpkgs/commit/e19951667cf3b391216a018b6ed78695b287461f) | `` syncplay: 1.7.3 -> 1.7.4 ``                                                |
| [`5e074a40`](https://github.com/NixOS/nixpkgs/commit/5e074a400fe41abfdc1b7eddba51f7735f76740f) | `` thunderbird-latest-unwrapped: 136.0 -> 136.0.1 ``                          |
| [`0cc72779`](https://github.com/NixOS/nixpkgs/commit/0cc72779867cc8814b28eef9aa39948558497402) | `` open-policy-agent: 1.1.0 -> 1.2.0 ``                                       |