### PR TITLE
chore(flake/better-control): `fd474ff9` -> `4df59391`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -91,11 +91,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1744437210,
-        "narHash": "sha256-UxcPVkli51gNpBiDzFsqa+mG9m0BiDC54xU26M+3WlQ=",
+        "lastModified": 1744518097,
+        "narHash": "sha256-Ng8/nxZStwE5ET3A96y3vILvV3Dw2KLf6fVo21/DkWs=",
         "owner": "rishabh5321",
         "repo": "better-control-flake",
-        "rev": "fd474ff946a2f3dd5dcaeb71f9f187f5d1e34a75",
+        "rev": "4df59391832413a34a6745979046b436c9806335",
         "type": "github"
       },
       "original": {
@@ -496,11 +496,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1744232761,
-        "narHash": "sha256-gbl9hE39nQRpZaLjhWKmEu5ejtQsgI5TWYrIVVJn30U=",
+        "lastModified": 1744463964,
+        "narHash": "sha256-LWqduOgLHCFxiTNYi3Uj5Lgz0SR+Xhw3kr/3Xd0GPTM=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "f675531bc7e6657c10a18b565cfebd8aa9e24c14",
+        "rev": "2631b0b7abcea6e640ce31cd78ea58910d31e650",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                            | Message                                          |
| ----------------------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
| [`4df59391`](https://github.com/Rishabh5321/better-control-flake/commit/4df59391832413a34a6745979046b436c9806335) | `` chore(flake/nixpkgs): f675531b -> 2631b0b7 `` |