### PR TITLE
chore(flake/home-manager): `7ede02c3` -> `c6b75d69`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -357,11 +357,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1744820898,
-        "narHash": "sha256-gUldr3LtCm/OfEnbH6sFFlyyxqPMCsfMs2Ha+0fdPDs=",
+        "lastModified": 1744833442,
+        "narHash": "sha256-BBMWW2m64Grcc5FlXz74+vdkUyCJOfUGnl+VcS/4x44=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "7ede02c32a729db0d6340bdb41d10e73ec511ca0",
+        "rev": "c6b75d69b6994ba68ec281bd36faebcc56097800",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                    |
| ----------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------- |
| [`c6b75d69`](https://github.com/nix-community/home-manager/commit/c6b75d69b6994ba68ec281bd36faebcc56097800) | `` tests/firefox: add userchrome test cases ``             |
| [`1827e843`](https://github.com/nix-community/home-manager/commit/1827e84344ff7cb814e3e4dfad51a45856ea50f6) | `` mkFirefoxModule: fix userChrome ``                      |
| [`cb65c814`](https://github.com/nix-community/home-manager/commit/cb65c81403f61f49483858730b087ff6699c61c1) | `` chawan: init module (#6768) ``                          |
| [`b35bccc3`](https://github.com/nix-community/home-manager/commit/b35bccc32d3fc49f6fcc4e08ccfd6025c9eefa20) | `` home-manager-auto-expire: fix spelling error (#6829) `` |