### PR TITLE
chore(flake/stylix): `ac8dd8b1` -> `9ef80628`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1080,11 +1080,11 @@
         "tinted-zed": "tinted-zed"
       },
       "locked": {
-        "lastModified": 1743733287,
-        "narHash": "sha256-Yg2225KQ3hM6VJSPLRz7/+Ci3A9t4c/L5GZDFD/MGRU=",
+        "lastModified": 1743771862,
+        "narHash": "sha256-mFp77TPN9xxsXDveh3oyvDlKdON1Xnp+S9Z0oBZSEsE=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "ac8dd8b1a6bc2d367f7ec8e39e0032f03ae9a458",
+        "rev": "9ef806283b87f99dfa574b6642165cf052a1d49e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                        | Message                                                  |
| --------------------------------------------------------------------------------------------- | -------------------------------------------------------- |
| [`9ef80628`](https://github.com/danth/stylix/commit/9ef806283b87f99dfa574b6642165cf052a1d49e) | `` discord: fix template for  new ui redesign (#1063) `` |