### PR TITLE
chore(flake/zen-browser): `89838136` -> `48684cc5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1322,11 +1322,11 @@
         "nixpkgs": "nixpkgs_9"
       },
       "locked": {
-        "lastModified": 1743794176,
-        "narHash": "sha256-8NBzvxORnEiU0nExqlt2XSjb8EiCieZ/bIH1pP/EsVQ=",
+        "lastModified": 1743798013,
+        "narHash": "sha256-tu1oPYFWY8dPtalV7On0DVrrNqrn4g2pYyR5yBt44NU=",
         "owner": "0xc000022070",
         "repo": "zen-browser-flake",
-        "rev": "898381368418440745deee9145c4880e1d589213",
+        "rev": "48684cc5214f41f1e3fd64e41660fc064cf01815",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                          | Message                                                                   |
| --------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------- |
| [`48684cc5`](https://github.com/0xc000022070/zen-browser-flake/commit/48684cc5214f41f1e3fd64e41660fc064cf01815) | `` Update Zen Browser twilight @ x86_64 && aarch64 to 1.11t#1743797618 `` |