### PR TITLE
chore(flake/better-control): `e12f5202` -> `ff24e531`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -91,11 +91,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1744063861,
-        "narHash": "sha256-fs6RNwoLQBsHkmkPDQ+NCBdl941yAM4v+7izcualo9k=",
+        "lastModified": 1744169313,
+        "narHash": "sha256-wON/Y/TyIHm8F4+FxMEWMG/9omTlPBVUgB1zvXMFRHc=",
         "owner": "rishabh5321",
         "repo": "better-control-flake",
-        "rev": "e12f52023640c4fe37db62337892cfeaf7f95c05",
+        "rev": "ff24e5312238c46ff937c95a6f5faf2fba2bd041",
         "type": "github"
       },
       "original": {
@@ -700,11 +700,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1743964447,
-        "narHash": "sha256-nEo1t3Q0F+0jQ36HJfbJtiRU4OI+/0jX/iITURKe3EE=",
+        "lastModified": 1744098102,
+        "narHash": "sha256-tzCdyIJj9AjysC3OuKA+tMD/kDEDAF9mICPDU7ix0JA=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "063dece00c5a77e4a0ea24e5e5a5bd75232806f8",
+        "rev": "c8cd81426f45942bb2906d5ed2fe21d2f19d95b7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                            | Message                                          |
| ----------------------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
| [`ff24e531`](https://github.com/Rishabh5321/better-control-flake/commit/ff24e5312238c46ff937c95a6f5faf2fba2bd041) | `` chore(flake/nixpkgs): 063dece0 -> c8cd8142 `` |