### PR TITLE
chore(flake/zen-browser): `02e08405` -> `847dce40`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -896,11 +896,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1744727679,
-        "narHash": "sha256-DIAYck5TAJI8/8jXUL9YOteDjjkM81/oQOlX8ieLLnQ=",
+        "lastModified": 1744745981,
+        "narHash": "sha256-KVobwH20plfLKHqAaWbsJYNfC0uz9RDSeBm7vNYPFSQ=",
         "owner": "0xc000022070",
         "repo": "zen-browser-flake",
-        "rev": "02e0840599ba1e89b5adeeca77a0bcc2bcd22df8",
+        "rev": "847dce40516d8c8e424b37d423fa84aa6edaa631",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                          | Message                                                                     |
| --------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------- |
| [`847dce40`](https://github.com/0xc000022070/zen-browser-flake/commit/847dce40516d8c8e424b37d423fa84aa6edaa631) | `` ci(update): generated commit will have conventional commits format ``    |
| [`c0201fb6`](https://github.com/0xc000022070/zen-browser-flake/commit/c0201fb689a2e76610b1d91d307bde4fc70d78c9) | `` Update Zen Browser twilight @ x86_64 && aarch64 to 1.11.3t#1744742050 `` |