### PR TITLE
chore(flake/home-manager): `8c9b5450` -> `c15ab0ce`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -562,11 +562,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1743989761,
-        "narHash": "sha256-PF+SS1vHKXGMNelvPWVlRDk+12ZyovhVET0C3MjyAPQ=",
+        "lastModified": 1743998782,
+        "narHash": "sha256-gckmtwW/H0jEM1Y8G3wBLfr2nJvwBdjuqnjKNV0lcQY=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "8c9b54504c89f3aec9c82b262c1f4304407fbad6",
+        "rev": "c15ab0ce0dbe64843358a3081b09ed35144dfd65",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                          |
| ----------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------- |
| [`c15ab0ce`](https://github.com/nix-community/home-manager/commit/c15ab0ce0dbe64843358a3081b09ed35144dfd65) | `` swayr: systemd.target default to wayland.systemd target ``    |
| [`320e152d`](https://github.com/nix-community/home-manager/commit/320e152d0bade4ca3c1054c1ddee97bb50dfb541) | `` wlsunset: systemdTarget used for all targets ``               |
| [`a90ab0ab`](https://github.com/nix-community/home-manager/commit/a90ab0ab5f00efce68729df4e0ea196f03b2d2c6) | `` wlsunset: systemdTarget default to wayland.systemd target ``  |
| [`8871d0b1`](https://github.com/nix-community/home-manager/commit/8871d0b1ef705554db56982916bbceefd3253e78) | `` cliphist: systemdTargets default to wayland.systemd target `` |