### PR TITLE
chore(flake/zen-browser): `f4edde8a` -> `70fe8d4b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1541,11 +1541,11 @@
         "nixpkgs": "nixpkgs_11"
       },
       "locked": {
-        "lastModified": 1744032540,
-        "narHash": "sha256-KMshnTCoe11oTzsUp5T3e0+9/dVlLSI/wIA7Nli3LI0=",
+        "lastModified": 1744117961,
+        "narHash": "sha256-xtYr/9NIJO+NZXDJwVjqys23Cx3xIeCXZtb47XzLfLU=",
         "owner": "0xc000022070",
         "repo": "zen-browser-flake",
-        "rev": "f4edde8a094098c8f16de4efc93e057c2cd3c06b",
+        "rev": "70fe8d4b27feeb4c8651e5daf2eaf6a4072e820e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                          | Message                                                       |
| --------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------- |
| [`70fe8d4b`](https://github.com/0xc000022070/zen-browser-flake/commit/70fe8d4b27feeb4c8651e5daf2eaf6a4072e820e) | `` fix: default package eval (#41) ``                         |
| [`fc288d87`](https://github.com/0xc000022070/zen-browser-flake/commit/fc288d87ebb8c6ef451c8397258bac1f70486f8d) | `` refactor: move package definitions to default.nix (#40) `` |