### PR TITLE
chore(flake/home-manager): `a1036d4d` -> `542efdf2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -357,11 +357,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1744207189,
-        "narHash": "sha256-dTxaVEDb4qmYqfwRrqWbth5Blif+JO7R6nhkQElL7Ck=",
+        "lastModified": 1744208565,
+        "narHash": "sha256-vG3JJOar/r8ognz7wuwMtOJ8Knu1MMlOzHB1N6R2MbY=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "a1036d4d3e939d740149508aa68b2545c4964d37",
+        "rev": "542efdf2dfac351498f534eb71671525b9bd45ed",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                             |
| ----------------------------------------------------------------------------------------------------------- | --------------------------------------------------- |
| [`542efdf2`](https://github.com/nix-community/home-manager/commit/542efdf2dfac351498f534eb71671525b9bd45ed) | `` flake.lock: Update (#6785) ``                    |
| [`9864a2f4`](https://github.com/nix-community/home-manager/commit/9864a2f421e859d9784b6c413ec25d1415ddfe08) | `` thunderbird: add accountsOrder option (#6310) `` |