### PR TITLE
chore(flake/stylix): `042db377` -> `38aff11a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -710,11 +710,11 @@
         "tinted-zed": "tinted-zed"
       },
       "locked": {
-        "lastModified": 1744572782,
-        "narHash": "sha256-CFNluxLqxmDPQYxi37nBd4wrpB0lI4Os8nRA7UWAJK0=",
+        "lastModified": 1744668092,
+        "narHash": "sha256-XDmpI3ywMkypsHKRF2am6BzZ5OjwpQMulAe8L87Ek8U=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "042db377bccc99b1a724b076c89ba803e411d889",
+        "rev": "38aff11a7097f4da6b95d4c4d2c0438f25a08d52",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                        | Message                                         |
| --------------------------------------------------------------------------------------------- | ----------------------------------------------- |
| [`38aff11a`](https://github.com/danth/stylix/commit/38aff11a7097f4da6b95d4c4d2c0438f25a08d52) | `` plymouth: don't use static prompt (#1138) `` |