### PR TITLE
chore(flake/stylix): `be86a9aa` -> `a2f8840b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -929,11 +929,11 @@
         "tinted-zed": "tinted-zed"
       },
       "locked": {
-        "lastModified": 1744073349,
-        "narHash": "sha256-Ecc8SEfQ5RN2y2BtPGhnW+AQ+horuOHGGWIcT80a3JA=",
+        "lastModified": 1744127443,
+        "narHash": "sha256-8E4hqLYI4zJbEVPQBq5zzJDsiHGOU4+0htGKexwXRPw=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "be86a9aadb0519bf0e5fd98e5b63c57e049fba67",
+        "rev": "a2f8840bed6daade6b980426c9f72dd672e92329",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                        | Message                                                                     |
| --------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------- |
| [`a2f8840b`](https://github.com/danth/stylix/commit/a2f8840bed6daade6b980426c9f72dd672e92329) | `` hyprland: disable default wallpaper when hyprpaper is enabled (#1120) `` |