### PR TITLE
chore(flake/zen-browser): `41455486` -> `d0b39aeb`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1322,11 +1322,11 @@
         "nixpkgs": "nixpkgs_9"
       },
       "locked": {
-        "lastModified": 1743849740,
-        "narHash": "sha256-ggVct8jrTB8OZBtPxH++PZDBhOU1MJHdpzBDhs5PxtQ=",
+        "lastModified": 1743854692,
+        "narHash": "sha256-0j18TfmblTLRC/yJhx3uhaJZ1gmq1JDCZgKtJMjHb9s=",
         "owner": "0xc000022070",
         "repo": "zen-browser-flake",
-        "rev": "41455486298ef224e4bae6f551d3508b94d36456",
+        "rev": "d0b39aeb79744bc47c6cc3b0fde1d5156673d4a6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                          | Message                                              |
| --------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------- |
| [`07d29de1`](https://github.com/0xc000022070/zen-browser-flake/commit/07d29de12301ea7e6289b143563cd0803b6a5d74) | `` Force zen to set WM class to $MOZ_APP_LAUNCHER `` |