### PR TITLE
chore(flake/better-control): `096d85b8` -> `37e4b0df`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -124,11 +124,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1743874524,
-        "narHash": "sha256-xqTd67NXvkM0rMe/dIJoBNGjOdS/FL3GWQZHKLCms54=",
+        "lastModified": 1743900781,
+        "narHash": "sha256-YABSyBczm/sf9xgOyYj/eiplBb/Lq/ieid76U3a0HnE=",
         "owner": "rishabh5321",
         "repo": "better-control-flake",
-        "rev": "096d85b896edb7153895da6ea2474f7ecfe9543c",
+        "rev": "37e4b0df46db3bf0b1602333a90c059f43e780cb",
         "type": "github"
       },
       "original": {
@@ -826,11 +826,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1743583204,
-        "narHash": "sha256-F7n4+KOIfWrwoQjXrL2wD9RhFYLs2/GGe/MQY1sSdlE=",
+        "lastModified": 1743827369,
+        "narHash": "sha256-rpqepOZ8Eo1zg+KJeWoq1HAOgoMCDloqv5r2EAa9TSA=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "2c8d3f48d33929642c1c12cd243df4cc7d2ce434",
+        "rev": "42a1c966be226125b48c384171c44c651c236c22",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                            | Message                                          |
| ----------------------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
| [`37e4b0df`](https://github.com/Rishabh5321/better-control-flake/commit/37e4b0df46db3bf0b1602333a90c059f43e780cb) | `` chore(flake/nixpkgs): 2c8d3f48 -> 42a1c966 `` |