### PR TITLE
chore(flake/better-control): `012f5fe3` -> `0d28fb68`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -91,11 +91,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1744191220,
+        "lastModified": 1744258341,
         "narHash": "sha256-EyoxuGwyBOBTL5FqaqvlXzNpe0fLuUdx5YnWxylZbaM=",
         "owner": "rishabh5321",
         "repo": "better-control-flake",
-        "rev": "012f5fe3a9d29bef650cba5aaa7502a8b9760a43",
+        "rev": "0d28fb682d544b42806cbe684a5a97c51b5dcf61",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                            | Message                                                                                |
| ----------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------- |
| [`0d28fb68`](https://github.com/Rishabh5321/better-control-flake/commit/0d28fb682d544b42806cbe684a5a97c51b5dcf61) | `` fix: Update release fetching to get latest release info from GitHub API ``          |
| [`4b89c590`](https://github.com/Rishabh5321/better-control-flake/commit/4b89c590d397184a5377a30d479f5cc99ad0c35a) | `` fix: Uncomment version prefix removal for accurate version comparison ``            |
| [`76fc8cc1`](https://github.com/Rishabh5321/better-control-flake/commit/76fc8cc1a59823e4aa3a901a6d52651ffd48d28d) | `` feat: Update release fetching to retrieve all releases from GitHub API ``           |
| [`51a20085`](https://github.com/Rishabh5321/better-control-flake/commit/51a2008529586041c220a1b766f43bf98749b5a7) | `` feat: Refactor version fetching to use GitHub API for latest release information `` |
| [`c04a789c`](https://github.com/Rishabh5321/better-control-flake/commit/c04a789c7d596e1c4b171603a04a94175fe1ea71) | `` feat: Improve version fetching by using GitHub API for latest tags ``               |
| [`ccc715d8`](https://github.com/Rishabh5321/better-control-flake/commit/ccc715d8e083e56d08bcd076ae53a7072026cdb1) | `` feat: Enhance version fetching logic in release_check workflow ``                   |