### PR TITLE
chore(flake/better-control): `83c133dc` -> `26d3ce66`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -91,11 +91,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1744716808,
-        "narHash": "sha256-CbtmqlTK5Z5O4dzfRLRbKl2IKuRW0RR5eet4tbKQYqs=",
+        "lastModified": 1744898177,
+        "narHash": "sha256-j09DlWB8brIr2Rwhq5uMHpGNToIAyLK6NHkOYSqFTZs=",
         "owner": "rishabh5321",
         "repo": "better-control-flake",
-        "rev": "83c133dc81123ddb8ed227c6422800bff186e266",
+        "rev": "26d3ce667f8a9c9b659ebe81e191ec10ac2631d5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                            | Message                                            |
| ----------------------------------------------------------------------------------------------------------------- | -------------------------------------------------- |
| [`26d3ce66`](https://github.com/Rishabh5321/better-control-flake/commit/26d3ce667f8a9c9b659ebe81e191ec10ac2631d5) | `` feat: Update better-control to v6.10.3 (#73) `` |