### PR TITLE
chore(flake/zen-browser): `319990a0` -> `2bc982d4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -896,11 +896,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1744582618,
-        "narHash": "sha256-yV9mfAtCjsnCFa6iBtMxo2HgDTbi0hrUa7H52D22TGY=",
+        "lastModified": 1744594629,
+        "narHash": "sha256-NpTi3oHTbAlIX9d96DApyOlLmN6Rx64Lg24avysQ9nQ=",
         "owner": "0xc000022070",
         "repo": "zen-browser-flake",
-        "rev": "319990a06f76ccaa207b18cc79534ac65270f531",
+        "rev": "2bc982d49d24c52cab81aea143ee386936bfaf79",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                          | Message                                                                     |
| --------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------- |
| [`2bc982d4`](https://github.com/0xc000022070/zen-browser-flake/commit/2bc982d49d24c52cab81aea143ee386936bfaf79) | `` Update Zen Browser twilight @ x86_64 && aarch64 to 1.11.3t#1744591459 `` |