### PR TITLE
chore(flake/zen-browser): `a1beb7ed` -> `4f66642d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -896,11 +896,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1744167671,
-        "narHash": "sha256-ncxfJsY+yJfVjt1RTL3qij4tj3DM6RnEH+sLlzzgFVw=",
+        "lastModified": 1744219028,
+        "narHash": "sha256-OIlCvj5tSmHgpQzjut918nUwWrXTiT+BLU5UVhg6r2o=",
         "owner": "0xc000022070",
         "repo": "zen-browser-flake",
-        "rev": "a1beb7ed23f7d91c1034014e96384c6c6c096669",
+        "rev": "4f66642dbaea0571a2c6fe1fe3f36fe408ece037",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                          | Message                                                                     |
| --------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------- |
| [`4f66642d`](https://github.com/0xc000022070/zen-browser-flake/commit/4f66642dbaea0571a2c6fe1fe3f36fe408ece037) | `` Update Zen Browser twilight @ x86_64 && aarch64 to 1.11.2t#1744216403 `` |