### PR TITLE
chore(flake/stylix): `82f67a36` -> `ce45f19e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -710,11 +710,11 @@
         "tinted-zed": "tinted-zed"
       },
       "locked": {
-        "lastModified": 1744267551,
-        "narHash": "sha256-RYEPAoUO8aeu9GzaL2nLgVnCgtpx8GxIrEC1O/vumUw=",
+        "lastModified": 1744270948,
+        "narHash": "sha256-+1psY8uBaDdkqV/P3G40SzulPvUcb9VHisqQnDozC0U=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "82f67a36eba1b111f8d568bf5e5ceb30e4b623d6",
+        "rev": "ce45f19e8acb43e5f02888d873d451e2f994546b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                        | Message                            |
| --------------------------------------------------------------------------------------------- | ---------------------------------- |
| [`ce45f19e`](https://github.com/danth/stylix/commit/ce45f19e8acb43e5f02888d873d451e2f994546b) | `` kde: add run wrapper (#1117) `` |