### PR TITLE
chore(flake/nix-gaming): `3be2c407` -> `cba45fc4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -434,11 +434,11 @@
         "nixpkgs": "nixpkgs_4"
       },
       "locked": {
-        "lastModified": 1744524344,
-        "narHash": "sha256-n61Xx2svmzqRyfoQc9wDWCyBrWx1MvFGDYIXkQCx2vs=",
+        "lastModified": 1744611256,
+        "narHash": "sha256-NOtgDZm7BWODs9adMiveepo/+VTiTClTokD66pWxXE4=",
         "owner": "fufexan",
         "repo": "nix-gaming",
-        "rev": "3be2c40717a973af17228d2dd14de0dbd6b91a6d",
+        "rev": "cba45fc4da306733ae06853302ee8428feb29ea3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                              | Message                                                                  |
| --------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------ |
| [`cba45fc4`](https://github.com/fufexan/nix-gaming/commit/cba45fc4da306733ae06853302ee8428feb29ea3) | `` star-citizen: Add `--shell` to simplify recreating the environment `` |