### PR TITLE
chore(flake/home-manager): `f463902a` -> `a4d80208`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -562,11 +562,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1744008831,
-        "narHash": "sha256-g3mHJLB8ShKuMaBBZxiGuoftJ22f7Boegiw5xBUnS8E=",
+        "lastModified": 1744038920,
+        "narHash": "sha256-9a4V1wQXS8hXZtc7mRtz0qINkGW+C99aDrmXY6oYBFg=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "f463902a3f03e15af658e48bcc60b39188ddf734",
+        "rev": "a4d8020820a85b47f842eae76ad083b0ec2a886a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                             |
| ----------------------------------------------------------------------------------------------------------- | --------------------------------------------------- |
| [`a4d80208`](https://github.com/nix-community/home-manager/commit/a4d8020820a85b47f842eae76ad083b0ec2a886a) | `` flake.nix: include more doc outputs ``           |
| [`1a186efb`](https://github.com/nix-community/home-manager/commit/1a186efb48030b06975677a6b8331fbe9e9a3e46) | `` default.nix: add htmlOpenTool output for docs `` |
| [`14269b06`](https://github.com/nix-community/home-manager/commit/14269b06a06601aecfd10c33f3f2a45b304b23d5) | `` docs/flake.nix: add flake outputs for docs ``    |