### PR TITLE
chore(flake/akuse-flake): `c81aead7` -> `5c0ae7c0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -5,11 +5,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1743385837,
-        "narHash": "sha256-f21HebD5zIrEzdQmN8iVHTrhBoxgugS1qhm3IDE34+8=",
+        "lastModified": 1743563100,
+        "narHash": "sha256-3sIcFNJaSYRXvCdJt95JdbVwYXsL/eP2QIBD12CLVGw=",
         "owner": "Rishabh5321",
         "repo": "akuse-flake",
-        "rev": "c81aead7df1880839e142a2f7d9cd3020388deac",
+        "rev": "5c0ae7c02a0e0c63f9d95babfd21b7314af9502e",
         "type": "github"
       },
       "original": {
@@ -758,11 +758,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1743315132,
-        "narHash": "sha256-6hl6L/tRnwubHcA4pfUUtk542wn2Om+D4UnDhlDW9BE=",
+        "lastModified": 1743448293,
+        "narHash": "sha256-bmEPmSjJakAp/JojZRrUvNcDX2R5/nuX6bm+seVaGhs=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "52faf482a3889b7619003c0daec593a1912fddc1",
+        "rev": "77b584d61ff80b4cef9245829a6f1dfad5afdfa3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                   | Message                                          |
| -------------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
| [`5c0ae7c0`](https://github.com/Rishabh5321/akuse-flake/commit/5c0ae7c02a0e0c63f9d95babfd21b7314af9502e) | `` chore(flake/nixpkgs): 52faf482 -> 77b584d6 `` |