### PR TITLE
chore(flake/zen-browser): `2ce849d1` -> `966b1dcc`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -896,11 +896,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1744512816,
-        "narHash": "sha256-HzvjK2n/xqHuAOZJDY7IrnJQBsxV0e0U+BdLdTRNLOQ=",
+        "lastModified": 1744547666,
+        "narHash": "sha256-I+D0imAdkTl2cjS+zUyH5YBRhOlQlB925dxRUraiAbk=",
         "owner": "0xc000022070",
         "repo": "zen-browser-flake",
-        "rev": "2ce849d1102279d6c176bc0ea34b101e2b07ae77",
+        "rev": "966b1dcc86f9a82a95f920bfac5656f039088d95",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                          | Message                                                                     |
| --------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------- |
| [`966b1dcc`](https://github.com/0xc000022070/zen-browser-flake/commit/966b1dcc86f9a82a95f920bfac5656f039088d95) | `` Update Zen Browser twilight @ x86_64 && aarch64 to 1.11.3t#1744545805 `` |