### PR TITLE
chore(flake/grayjay): `03588a27` -> `8f66347a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -542,11 +542,11 @@
         "nixpkgs": "nixpkgs_5"
       },
       "locked": {
-        "lastModified": 1744036427,
-        "narHash": "sha256-SayTRpehcJ3kPWP7pUn0d7v1VUsqV3rlujwvkDcaLRg=",
+        "lastModified": 1744064383,
+        "narHash": "sha256-BlLa36XjEi+QBybo9/c/5qMDBMO/d/HbNul9XZtv6EE=",
         "owner": "rishabh5321",
         "repo": "grayjay-flake",
-        "rev": "03588a27c0e7ed47e7d184188b4c7ebba24fe2ea",
+        "rev": "8f66347a8cf516dd586e853dfc961b0ac3e91c3c",
         "type": "github"
       },
       "original": {
@@ -1092,11 +1092,11 @@
     },
     "nixpkgs_5": {
       "locked": {
-        "lastModified": 1743827369,
-        "narHash": "sha256-rpqepOZ8Eo1zg+KJeWoq1HAOgoMCDloqv5r2EAa9TSA=",
+        "lastModified": 1743964447,
+        "narHash": "sha256-nEo1t3Q0F+0jQ36HJfbJtiRU4OI+/0jX/iITURKe3EE=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "42a1c966be226125b48c384171c44c651c236c22",
+        "rev": "063dece00c5a77e4a0ea24e5e5a5bd75232806f8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                     | Message                                          |
| ---------------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
| [`8f66347a`](https://github.com/Rishabh5321/grayjay-flake/commit/8f66347a8cf516dd586e853dfc961b0ac3e91c3c) | `` chore(flake/nixpkgs): 42a1c966 -> 063dece0 `` |