### PR TITLE
chore(flake/spicetify-nix): `e0e0ade4` -> `af24d969`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1043,11 +1043,11 @@
         "systems": "systems_3"
       },
       "locked": {
-        "lastModified": 1743913010,
-        "narHash": "sha256-0vUy6MYKBdu9CqyDrl88AM/1+HiJBq2OgS4+DCSwlVo=",
+        "lastModified": 1743946771,
+        "narHash": "sha256-n/LxWCGJtDi/rWMKEXWQn39v46iFZpW+V9mY4/4LJQs=",
         "owner": "Gerg-L",
         "repo": "spicetify-nix",
-        "rev": "e0e0ade4c7f143ac4f000065b1d6e9376538e6cb",
+        "rev": "af24d96983faa41e79fa00312106c37a7cc2ca0a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                            |
| ----------------------------------------------------------------------------------------------------- | ---------------------------------- |
| [`af24d969`](https://github.com/Gerg-L/spicetify-nix/commit/af24d96983faa41e79fa00312106c37a7cc2ca0a) | `` revert: spicetify-cli update `` |