### PR TITLE
chore(flake/zen-browser): `d0b39aeb` -> `f4edde8a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1541,11 +1541,11 @@
         "nixpkgs": "nixpkgs_11"
       },
       "locked": {
-        "lastModified": 1743854692,
-        "narHash": "sha256-0j18TfmblTLRC/yJhx3uhaJZ1gmq1JDCZgKtJMjHb9s=",
+        "lastModified": 1744032540,
+        "narHash": "sha256-KMshnTCoe11oTzsUp5T3e0+9/dVlLSI/wIA7Nli3LI0=",
         "owner": "0xc000022070",
         "repo": "zen-browser-flake",
-        "rev": "d0b39aeb79744bc47c6cc3b0fde1d5156673d4a6",
+        "rev": "f4edde8a094098c8f16de4efc93e057c2cd3c06b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                          | Message                                                                     |
| --------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------- |
| [`f4edde8a`](https://github.com/0xc000022070/zen-browser-flake/commit/f4edde8a094098c8f16de4efc93e057c2cd3c06b) | `` Update Zen Browser twilight @ x86_64 && aarch64 to 1.11.1t#1744031320 `` |