### PR TITLE
chore(flake/home-manager): `2c71aae6` -> `e72178b8`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -357,11 +357,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1744902080,
-        "narHash": "sha256-px7OEMQYhS9StY3sTYYeM/jJspk6SXgoPU7OmOSx+1c=",
+        "lastModified": 1744912998,
+        "narHash": "sha256-7UkI7aP0tTXoLjVcK8yv5ZbFwM/Z3enw0wElnFYT7O0=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "2c71aae678c03a39c2542e136b87bd040ae1b3cb",
+        "rev": "e72178b84e440703e17ff5d393ba060784bed099",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                             |
| ----------------------------------------------------------------------------------------------------------- | ----------------------------------- |
| [`e72178b8`](https://github.com/nix-community/home-manager/commit/e72178b84e440703e17ff5d393ba060784bed099) | `` tests/atuin: add theme test ``   |
| [`88e61873`](https://github.com/nix-community/home-manager/commit/88e61873646616ed80605e14b75332de22934481) | `` atuin: add support for themes `` |