### PR TITLE
chore(flake/spicetify-nix): `82bb2321` -> `44ed9eb7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -673,11 +673,11 @@
         "systems": "systems_2"
       },
       "locked": {
-        "lastModified": 1744678506,
-        "narHash": "sha256-MGV6XUQxOsYwi+lfPaek96lyv6e39hg7shpfLtDLvhM=",
+        "lastModified": 1744682091,
+        "narHash": "sha256-zudMf0YW3mB0f2XnWPAjYdKioJPaJQchhO4bCeBOZAI=",
         "owner": "Gerg-L",
         "repo": "spicetify-nix",
-        "rev": "82bb232104a9edb196cd102c837aacad8f765e23",
+        "rev": "44ed9eb751a6966ffb291edbda2e9bebd3ebcd4a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                            |
| ----------------------------------------------------------------------------------------------------- | -------------------------------------------------- |
| [`44ed9eb7`](https://github.com/Gerg-L/spicetify-nix/commit/44ed9eb751a6966ffb291edbda2e9bebd3ebcd4a) | `` feat: use nixpkgs spicetify-cli ``              |
| [`5b304f48`](https://github.com/Gerg-L/spicetify-nix/commit/5b304f4827847b71fa2706f2ef6f5ee4394ccc7b) | `` CI update 2025-04-15 ``                         |
| [`ec45f009`](https://github.com/Gerg-L/spicetify-nix/commit/ec45f0099652d4b29a2815fdb0d865b427e01c6d) | `` docs: refactor to use easy-nix-documentation `` |