### PR TITLE
chore(flake/stylix): `9ef80628` -> `581fa67c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1080,11 +1080,11 @@
         "tinted-zed": "tinted-zed"
       },
       "locked": {
-        "lastModified": 1743771862,
-        "narHash": "sha256-mFp77TPN9xxsXDveh3oyvDlKdON1Xnp+S9Z0oBZSEsE=",
+        "lastModified": 1743775855,
+        "narHash": "sha256-ZhhiYvHlA9f/Ck1i76ilfapLS7abLPRlWJQRxJEDTnQ=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "9ef806283b87f99dfa574b6642165cf052a1d49e",
+        "rev": "581fa67c818aaf91a1533149fb737d3e8c0949b8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                        | Message                                                 |
| --------------------------------------------------------------------------------------------- | ------------------------------------------------------- |
| [`581fa67c`](https://github.com/danth/stylix/commit/581fa67c818aaf91a1533149fb737d3e8c0949b8) | `` stylix: guard entire overlay declarations (#1088) `` |
| [`a214b330`](https://github.com/danth/stylix/commit/a214b330e5d8940b05ccd951eb5c6ac0f13d125f) | `` mpv: unset subtitle font size (#1090) ``             |