### PR TITLE
chore(flake/spicetify-nix): `c0876c79` -> `e1326d6c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -673,11 +673,11 @@
         "systems": "systems_2"
       },
       "locked": {
-        "lastModified": 1744079955,
-        "narHash": "sha256-qIdHmNcq3qNCQA1cQTEfCZq7tqtgjhJqKKMFfZPTZPc=",
+        "lastModified": 1744251450,
+        "narHash": "sha256-4zwkN8aC/B8G48p2R5ptqp4/l8M+SmLN/VddF39DeXM=",
         "owner": "Gerg-L",
         "repo": "spicetify-nix",
-        "rev": "c0876c796c44a0a3ead0d36b5c100dbf47ea1dbd",
+        "rev": "e1326d6cd66f74595da4707ed7f1928e3d8cbbdd",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                    |
| ----------------------------------------------------------------------------------------------------- | ---------------------------------------------------------- |
| [`e1326d6c`](https://github.com/Gerg-L/spicetify-nix/commit/e1326d6cd66f74595da4707ed7f1928e3d8cbbdd) | `` build: update workflow to check spiced spotify build `` |
| [`63c4b5fb`](https://github.com/Gerg-L/spicetify-nix/commit/63c4b5fbaf9b36b4e284ec83301d5713eb676a54) | `` feat: update spicetify-cli package ``                   |