### PR TITLE
chore(flake/home-manager): `79461936` -> `140a7df9`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -357,11 +357,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1744223888,
-        "narHash": "sha256-reYpe0J1J+wH34JFs7KKp0G5nP7+XSQ5z0ZLFJcfJr8=",
+        "lastModified": 1744307861,
+        "narHash": "sha256-c4i69OsEMi3e5+HuWrwgcx9sOsn1Z1hxLlyiQOiWJi8=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "79461936709b12e17adb9c91dd02d1c66d577f09",
+        "rev": "140a7df916f6257c755b8663fb27ed79e81c8e89",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                               |
| ----------------------------------------------------------------------------------------------------------- | ----------------------------------------------------- |
| [`140a7df9`](https://github.com/nix-community/home-manager/commit/140a7df916f6257c755b8663fb27ed79e81c8e89) | `` formatter: use a different treefmt root (#6792) `` |
| [`92266c9a`](https://github.com/nix-community/home-manager/commit/92266c9a6f03b7d86efc056580a1fddb89635a59) | `` btop: adjust `themes` option example (#6793) ``    |