### PR TITLE
chore(flake/zen-browser): `6a9daeae` -> `02e08405`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -896,11 +896,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1744682635,
-        "narHash": "sha256-OUT678QP6m76y6kV1TdYAtaEfcz25uifGSvdPwamKUk=",
+        "lastModified": 1744727679,
+        "narHash": "sha256-DIAYck5TAJI8/8jXUL9YOteDjjkM81/oQOlX8ieLLnQ=",
         "owner": "0xc000022070",
         "repo": "zen-browser-flake",
-        "rev": "6a9daeae2f8564a23db2ca9d8e4fcad1686daa51",
+        "rev": "02e0840599ba1e89b5adeeca77a0bcc2bcd22df8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                          | Message                                                                |
| --------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------- |
| [`02e08405`](https://github.com/0xc000022070/zen-browser-flake/commit/02e0840599ba1e89b5adeeca77a0bcc2bcd22df8) | `` fix: desktop file name will match the one from the wrapper (#47) `` |