### PR TITLE
chore(flake/better-control): `0c56fe0d` -> `9673756f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -124,11 +124,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1743781514,
-        "narHash": "sha256-NXQHYoPjo7HkWj4xgB5GHKVQUyP5k+Mc+ce3fv3Ro6g=",
+        "lastModified": 1743786323,
+        "narHash": "sha256-YIViYtMhjO/WCTWcf52AVpMSt0QmUEV8a6fIjpd9xXQ=",
         "owner": "rishabh5321",
         "repo": "better-control-flake",
-        "rev": "0c56fe0d75c6b1ff0a9b35838d15ca1e710d03f1",
+        "rev": "9673756f577700ca1a5f849a257ed9bee1512709",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                            | Message                                                               |
| ----------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------- |
| [`9673756f`](https://github.com/Rishabh5321/better-control-flake/commit/9673756f577700ca1a5f849a257ed9bee1512709) | `` fix: correct syntax error in platforms specification ``            |
| [`c2eae71a`](https://github.com/Rishabh5321/better-control-flake/commit/c2eae71adb2713dad8253607bd14372a4dc2295d) | `` fix: update platforms specification to restrict to x86_64-linux `` |
| [`a36585ce`](https://github.com/Rishabh5321/better-control-flake/commit/a36585cede9edd172a71050c352c50c5f4dae103) | `` fix: downgrade better-control version to 5.9 and update hash ``    |