### PR TITLE
chore(flake/home-manager): `a4d80208` -> `0daadc77`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -562,11 +562,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1744038920,
-        "narHash": "sha256-9a4V1wQXS8hXZtc7mRtz0qINkGW+C99aDrmXY6oYBFg=",
+        "lastModified": 1744121320,
+        "narHash": "sha256-Rqso0BwMIAJwncKkNM4nGgcgPwsPXo35mhcI5bBfpgg=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "a4d8020820a85b47f842eae76ad083b0ec2a886a",
+        "rev": "0daadc77840a1ed34cafa581f8b0ab08cb2fcadc",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                    |
| ----------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------- |
| [`0daadc77`](https://github.com/nix-community/home-manager/commit/0daadc77840a1ed34cafa581f8b0ab08cb2fcadc) | `` btop: add `themes` option (#6777) ``                    |
| [`bd33ce40`](https://github.com/nix-community/home-manager/commit/bd33ce4000800a44b66e9d5a596d8abe6bf4bb16) | `` tests: stub neovim and vimPlugins and darwin (#6779) `` |