### PR TITLE
chore(flake/hyprland): `433b7881` -> `e96b8ce4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -557,11 +557,11 @@
         "xdph": "xdph"
       },
       "locked": {
-        "lastModified": 1743893669,
-        "narHash": "sha256-uqMsHhDQDAwJjuoKzZLM8wxxELiMr4y76kMKR/TqxVA=",
+        "lastModified": 1743895813,
+        "narHash": "sha256-Bj0DslgOrAxs16wSfVvkO8z6o+GF5VLSBn79I7pUZNQ=",
         "owner": "hyprwm",
         "repo": "Hyprland",
-        "rev": "433b7881a3a46473fbc9df526870e23562b31bf8",
+        "rev": "e96b8ce4cc5e5856b6da653f1d92af856b5e72c9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                                                     |
| ------------------------------------------------------------------------------------------------ | ----------------------------------------------------------- |
| [`e96b8ce4`](https://github.com/hyprwm/Hyprland/commit/e96b8ce4cc5e5856b6da653f1d92af856b5e72c9) | `` window: send fractional scale on updateScaleTransform `` |