### PR TITLE
chore(flake/nixpkgs-stable): `02f2af8c` -> `44a69ed6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -810,11 +810,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1743501102,
-        "narHash": "sha256-7PCBQ4aGVF8OrzMkzqtYSKyoQuU2jtpPi4lmABpe5X4=",
+        "lastModified": 1743576891,
+        "narHash": "sha256-vXiKURtntURybE6FMNFAVpRPr8+e8KoLPrYs9TGuAKc=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "02f2af8c8a8c3b2c05028936a1e84daefa1171d4",
+        "rev": "44a69ed688786e98a101f02b712c313f1ade37ab",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                            |
| ---------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------- |
| [`e734426a`](https://github.com/NixOS/nixpkgs/commit/e734426a3b10c2203199b7f0f3fa97c0a1b87e22) | `` lvm2: nixfmt ``                                                                 |
| [`e04ddc8d`](https://github.com/NixOS/nixpkgs/commit/e04ddc8dbde3a7430ff930d32ca01b7a9e5b15dd) | `` firefox-esr-128-unwrapped: 128.8.1esr -> 128.9.0esr ``                          |
| [`3abad743`](https://github.com/NixOS/nixpkgs/commit/3abad743b81654de25eae3675dd2b33e6dcd2f40) | `` firefox-esr-128-unwrapped: 128.8.0esr -> 128.8.1esr (#394111) ``                |
| [`53741239`](https://github.com/NixOS/nixpkgs/commit/53741239f212eb67900392694efc833fd1b11722) | `` firefox-bin-unwrapped: 136.0.3 -> 137.0 ``                                      |
| [`1fb6bd8f`](https://github.com/NixOS/nixpkgs/commit/1fb6bd8f9dd1fe696dd144aa7988205b63462076) | `` firefox-unwrapped: 136.0.3 -> 137.0 ``                                          |
| [`10239b97`](https://github.com/NixOS/nixpkgs/commit/10239b97f16bfd5eef0216ca555599cd3d9986e6) | `` build(deps): bump cachix/install-nix-action from {30,31} to 31.1.0 (#394893) `` |
| [`8d9a58a0`](https://github.com/NixOS/nixpkgs/commit/8d9a58a0722690621d3cde523fc2e5b77dabf320) | `` pnpm: 10.7.0 -> 10.7.1 ``                                                       |
| [`333d19c8`](https://github.com/NixOS/nixpkgs/commit/333d19c8b58402b94834ec7e0b58d83c0a0ba658) | `` vscode: 1.98.1 -> 1.98.2 ``                                                     |
| [`17fd7550`](https://github.com/NixOS/nixpkgs/commit/17fd75501e9e68a7017bcc41116be1b713845242) | `` vscode: 1.98.0 -> 1.98.1 ``                                                     |
| [`f4025192`](https://github.com/NixOS/nixpkgs/commit/f4025192cda2dff181194f2cfac15d31c5a8c8c7) | `` vscode: 1.97.2 -> 1.98.0 ``                                                     |
| [`a215622d`](https://github.com/NixOS/nixpkgs/commit/a215622da4f0d47c3e6c50ace8927f1141345a0f) | `` git-blame-ignore-revs: Add previous commit ``                                   |
| [`14182c19`](https://github.com/NixOS/nixpkgs/commit/14182c19701221692b84e7428e5b7281b099967a) | `` treewide: Format all Nix files ``                                               |
| [`ea444c00`](https://github.com/NixOS/nixpkgs/commit/ea444c0022a78364e1dc89ea07a72907ff619e4d) | `` CONTRIBUTING: Improve and update formatting docs ``                             |
| [`8c004946`](https://github.com/NixOS/nixpkgs/commit/8c004946a9ad87757bf5162051b05bf951f4d510) | `` workflows/check-nix-format: Enforce formatting on all files ``                  |
| [`c7065d2a`](https://github.com/NixOS/nixpkgs/commit/c7065d2ad97e93b21d8d67017fd99e31f894c99c) | `` flake.nix: Set formatter ``                                                     |
| [`b01d9f50`](https://github.com/NixOS/nixpkgs/commit/b01d9f50e3009dddaf3fb1cf1cc0a0a6ee324a4e) | `` shell: Introduce treefmt ``                                                     |
| [`29c23a86`](https://github.com/NixOS/nixpkgs/commit/29c23a860318513426400097136f8a8dbd6fdc53) | `` immich: 1.130.3 -> 1.131.2 ``                                                   |
| [`3c2befed`](https://github.com/NixOS/nixpkgs/commit/3c2befed8478db44513b9766aafef052649db6d8) | `` linux/hardened/patches/6.11: remove ``                                          |
| [`3cbf17cf`](https://github.com/NixOS/nixpkgs/commit/3cbf17cf450f121f30a670a22af4fd9704c77dfe) | `` linux-kernels: cleanup aliases ``                                               |
| [`4842361f`](https://github.com/NixOS/nixpkgs/commit/4842361f5a1cd614c0d56396e0d689f0fe0eef15) | `` rspamd: 3.11.0 -> 3.11.1 ``                                                     |
| [`a8747cb7`](https://github.com/NixOS/nixpkgs/commit/a8747cb72b2540d9da6252fe4826df31d572512b) | `` rspamd: build with vectorscan ``                                                |
| [`d4267211`](https://github.com/NixOS/nixpkgs/commit/d4267211bf0f6fd98c262678e474303ab1cedf21) | `` vectorscan: reformat ``                                                         |
| [`ce2effc7`](https://github.com/NixOS/nixpkgs/commit/ce2effc7e0bd88bf3bbacc00bf4176d76a7278d1) | `` vectorscan: fix pkg-config ``                                                   |
| [`52f8ed7d`](https://github.com/NixOS/nixpkgs/commit/52f8ed7d1f1c3226e42126c6135c5f5ea4d712e8) | `` vectorscan: fix cross-compile ``                                                |
| [`dc39e9f7`](https://github.com/NixOS/nixpkgs/commit/dc39e9f743292b7e4c60ae1b460b1b1d00354c4d) | `` vectorscan: unpin Boost ``                                                      |
| [`a5d25a17`](https://github.com/NixOS/nixpkgs/commit/a5d25a172673b225c36a90c4f22a0d7abae9f9ba) | `` rspamd: 3.10.2 -> 3.11.0 ``                                                     |
| [`0f7d4c22`](https://github.com/NixOS/nixpkgs/commit/0f7d4c22a9e5fee7db2f87d4574376f094bf3f20) | `` prowlarr: 1.31.2.4975 -> 1.32.2.4987 ``                                         |
| [`12dd591d`](https://github.com/NixOS/nixpkgs/commit/12dd591db7b784c44cd4df06dddb6eb6fa68a6b4) | `` python312Packages.cfn-lint: 1.18.1 -> 1.32.1 ``                                 |
| [`be5f4f88`](https://github.com/NixOS/nixpkgs/commit/be5f4f88eed89cba758afb0d7c389b41cd81e49a) | `` python312Packages.aws-sam-translator: 1.91.0 -> 1.95.0 ``                       |
| [`f8711b65`](https://github.com/NixOS/nixpkgs/commit/f8711b65fac3bead0f9934d9b91f49815d6da2fd) | `` hplip: fix plugin fetch (#391529) ``                                            |
| [`3953b1ef`](https://github.com/NixOS/nixpkgs/commit/3953b1ef81b465e0714613560e55d60329bd411d) | `` firefox-devedition-bin-unwrapped: 137.0b6 -> 137.0b10 ``                        |
| [`94cdec75`](https://github.com/NixOS/nixpkgs/commit/94cdec757ada805e1954b52894a4870c5e5a1eb7) | `` radarr: 5.19.3.9730 -> 5.21.1.9799 ``                                           |
| [`1da00df8`](https://github.com/NixOS/nixpkgs/commit/1da00df8511ad11f627f9eb67a5bee287cea8886) | `` gancio: 1.24.4 -> 1.25.1 ``                                                     |
| [`f9272f3e`](https://github.com/NixOS/nixpkgs/commit/f9272f3e3a96c7efaa0a67fe98c02aeeb3f02cca) | `` buildbox: init at 1.3.7 ``                                                      |
| [`dd77c216`](https://github.com/NixOS/nixpkgs/commit/dd77c216a320bf7c7eb44939b0896e86e7ded7a7) | `` brave: 1.76.74 -> 1.76.81 ``                                                    |
| [`2766c826`](https://github.com/NixOS/nixpkgs/commit/2766c826e53a6e40daa4de873d18c5cd55950653) | `` skypeforlinux: 8.138.0.203 -> 8.138.0.213 ``                                    |
| [`955c9033`](https://github.com/NixOS/nixpkgs/commit/955c9033179e4835f2977e4ba3bb3b39d8df2617) | `` db-rest: 6.0.6 -> 6.1.0 ``                                                      |
| [`e9908701`](https://github.com/NixOS/nixpkgs/commit/e9908701968d5341edd73768277dbee66142e8aa) | `` firefly-iii: 6.2.9 -> 6.2.10 ``                                                 |
| [`b284ea57`](https://github.com/NixOS/nixpkgs/commit/b284ea5784b6b65ff07e1a8279dfb251f0033d58) | `` mozillavpn: 2.25.0 -> 2.26.0 ``                                                 |
| [`db07b213`](https://github.com/NixOS/nixpkgs/commit/db07b21397089d01aebfe736181947ba65a9b42c) | `` tzdata: 2025a -> 2025b ``                                                       |
| [`4652098e`](https://github.com/NixOS/nixpkgs/commit/4652098e774d130001e046737792ffde1122c5ce) | `` tzdata: 2024b -> 2025a ``                                                       |
| [`4dae7a96`](https://github.com/NixOS/nixpkgs/commit/4dae7a96dc9e2c4c518d2ecfd20c40d323f7e857) | `` libical: 3.0.18 -> 3.0.19 ``                                                    |
| [`884c7c09`](https://github.com/NixOS/nixpkgs/commit/884c7c09cf34daeb0c0dce0c51f3be40fb56f9c8) | `` nodejs_20: 20.18.3 -> 20.19.0 ``                                                |
| [`c6768cef`](https://github.com/NixOS/nixpkgs/commit/c6768cef4d6081e35deeb8b97921d43926dd2daa) | `` hunspell: add wrapper test ``                                                   |
| [`8d16e501`](https://github.com/NixOS/nixpkgs/commit/8d16e5016c85f243705a9b33c6483bbc17fffc46) | `` hunspell: use binary wrapper ``                                                 |
| [`ba069577`](https://github.com/NixOS/nixpkgs/commit/ba069577ebb4282db4dbccb9e3decc2b8dbde573) | `` hunspell: migrate to by-name ``                                                 |
| [`e9ca04d1`](https://github.com/NixOS/nixpkgs/commit/e9ca04d1a27bd3ee2e5f2d4a537c0d33f6ed10cd) | `` hunspell: update upstream URLs ``                                               |
| [`1c6e8dd1`](https://github.com/NixOS/nixpkgs/commit/1c6e8dd14bd1abb9e3ed663d207b259ce1212514) | `` hunspell: add updateScript ``                                                   |
| [`634aa190`](https://github.com/NixOS/nixpkgs/commit/634aa190adfac70070ea719be52924f48a2360d7) | `` hunspell: add version test ``                                                   |
| [`f2e20774`](https://github.com/NixOS/nixpkgs/commit/f2e207748033e14b59e11f8ba459ca123abab5dd) | `` hunspell: add pkg-config checks ``                                              |
| [`cb088a69`](https://github.com/NixOS/nixpkgs/commit/cb088a693c0b30acc7df752f485741f602eacc6f) | `` hunspell: modernize ``                                                          |
| [`c351a7bc`](https://github.com/NixOS/nixpkgs/commit/c351a7bc9044d3f38d88bb72060840af8d428526) | `` hunspell: add getchoo as maintainer ``                                          |
| [`c8de2098`](https://github.com/NixOS/nixpkgs/commit/c8de2098dc48751173294f75de41dbbcf78e170e) | `` hunspell: format with nixfmt ``                                                 |
| [`e168cc8e`](https://github.com/NixOS/nixpkgs/commit/e168cc8e97c7ea9fa6468a54059b159da49499de) | `` ghostscript: 10.04.0 -> 10.05.0 ``                                              |
| [`1e306f31`](https://github.com/NixOS/nixpkgs/commit/1e306f31e316ccadc513e81474c04ccca7fa2c79) | `` nixos/doc/release-notes: mention xf86videointel has been fixed ``               |
| [`1d41354f`](https://github.com/NixOS/nixpkgs/commit/1d41354f4dd25ae7b8997b90783b6c086d45b6b2) | `` go_1_23: 1.23.6 -> 1.23.7 ``                                                    |
| [`8ec99711`](https://github.com/NixOS/nixpkgs/commit/8ec997111ad42c9120e9e647222cdb0be10fc7d2) | `` lvm2: 2.03.30 -> 2.03.31 ``                                                     |
| [`8a6c086a`](https://github.com/NixOS/nixpkgs/commit/8a6c086a8fc315af6053fb863b3fc3733f2c7b85) | `` lvm2: 2.03.29 -> 2.03.30 ``                                                     |
| [`2bb4a685`](https://github.com/NixOS/nixpkgs/commit/2bb4a6855c739d55e632b5ba9866e9c5601bad83) | `` lvm2: fix libdevmapper SONAME when onlyLib is on ``                             |
| [`5760fbca`](https://github.com/NixOS/nixpkgs/commit/5760fbca8814995d381064b087d73f2534ddf230) | `` lvm2: 2.03.28 -> 2.03.29 ``                                                     |
| [`e114c493`](https://github.com/NixOS/nixpkgs/commit/e114c493b6a51043b4863bde53d8755c687d54e1) | `` lvm2: 2.03.27 -> 2.03.28 ``                                                     |
| [`b2e249c2`](https://github.com/NixOS/nixpkgs/commit/b2e249c229e42c7162e6e3d8ef624e9ff06a6380) | `` nixos/doc: xf86videointel is available again ``                                 |
| [`f84493bc`](https://github.com/NixOS/nixpkgs/commit/f84493bc5836af46835aa01dee7d8450b6516f43) | `` qt6.qtbase: add Vulkan loader to rpath for QtGui ``                             |
| [`6aa8357c`](https://github.com/NixOS/nixpkgs/commit/6aa8357c68d481cf025ac33638b99f5920a871a6) | `` xorg.xf86videointel: re-add driver ``                                           |
| [`62c722a8`](https://github.com/NixOS/nixpkgs/commit/62c722a8083ff6d3cc44805ec9a3ea72225f8426) | `` Mesa: backport dril patch ``                                                    |
| [`e3ab63dd`](https://github.com/NixOS/nixpkgs/commit/e3ab63dd854d181a0336eb85171c00cb0b8e4d12) | `` vim: 9.1.1111 -> 9.1.1122 ``                                                    |
| [`2d8295be`](https://github.com/NixOS/nixpkgs/commit/2d8295be2341bc59e97cb4dd4302dd4cce1bebe0) | `` vim: 9.1.1046 -> 9.1.1111 ``                                                    |
| [`16aed6ea`](https://github.com/NixOS/nixpkgs/commit/16aed6eafd72e747e64f59af27ddc2ffb7494fb7) | `` cairo: pull upstream fix for "out of memory" errors ``                          |