### PR TITLE
chore(flake/better-control): `37e4b0df` -> `04a925e3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -124,11 +124,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1743900781,
-        "narHash": "sha256-YABSyBczm/sf9xgOyYj/eiplBb/Lq/ieid76U3a0HnE=",
+        "lastModified": 1743911166,
+        "narHash": "sha256-XkmZwnwcghs4EwNKL263DjFC48CbqGMEIBaZrvbWfFw=",
         "owner": "rishabh5321",
         "repo": "better-control-flake",
-        "rev": "37e4b0df46db3bf0b1602333a90c059f43e780cb",
+        "rev": "04a925e3e67d6faeb065c5bdfa4f3bcb25f9b52f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                            | Message                                                                          |
| ----------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------- |
| [`04a925e3`](https://github.com/Rishabh5321/better-control-flake/commit/04a925e3e67d6faeb065c5bdfa4f3bcb25f9b52f) | `` feat: update README for USBGuard usage and add usbguard configuration file `` |