### PR TITLE
chore(flake/stylix): `3a698571` -> `8865a737`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1080,11 +1080,11 @@
         "tinted-zed": "tinted-zed"
       },
       "locked": {
-        "lastModified": 1743877209,
-        "narHash": "sha256-DTSnxnN/OS+5eI17ycTEddiY940zYB15pLJ9TAxvUgU=",
+        "lastModified": 1743883696,
+        "narHash": "sha256-7utAiapp3suMv9Ht7sFb/gcFIP5A7A85A86qEz1qkmw=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "3a6985718a3cad0fb873c9d465607fe96bcbcf7a",
+        "rev": "8865a737ced73e2a45146c231f6ed5a766688ece",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                        | Message                        |
| --------------------------------------------------------------------------------------------- | ------------------------------ |
| [`8865a737`](https://github.com/danth/stylix/commit/8865a737ced73e2a45146c231f6ed5a766688ece) | `` bat: add testbed (#1095) `` |