### PR TITLE
chore(flake/stylix): `54721996` -> `1832ffa9`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1059,11 +1059,11 @@
         "tinted-zed": "tinted-zed"
       },
       "locked": {
-        "lastModified": 1743496321,
-        "narHash": "sha256-xhHg8ixBhZngvGOMb2SJuJEHhHA10n8pA02fEKuKzek=",
+        "lastModified": 1743602771,
+        "narHash": "sha256-Qv8N90FnX0Cj3mH78EtgUCa7OG7zF0C4CtclEatWqak=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "54721996d6590267d095f63297d9051e9342a33d",
+        "rev": "1832ffa9a27037388277591612af7437d1bd2bad",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                        | Message                                                 |
| --------------------------------------------------------------------------------------------- | ------------------------------------------------------- |
| [`1832ffa9`](https://github.com/danth/stylix/commit/1832ffa9a27037388277591612af7437d1bd2bad) | `` stylix: prevent partially declared cursor (#1080) `` |