### PR TITLE
chore(flake/spicetify-nix): `12c1c94f` -> `c0876c79`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1262,11 +1262,11 @@
         "systems": "systems_3"
       },
       "locked": {
-        "lastModified": 1744072721,
-        "narHash": "sha256-kJiXAeVL2xEoauc7FJkOWeiGzFD3Ah7jTmV1HDdVz4o=",
+        "lastModified": 1744079955,
+        "narHash": "sha256-qIdHmNcq3qNCQA1cQTEfCZq7tqtgjhJqKKMFfZPTZPc=",
         "owner": "Gerg-L",
         "repo": "spicetify-nix",
-        "rev": "12c1c94f6f9c26750b27915f64485104c30a887a",
+        "rev": "c0876c796c44a0a3ead0d36b5c100dbf47ea1dbd",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                |
| ----------------------------------------------------------------------------------------------------- | -------------------------------------- |
| [`c0876c79`](https://github.com/Gerg-L/spicetify-nix/commit/c0876c796c44a0a3ead0d36b5c100dbf47ea1dbd) | `` fix: reversion of: c1d7197 ``       |
| [`8e24ec6f`](https://github.com/Gerg-L/spicetify-nix/commit/8e24ec6ffd117cb1c42b8a594134a44db12e9765) | `` ci: goodbye detsys, hello cachix `` |