### PR TITLE
chore(flake/better-control): `33321e83` -> `291a61f1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -91,11 +91,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1744259617,
-        "narHash": "sha256-v66nJXpU2qBV5h7iovr6zqma2iKw4JK3w85+BOBxH48=",
+        "lastModified": 1744355995,
+        "narHash": "sha256-DtR1bfIy9LRIvh3IFmoPXcRdS3gbJJuO13GnkZCCbvs=",
         "owner": "rishabh5321",
         "repo": "better-control-flake",
-        "rev": "33321e83fa374b1422688a2856f6876abd574080",
+        "rev": "291a61f1deb4096e7bc5e61a09161526c82369e7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                            | Message                                         |
| ----------------------------------------------------------------------------------------------------------------- | ----------------------------------------------- |
| [`291a61f1`](https://github.com/Rishabh5321/better-control-flake/commit/291a61f1deb4096e7bc5e61a09161526c82369e7) | `` chore: auto lint and format (#66) ``         |
| [`40604b4a`](https://github.com/Rishabh5321/better-control-flake/commit/40604b4aec758d0c94e94d2c4902587fa827c98d) | `` feat: Update better-control to v6.7 (#65) `` |