### PR TITLE
chore(flake/thorium): `e4dfb70a` -> `0a278218`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -922,11 +922,11 @@
     },
     "nixpkgs_8": {
       "locked": {
-        "lastModified": 1743583204,
-        "narHash": "sha256-F7n4+KOIfWrwoQjXrL2wD9RhFYLs2/GGe/MQY1sSdlE=",
+        "lastModified": 1743827369,
+        "narHash": "sha256-rpqepOZ8Eo1zg+KJeWoq1HAOgoMCDloqv5r2EAa9TSA=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "2c8d3f48d33929642c1c12cd243df4cc7d2ce434",
+        "rev": "42a1c966be226125b48c384171c44c651c236c22",
         "type": "github"
       },
       "original": {
@@ -1158,11 +1158,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1743632385,
-        "narHash": "sha256-zpBuuFZy21PqbbnUX2VTwO7R98SYYhlQib9xnvO4Qkc=",
+        "lastModified": 1743903766,
+        "narHash": "sha256-R2tqCavl3dZPTQcxLu5dlUhVnY1nZOowqCPWrGwAkko=",
         "owner": "Rishabh5321",
         "repo": "thorium_flake",
-        "rev": "e4dfb70abbe099087a1bb4b7769e6484905c3efd",
+        "rev": "0a2782181317d134b5bbb41b7a03d877cf5c4e8a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                     | Message                                          |
| ---------------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
| [`0a278218`](https://github.com/Rishabh5321/thorium_flake/commit/0a2782181317d134b5bbb41b7a03d877cf5c4e8a) | `` chore(flake/nixpkgs): 2c8d3f48 -> 42a1c966 `` |