### PR TITLE
chore(flake/nixpkgs-stable): `44a69ed6` -> `bdb91860`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -810,11 +810,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1743576891,
-        "narHash": "sha256-vXiKURtntURybE6FMNFAVpRPr8+e8KoLPrYs9TGuAKc=",
+        "lastModified": 1743703532,
+        "narHash": "sha256-s1KLDALEeqy+ttrvqV3jx9mBZEvmthQErTVOAzbjHZs=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "44a69ed688786e98a101f02b712c313f1ade37ab",
+        "rev": "bdb91860de2f719b57eef819b5617762f7120c70",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                      |
| ---------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------- |
| [`e35d9ad4`](https://github.com/NixOS/nixpkgs/commit/e35d9ad43fdf53bf9dd01b82baa9ae088d868828) | `` yandex-disk: fix missing libstdc++.so.6 ``                                |
| [`f0bc4bf4`](https://github.com/NixOS/nixpkgs/commit/f0bc4bf49164cba761177b8d5997600e522b0577) | `` sdl3: 3.2.8 -> 3.2.10 ``                                                  |
| [`ab925160`](https://github.com/NixOS/nixpkgs/commit/ab925160749909c82275efdb2a018ffbc26f2b49) | `` modrinth-app: 0.9.0 -> 0.9.3 (#395691) ``                                 |
| [`d4d11f5f`](https://github.com/NixOS/nixpkgs/commit/d4d11f5f6ff71909b801820bbeb2bb9191059bd9) | `` python313Packages.django_5: 5.1.7 -> 5.1.8 ``                             |
| [`9499c35a`](https://github.com/NixOS/nixpkgs/commit/9499c35ad4516dec13e6e0f27c9dd8d8b74be3cd) | `` miniflux: 2.2.6 -> 2.2.7 ``                                               |
| [`04afa164`](https://github.com/NixOS/nixpkgs/commit/04afa164df9f8f919663861bf727e60d69b821e0) | `` gerrit: 3.10.4 -> 3.10.5 ``                                               |
| [`e0db5366`](https://github.com/NixOS/nixpkgs/commit/e0db53665fb71441f9fb40b392dece7ba37cc8b8) | `` element-call: 0.7.1 -> 0.9.0 ``                                           |
| [`26e16847`](https://github.com/NixOS/nixpkgs/commit/26e168479fdc7a75fe55e457e713d8b5f794606a) | `` electron-source.electron_35: 35.0.3 -> 35.1.2 ``                          |
| [`e1627183`](https://github.com/NixOS/nixpkgs/commit/e1627183e65294137574476af707a517270bcca5) | `` electron-source.electron_34: 34.3.4 -> 34.4.1 ``                          |
| [`ce628b49`](https://github.com/NixOS/nixpkgs/commit/ce628b49b794ba289828b2959f3bb4a47ecee9e4) | `` electron-source.electron_33: 33.4.6 -> 33.4.8 ``                          |
| [`b671bfa1`](https://github.com/NixOS/nixpkgs/commit/b671bfa1a4440ba1c3e8606fd5fc2f47445c86b2) | `` electron-chromedriver_35: 35.0.3 -> 35.1.2 ``                             |
| [`7c0ff365`](https://github.com/NixOS/nixpkgs/commit/7c0ff365c76fdafa932ee0786c2e693ff5c7be14) | `` electron_35-bin: 35.0.3 -> 35.1.2 ``                                      |
| [`35c6b4ec`](https://github.com/NixOS/nixpkgs/commit/35c6b4ecbba4c4df3cd1b7eefecbf54e30d0b962) | `` electron-chromedriver_34: 34.3.4 -> 34.4.1 ``                             |
| [`fe809c9b`](https://github.com/NixOS/nixpkgs/commit/fe809c9bc3c0116c5b2b685f591603d4d428fa63) | `` electron_34-bin: 34.3.4 -> 34.4.1 ``                                      |
| [`c014c271`](https://github.com/NixOS/nixpkgs/commit/c014c271c387bdc2cac6ad35acb8a2f4b8e25119) | `` electron-chromedriver_33: 33.4.6 -> 33.4.8 ``                             |
| [`5f4df15c`](https://github.com/NixOS/nixpkgs/commit/5f4df15c02a2f03f0a53c0c36de6f6f808940e2f) | `` electron_33-bin: 33.4.6 -> 33.4.8 ``                                      |
| [`34342757`](https://github.com/NixOS/nixpkgs/commit/34342757a0755c99658361df7f50be244c548f53) | `` electron-source.electron_34: 34.3.3 -> 34.3.4 ``                          |
| [`040a52d9`](https://github.com/NixOS/nixpkgs/commit/040a52d99977305148a139147b867e192680b650) | `` electron-source.electron_33: 33.4.5 -> 33.4.6 ``                          |
| [`01275985`](https://github.com/NixOS/nixpkgs/commit/01275985a1c185a36747a4601534235533ce6716) | `` electron-chromedriver_34: 34.3.3 -> 34.3.4 ``                             |
| [`ceb5b6f0`](https://github.com/NixOS/nixpkgs/commit/ceb5b6f0d3152f5c64b05a2025b0b28a02dc2b19) | `` electron_34-bin: 34.3.3 -> 34.3.4 ``                                      |
| [`f4847ed6`](https://github.com/NixOS/nixpkgs/commit/f4847ed6010109b83069af7ae7be734c03d4569a) | `` electron-chromedriver_33: 33.4.5 -> 33.4.6 ``                             |
| [`8eec3130`](https://github.com/NixOS/nixpkgs/commit/8eec3130ff782fa75b014a3fdcc434a951956c7c) | `` electron_33-bin: 33.4.5 -> 33.4.6 ``                                      |
| [`1150fd62`](https://github.com/NixOS/nixpkgs/commit/1150fd62a65d3ce7c3916b61d48d29611c3f904d) | `` Take systemd configuration from upstream package instead of definiting `` |
| [`196d9b74`](https://github.com/NixOS/nixpkgs/commit/196d9b74422e9eb5ebe1b4eb893fb9330bb0a334) | `` paretosecurity: 0.0.91 -> 0.0.92 ``                                       |
| [`86e7e0eb`](https://github.com/NixOS/nixpkgs/commit/86e7e0ebe62a40cc0522e36e64187b127f991db0) | `` [release-24.11] xorg: format ``                                           |
| [`d7b8c4d7`](https://github.com/NixOS/nixpkgs/commit/d7b8c4d7aaf01a735a34a382fd18b67560335733) | `` nixos/nextcloud: check if ownership of config is correct ``               |
| [`d45e9346`](https://github.com/NixOS/nixpkgs/commit/d45e9346f03010c76f890de48c23d10d47f68fbf) | `` firejail: 0.9.72 -> 0.9.74 (#393185) ``                                   |
| [`a4507380`](https://github.com/NixOS/nixpkgs/commit/a45073800c9888718f8ca9a33ceed9e3a8fa6e27) | `` tail-tray: 0.2.18 -> 0.2.19 ``                                            |
| [`f8c80531`](https://github.com/NixOS/nixpkgs/commit/f8c805319ae8f06812755f0145637ce1f0a041dd) | `` mullvad-browser: 14.0.7 -> 14.0.9 ``                                      |
| [`9a277aa0`](https://github.com/NixOS/nixpkgs/commit/9a277aa0b27b7b73a74a5a25cc672329ca887454) | `` tor-browser: 14.0.7 -> 14.0.9 ``                                          |
| [`561258e9`](https://github.com/NixOS/nixpkgs/commit/561258e94d5d59364630ca123b78a5657c298f22) | `` chromium,chromedriver: 134.0.6998.165 -> 135.0.7049.52 ``                 |
| [`bcb4ba7c`](https://github.com/NixOS/nixpkgs/commit/bcb4ba7cbe3d9a18020946338882a564fbd3326c) | `` libdigidocpp: 4.0.0 -> 4.1.0 ``                                           |
| [`128cbd4b`](https://github.com/NixOS/nixpkgs/commit/128cbd4b95307f1ac447174d80869811d3325d1b) | `` thunderbird-128: 128.8.0esr -> 128.8.1esr ``                              |
| [`3bb04249`](https://github.com/NixOS/nixpkgs/commit/3bb04249680205e966a0f9fb71c9e49c4c9dae02) | `` qdigidoc: 4.6.0 -> 4.7.0 ``                                               |
| [`9f881d80`](https://github.com/NixOS/nixpkgs/commit/9f881d807fb50fa20ad84c92b130cec7e5d8ddb1) | `` authenticator: modernize ``                                               |
| [`dbc19c8d`](https://github.com/NixOS/nixpkgs/commit/dbc19c8d757d58a36ea1399e229adfbd2bdbc5d7) | `` authenticator: format with nixfmt ``                                      |
| [`36bc96da`](https://github.com/NixOS/nixpkgs/commit/36bc96da9fa2b7931f8839cc8e15536bdfff461b) | `` authenticator: 4.6.0 -> 4.6.2 ``                                          |
| [`e39b5d79`](https://github.com/NixOS/nixpkgs/commit/e39b5d7914eee9819bf9c15f1d696ebb0c848b63) | `` authenticator: 4.5.0 -> 4.6.0 ``                                          |