### PR TITLE
chore(flake/zen-browser): `05274a63` -> `89838136`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1322,11 +1322,11 @@
         "nixpkgs": "nixpkgs_9"
       },
       "locked": {
-        "lastModified": 1743722669,
-        "narHash": "sha256-XNw/PBxt8HLFkUUXQbdt8YMP7AHRzVbGAbOi1BUFIsA=",
+        "lastModified": 1743794176,
+        "narHash": "sha256-8NBzvxORnEiU0nExqlt2XSjb8EiCieZ/bIH1pP/EsVQ=",
         "owner": "0xc000022070",
         "repo": "zen-browser-flake",
-        "rev": "05274a63b9dd6c951d66cf80db202741a5b5cbdb",
+        "rev": "898381368418440745deee9145c4880e1d589213",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                          | Message                                                                   |
| --------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------- |
| [`89838136`](https://github.com/0xc000022070/zen-browser-flake/commit/898381368418440745deee9145c4880e1d589213) | `` Update Zen Browser twilight @ x86_64 && aarch64 to 1.11t#1743792908 `` |