### PR TITLE
chore(flake/home-manager): `d5cdf55b` -> `db7738e6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -357,11 +357,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1744663884,
-        "narHash": "sha256-a6QGaZMDM1miK8VWzAITsEPOdmLk+xTPyJSTjVs3WhI=",
+        "lastModified": 1744735751,
+        "narHash": "sha256-OPpfgL3qUIbQdbmp1/ZwnlsuTLooHN4or0EABnZTFRY=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "d5cdf55bd9f19a3debd55b6cb5d38f7831426265",
+        "rev": "db7738e67a101ad945abbcb447e1310147afaf1b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                    |
| ----------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------- |
| [`db7738e6`](https://github.com/nix-community/home-manager/commit/db7738e67a101ad945abbcb447e1310147afaf1b) | `` nh: remove incorrect warning on gc conflicts (#6802) `` |
| [`85c513aa`](https://github.com/nix-community/home-manager/commit/85c513aa862228d5b51295b20ccbdcc5fdf086bc) | `` home-manager: Feature test for flake support (#6824) `` |