### PR TITLE
chore(flake/akuse-flake): `d23c3903` -> `449f5ed6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -5,11 +5,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1744064516,
-        "narHash": "sha256-tXxtxTsC7AVDrm9e/IcvNENUqeF2M7KoMj9d79n5cBw=",
+        "lastModified": 1744172848,
+        "narHash": "sha256-fMYmij+UqfLWV6914T0QpG1+DsHlvkKT809jvBkoiMk=",
         "owner": "Rishabh5321",
         "repo": "akuse-flake",
-        "rev": "d23c3903525931332bddf53c6b637e6d8b8d4727",
+        "rev": "449f5ed64b316f545b42917f2a1525766f1da5c5",
         "type": "github"
       },
       "original": {
@@ -605,11 +605,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1743964447,
-        "narHash": "sha256-nEo1t3Q0F+0jQ36HJfbJtiRU4OI+/0jX/iITURKe3EE=",
+        "lastModified": 1744098102,
+        "narHash": "sha256-tzCdyIJj9AjysC3OuKA+tMD/kDEDAF9mICPDU7ix0JA=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "063dece00c5a77e4a0ea24e5e5a5bd75232806f8",
+        "rev": "c8cd81426f45942bb2906d5ed2fe21d2f19d95b7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                   | Message                                          |
| -------------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
| [`449f5ed6`](https://github.com/Rishabh5321/akuse-flake/commit/449f5ed64b316f545b42917f2a1525766f1da5c5) | `` chore(flake/nixpkgs): 063dece0 -> c8cd8142 `` |