### PR TITLE
chore(flake/zen-browser): `4f66642d` -> `a6c570c9`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -896,11 +896,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1744219028,
-        "narHash": "sha256-OIlCvj5tSmHgpQzjut918nUwWrXTiT+BLU5UVhg6r2o=",
+        "lastModified": 1744237067,
+        "narHash": "sha256-lgJFMxjkT1UAT1oDVjYxXEf+3HJkV4HDFhv1ja/sSLw=",
         "owner": "0xc000022070",
         "repo": "zen-browser-flake",
-        "rev": "4f66642dbaea0571a2c6fe1fe3f36fe408ece037",
+        "rev": "a6c570c926025db925d82282463ac3c9b399b63f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                          | Message                                                                     |
| --------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------- |
| [`a6c570c9`](https://github.com/0xc000022070/zen-browser-flake/commit/a6c570c926025db925d82282463ac3c9b399b63f) | `` Update Zen Browser twilight @ x86_64 && aarch64 to 1.11.2t#1744233681 `` |