### PR TITLE
chore(flake/grayjay): `8f66347a` -> `d967146b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -471,11 +471,11 @@
         "nixpkgs": "nixpkgs_5"
       },
       "locked": {
-        "lastModified": 1744064383,
-        "narHash": "sha256-BlLa36XjEi+QBybo9/c/5qMDBMO/d/HbNul9XZtv6EE=",
+        "lastModified": 1744172679,
+        "narHash": "sha256-sxfLFvXKTozmGrCNqP+u7GciqiTJnbt+F6sOCYew9HM=",
         "owner": "rishabh5321",
         "repo": "grayjay-flake",
-        "rev": "8f66347a8cf516dd586e853dfc961b0ac3e91c3c",
+        "rev": "d967146b5f1e5b543f4797744d43794576dec0e3",
         "type": "github"
       },
       "original": {
@@ -746,11 +746,11 @@
     },
     "nixpkgs_5": {
       "locked": {
-        "lastModified": 1743964447,
-        "narHash": "sha256-nEo1t3Q0F+0jQ36HJfbJtiRU4OI+/0jX/iITURKe3EE=",
+        "lastModified": 1744098102,
+        "narHash": "sha256-tzCdyIJj9AjysC3OuKA+tMD/kDEDAF9mICPDU7ix0JA=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "063dece00c5a77e4a0ea24e5e5a5bd75232806f8",
+        "rev": "c8cd81426f45942bb2906d5ed2fe21d2f19d95b7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                     | Message                                          |
| ---------------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
| [`d967146b`](https://github.com/Rishabh5321/grayjay-flake/commit/d967146b5f1e5b543f4797744d43794576dec0e3) | `` chore(flake/nixpkgs): 063dece0 -> c8cd8142 `` |