### PR TITLE
chore(flake/thorium): `282d1820` -> `c8e910a8`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -576,11 +576,11 @@
     },
     "nixpkgs_7": {
       "locked": {
-        "lastModified": 1744232761,
-        "narHash": "sha256-gbl9hE39nQRpZaLjhWKmEu5ejtQsgI5TWYrIVVJn30U=",
+        "lastModified": 1744463964,
+        "narHash": "sha256-LWqduOgLHCFxiTNYi3Uj5Lgz0SR+Xhw3kr/3Xd0GPTM=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "f675531bc7e6657c10a18b565cfebd8aa9e24c14",
+        "rev": "2631b0b7abcea6e640ce31cd78ea58910d31e650",
         "type": "github"
       },
       "original": {
@@ -773,11 +773,11 @@
         "nixpkgs": "nixpkgs_7"
       },
       "locked": {
-        "lastModified": 1744375235,
-        "narHash": "sha256-zZB3lgJxlPkynh083JxfpGnTPmnpoQglAozKfBpyvRs=",
+        "lastModified": 1744513074,
+        "narHash": "sha256-rDfBJaUWJyh1hO4wKvLihYn0kQ3qnyNUECizEMUyBas=",
         "owner": "Rishabh5321",
         "repo": "thorium_flake",
-        "rev": "282d1820114f5399a08ae405c36bd990cefdd3e6",
+        "rev": "c8e910a8b5e4c7a865792633e04f5bde49052860",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                     | Message                                          |
| ---------------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
| [`c8e910a8`](https://github.com/Rishabh5321/thorium_flake/commit/c8e910a8b5e4c7a865792633e04f5bde49052860) | `` chore(flake/nixpkgs): f675531b -> 2631b0b7 `` |