### PR TITLE
chore(flake/home-manager): `e43c6bcb` -> `b74b22bb`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -357,11 +357,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1744380363,
-        "narHash": "sha256-cXjAUuAfQDPSLSsckZuTioQ986iqSPTzx8D7dLAcC+Q=",
+        "lastModified": 1744400600,
+        "narHash": "sha256-qYhUgA98mhq1QK13r9qVY+sG1ri6FBgyp+GApX6wS20=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "e43c6bcb101ba3301522439c459288c4a248f624",
+        "rev": "b74b22bb6167e8dff083ec6988c98798bf8954d3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                    |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------ |
| [`b74b22bb`](https://github.com/nix-community/home-manager/commit/b74b22bb6167e8dff083ec6988c98798bf8954d3) | `` waybar: add debug option ``             |
| [`d8e2fdc0`](https://github.com/nix-community/home-manager/commit/d8e2fdc09c9ee737ec66e64578413690833be3d9) | `` .git-blame-ignore-revs: fix fmt hash `` |
| [`cfd7df8a`](https://github.com/nix-community/home-manager/commit/cfd7df8a2151682ea8efadf4618e98a08c6a8907) | `` waybar: systemd cleanup ``              |