### PR TITLE
chore(flake/seanime): `ccfc2e1b` -> `2557a13a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1156,11 +1156,11 @@
     },
     "nixpkgs_9": {
       "locked": {
-        "lastModified": 1743827369,
-        "narHash": "sha256-rpqepOZ8Eo1zg+KJeWoq1HAOgoMCDloqv5r2EAa9TSA=",
+        "lastModified": 1743964447,
+        "narHash": "sha256-nEo1t3Q0F+0jQ36HJfbJtiRU4OI+/0jX/iITURKe3EE=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "42a1c966be226125b48c384171c44c651c236c22",
+        "rev": "063dece00c5a77e4a0ea24e5e5a5bd75232806f8",
         "type": "github"
       },
       "original": {
@@ -1241,11 +1241,11 @@
         "nixpkgs": "nixpkgs_9"
       },
       "locked": {
-        "lastModified": 1744036716,
-        "narHash": "sha256-r9J0WymwEu4WmY8cqPVY15H4/tGavAJ1N2NTkd+m39M=",
+        "lastModified": 1744063800,
+        "narHash": "sha256-JO6vwUcJskkiugTVOLiFVP/2flqY1/IVTI6xfyaXlE4=",
         "owner": "rishabh5321",
         "repo": "seanime-flake",
-        "rev": "ccfc2e1b2f453c71a475f7be413dbeab9d40a02d",
+        "rev": "2557a13aaae96fd25cc0404e1d8dcd394509ca4c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                     | Message                                          |
| ---------------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
| [`2557a13a`](https://github.com/Rishabh5321/seanime-flake/commit/2557a13aaae96fd25cc0404e1d8dcd394509ca4c) | `` chore(flake/nixpkgs): 42a1c966 -> 063dece0 `` |