### PR TITLE
chore(flake/zen-browser): `847dce40` -> `d2bb30f4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -896,11 +896,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1744745981,
-        "narHash": "sha256-KVobwH20plfLKHqAaWbsJYNfC0uz9RDSeBm7vNYPFSQ=",
+        "lastModified": 1744777359,
+        "narHash": "sha256-20REqJW54bbQIBuP19fcjPamV9mpWN0+RPcp5hQwwLI=",
         "owner": "0xc000022070",
         "repo": "zen-browser-flake",
-        "rev": "847dce40516d8c8e424b37d423fa84aa6edaa631",
+        "rev": "d2bb30f451ef7802aca1954a6eb75efbc4c25872",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                          | Message                                                                  |
| --------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------ |
| [`d2bb30f4`](https://github.com/0xc000022070/zen-browser-flake/commit/d2bb30f451ef7802aca1954a6eb75efbc4c25872) | `` chore(update):  twilight @ x86_64 && aarch64 to 1.11.3t#1744775893 `` |