### PR TITLE
chore(flake/spicetify-nix): `23bd764b` -> `4c4b9611`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -673,11 +673,11 @@
         "systems": "systems_2"
       },
       "locked": {
-        "lastModified": 1744419307,
-        "narHash": "sha256-DbS56iVI2OzycwHNRWGAx2MLjEWwxcQ2W0LeUt2sIHA=",
+        "lastModified": 1744423915,
+        "narHash": "sha256-6Hd8VyrOlmjlDBgPpx9NwX4+/uO4gEDIyjqbQLyniwE=",
         "owner": "Gerg-L",
         "repo": "spicetify-nix",
-        "rev": "23bd764b5d88034766e53fc7000a4d1df06fa211",
+        "rev": "4c4b9611c71d586ea818fa5b8dcbd81129f62560",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                              |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------ |
| [`4c4b9611`](https://github.com/Gerg-L/spicetify-nix/commit/4c4b9611c71d586ea818fa5b8dcbd81129f62560) | `` feat: colorScheme verification `` |