### PR TITLE
chore(flake/zen-browser): `407f0661` -> `4d9ee0da`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -896,11 +896,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1744398946,
-        "narHash": "sha256-KJLrn9ONdiheUyEL/LIxGV4eeJrlUtUkLZvl6aFh0JI=",
+        "lastModified": 1744406237,
+        "narHash": "sha256-Xbt5m3/ZNeye4b42rCZOLbD8OhCOeJfUSEJ+FvfXwpg=",
         "owner": "0xc000022070",
         "repo": "zen-browser-flake",
-        "rev": "407f06610d0d149b2a284560fc9073b12c58707b",
+        "rev": "4d9ee0daab52a7a205e69cfddcd441ffaa09c802",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                          | Message                                                      |
| --------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------ |
| [`4d9ee0da`](https://github.com/0xc000022070/zen-browser-flake/commit/4d9ee0daab52a7a205e69cfddcd441ffaa09c802) | `` Update Zen Browser beta @ x86_64 && aarch64 to 1.11.2b `` |