### PR TITLE
chore(flake/thorium): `f01d8ecd` -> `4746b796`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1014,11 +1014,11 @@
     },
     "nixpkgs_10": {
       "locked": {
-        "lastModified": 1743827369,
-        "narHash": "sha256-rpqepOZ8Eo1zg+KJeWoq1HAOgoMCDloqv5r2EAa9TSA=",
+        "lastModified": 1743964447,
+        "narHash": "sha256-nEo1t3Q0F+0jQ36HJfbJtiRU4OI+/0jX/iITURKe3EE=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "42a1c966be226125b48c384171c44c651c236c22",
+        "rev": "063dece00c5a77e4a0ea24e5e5a5bd75232806f8",
         "type": "github"
       },
       "original": {
@@ -1377,11 +1377,11 @@
         "nixpkgs": "nixpkgs_10"
       },
       "locked": {
-        "lastModified": 1744037079,
-        "narHash": "sha256-WGxFkUe23FOMdKwz7s4ePx2VjdcZ9LIkRUpEqkwoKqU=",
+        "lastModified": 1744064417,
+        "narHash": "sha256-0PFmvtb4i3H/lDHM8ULH53erXJ2aGQx3ArqSZlwtwDE=",
         "owner": "Rishabh5321",
         "repo": "thorium_flake",
-        "rev": "f01d8ecdfee256fcfdf96d0c537e3f6e1e38eab5",
+        "rev": "4746b79631c015e1524522e8b324c2ecdd9491f9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                     | Message                                          |
| ---------------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
| [`4746b796`](https://github.com/Rishabh5321/thorium_flake/commit/4746b79631c015e1524522e8b324c2ecdd9491f9) | `` chore(flake/nixpkgs): 42a1c966 -> 063dece0 `` |