### PR TITLE
chore(flake/nixpkgs-stable): `7819a0d2` -> `a880f499`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -998,11 +998,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1743813633,
-        "narHash": "sha256-BgkBz4NpV6Kg8XF7cmHDHRVGZYnKbvG0Y4p+jElwxaM=",
+        "lastModified": 1743975612,
+        "narHash": "sha256-o4FjFOUmjSRMK7dn0TFdAT0RRWUWD+WsspPHa+qEQT8=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "7819a0d29d1dd2bc331bec4b327f0776359b1fa6",
+        "rev": "a880f49904d68b5e53338d1e8c7bf80f59903928",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                |
| ---------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------- |
| [`5a8ac470`](https://github.com/NixOS/nixpkgs/commit/5a8ac47072e964988d9de7b96b87860f21560a06) | `` flexoptix-app: update hash for udev rules ``                        |
| [`1f7866f7`](https://github.com/NixOS/nixpkgs/commit/1f7866f7e4ea3d5c97851457d197bfa8c4df7c83) | `` dolibarr: 21.0.0 -> 21.0.1 ``                                       |
| [`0a5e1403`](https://github.com/NixOS/nixpkgs/commit/0a5e14039c15ee029fbfa6da9bda56d61e56905d) | `` python312Packages.ical: disable failing test ``                     |
| [`5251807f`](https://github.com/NixOS/nixpkgs/commit/5251807f0a6f6a94c7766d54b8b7c433ee843f38) | `` unibilium: add missing homepage ``                                  |
| [`bd4d7697`](https://github.com/NixOS/nixpkgs/commit/bd4d76979b8d311aca468148d3bc0dc67bbf5748) | `` google-chrome: 134.0.6998.165 -> 135.0.7049.52 (#396503) ``         |
| [`5a3ace7b`](https://github.com/NixOS/nixpkgs/commit/5a3ace7b641685fd7173c28315e9a828b7eb75a4) | `` bird-lg: 1.3.5 -> 1.3.8 ``                                          |
| [`c3cc1b96`](https://github.com/NixOS/nixpkgs/commit/c3cc1b968e8eb9314fd565a39b9c71b8710872c5) | `` jellyfin: 10.10.6 -> 10.10.7 ``                                     |
| [`95a9db5e`](https://github.com/NixOS/nixpkgs/commit/95a9db5eff32f98492345fa94c75cb71dee8baad) | `` jellyfin-web: 10.10.6 -> 10.10.7 ``                                 |
| [`8f53a4de`](https://github.com/NixOS/nixpkgs/commit/8f53a4de841f5ee6e057952c0c389d127f24fb6a) | `` dub-to-nix: strip git+ prefix from repository URLs ``               |
| [`fba281bf`](https://github.com/NixOS/nixpkgs/commit/fba281bfbc3d48646ff81ad02faf5537af70486d) | `` velocity: 3.4.0-unstable-2025-03-27 -> 3.4.0-unstable-2025-04-03 `` |
| [`c837699e`](https://github.com/NixOS/nixpkgs/commit/c837699e6e7062ada013bb98438b894d5892d3e1) | `` fastnetmon-advanced: 2.0.370 -> 2.0.371 (#394912) ``                |
| [`e597a270`](https://github.com/NixOS/nixpkgs/commit/e597a27087e8b5a23e78e39ba05f661a69d16978) | `` nextcloudPackages.apps: add uppush ``                               |
| [`881a3591`](https://github.com/NixOS/nixpkgs/commit/881a3591d83701fea17193ec5609422e44337480) | `` nextcloudPackages.apps: update ``                                   |
| [`d6ebcd6c`](https://github.com/NixOS/nixpkgs/commit/d6ebcd6cc134ae643484c515c069fe50336ce0b0) | `` nextcloud30Packages: restore .override { apps = ...; } support ``   |
| [`73ead7fa`](https://github.com/NixOS/nixpkgs/commit/73ead7fad6536794f1083bc78a3ed8c2a5275352) | `` cargo-embassy: init at 0.3.4 ``                                     |
| [`d05aeea0`](https://github.com/NixOS/nixpkgs/commit/d05aeea00fd6126529805f25255ebbc1029299a4) | `` raycast: 1.94.0 -> 1.94.3 ``                                        |
| [`3c25ea61`](https://github.com/NixOS/nixpkgs/commit/3c25ea613c5b86d6020673b4fc096316388f3bbd) | `` pkgsCross.aarch64-darwin.discord-development: 0.0.84 -> 0.0.85 ``   |
| [`622421cc`](https://github.com/NixOS/nixpkgs/commit/622421cc713306b6edb76348ed3022d8a0f81f0d) | `` pkgsCross.aarch64-darwin.discord-canary: 0.0.727 -> 0.0.729 ``      |
| [`79607381`](https://github.com/NixOS/nixpkgs/commit/79607381ce4cfb6fb674a24a26ffd04c4ee040a3) | `` pkgsCross.aarch64-darwin.discord-ptb: 0.0.166 -> 0.0.167 ``         |
| [`50b63798`](https://github.com/NixOS/nixpkgs/commit/50b6379815681ff57d55418e4c9f112c9c38cfd6) | `` discord-canary: 0.0.619 -> 0.0.621 ``                               |
| [`0a26e340`](https://github.com/NixOS/nixpkgs/commit/0a26e340157ad77dc35f6c05493ec84b0acb5ccd) | `` discord-ptb: 0.0.135 -> 0.0.136 ``                                  |
| [`d50ab5c6`](https://github.com/NixOS/nixpkgs/commit/d50ab5c660567543b7c2ec9ddb3a6760050e972d) | `` microsoft-edge: 134.0.3124.68 -> 134.0.3124.95 ``                   |
| [`c368fe2e`](https://github.com/NixOS/nixpkgs/commit/c368fe2e665bd0963356a5f9f6030b17281c84d5) | `` gitoxide: mark as vulnerable ``                                     |
| [`906e39da`](https://github.com/NixOS/nixpkgs/commit/906e39da3f5efd07cd5d532123b90aface2662c5) | `` jujutsu: mark as vulnerable ``                                      |
| [`cebd3d29`](https://github.com/NixOS/nixpkgs/commit/cebd3d29a52db8351f3d368e9c5a24732dc7e662) | `` mangojuice: 0.8.2 -> 0.8.3 ``                                       |
| [`ec7d3d1e`](https://github.com/NixOS/nixpkgs/commit/ec7d3d1e7b9c0dcd28ae4409e344d6aa9f49fea2) | `` refine: 0.5.5 -> 0.5.6 ``                                           |
| [`a8fabe99`](https://github.com/NixOS/nixpkgs/commit/a8fabe9998204bf3d2bba213f0cf2f7ba49609b3) | `` concessio: 0.1.9 -> 0.1.10 ``                                       |
| [`def7c417`](https://github.com/NixOS/nixpkgs/commit/def7c4179c39541651a253d390c77c78aa69715b) | `` docker_28: init at 28.0.4 ``                                        |
| [`b62d8e45`](https://github.com/NixOS/nixpkgs/commit/b62d8e454494b8c185249a437feb04ed47b0b75e) | `` docker_25: 25.0.6 -> 25.0.8 ``                                      |
| [`371bdcb2`](https://github.com/NixOS/nixpkgs/commit/371bdcb2e4b5971022bda5dc5884f3bca02f21c4) | `` cargo-tauri: 2.4.0 -> 2.4.1 ``                                      |
| [`b62e46dc`](https://github.com/NixOS/nixpkgs/commit/b62e46dc597e4b3e20152a13f94f7e785109acb4) | `` cargo-tauri: don't fail on existing `$out` on darwin ``             |
| [`56dc1190`](https://github.com/NixOS/nixpkgs/commit/56dc1190e59755d9d13f89373f04a996c5bb49c4) | `` nixos/dhcpcd: fix typo in documentation ``                          |
| [`14f4292d`](https://github.com/NixOS/nixpkgs/commit/14f4292dc4ed9ad3fe2ac2316323db187e5d03ff) | `` mcpelauncher-ui-qt: init at 1.1.2-qt6 ``                            |
| [`92cea846`](https://github.com/NixOS/nixpkgs/commit/92cea846526b8e6ca0e48dea343635ffc4fea8cd) | `` mcpelauncher-client: init at 1.1.2-qt6 ``                           |
| [`ff7165fa`](https://github.com/NixOS/nixpkgs/commit/ff7165fa605b06f3e386c48066c6930ef29011f4) | `` maintainers: add morxemplum ``                                      |
| [`60f77270`](https://github.com/NixOS/nixpkgs/commit/60f77270be55c526baf73e141ad40ef93095018a) | `` amberol: 2024.2 -> 2025.1 ``                                        |
| [`8778f126`](https://github.com/NixOS/nixpkgs/commit/8778f126d5f1391885b46d602008054f82c0278f) | `` nodejs_23: 23.10.0 -> 23.11.0 ``                                    |
| [`9d305b2d`](https://github.com/NixOS/nixpkgs/commit/9d305b2dce67f5bb8f6a27fb1e376c07ddf8ad80) | `` libnoise: init at 0-unstable-2024-09-01 ``                          |
| [`3960c0f5`](https://github.com/NixOS/nixpkgs/commit/3960c0f5280f79ff773bcefae8b6e127dc42aa4c) | `` mattermostLatest: 10.4.2 -> 10.4.4 ``                               |
| [`5422963e`](https://github.com/NixOS/nixpkgs/commit/5422963e462a52f3ab1043e050c0009de3b95b49) | `` varnish75: apply patch for CVE-2025-30346 ``                        |
| [`b6c12503`](https://github.com/NixOS/nixpkgs/commit/b6c125032d83fb05be65f4f9868fb393cbb6373a) | `` riffdiff: 3.3.8 -> 3.3.9 ``                                         |
| [`fd455da9`](https://github.com/NixOS/nixpkgs/commit/fd455da9cf150debce222abca5ef7f834b1d37e3) | `` nbstripout: fix tests ``                                            |
| [`abe4f50e`](https://github.com/NixOS/nixpkgs/commit/abe4f50e1dd8c43146381c90ffb67c7aa4359754) | `` nbstripout: 0.6.1 -> 0.8.1 ``                                       |