### PR TITLE
chore(flake/seanime): `62b449bf` -> `78c5a49a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -652,11 +652,11 @@
         "nixpkgs": "nixpkgs_6"
       },
       "locked": {
-        "lastModified": 1744528294,
-        "narHash": "sha256-+PLv6jBOIpI5mKoo9WBuGCtXN24UE3xzFS+pnlQSt4o=",
+        "lastModified": 1744530381,
+        "narHash": "sha256-3PvEbCCJzpgz8hPz4anduCL3tlGFZaQYQ/PZFd+oULo=",
         "owner": "rishabh5321",
         "repo": "seanime-flake",
-        "rev": "62b449bf4e0699a93d6412e51bcd290c0a33a0d5",
+        "rev": "78c5a49a58daa5c13cb6c1bd33d04bf3a36ec430",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                     | Message                                                                                                                     |
| ---------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------- |
| [`78c5a49a`](https://github.com/Rishabh5321/seanime-flake/commit/78c5a49a58daa5c13cb6c1bd33d04bf3a36ec430) | `` feat: Update seanime to 2.8.0 ``                                                                                         |
| [`a5128466`](https://github.com/Rishabh5321/seanime-flake/commit/a512846689a278a3f945198f228721afa642c603) | `` fix(release_check): remove unnecessary conditional statement in hash calculation cleanup process for improved clarity `` |
| [`d834df12`](https://github.com/Rishabh5321/seanime-flake/commit/d834df1233d6a962e4c2dfe25b15c69a4ccda503) | `` fix(release_check): update fallback method for hash calculation to use base64 encoding for improved compatibility ``     |
| [`a82f707c`](https://github.com/Rishabh5321/seanime-flake/commit/a82f707cee18ee058f8629c829a3b61f7be72682) | `` refactor(release_check): remove hash verification step from workflow to streamline the update process ``                 |