### PR TITLE
chore(flake/zen-browser): `d2bb30f4` -> `e47f96fa`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -896,11 +896,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1744777359,
-        "narHash": "sha256-20REqJW54bbQIBuP19fcjPamV9mpWN0+RPcp5hQwwLI=",
+        "lastModified": 1744812519,
+        "narHash": "sha256-uGYXB1s4PvRFlv2wPFTSNaG9wJKSKbv+uhIi/rLSPJg=",
         "owner": "0xc000022070",
         "repo": "zen-browser-flake",
-        "rev": "d2bb30f451ef7802aca1954a6eb75efbc4c25872",
+        "rev": "e47f96fa8e98c1395def6550e35d407ac29e2ebd",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                          | Message                                          |
| --------------------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
| [`e47f96fa`](https://github.com/0xc000022070/zen-browser-flake/commit/e47f96fa8e98c1395def6550e35d407ac29e2ebd) | `` ci(update): fix format of generated commit `` |