### PR TITLE
chore(flake/better-control): `26d3ce66` -> `0c448062`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -91,11 +91,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1744898177,
-        "narHash": "sha256-j09DlWB8brIr2Rwhq5uMHpGNToIAyLK6NHkOYSqFTZs=",
+        "lastModified": 1744989088,
+        "narHash": "sha256-j3HCGYdauq74hZzlgsDpQKx8rKLRX2oNhrsS8Jr8ZE8=",
         "owner": "rishabh5321",
         "repo": "better-control-flake",
-        "rev": "26d3ce667f8a9c9b659ebe81e191ec10ac2631d5",
+        "rev": "0c4480620461c1b5d8bcf1112b915be5a26f8308",
         "type": "github"
       },
       "original": {
@@ -496,11 +496,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1744463964,
-        "narHash": "sha256-LWqduOgLHCFxiTNYi3Uj5Lgz0SR+Xhw3kr/3Xd0GPTM=",
+        "lastModified": 1744932701,
+        "narHash": "sha256-fusHbZCyv126cyArUwwKrLdCkgVAIaa/fQJYFlCEqiU=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "2631b0b7abcea6e640ce31cd78ea58910d31e650",
+        "rev": "b024ced1aac25639f8ca8fdfc2f8c4fbd66c48ef",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                            | Message                                          |
| ----------------------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
| [`0c448062`](https://github.com/Rishabh5321/better-control-flake/commit/0c4480620461c1b5d8bcf1112b915be5a26f8308) | `` chore(flake/nixpkgs): 2631b0b7 -> b024ced1 `` |