### PR TITLE
chore(flake/akuse-flake): `449f5ed6` -> `d2b69c0e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -5,11 +5,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1744172848,
-        "narHash": "sha256-fMYmij+UqfLWV6914T0QpG1+DsHlvkKT809jvBkoiMk=",
+        "lastModified": 1744375430,
+        "narHash": "sha256-SWzwZcO+4+HE0g2lKhjI2zYVOIHZT9dcNrTAdd5gByo=",
         "owner": "Rishabh5321",
         "repo": "akuse-flake",
-        "rev": "449f5ed64b316f545b42917f2a1525766f1da5c5",
+        "rev": "d2b69c0e256e3b1801a8b7974334f63d5da52cb3",
         "type": "github"
       },
       "original": {
@@ -449,11 +449,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1744098102,
-        "narHash": "sha256-tzCdyIJj9AjysC3OuKA+tMD/kDEDAF9mICPDU7ix0JA=",
+        "lastModified": 1744232761,
+        "narHash": "sha256-gbl9hE39nQRpZaLjhWKmEu5ejtQsgI5TWYrIVVJn30U=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "c8cd81426f45942bb2906d5ed2fe21d2f19d95b7",
+        "rev": "f675531bc7e6657c10a18b565cfebd8aa9e24c14",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                   | Message                                          |
| -------------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
| [`d2b69c0e`](https://github.com/Rishabh5321/akuse-flake/commit/d2b69c0e256e3b1801a8b7974334f63d5da52cb3) | `` chore(flake/nixpkgs): c8cd8142 -> f675531b `` |