### PR TITLE
chore(flake/stylix): `aee4df6d` -> `194a91d0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1080,11 +1080,11 @@
         "tinted-zed": "tinted-zed"
       },
       "locked": {
-        "lastModified": 1743603960,
-        "narHash": "sha256-ZmQFr0HbZBSQPK9TuVmyhLcPQq2MvCClX9LzNQbRG9E=",
+        "lastModified": 1743630094,
+        "narHash": "sha256-irmHQhaHgq6iwHAuexgdqPA4X/254ss00zXPRcc8sZw=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "aee4df6dc1509fc38fb868c06bc58351446a5871",
+        "rev": "194a91d0018daaf5bcfcea4702e6800426a82445",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                        | Message                                                       |
| --------------------------------------------------------------------------------------------- | ------------------------------------------------------------- |
| [`194a91d0`](https://github.com/danth/stylix/commit/194a91d0018daaf5bcfcea4702e6800426a82445) | `` doc: collapse flake.lock in GitHub bug template (#1059) `` |