### PR TITLE
chore(flake/hyprland): `b496e2c7` -> `5e8bb717`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -557,11 +557,11 @@
         "xdph": "xdph"
       },
       "locked": {
-        "lastModified": 1743666186,
-        "narHash": "sha256-Mt2hsnJnYUodsfkBowkHNG5U66WpJ4pwsb05oyFbeSE=",
+        "lastModified": 1743691259,
+        "narHash": "sha256-7HH0BRp+jkGK+4kjIgcABnttUL9vyQjmaZz2VU661ow=",
         "owner": "hyprwm",
         "repo": "Hyprland",
-        "rev": "b496e2c71817aae5560af04b8c6439c39f4e05d8",
+        "rev": "5e8bb7178501ea65fe54be5614e6ba4a6369c600",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                                                                           |
| ------------------------------------------------------------------------------------------------ | --------------------------------------------------------------------------------- |
| [`5e8bb717`](https://github.com/hyprwm/Hyprland/commit/5e8bb7178501ea65fe54be5614e6ba4a6369c600) | `` ctm: fix crash when finishing ctm progress with a destroyed monitor (#9835) `` |