### PR TITLE
chore(flake/zen-browser): `fa21b240` -> `05274a63`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1322,11 +1322,11 @@
         "nixpkgs": "nixpkgs_9"
       },
       "locked": {
-        "lastModified": 1743704747,
-        "narHash": "sha256-aaC3O8QFEEn/h450ksMj05fPv5sI9s2bmGjbLtp0YUo=",
+        "lastModified": 1743722669,
+        "narHash": "sha256-XNw/PBxt8HLFkUUXQbdt8YMP7AHRzVbGAbOi1BUFIsA=",
         "owner": "0xc000022070",
         "repo": "zen-browser-flake",
-        "rev": "fa21b2402e0cea3616121dff915f1be54dd8dca2",
+        "rev": "05274a63b9dd6c951d66cf80db202741a5b5cbdb",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                          | Message                                                      |
| --------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------ |
| [`05274a63`](https://github.com/0xc000022070/zen-browser-flake/commit/05274a63b9dd6c951d66cf80db202741a5b5cbdb) | `` fix(package): create symlink to expose binary as "zen" `` |
| [`93a71620`](https://github.com/0xc000022070/zen-browser-flake/commit/93a716206efc7904425efb080ec4b1f4819fbc54) | `` dev: add alejandra as project formatter ``                |
| [`e3565720`](https://github.com/0xc000022070/zen-browser-flake/commit/e3565720916554a0b52f9a8fd4d6f3cef0f98041) | `` style: nix code with alejandra format ``                  |