### PR TITLE
chore(flake/home-manager): `80ae77ee` -> `fefb6ae1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -488,14 +488,15 @@
       "inputs": {
         "nixpkgs": [
           "nixpkgs"
-        ]
+        ],
+        "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1744123880,
-        "narHash": "sha256-jEyP0MPtpYtQwaRVYWBA6SL3eXgp8H27/apVNdrYoJg=",
+        "lastModified": 1744127405,
+        "narHash": "sha256-Cqkmsb3CDcUREjszRe2/qkvztFzEujkaaqV5/nqfdlk=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "80ae77eed3a3b48597ec9c1d23ce6e4784214071",
+        "rev": "fefb6ae1b301b620a81645789e19945092b079da",
         "type": "github"
       },
       "original": {
@@ -831,7 +832,7 @@
           "stylix",
           "nixpkgs"
         ],
-        "treefmt-nix": "treefmt-nix"
+        "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
         "lastModified": 1743884191,
@@ -1088,6 +1089,27 @@
       }
     },
     "treefmt-nix": {
+      "inputs": {
+        "nixpkgs": [
+          "home-manager",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1743748085,
+        "narHash": "sha256-uhjnlaVTWo5iD3LXics1rp9gaKgDRQj6660+gbUU3cE=",
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "rev": "815e4121d6a5d504c0f96e5be2dd7f871e4fd99d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "type": "github"
+      }
+    },
+    "treefmt-nix_2": {
       "inputs": {
         "nixpkgs": [
           "stylix",


### PR DESCRIPTION
| Commit                                                                                                      | Message                                               |
| ----------------------------------------------------------------------------------------------------------- | ----------------------------------------------------- |
| [`fefb6ae1`](https://github.com/nix-community/home-manager/commit/fefb6ae1b301b620a81645789e19945092b079da) | `` .git-blame-ignore-revs: add treewide reformat ``   |
| [`cba2f9ce`](https://github.com/nix-community/home-manager/commit/cba2f9ce95c8d10b66cacf05a275e3ad71959638) | `` treewide: reformat nixfmt-rfc-style ``             |
| [`5df48c42`](https://github.com/nix-community/home-manager/commit/5df48c425569a638a7471af3ad61fb62e4c18c60) | `` flake.nix: add formatter check ``                  |
| [`04a2e5ce`](https://github.com/nix-community/home-manager/commit/04a2e5cedeeaf6c1dd69f4356c87902054669cce) | `` format: use nixfmt-tree treefmt ``                 |
| [`74b681d6`](https://github.com/nix-community/home-manager/commit/74b681d66552e24248a3c36524c932c4c796f985) | `` flake.nix: nixfmt -> treefmt ``                    |
| [`7137c8ae`](https://github.com/nix-community/home-manager/commit/7137c8ae4e63fe010cb86676f2d3da9752da566c) | `` tests/aerospace: include on-window-detected ``     |
| [`95861b5d`](https://github.com/nix-community/home-manager/commit/95861b5d9fc73f080b385776167c3dd2874e355b) | `` aerospace: Add flattenOnWindowDetected function `` |