### PR TITLE
chore(flake/akuse-flake): `5c0ae7c0` -> `02a6e37d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -5,11 +5,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1743563100,
-        "narHash": "sha256-3sIcFNJaSYRXvCdJt95JdbVwYXsL/eP2QIBD12CLVGw=",
+        "lastModified": 1743632505,
+        "narHash": "sha256-gVX8tkMENFcOq6AAYjedHHbvK92t+NsRzQJ89ODp5g4=",
         "owner": "Rishabh5321",
         "repo": "akuse-flake",
-        "rev": "5c0ae7c02a0e0c63f9d95babfd21b7314af9502e",
+        "rev": "02a6e37d7c10c7487812a89af7aed4a6c2c2aa95",
         "type": "github"
       },
       "original": {
@@ -779,11 +779,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1743448293,
-        "narHash": "sha256-bmEPmSjJakAp/JojZRrUvNcDX2R5/nuX6bm+seVaGhs=",
+        "lastModified": 1743583204,
+        "narHash": "sha256-F7n4+KOIfWrwoQjXrL2wD9RhFYLs2/GGe/MQY1sSdlE=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "77b584d61ff80b4cef9245829a6f1dfad5afdfa3",
+        "rev": "2c8d3f48d33929642c1c12cd243df4cc7d2ce434",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                   | Message                                          |
| -------------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
| [`02a6e37d`](https://github.com/Rishabh5321/akuse-flake/commit/02a6e37d7c10c7487812a89af7aed4a6c2c2aa95) | `` chore(flake/nixpkgs): 77b584d6 -> 2c8d3f48 `` |