### PR TITLE
chore(flake/akuse-flake): `0797734f` -> `1b05ecda`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -5,11 +5,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1743904257,
-        "narHash": "sha256-diiEy/U/Im7jgfN6SVI1W0mk6/oi68VZJp4tBBpiWB4=",
+        "lastModified": 1744036860,
+        "narHash": "sha256-38hFiktk+E/OeharE7Cr/s0UbqNonkKYAzPCgFcp6h0=",
         "owner": "Rishabh5321",
         "repo": "akuse-flake",
-        "rev": "0797734f137d924c73729ecc4425829ce98f5883",
+        "rev": "1b05ecda86c80f8521ca1a203154134ddadb7813",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                   | Message                                                       |
| -------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------- |
| [`1b05ecda`](https://github.com/Rishabh5321/akuse-flake/commit/1b05ecda86c80f8521ca1a203154134ddadb7813) | `` chore(flake/nixpkgs): update Cachix setup with new name `` |