### PR TITLE
chore(flake/stylix): `31fdf606` -> `82f67a36`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -710,11 +710,11 @@
         "tinted-zed": "tinted-zed"
       },
       "locked": {
-        "lastModified": 1744196911,
-        "narHash": "sha256-zzkDmUG04/1ALtUOoZNGkrtjjId8RbM38zlpYFtgXVs=",
+        "lastModified": 1744267551,
+        "narHash": "sha256-RYEPAoUO8aeu9GzaL2nLgVnCgtpx8GxIrEC1O/vumUw=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "31fdf60634beaa0bb14fa57fc64cd5a67d1bf101",
+        "rev": "82f67a36eba1b111f8d568bf5e5ceb30e4b623d6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                        | Message                                        |
| --------------------------------------------------------------------------------------------- | ---------------------------------------------- |
| [`82f67a36`](https://github.com/danth/stylix/commit/82f67a36eba1b111f8d568bf5e5ceb30e4b623d6) | `` doc: align module capitalization (#1115) `` |