### PR TITLE
chore(flake/home-manager): `c6b75d69` -> `2c71aae6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -357,11 +357,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1744833442,
-        "narHash": "sha256-BBMWW2m64Grcc5FlXz74+vdkUyCJOfUGnl+VcS/4x44=",
+        "lastModified": 1744902080,
+        "narHash": "sha256-px7OEMQYhS9StY3sTYYeM/jJspk6SXgoPU7OmOSx+1c=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "c6b75d69b6994ba68ec281bd36faebcc56097800",
+        "rev": "2c71aae678c03a39c2542e136b87bd040ae1b3cb",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                            |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------ |
| [`2c71aae6`](https://github.com/nix-community/home-manager/commit/2c71aae678c03a39c2542e136b87bd040ae1b3cb) | `` tests/firefox: validate folder linking ``                       |
| [`baa2a0b3`](https://github.com/nix-community/home-manager/commit/baa2a0b3bd23de23ba23f50508e44e9d77819ec2) | `` tests/firefox: consolidate userChrome.css test files ``         |
| [`c3c91dd8`](https://github.com/nix-community/home-manager/commit/c3c91dd8b4974ce221748b997e644c4838e3ebbc) | `` mkFirefoxModule: fix userChrome with leading comment (#6836) `` |