### PR TITLE
chore(flake/seanime): `acbc5c71` -> `ce815c4e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -652,11 +652,11 @@
         "nixpkgs": "nixpkgs_6"
       },
       "locked": {
-        "lastModified": 1744520368,
-        "narHash": "sha256-PkeZ2eLzP2VOTnKjmVTh3V7QZeSCRUAudnwp5Ii/fhs=",
+        "lastModified": 1744525024,
+        "narHash": "sha256-FHggyIILQbYurdgpAlMGhVQYOKlgan6MOPbXzWrdsj8=",
         "owner": "rishabh5321",
         "repo": "seanime-flake",
-        "rev": "acbc5c719365e4387cc770018f9b7ba3f1daae05",
+        "rev": "ce815c4ea76049f2a347b116edd6c1f90f7e2f8c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                     | Message                                                                                                                                  |
| ---------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
| [`ce815c4e`](https://github.com/Rishabh5321/seanime-flake/commit/ce815c4ea76049f2a347b116edd6c1f90f7e2f8c) | `` fix(release_check): remove redundant package reference from nix profile installation command ``                                       |
| [`8b75d707`](https://github.com/Rishabh5321/seanime-flake/commit/8b75d7078c737462a5a7ed58992db5b92430c8d4) | `` fix(release_check): correct nix profile installation command by removing redundant package reference ``                               |
| [`44f72eb5`](https://github.com/Rishabh5321/seanime-flake/commit/44f72eb55f0d4bf0cf8423cc9f646b1c6fa86d33) | `` feat(release_check): update workflow to use nix-prefetch-url for pre-built binary and enhance version update process ``               |
| [`6b9a68f3`](https://github.com/Rishabh5321/seanime-flake/commit/6b9a68f3131a4a857a9d09558565cf13e102a51f) | `` refactor(release_check): enhance version handling by cleaning version strings and updating commit messages to use cleaned versions `` |