### PR TITLE
chore(flake/better-control): `351ca4aa` -> `32d31642`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -124,11 +124,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1743659224,
-        "narHash": "sha256-YQRSEd9V2U/uo9E/5pCkdRA4Fgupky/KsmBLRa7EF8g=",
+        "lastModified": 1743701109,
+        "narHash": "sha256-YXBkcfBg83eiPuIRbtGwbU6Yd/JNJ7EQimCTWi04XMI=",
         "owner": "rishabh5321",
         "repo": "better-control-flake",
-        "rev": "351ca4aa9180105b037173cd7d444cea2b31a52c",
+        "rev": "32d316423b01b7e35597d5f75b3a85c48bd6c9f9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                            | Message                                                                         |
| ----------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------- |
| [`eca351e4`](https://github.com/Rishabh5321/better-control-flake/commit/eca351e47eace9c809bca4ff0bb90d2d40003e8e) | `` refactor: simplify package.nix and update dependencies for better-control `` |
| [`3d3dd535`](https://github.com/Rishabh5321/better-control-flake/commit/3d3dd5359b52154493b331fa9056dcda71f7baa3) | `` Update better-control to 5.9 ``                                              |