### PR TITLE
chore(flake/spicetify-nix): `567e5b6e` -> `543f12dd`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1022,11 +1022,11 @@
         "systems": "systems_3"
       },
       "locked": {
-        "lastModified": 1743308176,
-        "narHash": "sha256-xiHVIJsxj3tknObHzfKsWHQ0N38zyFsb8edB3oXDOxg=",
+        "lastModified": 1743595372,
+        "narHash": "sha256-e3x1mhpPpYgyyin9j/VbrBpOT5PFpEfx2hkxVZuJZhg=",
         "owner": "Gerg-L",
         "repo": "spicetify-nix",
-        "rev": "567e5b6ee6d7433261f16b400e424a6bd5c8c8b3",
+        "rev": "543f12dd14c62ddee79ab79fbfd8726f312b89ff",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                |
| ----------------------------------------------------------------------------------------------------- | -------------------------------------- |
| [`543f12dd`](https://github.com/Gerg-L/spicetify-nix/commit/543f12dd14c62ddee79ab79fbfd8726f312b89ff) | `` Clarify modules import in README `` |