### PR TITLE
chore(flake/better-control): `291a61f1` -> `8ae7a2a1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -91,11 +91,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1744355995,
-        "narHash": "sha256-DtR1bfIy9LRIvh3IFmoPXcRdS3gbJJuO13GnkZCCbvs=",
+        "lastModified": 1744374005,
+        "narHash": "sha256-Ove6h8mleykQgsGbhz+IhkzwuugKhuNGnWwUXhm6dAE=",
         "owner": "rishabh5321",
         "repo": "better-control-flake",
-        "rev": "291a61f1deb4096e7bc5e61a09161526c82369e7",
+        "rev": "8ae7a2a1d61c2f62b1537496d5d01e4af390bde0",
         "type": "github"
       },
       "original": {
@@ -496,11 +496,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1744098102,
-        "narHash": "sha256-tzCdyIJj9AjysC3OuKA+tMD/kDEDAF9mICPDU7ix0JA=",
+        "lastModified": 1744232761,
+        "narHash": "sha256-gbl9hE39nQRpZaLjhWKmEu5ejtQsgI5TWYrIVVJn30U=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "c8cd81426f45942bb2906d5ed2fe21d2f19d95b7",
+        "rev": "f675531bc7e6657c10a18b565cfebd8aa9e24c14",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                            | Message                                          |
| ----------------------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
| [`8ae7a2a1`](https://github.com/Rishabh5321/better-control-flake/commit/8ae7a2a1d61c2f62b1537496d5d01e4af390bde0) | `` chore(flake/nixpkgs): c8cd8142 -> f675531b `` |