### PR TITLE
chore(flake/zen-browser): `e562cb38` -> `fa21b240`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1322,11 +1322,11 @@
         "nixpkgs": "nixpkgs_9"
       },
       "locked": {
-        "lastModified": 1743643497,
-        "narHash": "sha256-+8T42oUfQhUaT/K8UQeCT7ZFlBHKXm+j9fvmR/6MaQQ=",
+        "lastModified": 1743704747,
+        "narHash": "sha256-aaC3O8QFEEn/h450ksMj05fPv5sI9s2bmGjbLtp0YUo=",
         "owner": "0xc000022070",
         "repo": "zen-browser-flake",
-        "rev": "e562cb38d2d2466f2d560517e757f7648154852c",
+        "rev": "fa21b2402e0cea3616121dff915f1be54dd8dca2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                          | Message                                                    |
| --------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------- |
| [`fa21b240`](https://github.com/0xc000022070/zen-browser-flake/commit/fa21b2402e0cea3616121dff915f1be54dd8dca2) | `` Update Zen Browser beta @ x86_64 && aarch64 to 1.11b `` |