### PR TITLE
chore(flake/akuse-flake): `02a6e37d` -> `0797734f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -5,11 +5,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1743632505,
-        "narHash": "sha256-gVX8tkMENFcOq6AAYjedHHbvK92t+NsRzQJ89ODp5g4=",
+        "lastModified": 1743904257,
+        "narHash": "sha256-diiEy/U/Im7jgfN6SVI1W0mk6/oi68VZJp4tBBpiWB4=",
         "owner": "Rishabh5321",
         "repo": "akuse-flake",
-        "rev": "02a6e37d7c10c7487812a89af7aed4a6c2c2aa95",
+        "rev": "0797734f137d924c73729ecc4425829ce98f5883",
         "type": "github"
       },
       "original": {
@@ -779,11 +779,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1743583204,
-        "narHash": "sha256-F7n4+KOIfWrwoQjXrL2wD9RhFYLs2/GGe/MQY1sSdlE=",
+        "lastModified": 1743827369,
+        "narHash": "sha256-rpqepOZ8Eo1zg+KJeWoq1HAOgoMCDloqv5r2EAa9TSA=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "2c8d3f48d33929642c1c12cd243df4cc7d2ce434",
+        "rev": "42a1c966be226125b48c384171c44c651c236c22",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                   | Message                                          |
| -------------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
| [`0797734f`](https://github.com/Rishabh5321/akuse-flake/commit/0797734f137d924c73729ecc4425829ce98f5883) | `` chore(flake/nixpkgs): 2c8d3f48 -> 42a1c966 `` |