### PR TITLE
chore(flake/nixpkgs-stable): `60e405b2` -> `f9ebe33a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -480,11 +480,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1744168086,
-        "narHash": "sha256-S9M4HddBCxbbX1CKSyDYgZ8NCVyHcbKnBfoUXeRu2jQ=",
+        "lastModified": 1744309437,
+        "narHash": "sha256-QZnNHM823am8apCqKSPdtnzPGTy2ZB4zIXOVoBp5+W0=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "60e405b241edb6f0573f3d9f944617fe33ac4a73",
+        "rev": "f9ebe33a928b5d529c895202263a5ce46bdf12f7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                  |
| ---------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------- |
| [`f9ebe33a`](https://github.com/NixOS/nixpkgs/commit/f9ebe33a928b5d529c895202263a5ce46bdf12f7) | `` [Backport release-24.11] linuxPackages.vhba: 20240917 -> 20250329 (#397358) ``        |
| [`dc5d95a8`](https://github.com/NixOS/nixpkgs/commit/dc5d95a83d6fe7dd6ef14732634f8e110042d265) | `` chromium: make warnObsoleteVersionConditional conditional ``                          |
| [`a4b5e397`](https://github.com/NixOS/nixpkgs/commit/a4b5e397805b1b07b5a26a420bfb9d19a124edd1) | `` dotnet-sdk-setup-hook: add nuget.org as a package source when there is no <clear/> `` |
| [`5e195115`](https://github.com/NixOS/nixpkgs/commit/5e1951154b605bd510b082ed15363d9d7c0d760a) | `` dotnetCorePackages.combinePackages: add "metadata" to linked paths ``                 |
| [`a4e217e9`](https://github.com/NixOS/nixpkgs/commit/a4e217e92a7fd34c47343adb4435a541cd92a591) | `` ungoogled-chromium: 135.0.7049.52-1 -> 135.0.7049.84-1 ``                             |
| [`034f65fd`](https://github.com/NixOS/nixpkgs/commit/034f65fd3f1182f6a939ce99abaea2428a3a8c4e) | `` calibre: format ``                                                                    |
| [`ebf778ee`](https://github.com/NixOS/nixpkgs/commit/ebf778ee41da904187881175d682e14c79e579cc) | `` calibre: add image optimization programs ``                                           |
| [`d339a357`](https://github.com/NixOS/nixpkgs/commit/d339a357c65456eab036821893b1fe19128f646f) | `` raycast: 1.94.3 -> 1.95.0 ``                                                          |
| [`148d93e8`](https://github.com/NixOS/nixpkgs/commit/148d93e8970979a32ef56ec793c246afc20e6217) | `` simple-http-server: 0.6.10 -> 0.6.12 ``                                               |
| [`d4eaf117`](https://github.com/NixOS/nixpkgs/commit/d4eaf117403105ad4ac5400eba7bd56750bdc215) | `` gclient2nix: fix attrs -> args ``                                                     |
| [`0729ad45`](https://github.com/NixOS/nixpkgs/commit/0729ad45f15be8cf9d7d5192144d62fa78b4b5d7) | `` gclient2nix: do not depend on nixpkgs path ``                                         |
| [`91af8973`](https://github.com/NixOS/nixpkgs/commit/91af8973286217251303a4d847c727466e01b6e0) | `` electron_33: regenerate info for new format ``                                        |
| [`87a5e49a`](https://github.com/NixOS/nixpkgs/commit/87a5e49a805bb8115579e614d830508b344d6721) | `` electron-source.electron_35: 35.1.2 -> 35.1.4 ``                                      |
| [`20f55b5d`](https://github.com/NixOS/nixpkgs/commit/20f55b5d6f8fb15e9b767f6360ef51da1a23482d) | `` electron-source.electron_34: 34.4.1 -> 34.5.0 ``                                      |
| [`a2f4824d`](https://github.com/NixOS/nixpkgs/commit/a2f4824d8a8b562727676de0ac1c4e104e9bfa3f) | `` electron: use gclientUnpackHook from gclient2nix ``                                   |
| [`be8d0859`](https://github.com/NixOS/nixpkgs/commit/be8d08597eb640fb5be67debeb35fa016dce3d6a) | `` electron: refactor update scripts ``                                                  |
| [`04d8cc8c`](https://github.com/NixOS/nixpkgs/commit/04d8cc8ceeb3764016813c3b58e5d5deadf913d1) | `` gclient2nix: add importGclientDeps & gclientUnpackHook ``                             |
| [`1dd2c79e`](https://github.com/NixOS/nixpkgs/commit/1dd2c79e15546127bfeec39cb6139ed220642403) | `` gclient2nix: init ``                                                                  |
| [`0665d2a4`](https://github.com/NixOS/nixpkgs/commit/0665d2a4a62c5d93ce8294c73eb4d1712a5c9620) | `` firefox-bin-unwrapped: 137.0 -> 137.0.1 ``                                            |
| [`71f4bc59`](https://github.com/NixOS/nixpkgs/commit/71f4bc59b5c1d6df55d22c8bacc56ca168a1ed64) | `` firefox-unwrapped: 137.0 -> 137.0.1 ``                                                |
| [`ce4f79da`](https://github.com/NixOS/nixpkgs/commit/ce4f79da1ab5273b1dfba643bcd9606b6a039f6f) | `` google-chrome: 135.0.7049.52 -> 135.0.7049.84 ``                                      |
| [`3173f722`](https://github.com/NixOS/nixpkgs/commit/3173f7222f681f7038f259cf48f987c54e52189f) | `` chromium,chromedriver: 135.0.7049.52 -> 135.0.7049.84 ``                              |
| [`195f0d43`](https://github.com/NixOS/nixpkgs/commit/195f0d4371799d756aa0805ee81cf864869db15d) | `` commit: 4.2 -> 4.3 ``                                                                 |
| [`12c7ae8f`](https://github.com/NixOS/nixpkgs/commit/12c7ae8fcefaf8686a9d53e16e78a4815518f0a2) | `` decibels: 46.0 -> 48.0 ``                                                             |
| [`d2c442b2`](https://github.com/NixOS/nixpkgs/commit/d2c442b26f5d5aecdd499ac6424a80251780207d) | `` garnet: 1.0.58 -> 1.0.61 ``                                                           |