### PR TITLE
chore(flake/zen-browser): `9818e303` -> `a7cc40bd`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -462,6 +462,27 @@
         "type": "github"
       }
     },
+    "home-manager_3": {
+      "inputs": {
+        "nixpkgs": [
+          "zen-browser",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1743604125,
+        "narHash": "sha256-ZD61DNbsBt1mQbinAaaEqKaJk2RFo9R/j+eYWeGMx7A=",
+        "owner": "nix-community",
+        "repo": "home-manager",
+        "rev": "180fd43eea296e62ae68e079fcf56aba268b9a1a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "home-manager",
+        "type": "github"
+      }
+    },
     "hyprcursor": {
       "inputs": {
         "hyprlang": [
@@ -917,11 +938,11 @@
     },
     "nixpkgs_9": {
       "locked": {
-        "lastModified": 1742288794,
-        "narHash": "sha256-Txwa5uO+qpQXrNG4eumPSD+hHzzYi/CdaM80M9XRLCo=",
+        "lastModified": 1743448293,
+        "narHash": "sha256-bmEPmSjJakAp/JojZRrUvNcDX2R5/nuX6bm+seVaGhs=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "b6eaf97c6960d97350c584de1b6dcff03c9daf42",
+        "rev": "77b584d61ff80b4cef9245829a6f1dfad5afdfa3",
         "type": "github"
       },
       "original": {
@@ -1297,14 +1318,15 @@
     },
     "zen-browser": {
       "inputs": {
+        "home-manager": "home-manager_3",
         "nixpkgs": "nixpkgs_9"
       },
       "locked": {
-        "lastModified": 1743600524,
-        "narHash": "sha256-ZJesdL2jwCwBF4SsWvxNyGuHUv8cGLHIQwJxma6JQR0=",
+        "lastModified": 1743618427,
+        "narHash": "sha256-tHAEredlnwXSuMTIiBgpDv7s5BqyDUubPwx28Q7GKOY=",
         "owner": "0xc000022070",
         "repo": "zen-browser-flake",
-        "rev": "9818e303273448dde6ada0f7bff8b98f5ce261da",
+        "rev": "a7cc40bda0655b67e89949bdb806e5fe1efd7ee1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                          | Message                                                                                           |
| --------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------- |
| [`a7cc40bd`](https://github.com/0xc000022070/zen-browser-flake/commit/a7cc40bda0655b67e89949bdb806e5fe1efd7ee1) | `` Update Zen Browser twilight @ x86_64 && aarch64 to 1.11t#1743616124 ``                         |
| [`c3bb78a3`](https://github.com/0xc000022070/zen-browser-flake/commit/c3bb78a3e4fbe37c3565be8929cb74035c15d0cb) | `` remove extra gappsWrapperArgs because they are inserted automatically with pkgs.wrapFirefox `` |
| [`80856259`](https://github.com/0xc000022070/zen-browser-flake/commit/808562590c116a65b063524dd54e55dc7e043d25) | `` use the .desktop file generated via wrapFirefox ``                                             |
| [`8f64cd43`](https://github.com/0xc000022070/zen-browser-flake/commit/8f64cd437e8effc13636a6e1ed567aa1772f15c6) | `` hm module: set policy properties with lib.mkDefault ``                                         |
| [`a8f6bb68`](https://github.com/0xc000022070/zen-browser-flake/commit/a8f6bb6854c0ede26a8ace4434436fc6c4302dc9) | `` fix binary names & wrapping (follow `firefox-bin` installPhase logic) ``                       |
| [`13024d81`](https://github.com/0xc000022070/zen-browser-flake/commit/13024d813c4a6e218078c960f1c14daaa00cf2ae) | `` fix mainProgram name ``                                                                        |
| [`ffb45b18`](https://github.com/0xc000022070/zen-browser-flake/commit/ffb45b18bf936562a7669d74a9e388a3013a69d5) | `` rewrite ``                                                                                     |