### PR TITLE
chore(flake/nix-gaming): `c78f0265` -> `3be2c407`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -434,11 +434,11 @@
         "nixpkgs": "nixpkgs_4"
       },
       "locked": {
-        "lastModified": 1744513856,
-        "narHash": "sha256-4e1Q81PxVooO+dkFtpDLKqVwxvBhdWmd1N8pgzqF0Zo=",
+        "lastModified": 1744524344,
+        "narHash": "sha256-n61Xx2svmzqRyfoQc9wDWCyBrWx1MvFGDYIXkQCx2vs=",
         "owner": "fufexan",
         "repo": "nix-gaming",
-        "rev": "c78f02655006afbbcb4ce6a6256162004ca47332",
+        "rev": "3be2c40717a973af17228d2dd14de0dbd6b91a6d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                              | Message   |
| --------------------------------------------------------------------------------------------------- | --------- |
| [`3be2c407`](https://github.com/fufexan/nix-gaming/commit/3be2c40717a973af17228d2dd14de0dbd6b91a6d) | `` fmt `` |