### PR TITLE
chore(flake/hyprland): `ff97d18c` -> `8ba20fca`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -557,11 +557,11 @@
         "xdph": "xdph"
       },
       "locked": {
-        "lastModified": 1743703735,
-        "narHash": "sha256-xcxT/1X0quzovhfLkz9UL8nt4QGnoi8uNHGUl26x2eQ=",
+        "lastModified": 1743809433,
+        "narHash": "sha256-tCOlE2zMXfd+KNG5ETr2VxhbniDMD7jBbD0JQhYBrlc=",
         "owner": "hyprwm",
         "repo": "Hyprland",
-        "rev": "ff97d18c4c61ae14f8f3b80178e6b72c8a4b7901",
+        "rev": "8ba20fcae124591718bddadd94c5e8c381d02097",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                                                   |
| ------------------------------------------------------------------------------------------------ | --------------------------------------------------------- |
| [`8ba20fca`](https://github.com/hyprwm/Hyprland/commit/8ba20fcae124591718bddadd94c5e8c381d02097) | `` compositor: avoid crash on null window monitor move `` |