### PR TITLE
chore(flake/home-manager): `bb036cb3` -> `0f5908da`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -428,11 +428,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1743783108,
-        "narHash": "sha256-Lg1cK7oGCNPOO1ts481m269WmdGNoigz8RNXLRE9Co0=",
+        "lastModified": 1743788974,
+        "narHash": "sha256-2LeVyQZI2wTkSzMLvnN/kJjXVWp4HCVUoq17Bv8TNTk=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "bb036cb35383982066e01a6ac8d45597132cf5d5",
+        "rev": "0f5908daf890c3d7e7052bef1d6deb0f2710aaa1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                         |
| ----------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------- |
| [`0f5908da`](https://github.com/nix-community/home-manager/commit/0f5908daf890c3d7e7052bef1d6deb0f2710aaa1) | `` home-environment: enable home aliases for nushell (#6754) `` |
| [`07547d29`](https://github.com/nix-community/home-manager/commit/07547d29e12deeb82dedf893cdc89b127fe7195c) | `` swaync: use lib.getExe (#6755) ``                            |