### PR TITLE
chore(flake/nixpkgs): `42a1c966` -> `063dece0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1140,11 +1140,11 @@
     },
     "nixpkgs_8": {
       "locked": {
-        "lastModified": 1743827369,
-        "narHash": "sha256-rpqepOZ8Eo1zg+KJeWoq1HAOgoMCDloqv5r2EAa9TSA=",
+        "lastModified": 1743964447,
+        "narHash": "sha256-nEo1t3Q0F+0jQ36HJfbJtiRU4OI+/0jX/iITURKe3EE=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "42a1c966be226125b48c384171c44c651c236c22",
+        "rev": "063dece00c5a77e4a0ea24e5e5a5bd75232806f8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                           |
| ---------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------- |
| [`232e3f69`](https://github.com/NixOS/nixpkgs/commit/232e3f6966d9375df3131fed69af10497e9a6a91) | `` androidStudioPackages.canary: 2025.1.1.2 -> 2025.1.1.4 ``                      |
| [`6bb30abc`](https://github.com/NixOS/nixpkgs/commit/6bb30abc46c01aae233f4e123612f108f6ada846) | `` androidStudioPackages.beta: 2024.3.2.9 -> 2024.3.2.10 ``                       |
| [`b25f8e81`](https://github.com/NixOS/nixpkgs/commit/b25f8e81ba2c90380ce60ba406be7e1ddc62dea1) | `` anubis: 1.15.1 -> 1.15.2 ``                                                    |
| [`1a01e367`](https://github.com/NixOS/nixpkgs/commit/1a01e367f6ecc25c4d6c0a7bcad19e30d06e8f70) | `` nixos/bash: Reset title bar when logging out of remote NixOS system ``         |
| [`b1bcd7ac`](https://github.com/NixOS/nixpkgs/commit/b1bcd7acba553608e44cd4e3d11b92d792d520d3) | `` nixos/bash: Add support for `/etc/bash_logout` ``                              |
| [`33ff0f4b`](https://github.com/NixOS/nixpkgs/commit/33ff0f4bec532961027068b875122f5785a781f7) | `` fex: 2503 -> 2504 ``                                                           |
| [`1a7bf680`](https://github.com/NixOS/nixpkgs/commit/1a7bf6808cfcfc99b0253a387f11b7b5be80b539) | `` .devcontainer: clarify the formatter is nixfmt-rfc-style ``                    |
| [`cfc19d7f`](https://github.com/NixOS/nixpkgs/commit/cfc19d7f8470dc1613219f923dbb32c7754536b6) | `` home-assistant-custom-components.solax_modbus: 2025.02.1 -> 2025.04.1 ``       |
| [`71968cba`](https://github.com/NixOS/nixpkgs/commit/71968cbab63be88816f1c9e0127b7423b01f4afd) | `` python313Packages.pymodbus: 3.8.3 -> 3.8.6 ``                                  |
| [`3c2c42b7`](https://github.com/NixOS/nixpkgs/commit/3c2c42b78cc8423c4a0ccf62810918edd023e0a1) | `` python313Packages.model-checker: 0.8.19 -> 0.8.20 ``                           |
| [`b36b2b78`](https://github.com/NixOS/nixpkgs/commit/b36b2b7884db1725e7e9c1eaa8b7766c541f2328) | `` python313Packages.meshtastic: 2.6.0 -> 2.6.1 ``                                |
| [`5cca3ad4`](https://github.com/NixOS/nixpkgs/commit/5cca3ad45fa6ce6f890bfc72ce15bdb9765ea28e) | `` python313Packages.decora-wifi: refactor ``                                     |
| [`b1a549d4`](https://github.com/NixOS/nixpkgs/commit/b1a549d4fa7f58d046242a037fd5f58a3e2bee49) | `` .devcontainer: apply nixfmt-rfc-style on save ``                               |
| [`1f4837a9`](https://github.com/NixOS/nixpkgs/commit/1f4837a96ae6225d7eb0e987192c691850111472) | `` unibilium: add missing homepage ``                                             |
| [`a7d91185`](https://github.com/NixOS/nixpkgs/commit/a7d91185f3774b9e7a15a1eda7bb1735da7909c3) | `` linkerd_edge: 25.3.2 -> 25.4.1 ``                                              |
| [`fb7c7eb8`](https://github.com/NixOS/nixpkgs/commit/fb7c7eb834479d80caae492d9c362e2b65e3dd3b) | `` wakapi: 2.13.1 -> 2.13.2 ``                                                    |
| [`e0754b43`](https://github.com/NixOS/nixpkgs/commit/e0754b43a307c04a572d03cd797c946da3bd9b34) | `` abseil-cpp_202501: init at 20250127.1 ``                                       |
| [`f555156c`](https://github.com/NixOS/nixpkgs/commit/f555156cb02b558404fd3e6140b76e713df85efb) | `` Revert "double-entry-generator: 2.7.1 -> 2.8.0" ``                             |
| [`67e192c0`](https://github.com/NixOS/nixpkgs/commit/67e192c0737c8dfab655573e62af61b37f259ec8) | `` vscode: 1.98.2 -> 1.99.0 ``                                                    |
| [`79c9abe5`](https://github.com/NixOS/nixpkgs/commit/79c9abe566cc6da9d6937f0ea29a38d6a2f7b7a2) | `` python312Packages.decora-wifi: 1.4 -> 1.5 ``                                   |
| [`5f25acef`](https://github.com/NixOS/nixpkgs/commit/5f25aceff534e4f73ebf0b3d3902e8c99ed9a92c) | `` treewide: remove azahi from maintainers ``                                     |
| [`158b281e`](https://github.com/NixOS/nixpkgs/commit/158b281ec598b07c9bb1e3f574c3b06d2ed3b943) | `` podman-tui: 1.4.0 -> 1.5.0 ``                                                  |
| [`c186ef8d`](https://github.com/NixOS/nixpkgs/commit/c186ef8dbff7f583da22b2a9f2766088335a5741) | `` qq: 3.2.16-2025.3.18 -> 3.2.16-2025.4.1 ``                                     |
| [`61eecb22`](https://github.com/NixOS/nixpkgs/commit/61eecb22860b15d0faba4bf89ada7199576695f0) | `` vscode-extensions.42crunch.vscode-openapi: 4.27.0 -> 4.33.1 ``                 |
| [`ccd54179`](https://github.com/NixOS/nixpkgs/commit/ccd541790593c392cdc1e3c65381ceffee492886) | `` vscode-extensions.42crunch.vscode-openapi: update license gpl3 -> agpl3Only `` |
| [`34601bfa`](https://github.com/NixOS/nixpkgs/commit/34601bfafb979f65ad405ea899f098256a79c356) | `` torrentools: remove package ``                                                 |
| [`82a82feb`](https://github.com/NixOS/nixpkgs/commit/82a82febaa8aa4c633daf762ddcd0457d41d7f6a) | `` typos: 1.30.3 -> 1.31.1 ``                                                     |
| [`f8010113`](https://github.com/NixOS/nixpkgs/commit/f8010113169f584df1546a6c1b212f8c421de2de) | `` rio: 0.2.10 -> 0.2.12 ``                                                       |
| [`e1acb3b1`](https://github.com/NixOS/nixpkgs/commit/e1acb3b1f1a81ac3258591922b73c6052d0dff29) | `` vimPlugins.cord-nvim: cannot get `cord-server` executable path ``              |
| [`f6887f5f`](https://github.com/NixOS/nixpkgs/commit/f6887f5f479bb9079477d75b8e36ac4509c19942) | `` obs-studio-plugins.obs-color-monitor: 0.8.2 -> 0.9.0 ``                        |
| [`16cbb286`](https://github.com/NixOS/nixpkgs/commit/16cbb2868b69448229a74ea16b9c76a154babe3a) | `` altus: 5.6.0 -> 5.6.1 (#396515) ``                                             |
| [`3bd056cf`](https://github.com/NixOS/nixpkgs/commit/3bd056cf711a7013df6660f8d9a0a29dcb35e1ec) | `` python312Packages.dash: 3.0.0 -> 3.0.2 ``                                      |
| [`f8dfc0ff`](https://github.com/NixOS/nixpkgs/commit/f8dfc0ff8a4856ab00012d0f179853689750d5a2) | `` python313Packages.zlib-wrapper: init at 0.1.3 ``                               |
| [`af3fb0be`](https://github.com/NixOS/nixpkgs/commit/af3fb0be19d7f28d919cc671a1a9fb047fe26ab3) | `` python313Packages.pysecretsocks: init at 0.9.1-unstable-2023-11-04 ``          |
| [`fcc8071d`](https://github.com/NixOS/nixpkgs/commit/fcc8071df9fccccd3dc3fad90d258e137ae73b67) | `` double-entry-generator: 2.7.1 -> 2.8.0 ``                                      |
| [`c1ba4ff2`](https://github.com/NixOS/nixpkgs/commit/c1ba4ff2792f93d5af95ff1722321c762fedefb7) | `` open-webui: 0.6.0 -> 0.6.1 ``                                                  |
| [`33a06460`](https://github.com/NixOS/nixpkgs/commit/33a0646036647ee97cbfe3a720f2cd8ee9e6f606) | `` google-chrome: 134.0.6998.165 -> 135.0.7049.52 (#396503) ``                    |
| [`806ecdbf`](https://github.com/NixOS/nixpkgs/commit/806ecdbf5878836815b654753c5e5622d767e653) | `` github-mcp-server: init at 0.1.0 ``                                            |
| [`832151d6`](https://github.com/NixOS/nixpkgs/commit/832151d60cc809a34d35d595d8c9705e1e68f0da) | `` release-plz: 0.3.128 -> 0.3.130 ``                                             |