### PR TITLE
chore(flake/home-manager): `33754144` -> `273ad32f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -357,11 +357,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1744637364,
-        "narHash": "sha256-ZVINTNMJS6W3fqPYV549DSmjYQW5I9ceKBl83FwPP7k=",
+        "lastModified": 1744650422,
+        "narHash": "sha256-m3/FzlNbLzfbZ1F0PUm8oEHNjGgea+bXT5uvAodt4t4=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "337541447773985f825512afd0f9821a975186be",
+        "rev": "273ad32fbb4769ac56e15caccdbdaad2c2e6b88a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                            |
| ----------------------------------------------------------------------------------------------------------- | ---------------------------------- |
| [`273ad32f`](https://github.com/nix-community/home-manager/commit/273ad32fbb4769ac56e15caccdbdaad2c2e6b88a) | `` tests/nh: init tests (#6819) `` |