### PR TITLE
chore(flake/nixpkgs-stable): `a880f499` -> `60e405b2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -480,11 +480,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1743975612,
-        "narHash": "sha256-o4FjFOUmjSRMK7dn0TFdAT0RRWUWD+WsspPHa+qEQT8=",
+        "lastModified": 1744168086,
+        "narHash": "sha256-S9M4HddBCxbbX1CKSyDYgZ8NCVyHcbKnBfoUXeRu2jQ=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "a880f49904d68b5e53338d1e8c7bf80f59903928",
+        "rev": "60e405b241edb6f0573f3d9f944617fe33ac4a73",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                             |
| ---------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------- |
| [`d78e742f`](https://github.com/NixOS/nixpkgs/commit/d78e742ff7ad06108ab540fd17424dd9f7704813) | `` maintainers: caralice -> magistau ``                                             |
| [`65fe8ff3`](https://github.com/NixOS/nixpkgs/commit/65fe8ff3059b4a1a6ca67f89a0048993a888360c) | `` necesse-server: init at 0.31.1-17664948 ``                                       |
| [`d4126d6f`](https://github.com/NixOS/nixpkgs/commit/d4126d6fbdb9d81242e7cf7aae29ec0f4be0d7f3) | `` maintainers: add cr0n ``                                                         |
| [`04d1ca73`](https://github.com/NixOS/nixpkgs/commit/04d1ca7316041df0f229820f60e87a34ca24abc6) | `` emacs-macport: 29.1 -> 29.4 ``                                                   |
| [`44c592fe`](https://github.com/NixOS/nixpkgs/commit/44c592fe84ce9774454938fe66e5d8ab75d769c1) | `` emacs: allow specifying meta in sources ``                                       |
| [`f42cb78d`](https://github.com/NixOS/nixpkgs/commit/f42cb78dd6ce82895b2589258f9fd7f677b3d3f4) | `` nixVersions.{nix_2_28,nix_2_26}: switch simplified meson build ``                |
| [`613a0cf5`](https://github.com/NixOS/nixpkgs/commit/613a0cf5b630560e1f203113eda83c37e878c9b6) | `` nixVersions.git: Bump to latest ``                                               |
| [`652f40e9`](https://github.com/NixOS/nixpkgs/commit/652f40e9284dc8048e3db1f1e09fe25010e22353) | `` nixVersions: drop 2.27 in favour of 2.28 ``                                      |
| [`32d7e832`](https://github.com/NixOS/nixpkgs/commit/32d7e8321181d1f8a5d54e0d2aec052c119809df) | `` nixVersions.2_28: 2.28.1pre -> 2.28.1 ``                                         |
| [`41b9dd61`](https://github.com/NixOS/nixpkgs/commit/41b9dd61ee76599506e37412c4c1e38ac7610ecf) | `` nixVersions: use tags instead of commits ``                                      |
| [`46776beb`](https://github.com/NixOS/nixpkgs/commit/46776beb88d2ca55dd26147f46c1496e50308fd9) | `` nixVersions.nix_2_28: init at 2.28.1pre ``                                       |
| [`79a10ef4`](https://github.com/NixOS/nixpkgs/commit/79a10ef4a402ba8d8626b8069e60093b9268a3a5) | `` nixVersions.nix_2_27: Fix cross splices ``                                       |
| [`6b8fb148`](https://github.com/NixOS/nixpkgs/commit/6b8fb1483db39d593fb81001b56e8d5dfaeff9a5) | `` nixVersions.nix_2_26+: Simplify version handling ``                              |
| [`e211bbf3`](https://github.com/NixOS/nixpkgs/commit/e211bbf3c269833c1efebdd89e393579d1d41a11) | `` nixVersions.nix_2_26+: Document differences w/ upstream ``                       |
| [`95ac6e11`](https://github.com/NixOS/nixpkgs/commit/95ac6e1135820fdfcff58e2b80c7951fd285fa87) | `` nixVersions.nix_2_26+: Remove unused filesets ``                                 |
| [`c05f1357`](https://github.com/NixOS/nixpkgs/commit/c05f1357d07c77ee164af7c745f4e785e63d1368) | `` lib/tests/release.nix: Use nix.overrideScope for >=2.26 ``                       |
| [`a63934e5`](https://github.com/NixOS/nixpkgs/commit/a63934e56a2c41456066e5dcd70ecdab074d536c) | `` nixVersions.nix_2_26: Add .overrideScope ``                                      |
| [`532edb81`](https://github.com/NixOS/nixpkgs/commit/532edb81c9570ed9e09821c048d559863da202ad) | `` nixVersions.nix_2_26: Improve docs ``                                            |
| [`cb29926a`](https://github.com/NixOS/nixpkgs/commit/cb29926a942af041b3bfb72093cb0489eb7734d0) | `` nixVersions.nix_2_27: init ``                                                    |
| [`c80f892e`](https://github.com/NixOS/nixpkgs/commit/c80f892e0220ba394fa92b977e209f66e5ef3fbf) | `` nixVersions.nix_2_26: Add README to modular/ ``                                  |
| [`5e54bb24`](https://github.com/NixOS/nixpkgs/commit/5e54bb243a46e46554dd42b3a1a229be76c25d53) | `` nixVersions.nix_2_26: vendor/2_26/ -> modular/ ``                                |
| [`d8a4db1f`](https://github.com/NixOS/nixpkgs/commit/d8a4db1fb112197e8b74637fa6e17b176fa6e787) | `` nixVersions.nix_2_26: Move source.json to parameter ``                           |
| [`ea541da8`](https://github.com/NixOS/nixpkgs/commit/ea541da828c587f121cecf04ce9e2672f2954025) | `` nixVersions.nix_2_26: Move .version to parameter ``                              |
| [`15bf17f3`](https://github.com/NixOS/nixpkgs/commit/15bf17f34006de987aca3b69d64bbe5f4821b6d6) | `` nixVersions.*: Factor out nixDependencies ``                                     |
| [`285c6f41`](https://github.com/NixOS/nixpkgs/commit/285c6f41a356dacd52a572792e98116e629845de) | `` clamav: 1.4.1 -> 1.4.2 ``                                                        |
| [`d3b9a129`](https://github.com/NixOS/nixpkgs/commit/d3b9a129364b89d165b077cd9a8ae8a43a636a6b) | `` nixVersions.nix_2_26: Fix cross and static ``                                    |
| [`a19b9dbc`](https://github.com/NixOS/nixpkgs/commit/a19b9dbcb8ab90219b61e653064614a7941bfc45) | `` authentik,authentik.outposts.{ldap,radius}: 2024.12.1 -> 2024.12.4 ``            |
| [`95a93f01`](https://github.com/NixOS/nixpkgs/commit/95a93f0187890877373e82fcdd8feee0a424b285) | `` github-runner: 2.322.0 -> 2.323.0 ``                                             |
| [`45fdff1f`](https://github.com/NixOS/nixpkgs/commit/45fdff1fc30b2bcdb64e43c9c4a214c0c492c403) | `` linux/common-config: SCHED_DEBUG is removed in 6.15 ``                           |
| [`5b586b92`](https://github.com/NixOS/nixpkgs/commit/5b586b92ab5b3d5f3434df441e0f3781bb3a02f4) | `` pretix.plugins.dbvat: init at 1.1.0 ``                                           |
| [`02acd110`](https://github.com/NixOS/nixpkgs/commit/02acd1106cc3640ddef916380cb02004d815b4b0) | `` pnpm_10: 10.7.1 -> 10.8.0 ``                                                     |
| [`d206f466`](https://github.com/NixOS/nixpkgs/commit/d206f466ba4995bd71ea2547ae2eed6e2bb5629f) | `` mastodon: 4.3.6 -> 4.3.7 ``                                                      |
| [`dc1d33c2`](https://github.com/NixOS/nixpkgs/commit/dc1d33c2851fe4cf0fcbc734871376c1f74f0793) | `` nixVersions.nix_2_24: 2.24.13 -> 2.24.14 ``                                      |
| [`76cad4f1`](https://github.com/NixOS/nixpkgs/commit/76cad4f1cb34c839c4b08cedf50a4b8ef6849f5d) | `` build(deps): bump actions/create-github-app-token from 1.11.7 to 2.0.2 ``        |
| [`318a2626`](https://github.com/NixOS/nixpkgs/commit/318a2626a841184389df9c6f2a3579c340c6d75a) | `` qq: 3.2.16-2025.3.7 -> 3.2.16-2025.3.18 ``                                       |
| [`d6f8a762`](https://github.com/NixOS/nixpkgs/commit/d6f8a76212af49b30fe3ecc05f9d5f7b5e85441e) | `` buildstream: init at 2.4.1 ``                                                    |
| [`d1db1445`](https://github.com/NixOS/nixpkgs/commit/d1db14454c926aa21bcf84727c3dfb299d01546a) | `` python312Packages.pyroaring: init at 1.0.0 ``                                    |
| [`b9275ec7`](https://github.com/NixOS/nixpkgs/commit/b9275ec7815bbbe53a355a6b0d7e0c9387f9a141) | `` linux_6_1: 6.1.132 -> 6.1.133 ``                                                 |
| [`8634c12a`](https://github.com/NixOS/nixpkgs/commit/8634c12ab3ff6d83e275651c943ac5dcea3064b6) | `` linux_6_6: 6.6.85 -> 6.6.86 ``                                                   |
| [`855eb9eb`](https://github.com/NixOS/nixpkgs/commit/855eb9eb615ed7e10772f436f26380c4f57d8037) | `` linux_6_12: 6.12.21 -> 6.12.22 ``                                                |
| [`0a40eaf0`](https://github.com/NixOS/nixpkgs/commit/0a40eaf08bb1046949b16c29bda32c751809f6aa) | `` linux_6_13: 6.13.9 -> 6.13.10 ``                                                 |
| [`024f34a0`](https://github.com/NixOS/nixpkgs/commit/024f34a062a0e5c0c7c20cfbda67a74d9eddf43d) | `` linux_6_14: 6.14 -> 6.14.1 ``                                                    |
| [`dc6a670e`](https://github.com/NixOS/nixpkgs/commit/dc6a670e7322357aa12ac941d62dc08c3c36c59d) | `` linux_testing: 6.14-rc7 -> 6.15-rc1 ``                                           |
| [`047dd842`](https://github.com/NixOS/nixpkgs/commit/047dd84265e7c3040710e85727129d9d68b42ffe) | `` rundeck: 5.9.0 -> 5.10.0 ``                                                      |
| [`2f270c93`](https://github.com/NixOS/nixpkgs/commit/2f270c932f68d08eb0a7c29a773bd08266e6b1ea) | `` pgadmin: 9.1 -> 9.2 ``                                                           |
| [`c97e8f17`](https://github.com/NixOS/nixpkgs/commit/c97e8f17427bd99ff39814fdb75d83188b7c1703) | `` pgadmin: 9.0 -> 9.1 ``                                                           |
| [`12748212`](https://github.com/NixOS/nixpkgs/commit/12748212594bd9f494e53ed5ec19ad15d7c7c439) | `` pgadmin4: 8.12 -> 9.0 ``                                                         |
| [`d2b3957b`](https://github.com/NixOS/nixpkgs/commit/d2b3957beb6c57bb4ccebc2904e22a51e63b40c0) | `` librewolf-unwrapped: 136.0.4-1 -> 137.0-3 ``                                     |
| [`daa4bc14`](https://github.com/NixOS/nixpkgs/commit/daa4bc147bafa186527df90c88bbf382311de89f) | `` orca-slicer: fixing build on GCC < 14 ``                                         |
| [`7f9fdd71`](https://github.com/NixOS/nixpkgs/commit/7f9fdd719cf315b204b2ed88b86a69434e263583) | `` orca-slicer: v2.3.0-rc -> v2.3.0 ``                                              |
| [`fe3104ec`](https://github.com/NixOS/nixpkgs/commit/fe3104ecaf1022e89e77214a7365f3bc11bf0dfe) | `` orca-slicer: 2.2.0-unstable-2025-01-23 -> 2.3.0-rc ``                            |
| [`6b4c20a9`](https://github.com/NixOS/nixpkgs/commit/6b4c20a9fcd2aaebd4b2b3dfa94dded69423ca81) | `` orca-slicer: get rid of osmesa dependency, clean up other mesa-related things `` |
| [`79e878bc`](https://github.com/NixOS/nixpkgs/commit/79e878bc15b32b69982954da8c5873098b0c8251) | `` orca-slicer: Don't show update dialog by default (#378396) ``                    |
| [`eae6c6cd`](https://github.com/NixOS/nixpkgs/commit/eae6c6cd8212e9c6589a5e11e8f002badfdd60f5) | `` orca-slicer v2.2.0-unstable-2025-01-06 -> v2.2.0-unstable-2025-01-23 ``          |
| [`5f6e1b8d`](https://github.com/NixOS/nixpkgs/commit/5f6e1b8d4f124516b70322208965b36e6b955d92) | `` orca-slicer: fix gcc14 ``                                                        |
| [`1e32081b`](https://github.com/NixOS/nixpkgs/commit/1e32081b91b207927479724acc51dadf77b57ba2) | `` [release-24.11] smartgithg: 23.1.3 -> 23.1.5 ``                                  |