### PR TITLE
chore(flake/thorium): `8491cfbb` -> `e4dfb70a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -922,11 +922,11 @@
     },
     "nixpkgs_8": {
       "locked": {
-        "lastModified": 1743448293,
-        "narHash": "sha256-bmEPmSjJakAp/JojZRrUvNcDX2R5/nuX6bm+seVaGhs=",
+        "lastModified": 1743583204,
+        "narHash": "sha256-F7n4+KOIfWrwoQjXrL2wD9RhFYLs2/GGe/MQY1sSdlE=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "77b584d61ff80b4cef9245829a6f1dfad5afdfa3",
+        "rev": "2c8d3f48d33929642c1c12cd243df4cc7d2ce434",
         "type": "github"
       },
       "original": {
@@ -1158,11 +1158,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1743563103,
-        "narHash": "sha256-zKCNoK7Ar7pX0PIW5vjwoQK8p1wJADKZY8NEmkfNf04=",
+        "lastModified": 1743632385,
+        "narHash": "sha256-zpBuuFZy21PqbbnUX2VTwO7R98SYYhlQib9xnvO4Qkc=",
         "owner": "Rishabh5321",
         "repo": "thorium_flake",
-        "rev": "8491cfbb1566deada3d82dea7a9066281d6edcd6",
+        "rev": "e4dfb70abbe099087a1bb4b7769e6484905c3efd",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                     | Message                                          |
| ---------------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
| [`e4dfb70a`](https://github.com/Rishabh5321/thorium_flake/commit/e4dfb70abbe099087a1bb4b7769e6484905c3efd) | `` chore(flake/nixpkgs): 77b584d6 -> 2c8d3f48 `` |