### PR TITLE
chore(flake/zen-browser): `a7cc40bd` -> `41455486`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1322,11 +1322,11 @@
         "nixpkgs": "nixpkgs_9"
       },
       "locked": {
-        "lastModified": 1743618427,
-        "narHash": "sha256-tHAEredlnwXSuMTIiBgpDv7s5BqyDUubPwx28Q7GKOY=",
+        "lastModified": 1743849740,
+        "narHash": "sha256-ggVct8jrTB8OZBtPxH++PZDBhOU1MJHdpzBDhs5PxtQ=",
         "owner": "0xc000022070",
         "repo": "zen-browser-flake",
-        "rev": "a7cc40bda0655b67e89949bdb806e5fe1efd7ee1",
+        "rev": "41455486298ef224e4bae6f551d3508b94d36456",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                          | Message                                                                     |
| --------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------- |
| [`464fe5b8`](https://github.com/0xc000022070/zen-browser-flake/commit/464fe5b828a179b00bcec16aea2b120321dae820) | `` Update Zen Browser beta @ x86_64 && aarch64 to 1.11.1b ``                |
| [`05e0ba13`](https://github.com/0xc000022070/zen-browser-flake/commit/05e0ba13f847ab7521fc85664d85727a5c32fdb5) | `` Update Zen Browser twilight @ x86_64 && aarch64 to 1.11.1t#1743833402 `` |
| [`48684cc5`](https://github.com/0xc000022070/zen-browser-flake/commit/48684cc5214f41f1e3fd64e41660fc064cf01815) | `` Update Zen Browser twilight @ x86_64 && aarch64 to 1.11t#1743797618 ``   |
| [`89838136`](https://github.com/0xc000022070/zen-browser-flake/commit/898381368418440745deee9145c4880e1d589213) | `` Update Zen Browser twilight @ x86_64 && aarch64 to 1.11t#1743792908 ``   |
| [`ab78c046`](https://github.com/0xc000022070/zen-browser-flake/commit/ab78c0467a997563e42e585d784b45e5853704b7) | `` Fix zen symlink: link to the binary that is going to be wrapped ``       |
| [`05274a63`](https://github.com/0xc000022070/zen-browser-flake/commit/05274a63b9dd6c951d66cf80db202741a5b5cbdb) | `` fix(package): create symlink to expose binary as "zen" ``                |
| [`93a71620`](https://github.com/0xc000022070/zen-browser-flake/commit/93a716206efc7904425efb080ec4b1f4819fbc54) | `` dev: add alejandra as project formatter ``                               |
| [`e3565720`](https://github.com/0xc000022070/zen-browser-flake/commit/e3565720916554a0b52f9a8fd4d6f3cef0f98041) | `` style: nix code with alejandra format ``                                 |
| [`fa21b240`](https://github.com/0xc000022070/zen-browser-flake/commit/fa21b2402e0cea3616121dff915f1be54dd8dca2) | `` Update Zen Browser beta @ x86_64 && aarch64 to 1.11b ``                  |
| [`e562cb38`](https://github.com/0xc000022070/zen-browser-flake/commit/e562cb38d2d2466f2d560517e757f7648154852c) | `` Update Zen Browser twilight @ x86_64 && aarch64 to 1.11t#1743640534 ``   |