### PR TITLE
chore(flake/spicetify-nix): `c5635a50` -> `82bb2321`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -673,11 +673,11 @@
         "systems": "systems_2"
       },
       "locked": {
-        "lastModified": 1744672049,
-        "narHash": "sha256-PjN8yVAYbyMHkFDICaSw3lSlZljkMshtYaeLyMbIjAw=",
+        "lastModified": 1744678506,
+        "narHash": "sha256-MGV6XUQxOsYwi+lfPaek96lyv6e39hg7shpfLtDLvhM=",
         "owner": "Gerg-L",
         "repo": "spicetify-nix",
-        "rev": "c5635a5043c182b8fc706a684f40cdac3dcc1e92",
+        "rev": "82bb232104a9edb196cd102c837aacad8f765e23",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                            |
| ----------------------------------------------------------------------------------------------------- | -------------------------------------------------- |
| [`82bb2321`](https://github.com/Gerg-L/spicetify-nix/commit/82bb232104a9edb196cd102c837aacad8f765e23) | `` feat: use nixpkgs spicetify-cli ``              |
| [`835fc756`](https://github.com/Gerg-L/spicetify-nix/commit/835fc7569dba095e7789b18e1e7bad1652180361) | `` CI update 2025-04-15 ``                         |
| [`3afba5e4`](https://github.com/Gerg-L/spicetify-nix/commit/3afba5e4bc61320c15b45389a0d95bdc6a8314db) | `` docs: refactor to use easy-nix-documentation `` |
| [`e819f3e3`](https://github.com/Gerg-L/spicetify-nix/commit/e819f3e36139632560529e20583c40af4eb6a93d) | `` fix(deps): update all non-major dependencies `` |
| [`81e11520`](https://github.com/Gerg-L/spicetify-nix/commit/81e115206e0960809ad151227b146ec159167600) | `` build: renovate group PR's ``                   |
| [`52db17f9`](https://github.com/Gerg-L/spicetify-nix/commit/52db17f9902b4e52dcec8df488c5a8b076ecc318) | `` build: add renovate ``                          |