### PR TITLE
chore(flake/nixpkgs): `2631b0b7` -> `b024ced1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -544,11 +544,11 @@
     },
     "nixpkgs_5": {
       "locked": {
-        "lastModified": 1744463964,
-        "narHash": "sha256-LWqduOgLHCFxiTNYi3Uj5Lgz0SR+Xhw3kr/3Xd0GPTM=",
+        "lastModified": 1744932701,
+        "narHash": "sha256-fusHbZCyv126cyArUwwKrLdCkgVAIaa/fQJYFlCEqiU=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "2631b0b7abcea6e640ce31cd78ea58910d31e650",
+        "rev": "b024ced1aac25639f8ca8fdfc2f8c4fbd66c48ef",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                           |
| ---------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------- |
| [`419e4d18`](https://github.com/NixOS/nixpkgs/commit/419e4d1822f7a8bd747f2c9e093a2abfca87ddee) | `` nixos/hardware/nvidia: eager load nvidia-uvm for open driver ``                |
| [`01bea94f`](https://github.com/NixOS/nixpkgs/commit/01bea94f3c9a8adf7c35f9ad7509703aa10a1620) | `` postfix-tlspol: init at v1.8.8 ``                                              |
| [`ac32f28f`](https://github.com/NixOS/nixpkgs/commit/ac32f28f899642f540318419df9ab7661b569062) | `` libretro.vecx: 0-unstable-2024-10-21 -> 0-unstable-2025-04-12 ``               |
| [`68af1782`](https://github.com/NixOS/nixpkgs/commit/68af17828cae59244f85465eb1384ae073bcf67c) | `` obs-studio-plugins.obs-color-monitor: 0.9.1 -> 0.9.3 ``                        |
| [`c998abfd`](https://github.com/NixOS/nixpkgs/commit/c998abfdd659d1303952a176c678dae3005bf36b) | `` libretro.fceumm: 0-unstable-2025-04-06 -> 0-unstable-2025-04-11 ``             |
| [`0dba425c`](https://github.com/NixOS/nixpkgs/commit/0dba425c17927280f8f7c88ec104cfda34743124) | `` libretro.bsnes: 0-unstable-2025-04-04 -> 0-unstable-2025-04-11 ``              |
| [`49f50dee`](https://github.com/NixOS/nixpkgs/commit/49f50deed77151ad217818e48703cdcbadfddb0f) | `` libretro.beetle-psx: 0-unstable-2025-04-04 -> 0-unstable-2025-04-11 ``         |
| [`7c3b19f2`](https://github.com/NixOS/nixpkgs/commit/7c3b19f2a10f92c4dd8b56e7546891e72764287f) | `` libretro.bluemsx: 0-unstable-2024-12-04 -> 0-unstable-2025-04-15 ``            |
| [`1d96b39f`](https://github.com/NixOS/nixpkgs/commit/1d96b39f2f81020ee1f730008dcaf185c4fcc842) | `` libretro.puae: 0-unstable-2025-03-27 -> 0-unstable-2025-04-15 ``               |
| [`34c62aec`](https://github.com/NixOS/nixpkgs/commit/34c62aec160a476ab12c4379bf0355806e8f621f) | `` libretro.mame2003-plus: 0-unstable-2025-04-07 -> 0-unstable-2025-04-16 ``      |
| [`73aa0c39`](https://github.com/NixOS/nixpkgs/commit/73aa0c39be36bd8f0ee07a086f320b4605333454) | `` simplex-chat-desktop: 6.3.1 -> 6.3.2 ``                                        |
| [`096cc6b8`](https://github.com/NixOS/nixpkgs/commit/096cc6b8f1fe3754295e2171bef56ca883d72d61) | `` libretro.pcsx-rearmed: 0-unstable-2025-03-30 -> 0-unstable-2025-04-13 ``       |
| [`b9a0f268`](https://github.com/NixOS/nixpkgs/commit/b9a0f268fadbfe53ec47d00648993a0e41182f56) | `` libretro.picodrive: 0-unstable-2025-04-03 -> 0-unstable-2025-04-10 ``          |
| [`c8c153cd`](https://github.com/NixOS/nixpkgs/commit/c8c153cdfcd92ccfae1fffbf0cc0053c7ff95a93) | `` dmlive: 5.5.7-unstable-2025-01-25 -> 5.5.8-unstable-2025-04-06 ``              |
| [`dcbd3c11`](https://github.com/NixOS/nixpkgs/commit/dcbd3c11613a7af6ace080ebd3acdc360323af5a) | `` tbls: 1.84.1 -> 1.85.0 ``                                                      |
| [`5570aab3`](https://github.com/NixOS/nixpkgs/commit/5570aab340330a24de669166ba40e84a4c329bef) | `` nixosTests.writefreely: migrate to runTest ``                                  |
| [`7e5a9595`](https://github.com/NixOS/nixpkgs/commit/7e5a9595f2c78042cac48ed83d10d62b29c38bcf) | `` cosmic-notifications: remove unnecessary patch ``                              |
| [`6447f09c`](https://github.com/NixOS/nixpkgs/commit/6447f09c06b11158cfbe4d937c8c4e33a9d3b2b5) | `` cosmic-notifications: disable just check ``                                    |
| [`a0912c4a`](https://github.com/NixOS/nixpkgs/commit/a0912c4aa4723516055074932c826bbd66a1dd81) | `` cosmic-notifications: add updateScript ``                                      |
| [`7eca501a`](https://github.com/NixOS/nixpkgs/commit/7eca501ae59f3d5372945917993cebfcd5a85a36) | `` cosmic-notifications: remove `with lib` from meta ``                           |
| [`81800f2f`](https://github.com/NixOS/nixpkgs/commit/81800f2f5514b9cba31bf435092b124b2f594cc3) | `` cosmic-notifications: use libcosmicAppHook ``                                  |
| [`064ca475`](https://github.com/NixOS/nixpkgs/commit/064ca4757418b16061a4e4c1c3eee75296f6ad35) | `` ocamlPackages.qcheck: 0.24 → 0.25 ``                                           |
| [`ed79c059`](https://github.com/NixOS/nixpkgs/commit/ed79c059831b0e87580654c3b0b3be4bb4211ba9) | `` ocamlPackages.batteries: add missing dependency to ounit ``                    |
| [`95542b81`](https://github.com/NixOS/nixpkgs/commit/95542b8157a89e952af378334e665b85631b83ce) | `` libretro.play: 0-unstable-2025-04-04 -> 0-unstable-2025-04-07 ``               |
| [`5a39aa32`](https://github.com/NixOS/nixpkgs/commit/5a39aa326f73d0a6ebfc6b0ae8249dad15948d16) | `` viceroy: 0.12.4 -> 0.13.0 ``                                                   |
| [`ef3ac13c`](https://github.com/NixOS/nixpkgs/commit/ef3ac13c3c9d22ef75a927f012f54916787cb8b3) | `` wasm-tools: 1.228.0 -> 1.229.0 ``                                              |
| [`93f3089e`](https://github.com/NixOS/nixpkgs/commit/93f3089edb3521f415cc1a8daf97fd1a08bcd176) | `` fcitx5-pinyin-moegirl: 20250309 -> 20250409 ``                                 |
| [`ba4dee17`](https://github.com/NixOS/nixpkgs/commit/ba4dee17a70d8a5704dfcaa85f93963395659ad5) | `` erigon: 3.0.0 -> 3.0.2 ``                                                      |
| [`65bc1912`](https://github.com/NixOS/nixpkgs/commit/65bc1912f45ed99ffceb23826f8baa1c79f23424) | `` jsonschema-cli: 0.29.1 -> 0.30.0 ``                                            |
| [`bdde94f9`](https://github.com/NixOS/nixpkgs/commit/bdde94f90e95421728fa8318915280c9c299ef54) | `` python312Packages.knx-frontend: 2025.3.8.214559 -> 2025.4.1.91934 (#399520) `` |
| [`3429b725`](https://github.com/NixOS/nixpkgs/commit/3429b725d76945608c523bee1db82226eddad684) | `` cewler: 1.2.0 -> 1.3.1 ``                                                      |
| [`116ca6b9`](https://github.com/NixOS/nixpkgs/commit/116ca6b9658faca8cc24d863daebeb4d77e09661) | `` gpsd: set rundir deterministically for reproducible builds ``                  |
| [`aee2f29f`](https://github.com/NixOS/nixpkgs/commit/aee2f29fd37aa7cff4ee6c613df8ac73e61d88a2) | `` valeStyles.google: 0.6.2 -> 0.6.3 ``                                           |
| [`b4cf24d6`](https://github.com/NixOS/nixpkgs/commit/b4cf24d6daf67a6d033b58a97e1569670d470ba0) | `` frigate: 0.15.0 -> 0.15.1 (#399382) ``                                         |
| [`af58e86d`](https://github.com/NixOS/nixpkgs/commit/af58e86d62cb63c69b1983d778c1aeeb8fef362c) | `` urn-timer: 0-unstable-2025-02-07 -> 0-unstable-2025-04-17 ``                   |
| [`568e4161`](https://github.com/NixOS/nixpkgs/commit/568e4161b912f802f8adf0b2d358e0dd1d10ffae) | `` valeStyles.microsoft: 0.14.1 -> 0.14.2 ``                                      |
| [`ca50aa3f`](https://github.com/NixOS/nixpkgs/commit/ca50aa3fad430a654a62d73d54a8681f9f277348) | `` icloudpd: 1.27.2 -> 1.27.4 ``                                                  |
| [`52bf12ad`](https://github.com/NixOS/nixpkgs/commit/52bf12ad5f3d253c8c8b4eab397e26c3f4b0be3b) | `` fleeting-plugin-aws: 1.0.0 -> 1.0.1 ``                                         |
| [`8a11a371`](https://github.com/NixOS/nixpkgs/commit/8a11a371d9b9cf63d70edbd85fd2344a95da5def) | `` geocode-glib: drop, geocode-glib_2: refactor ``                                |
| [`bfbb04a4`](https://github.com/NixOS/nixpkgs/commit/bfbb04a481a3c5e10aa03c68d572d256f84d2ad0) | `` roon-server: 2.48.1517 -> 2.49.1525 ``                                         |
| [`e9d0f344`](https://github.com/NixOS/nixpkgs/commit/e9d0f34404f83e300aea35700a6e0e184a068f96) | `` signal-desktop-source: rename to signal-desktop ``                             |
| [`09ad07b2`](https://github.com/NixOS/nixpkgs/commit/09ad07b2d5970ed054def44992a2ebc39d6eab08) | `` python312Packages.nutpie: disable flaky test on aarch64-linux ``               |
| [`353f7b0c`](https://github.com/NixOS/nixpkgs/commit/353f7b0cc53778f1a6956d6b60f362369b7cf932) | `` oterm: 0.9.3 -> 0.11.1 ``                                                      |
| [`0d0a2a68`](https://github.com/NixOS/nixpkgs/commit/0d0a2a68fc8b0af91e406797405e33b3e1b295e3) | `` hifile: 0.9.9.23 -> 0.9.9.25 ``                                                |
| [`5941de3f`](https://github.com/NixOS/nixpkgs/commit/5941de3fbf314aaefea112d8e69679fe4d9f66d4) | `` python312Packages.open-interpreter: 0.3.6 -> 0.4.2 ``                          |
| [`2090abd3`](https://github.com/NixOS/nixpkgs/commit/2090abd3d758e79190e5f0a7907a7b1c6a0358f5) | `` devenv: 1.5.1 -> 1.5.2 ``                                                      |
| [`d4b1f5ef`](https://github.com/NixOS/nixpkgs/commit/d4b1f5efbdacc8542215afc3e5f4d9ead7833a7a) | `` python312Packages.smolagents: fix build by relaxing pillow ``                  |
| [`ce9ec7ae`](https://github.com/NixOS/nixpkgs/commit/ce9ec7ae776c3c3ab9b587de0a17256d7f4b92e3) | `` arc-browser: 1.87.1-60573 -> 1.90.1-61364 ``                                   |
| [`fc4e3c3a`](https://github.com/NixOS/nixpkgs/commit/fc4e3c3a873639bf30b668774997c9c45ae8866a) | `` aonsoku: 0.8.3 -> 0.9.1 ``                                                     |
| [`6441a16a`](https://github.com/NixOS/nixpkgs/commit/6441a16a246fb3dccc925a0b7790982d620e5042) | `` cargo-vet: refactor ``                                                         |
| [`dd0ad741`](https://github.com/NixOS/nixpkgs/commit/dd0ad7419785fe0c5e0f3f089abdefef545f79b1) | `` python312Packages.ale-py: disable crashing test ``                             |
| [`422b986b`](https://github.com/NixOS/nixpkgs/commit/422b986bc3c136824d66171ac250f088d8f00477) | `` cargo-vet: 0.8.0 -> 0.10.1 ``                                                  |
| [`51f85815`](https://github.com/NixOS/nixpkgs/commit/51f858150e1a004ef9727a86fa43710f8ff4afce) | `` yandex-browser{,-beta,-corporate}: drop ``                                     |
| [`a55398fb`](https://github.com/NixOS/nixpkgs/commit/a55398fb5be7a38618831723fbcab6ba4422963d) | `` parca-agent: 0.37.0 -> 0.38.0 ``                                               |
| [`19286d44`](https://github.com/NixOS/nixpkgs/commit/19286d440966ed00115b69c91002932f3e349ee1) | `` markets: drop ``                                                               |
| [`78edb0c5`](https://github.com/NixOS/nixpkgs/commit/78edb0c5391808cfe52cdadab104b0e0bd512668) | `` protols: 0.11.5 -> 0.11.6 ``                                                   |
| [`a9141327`](https://github.com/NixOS/nixpkgs/commit/a91413279a72fbf21775ece5b14965089ab9fa5e) | `` fflogs: 8.16.31 -> 8.16.56 ``                                                  |
| [`5d6c113e`](https://github.com/NixOS/nixpkgs/commit/5d6c113ec78725208448f1c5f225e171170dd84d) | `` python313Packages.reflex-hosting-cli: fix build ``                             |
| [`0e11d17f`](https://github.com/NixOS/nixpkgs/commit/0e11d17fb3b0b6e6a6970cf0822702a96aca6de6) | `` python313Packages.reflex: 0.7.6 -> 0.7.7 ``                                    |
| [`b5ad0ced`](https://github.com/NixOS/nixpkgs/commit/b5ad0ced93ad15fe54a7f4da76ed3ec94841caf7) | `` python312Packages.pygame: mark as broken on darwin ``                          |
| [`30290db7`](https://github.com/NixOS/nixpkgs/commit/30290db7e54c31ffdd40b380bf931b9722abe036) | `` khal: add antonmosich as maintainer ``                                         |
| [`57c346e9`](https://github.com/NixOS/nixpkgs/commit/57c346e9985f85781219e44d47459b1fdde32a6a) | `` khal: 0.11.3 -> 0.13.0 ``                                                      |
| [`48ae7836`](https://github.com/NixOS/nixpkgs/commit/48ae783679f5b8f88b0a45e9f79895bbe3ff8e6b) | `` libhttpseverywhere: remove ``                                                  |
| [`6b2d2f75`](https://github.com/NixOS/nixpkgs/commit/6b2d2f7549d315979dc07b35db3a50d81cbb6f3f) | `` nixosTests.mailhog: reenable the flags ``                                      |
| [`649ec091`](https://github.com/NixOS/nixpkgs/commit/649ec091cd1589fa58f7df38c224f0f30eeb57b0) | `` mailhog: update mhsendmail to support the new args ``                          |
| [`1f2ca74a`](https://github.com/NixOS/nixpkgs/commit/1f2ca74a7c95833b3ead6ab78052b639019687c6) | `` zashboard: 1.77.0 -> 1.80.1 ``                                                 |
| [`3bcd8378`](https://github.com/NixOS/nixpkgs/commit/3bcd8378f3a1efacbda34d155a4e4b9922d2ce9a) | `` tailscale: skip flaky test ``                                                  |
| [`62401333`](https://github.com/NixOS/nixpkgs/commit/62401333cb7923dbae31fe213bddfdf0f3e0f0e5) | `` libvlc: build reproducibly ``                                                  |
| [`727fcb84`](https://github.com/NixOS/nixpkgs/commit/727fcb84ec89a613efad3529c5fccda7d63e5f40) | `` osm2pgsql: 2.1.0 -> 2.1.1 ``                                                   |
| [`0341e002`](https://github.com/NixOS/nixpkgs/commit/0341e0026a803349173cfc3cfc219ef9082eb45d) | `` python312Packages.mpi4py: fix tests in darwin sandbox ``                       |
| [`715bf806`](https://github.com/NixOS/nixpkgs/commit/715bf80632147de7a8c538a352a50094ecbc7f53) | `` garnet: 1.0.61 -> 1.0.63 ``                                                    |
| [`31505d13`](https://github.com/NixOS/nixpkgs/commit/31505d13e9d24f14e2677364725da7456e6702f5) | `` crosvm: 0-unstable-2025-04-07 -> 0-unstable-2025-04-16 ``                      |
| [`5084300a`](https://github.com/NixOS/nixpkgs/commit/5084300a28b2f5ef220e925d40c30f20440750b0) | `` sing-box: 1.11.6 -> 1.11.7 ``                                                  |
| [`b0d51991`](https://github.com/NixOS/nixpkgs/commit/b0d519919c9ddee59eada9347fb30912879547de) | `` golds: 0.7.5 -> 0.7.6 ``                                                       |
| [`d863bd87`](https://github.com/NixOS/nixpkgs/commit/d863bd87288d8d9c44cb94b5b1117615b20eb31d) | `` libgrss: remove ``                                                             |
| [`cf75c66e`](https://github.com/NixOS/nixpkgs/commit/cf75c66ea3648ef8e65ed7ea30dacbb5283531ba) | `` linux_xanmod, linux_xanmod_latest: 2025-04-10 (#397468) ``                     |
| [`8a991f1e`](https://github.com/NixOS/nixpkgs/commit/8a991f1eb9ed8b6d9310e6d286228a213622118c) | `` mpvScripts.manga-reader: 0-unstable-2025-02-16 -> 0-unstable-2025-04-16 ``     |
| [`0189ce4c`](https://github.com/NixOS/nixpkgs/commit/0189ce4ca6ac2ec3e2192092ff1d7783b8e1ad9f) | `` nu_scripts: 0-unstable-2025-04-07 -> 0-unstable-2025-04-14 ``                  |
| [`956062c0`](https://github.com/NixOS/nixpkgs/commit/956062c0084a5cdeccb70b2cd76710c29897f876) | `` hardinfo: drop ``                                                              |
| [`757d8b29`](https://github.com/NixOS/nixpkgs/commit/757d8b299c16036c099edf51623901d38f9bfb03) | `` python312Packages.minari: 0.5.2 -> 0.5.3 ``                                    |
| [`271061c8`](https://github.com/NixOS/nixpkgs/commit/271061c86353be15b6bc5d380f36a3fd5dc602c4) | `` wasmtime: cleanup ``                                                           |
| [`d21b227d`](https://github.com/NixOS/nixpkgs/commit/d21b227d3bf3bea27dc6f674efe14b059760f797) | `` codex: 0.1.04160940 -> 0.1.2504161510, add `versionCheckHook` ``               |
| [`21e6718f`](https://github.com/NixOS/nixpkgs/commit/21e6718fee665c9b5b50e3be629126f526a77431) | `` wasmtime: move to by-name ``                                                   |
| [`0bc5c733`](https://github.com/NixOS/nixpkgs/commit/0bc5c733a72a42aadb7687158e0656121a1ca7c0) | `` ed-odyssey-materials-helper: init at 2.156 ``                                  |
| [`7cef973e`](https://github.com/NixOS/nixpkgs/commit/7cef973e9542f28d7fa330ea55d52c45243d2761) | `` gsignond, gsignondPlugins: remove ``                                           |
| [`4ecb83ed`](https://github.com/NixOS/nixpkgs/commit/4ecb83edb0d5e5874f71009855c48dc09ddd4a48) | `` nixos/gsignond: remove ``                                                      |
| [`9e0eea62`](https://github.com/NixOS/nixpkgs/commit/9e0eea626cff230f73278bdd30e3154d194c320a) | `` gitlab-ci-local: add rsync to wrapper ``                                       |
| [`e0c85b54`](https://github.com/NixOS/nixpkgs/commit/e0c85b54436de33842879687b4d62cbff68af66a) | `` python312Packages.cyclopts: 3.12.0 -> 3.13.0 ``                                |
| [`3e424ece`](https://github.com/NixOS/nixpkgs/commit/3e424eceb849599ce4f5c112e4737fe0e15b4a2a) | `` gajim: 2.1.0 → 2.1.1 ``                                                        |
| [`e273bb5d`](https://github.com/NixOS/nixpkgs/commit/e273bb5d49b59eb666b7264e626542cdb544fabb) | `` python313Packages.boto3-stubs: 1.37.34 -> 1.37.35 ``                           |
| [`8265550e`](https://github.com/NixOS/nixpkgs/commit/8265550e41aede9fea246ae3ded20fd1bc925b8f) | `` python312Packages.mypy-boto3-servicecatalog: 1.37.0 -> 1.37.35 ``              |
| [`bdc47568`](https://github.com/NixOS/nixpkgs/commit/bdc47568a373bff000a138b5c6531aaa254ed18b) | `` python312Packages.mypy-boto3-resource-groups: 1.37.0 -> 1.37.35 ``             |
| [`7ea8a421`](https://github.com/NixOS/nixpkgs/commit/7ea8a421b98df7373262a2eba8825c2a3e0b9c57) | `` python312Packages.mypy-boto3-events: 1.37.28 -> 1.37.35 ``                     |