### PR TITLE
chore(flake/hyprland): `51838fb5` -> `8a8f394d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -691,11 +691,11 @@
         "xdph": "xdph"
       },
       "locked": {
-        "lastModified": 1743975687,
-        "narHash": "sha256-k21wOvAEzCLHIUsVG551y6cMxmQ7sXQLOtlxQXV09xk=",
+        "lastModified": 1744029991,
+        "narHash": "sha256-++WgYi6LeTvsRtCwEF0G91cFctfPCK+mA32jkokNAPs=",
         "owner": "hyprwm",
         "repo": "Hyprland",
-        "rev": "51838fb5f5b5b03bca99b324fb1f6494d3854f89",
+        "rev": "8a8f394da70e40043d1ba2c193b81867560b2b05",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                                                                                |
| ------------------------------------------------------------------------------------------------ | -------------------------------------------------------------------------------------- |
| [`8a8f394d`](https://github.com/hyprwm/Hyprland/commit/8a8f394da70e40043d1ba2c193b81867560b2b05) | `` swipe: fix swiping onto a new workspace bound to another monitor (#8176) (#9927) `` |