### PR TITLE
chore(flake/grayjay): `331f2332` -> `82a65106`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -408,11 +408,11 @@
         "nixpkgs": "nixpkgs_3"
       },
       "locked": {
-        "lastModified": 1743385369,
-        "narHash": "sha256-iueUQ5ap/4a85OCe6egnzQPqryC1XgoTjc7GpNNHQ7c=",
+        "lastModified": 1743563044,
+        "narHash": "sha256-UkykPaJt9Yr8YbBg34Bnh4wE+J2sksSDFdaalfnkG6k=",
         "owner": "rishabh5321",
         "repo": "grayjay-flake",
-        "rev": "331f233221d935ce0619b1c503271d510c4e0e70",
+        "rev": "82a651064b00480042d1b7f180ca77e04ea08689",
         "type": "github"
       },
       "original": {
@@ -821,11 +821,11 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1743315132,
-        "narHash": "sha256-6hl6L/tRnwubHcA4pfUUtk542wn2Om+D4UnDhlDW9BE=",
+        "lastModified": 1743448293,
+        "narHash": "sha256-bmEPmSjJakAp/JojZRrUvNcDX2R5/nuX6bm+seVaGhs=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "52faf482a3889b7619003c0daec593a1912fddc1",
+        "rev": "77b584d61ff80b4cef9245829a6f1dfad5afdfa3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                     | Message                                          |
| ---------------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
| [`82a65106`](https://github.com/Rishabh5321/grayjay-flake/commit/82a651064b00480042d1b7f180ca77e04ea08689) | `` chore(flake/nixpkgs): 52faf482 -> 77b584d6 `` |