### PR TITLE
chore(flake/hyprland): `a4e6c5d6` -> `a41b8d5e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -557,11 +557,11 @@
         "xdph": "xdph"
       },
       "locked": {
-        "lastModified": 1743547897,
-        "narHash": "sha256-14VSGZy+0D/zVRxZl/0ZiAcTSd+R6Cw87TsmsdU1clM=",
+        "lastModified": 1743625606,
+        "narHash": "sha256-UF/Uw60W6+0n+4+CLPZB94NHSyBlETfj13L/U6DC9ak=",
         "owner": "hyprwm",
         "repo": "Hyprland",
-        "rev": "a4e6c5d678e8dd27ab07a6d6eb4ba2834fab81d1",
+        "rev": "a41b8d5e977a7382bce3de251a3a014ae7b3c625",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                                                         |
| ------------------------------------------------------------------------------------------------ | --------------------------------------------------------------- |
| [`a41b8d5e`](https://github.com/hyprwm/Hyprland/commit/a41b8d5e977a7382bce3de251a3a014ae7b3c625) | `` groupbar: add text offset and upper gap settings (#9733) ``  |
| [`8654029f`](https://github.com/hyprwm/Hyprland/commit/8654029f8662d388eefa65711a2fda360d2aa73f) | `` versionkeeper: create version file if not present (#9829) `` |