### PR TITLE
chore(flake/nixpkgs-stable): `bdb91860` -> `7819a0d2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -810,11 +810,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1743703532,
-        "narHash": "sha256-s1KLDALEeqy+ttrvqV3jx9mBZEvmthQErTVOAzbjHZs=",
+        "lastModified": 1743813633,
+        "narHash": "sha256-BgkBz4NpV6Kg8XF7cmHDHRVGZYnKbvG0Y4p+jElwxaM=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "bdb91860de2f719b57eef819b5617762f7120c70",
+        "rev": "7819a0d29d1dd2bc331bec4b327f0776359b1fa6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                               |
| ---------------------------------------------------------------------------------------------- | --------------------------------------------------------------------- |
| [`673c5246`](https://github.com/NixOS/nixpkgs/commit/673c52461d646254c6599c4a28cfebdda17d9b1c) | `` ungoogled-chromium: 134.0.6998.165-1 -> 135.0.7049.52-1 ``         |
| [`64f81e68`](https://github.com/NixOS/nixpkgs/commit/64f81e68ce90abb381a1995a542b12877df8dd3e) | `` docker_27: sync runc and containerd versions with upstream ``      |
| [`e4c15926`](https://github.com/NixOS/nixpkgs/commit/e4c15926318e62e486a3ad2185d013e3ba99bd66) | `` docker: 27.5.0 -> 27.5.1 ``                                        |
| [`87c5bd06`](https://github.com/NixOS/nixpkgs/commit/87c5bd062e3cdda2512840499bbedb81d9644e4a) | `` docker: 27.4.1 -> 27.5.0 ``                                        |
| [`b72d9ec9`](https://github.com/NixOS/nixpkgs/commit/b72d9ec993ed62c4077a41909575ca45cf644608) | `` docker: 27.4.0 -> 27.4.1 ``                                        |
| [`809c7cd8`](https://github.com/NixOS/nixpkgs/commit/809c7cd8025b04702c0376c11a9d30977ae20bc6) | `` erlang_27: 27.3.1 -> 27.3.2 ``                                     |
| [`b6150d02`](https://github.com/NixOS/nixpkgs/commit/b6150d02cd61d0688198bcf28d5ee8c0ea82b2be) | `` docker: 27.3.1 -> 27.4.0 ``                                        |
| [`b99260b2`](https://github.com/NixOS/nixpkgs/commit/b99260b2714af8e5cca5fafbf001c2db941ef1cd) | `` ci/eval: check that flake outputs on all systems still evaluate `` |
| [`81605266`](https://github.com/NixOS/nixpkgs/commit/81605266411a8157cea3acba6778e5df56566965) | `` flake: fix `nix flake check --all-systems --no-build` again ``     |
| [`1d4a9bb8`](https://github.com/NixOS/nixpkgs/commit/1d4a9bb830b7d45196a6f38bef84259819850765) | `` linux-doc: fix build (#395281) ``                                  |
| [`16cf86be`](https://github.com/NixOS/nixpkgs/commit/16cf86bef7e656d6349940efc297d808a8b73ed1) | `` paretosecurity: 0.0.96 -> 0.1.3 ``                                 |
| [`dc28c22d`](https://github.com/NixOS/nixpkgs/commit/dc28c22d71f4162b7aebd83085f7e7004cf41daf) | `` vencord: 1.11.7 -> 1.11.8 ``                                       |
| [`532247cc`](https://github.com/NixOS/nixpkgs/commit/532247cc647f168465afa9d04f7e86904a864738) | `` [Backport release-24.11] bird3: 3.0.1 -> 3.1.0 (#395990) ``        |
| [`d65fdc8f`](https://github.com/NixOS/nixpkgs/commit/d65fdc8fbaa7f7bbe364eb9b71979631980f6a05) | `` firefox-devedition-unwrapped: 137.0b8 -> 137.0b10 ``               |
| [`a4a36d4a`](https://github.com/NixOS/nixpkgs/commit/a4a36d4ac791fa99f7c462d661361fdff482bb29) | `` firefox-devedition-unwrapped: 137.0b6 -> 137.0b8 ``                |
| [`8e41292f`](https://github.com/NixOS/nixpkgs/commit/8e41292f6f48ca4e9ea372ed30223ddb5f2430ab) | `` inv-sig-helper: 0-unstable-2025-03-27 -> 0-unstable-2025-04-03 ``  |
| [`cd5f28f2`](https://github.com/NixOS/nixpkgs/commit/cd5f28f257817edf0944f2c597c0c7f5d3b223c0) | `` lockbook-desktop: 0.9.20 -> 0.9.21 ``                              |
| [`61015124`](https://github.com/NixOS/nixpkgs/commit/6101512453d0063d912445b60f45bf0c126fda76) | `` lockbook: 0.9.20 -> 0.9.21 ``                                      |