### PR TITLE
chore(flake/better-control): `d7f9124f` -> `351ca4aa`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -124,11 +124,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1743655874,
-        "narHash": "sha256-0z7lFlDIqLoDWmdPNyzSu5XDMCISWXWGcGYtGtFqvTA=",
+        "lastModified": 1743659224,
+        "narHash": "sha256-YQRSEd9V2U/uo9E/5pCkdRA4Fgupky/KsmBLRa7EF8g=",
         "owner": "rishabh5321",
         "repo": "better-control-flake",
-        "rev": "d7f9124fd27ef81d11b171752188946ca494d542",
+        "rev": "351ca4aa9180105b037173cd7d444cea2b31a52c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                            | Message                                                                          |
| ----------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------- |
| [`5dc7f9fd`](https://github.com/Rishabh5321/better-control-flake/commit/5dc7f9fda6c5e384aa2d58a9d72c41a831b84771) | `` chore: auto lint and format ``                                                |
| [`364de23b`](https://github.com/Rishabh5321/better-control-flake/commit/364de23b2f57150f8600e0faf5165c7fc5d98b3c) | `` chore: remove dead code ``                                                    |
| [`d72e0401`](https://github.com/Rishabh5321/better-control-flake/commit/d72e04016e84b40415ed8d9babdb571ec4cd5206) | `` fix: update flake_check workflow to only capture errors in logs ``            |
| [`83d56c93`](https://github.com/Rishabh5321/better-control-flake/commit/83d56c9336cae005ace9918b5aed3736409a1f2a) | `` fix: update release_check workflow to reference package.nix for versioning `` |