### PR TITLE
chore(flake/stylix): `581fa67c` -> `3a698571`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1080,11 +1080,11 @@
         "tinted-zed": "tinted-zed"
       },
       "locked": {
-        "lastModified": 1743775855,
-        "narHash": "sha256-ZhhiYvHlA9f/Ck1i76ilfapLS7abLPRlWJQRxJEDTnQ=",
+        "lastModified": 1743877209,
+        "narHash": "sha256-DTSnxnN/OS+5eI17ycTEddiY940zYB15pLJ9TAxvUgU=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "581fa67c818aaf91a1533149fb737d3e8c0949b8",
+        "rev": "3a6985718a3cad0fb873c9d465607fe96bcbcf7a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                        | Message                                                      |
| --------------------------------------------------------------------------------------------- | ------------------------------------------------------------ |
| [`3a698571`](https://github.com/danth/stylix/commit/3a6985718a3cad0fb873c9d465607fe96bcbcf7a) | `` swaylock: align colors better with style guide (#1099) `` |