### PR TITLE
chore(flake/home-manager): `0daadc77` -> `80ae77ee`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -491,11 +491,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1744121320,
-        "narHash": "sha256-Rqso0BwMIAJwncKkNM4nGgcgPwsPXo35mhcI5bBfpgg=",
+        "lastModified": 1744123880,
+        "narHash": "sha256-jEyP0MPtpYtQwaRVYWBA6SL3eXgp8H27/apVNdrYoJg=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "0daadc77840a1ed34cafa581f8b0ab08cb2fcadc",
+        "rev": "80ae77eed3a3b48597ec9c1d23ce6e4784214071",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                                       |
| ----------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------- |
| [`80ae77ee`](https://github.com/nix-community/home-manager/commit/80ae77eed3a3b48597ec9c1d23ce6e4784214071) | `` kdeconnect: trigger indicator service after generic tray.target (#6711) `` |
| [`5966fc8b`](https://github.com/nix-community/home-manager/commit/5966fc8bd1e3da947e917767d0a3b5936f7cc9db) | `` xdg-portal: improve description of `extraPortals` (#6760) ``               |
| [`df09fb59`](https://github.com/nix-community/home-manager/commit/df09fb59817f68fa4c8049b58d12a9b398b92aee) | `` tests: stub more packages on darwin (#6780) ``                             |
| [`05cd3420`](https://github.com/nix-community/home-manager/commit/05cd34203e04ed9b948c06929924017008c1eb4c) | `` kitty: fromJSON to importJSON ``                                           |
| [`cbdf1c1e`](https://github.com/nix-community/home-manager/commit/cbdf1c1e330fd2aae62ffcfa0892b3457b0c60d8) | `` astroid: fromJSON to importJSON ``                                         |
| [`e741f979`](https://github.com/nix-community/home-manager/commit/e741f97967aa8225c7d866c76833634b7df32202) | `` astroid: Fix use of `fromJSON` ``                                          |