### PR TITLE
chore(flake/better-control): `3e5ca685` -> `c334b2e1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -124,11 +124,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1743635445,
-        "narHash": "sha256-uh5WCB71gPV0cSiJId+ZXSFAWhVaFgVIF36X7Ry5ImM=",
+        "lastModified": 1743655437,
+        "narHash": "sha256-KnUiUUEPjT6IEiGedSWiADlZR9xG2s6wmg/WEF0up9M=",
         "owner": "rishabh5321",
         "repo": "better-control-flake",
-        "rev": "3e5ca6852f9d26023bd27cb79ba603504a7650aa",
+        "rev": "c334b2e165c170bc93f41e5e6ca90f28b8c15611",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                            | Message                                                                              |
| ----------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------ |
| [`c334b2e1`](https://github.com/Rishabh5321/better-control-flake/commit/c334b2e165c170bc93f41e5e6ca90f28b8c15611) | `` refactor: restructure better-control package and remove obsolete desktop entry `` |