### PR TITLE
chore(flake/grayjay): `bf510a89` -> `323a62a8`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -408,11 +408,11 @@
         "nixpkgs": "nixpkgs_3"
       },
       "locked": {
-        "lastModified": 1743639555,
-        "narHash": "sha256-9aQwP+UNqzSEG9v00EsBDTIxhqjBggXM10mVwSUWlV4=",
+        "lastModified": 1743903782,
+        "narHash": "sha256-e8n5MDOe2bbpdKWHyvNnHYHfOWgMZgoQlEg7rqgdIcM=",
         "owner": "rishabh5321",
         "repo": "grayjay-flake",
-        "rev": "bf510a89a39b21dd33ca1ea2c84906fc152d2b6e",
+        "rev": "323a62a8a7211641406a13b1c4134cb02d597813",
         "type": "github"
       },
       "original": {
@@ -842,11 +842,11 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1743583204,
-        "narHash": "sha256-F7n4+KOIfWrwoQjXrL2wD9RhFYLs2/GGe/MQY1sSdlE=",
+        "lastModified": 1743827369,
+        "narHash": "sha256-rpqepOZ8Eo1zg+KJeWoq1HAOgoMCDloqv5r2EAa9TSA=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "2c8d3f48d33929642c1c12cd243df4cc7d2ce434",
+        "rev": "42a1c966be226125b48c384171c44c651c236c22",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                     | Message                                          |
| ---------------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
| [`323a62a8`](https://github.com/Rishabh5321/grayjay-flake/commit/323a62a8a7211641406a13b1c4134cb02d597813) | `` chore(flake/nixpkgs): 2c8d3f48 -> 42a1c966 `` |