### PR TITLE
chore(flake/akuse-flake): `1b05ecda` -> `d23c3903`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -5,11 +5,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1744036860,
-        "narHash": "sha256-38hFiktk+E/OeharE7Cr/s0UbqNonkKYAzPCgFcp6h0=",
+        "lastModified": 1744064516,
+        "narHash": "sha256-tXxtxTsC7AVDrm9e/IcvNENUqeF2M7KoMj9d79n5cBw=",
         "owner": "Rishabh5321",
         "repo": "akuse-flake",
-        "rev": "1b05ecda86c80f8521ca1a203154134ddadb7813",
+        "rev": "d23c3903525931332bddf53c6b637e6d8b8d4727",
         "type": "github"
       },
       "original": {
@@ -935,11 +935,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1743827369,
-        "narHash": "sha256-rpqepOZ8Eo1zg+KJeWoq1HAOgoMCDloqv5r2EAa9TSA=",
+        "lastModified": 1743964447,
+        "narHash": "sha256-nEo1t3Q0F+0jQ36HJfbJtiRU4OI+/0jX/iITURKe3EE=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "42a1c966be226125b48c384171c44c651c236c22",
+        "rev": "063dece00c5a77e4a0ea24e5e5a5bd75232806f8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                   | Message                                          |
| -------------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
| [`d23c3903`](https://github.com/Rishabh5321/akuse-flake/commit/d23c3903525931332bddf53c6b637e6d8b8d4727) | `` chore(flake/nixpkgs): 42a1c966 -> 063dece0 `` |