### PR TITLE
chore(flake/seanime): `970c09c2` -> `acbc5c71`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -652,11 +652,11 @@
         "nixpkgs": "nixpkgs_6"
       },
       "locked": {
-        "lastModified": 1744510248,
-        "narHash": "sha256-Jn+AVQvDOF8/i/Wge+ak9+3/ICcQOlRQRjd3l4Mkoyo=",
+        "lastModified": 1744520368,
+        "narHash": "sha256-PkeZ2eLzP2VOTnKjmVTh3V7QZeSCRUAudnwp5Ii/fhs=",
         "owner": "rishabh5321",
         "repo": "seanime-flake",
-        "rev": "970c09c26d65e10b28bac5f21c17d81392a4e0a9",
+        "rev": "acbc5c719365e4387cc770018f9b7ba3f1daae05",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                     | Message                                                                                       |
| ---------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------- |
| [`acbc5c71`](https://github.com/Rishabh5321/seanime-flake/commit/acbc5c719365e4387cc770018f9b7ba3f1daae05) | `` fix(seanime-pkg): change 'sha256' to 'hash' for consistency in fetchurl ``                 |
| [`a91a83ee`](https://github.com/Rishabh5321/seanime-flake/commit/a91a83eec9f54d6b4839fad83d26d6396e36167b) | `` chore(release_check): update references from package.nix to seanime-pkg.nix in workflow `` |
| [`61d3ff60`](https://github.com/Rishabh5321/seanime-flake/commit/61d3ff603ac6a033c1c58714b7f9f3581b0f3be5) | `` chore(flake/nixpkgs): update flake.lock to latest revisions ``                             |