### PR TITLE
chore(flake/thorium): `1c2c31d1` -> `282d1820`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -576,11 +576,11 @@
     },
     "nixpkgs_7": {
       "locked": {
-        "lastModified": 1744098102,
-        "narHash": "sha256-tzCdyIJj9AjysC3OuKA+tMD/kDEDAF9mICPDU7ix0JA=",
+        "lastModified": 1744232761,
+        "narHash": "sha256-gbl9hE39nQRpZaLjhWKmEu5ejtQsgI5TWYrIVVJn30U=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "c8cd81426f45942bb2906d5ed2fe21d2f19d95b7",
+        "rev": "f675531bc7e6657c10a18b565cfebd8aa9e24c14",
         "type": "github"
       },
       "original": {
@@ -773,11 +773,11 @@
         "nixpkgs": "nixpkgs_7"
       },
       "locked": {
-        "lastModified": 1744172715,
-        "narHash": "sha256-FeJ5kEcTFmRJpnvHIl0j20JvKx+JUi7YyyNAxrefGdI=",
+        "lastModified": 1744375235,
+        "narHash": "sha256-zZB3lgJxlPkynh083JxfpGnTPmnpoQglAozKfBpyvRs=",
         "owner": "Rishabh5321",
         "repo": "thorium_flake",
-        "rev": "1c2c31d1482b1bacc3511de53023f7b26271ca98",
+        "rev": "282d1820114f5399a08ae405c36bd990cefdd3e6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                     | Message                                          |
| ---------------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
| [`282d1820`](https://github.com/Rishabh5321/thorium_flake/commit/282d1820114f5399a08ae405c36bd990cefdd3e6) | `` chore(flake/nixpkgs): c8cd8142 -> f675531b `` |