### PR TITLE
chore(flake/home-manager): `47eb2d80` -> `f1ffd097`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -357,11 +357,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1744342170,
-        "narHash": "sha256-5IaNZfOqhqP4cnRoD1cLV29u3zteElve5zGpZWARUvI=",
+        "lastModified": 1744343724,
+        "narHash": "sha256-DkiOZlkXbdf6f09pSulJPE0IaaJi1p7sqia/G2kqNKI=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "47eb2d80f943521ec88fe92899925c5f444c8a5c",
+        "rev": "f1ffd097e717a8d1b441577b8d23f9d2c96e0657",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                            |
| ----------------------------------------------------------------------------------------------------------- | -------------------------------------------------- |
| [`f1ffd097`](https://github.com/nix-community/home-manager/commit/f1ffd097e717a8d1b441577b8d23f9d2c96e0657) | `` hyprsunset: support multiple commands to IPC `` |
| [`cf6314f8`](https://github.com/nix-community/home-manager/commit/cf6314f8e173e208882e32ed85158f78bf74d085) | `` hyprsunset: init ``                             |