### PR TITLE
chore(flake/better-control): `57efc5fe` -> `a7aae0be`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -124,11 +124,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1743948153,
-        "narHash": "sha256-L/ID/xjtf8KOAhDIpZaAAWN+E1+xdTDBNDwgHzAYJa4=",
+        "lastModified": 1744000386,
+        "narHash": "sha256-ZkTQI9x7orN0dqetos9cHcT9lMoVB5uk2ukrdThpMIs=",
         "owner": "rishabh5321",
         "repo": "better-control-flake",
-        "rev": "57efc5fe6ba0820336abedc6076d853169c37bf2",
+        "rev": "a7aae0be3398c0c33f32a8df2de682e772bbd632",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                            | Message                                                                    |
| ----------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------- |
| [`eae96669`](https://github.com/Rishabh5321/better-control-flake/commit/eae966696b54a0b65e743fe881dfd2ab1259c9b5) | `` feat: Remove outdated GitHub Actions workflow for version badge data `` |
| [`6010cb3a`](https://github.com/Rishabh5321/better-control-flake/commit/6010cb3a63b6437d8a45106c7bebee0902e4fe2c) | `` feat: Update better-control to v6.4 ``                                  |