### PR TITLE
chore(flake/spicetify-nix): `59793e4f` -> `c5635a50`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -673,11 +673,11 @@
         "systems": "systems_2"
       },
       "locked": {
-        "lastModified": 1744624447,
-        "narHash": "sha256-RiUXytWYM4tKn+sgZaL01Y//YXh+CQGKGPiryfQ2DVU=",
+        "lastModified": 1744672049,
+        "narHash": "sha256-PjN8yVAYbyMHkFDICaSw3lSlZljkMshtYaeLyMbIjAw=",
         "owner": "Gerg-L",
         "repo": "spicetify-nix",
-        "rev": "59793e4f825f2e73a0d30dcd6ccffd1e219f5efb",
+        "rev": "c5635a5043c182b8fc706a684f40cdac3dcc1e92",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                        |
| ----------------------------------------------------------------------------------------------------- | ------------------------------ |
| [`c5635a50`](https://github.com/Gerg-L/spicetify-nix/commit/c5635a5043c182b8fc706a684f40cdac3dcc1e92) | `` build: remove dependabot `` |