### PR TITLE
chore(flake/better-control): `533266af` -> `6a1404d1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -124,11 +124,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1743754780,
-        "narHash": "sha256-nWMPH/lJiEXQ4d+4GeYkpbO7F51MzsjkSkoBr2/z4Xc=",
+        "lastModified": 1743775976,
+        "narHash": "sha256-X+wjG5iFxs9oErsD7P8YLJKnKr6I9jTY7bTwEXplLUk=",
         "owner": "rishabh5321",
         "repo": "better-control-flake",
-        "rev": "533266af58d259879548bb9a1fa35aad7ff45ee0",
+        "rev": "6a1404d1e3dcea837b156ac27fe9e7846981dd61",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                            | Message                                                                                         |
| ----------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------- |
| [`6a1404d1`](https://github.com/Rishabh5321/better-control-flake/commit/6a1404d1e3dcea837b156ac27fe9e7846981dd61) | `` fix: add nix-prefetch-github installation to release_check workflow for version retrieval `` |
| [`83abee42`](https://github.com/Rishabh5321/better-control-flake/commit/83abee4257d5360a8a2d9d13e113e921f1de2c4d) | `` fix: enhance release_check workflow to create or update Pull Request if it already exists `` |
| [`0d49fb6c`](https://github.com/Rishabh5321/better-control-flake/commit/0d49fb6c5c7715e3f107810cf3f3e533b15b2767) | `` fix: streamline version and hash update process in release_check workflow ``                 |
| [`19bfc728`](https://github.com/Rishabh5321/better-control-flake/commit/19bfc7289d5627038a80d946c769d202381c2af1) | `` fix: improve error handling and hash retrieval in release_check workflow ``                  |
| [`fcd13458`](https://github.com/Rishabh5321/better-control-flake/commit/fcd13458fd62792195758a5b2cfba1ea83897126) | `` fix: enhance release_check workflow with improved error handling for version retrieval ``    |
| [`de87c062`](https://github.com/Rishabh5321/better-control-flake/commit/de87c062fc6bed1b53e85362f3eaf350a7241d8a) | `` fix: update release_check workflow to handle version and hash updates more robustly ``       |
| [`b2270438`](https://github.com/Rishabh5321/better-control-flake/commit/b2270438f7c1662e7c821bf2e9d5eae2fd81eb88) | `` fix: update release_check workflow to use 'hash' instead of 'sha256' ``                      |