### PR TITLE
chore(flake/nixpkgs-stable): `f9ebe33a` -> `26d499fc`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -480,11 +480,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1744309437,
-        "narHash": "sha256-QZnNHM823am8apCqKSPdtnzPGTy2ZB4zIXOVoBp5+W0=",
+        "lastModified": 1744440957,
+        "narHash": "sha256-FHlSkNqFmPxPJvy+6fNLaNeWnF1lZSgqVCl/eWaJRc4=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "f9ebe33a928b5d529c895202263a5ce46bdf12f7",
+        "rev": "26d499fc9f1d567283d5d56fcf367edd815dba1d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                  |
| ---------------------------------------------------------------------------------------------- | -------------------------------------------------------- |
| [`a6ac2406`](https://github.com/NixOS/nixpkgs/commit/a6ac24066c0bcb7be06e8ae57b6b4726343fcb8b) | `` nextcloud31: 31.0.2 -> 31.0.3 ``                      |
| [`1c515bce`](https://github.com/NixOS/nixpkgs/commit/1c515bcee20a58d724815c1bb426f9140179766e) | `` nextcloud30: 30.0.8 -> 30.0.9 ``                      |
| [`41aebd00`](https://github.com/NixOS/nixpkgs/commit/41aebd001ed4782ab42119ae7ee146da7f009162) | `` nextcloud29: 29.0.14 -> 19.0.15 ``                    |
| [`f5080388`](https://github.com/NixOS/nixpkgs/commit/f508038814b011ac99f8875bbcf5581865c17835) | `` jenkins: 2.492.2 -> 2.492.3 ``                        |
| [`0165e23d`](https://github.com/NixOS/nixpkgs/commit/0165e23dd60fad8bb566f8a333ea96dc6c9839bc) | `` firefox-devedition-unwrapped: 137.0b10 -> 138.0b5 ``  |
| [`ac4a13c9`](https://github.com/NixOS/nixpkgs/commit/ac4a13c97b67e69b5848edf60e780e942a52a60a) | `` hedgedoc: 1.10.2 -> 1.10.3 ``                         |
| [`972fd489`](https://github.com/NixOS/nixpkgs/commit/972fd489a2edc9a73dee397d2d083a982f9b3b95) | `` vscode-extensions.reditorsupport.r: 2.8.4 -> 2.8.5 `` |
| [`d9c292d7`](https://github.com/NixOS/nixpkgs/commit/d9c292d734c34b29a7c5a2352852088d6534f3b9) | `` linux-firmware: 20250311 -> 20250410 ``               |
| [`f959ac7c`](https://github.com/NixOS/nixpkgs/commit/f959ac7c353714e970779d03aefac611ace90edb) | `` linux_5_4: 5.4.291 -> 5.4.292 ``                      |
| [`7dbeed99`](https://github.com/NixOS/nixpkgs/commit/7dbeed990b5068f1461a39b2d2ad654d38297e1b) | `` linux_5_10: 5.10.235 -> 5.10.236 ``                   |
| [`9bd6d3ac`](https://github.com/NixOS/nixpkgs/commit/9bd6d3ac6bcd61e35a4c3592eb5b8f5bc0f76dcf) | `` linux_5_15: 5.15.179 -> 5.15.180 ``                   |
| [`58c53db5`](https://github.com/NixOS/nixpkgs/commit/58c53db56d2053484b7b87e8bc0d90f40f9a9126) | `` linux_6_1: 6.1.133 -> 6.1.134 ``                      |
| [`6945af1b`](https://github.com/NixOS/nixpkgs/commit/6945af1b9c516948cf88dc0487fc7d397b75d653) | `` linux_6_6: 6.6.86 -> 6.6.87 ``                        |
| [`a5ce662e`](https://github.com/NixOS/nixpkgs/commit/a5ce662eadfdb4940c17d7067aa812417b889780) | `` linux_6_12: 6.12.22 -> 6.12.23 ``                     |
| [`9308272d`](https://github.com/NixOS/nixpkgs/commit/9308272d1fc51bdd3b63a8384fbf2d6e648d6ce1) | `` linux_6_13: 6.13.10 -> 6.13.11 ``                     |
| [`0f58348b`](https://github.com/NixOS/nixpkgs/commit/0f58348b753facf27ba68ffa741abd0a4be8863e) | `` linux_6_14: 6.14.1 -> 6.14.2 ``                       |
| [`56a85507`](https://github.com/NixOS/nixpkgs/commit/56a8550746884b19d325b23ab0803becc4ea9620) | `` lock: 1.5.1 -> 1.5.2 ``                               |
| [`3df27f7d`](https://github.com/NixOS/nixpkgs/commit/3df27f7d13cb9d6d90dd4c67ee75db536baef00d) | `` riffdiff: 3.3.9 -> 3.3.10 ``                          |
| [`59917eee`](https://github.com/NixOS/nixpkgs/commit/59917eee8f90dd371e9f797f678a7c0d2a7e0e86) | `` diesel-cli: 2.2.8 -> 2.2.9 ``                         |
| [`45fe4bce`](https://github.com/NixOS/nixpkgs/commit/45fe4bce5ed0e69d69fb97a6180d7be429803693) | `` buildbox: 1.3.7 -> 1.3.11 ``                          |
| [`7c652ebf`](https://github.com/NixOS/nixpkgs/commit/7c652ebff21dbcb7288e4216f779a766a5e30758) | `` matrix-synapse: 1.127.1 -> 1.128.0 ``                 |
| [`7f33e3d0`](https://github.com/NixOS/nixpkgs/commit/7f33e3d0839b4dd86fec539ca00dd9f0b5dfb1cd) | `` perlPackages.DataEntropy: 0.007 -> 0.008 ``           |
| [`84491db5`](https://github.com/NixOS/nixpkgs/commit/84491db53d6cdef35226a58e75e121e31de8f8b1) | `` jetbrains.plugins: update ``                          |
| [`51ffe398`](https://github.com/NixOS/nixpkgs/commit/51ffe398fa6063f87c0bf1d7639c14b9a6735e57) | `` jetbrains.plugins: update ``                          |
| [`f0e7438e`](https://github.com/NixOS/nixpkgs/commit/f0e7438ea4e42cd9f34b2cceea8aeff4a819120c) | `` jetbrains.plugins: update ``                          |
| [`535374a8`](https://github.com/NixOS/nixpkgs/commit/535374a8c7392a540fd8dead84567b1419b17ff4) | `` jetbrains.plugins: update ``                          |
| [`d795672b`](https://github.com/NixOS/nixpkgs/commit/d795672b7fd4ec461db81f911520d4f59ac0701b) | `` jetbrains.plugins: update ``                          |
| [`418e57de`](https://github.com/NixOS/nixpkgs/commit/418e57de6bfd902cf428a0d0cfc5c59220383200) | `` jetbrains.plugins: update ``                          |
| [`4774a880`](https://github.com/NixOS/nixpkgs/commit/4774a8802f385fd8d36cb9ab88c779c6240122d8) | `` jetbrains.plugins: update ``                          |