### PR TITLE
chore(flake/zen-browser): `e8429a2a` -> `805c8f56`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -896,11 +896,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1744974908,
-        "narHash": "sha256-W7kK1F30oml4BBJ6bXy3lfmz6Udm8uRP59H9hV73cyk=",
+        "lastModified": 1744992674,
+        "narHash": "sha256-6AEr+Ej/f4QmGw2OcpPsoj4Ru3oGmX3rv2tro8ev0ag=",
         "owner": "0xc000022070",
         "repo": "zen-browser-flake",
-        "rev": "e8429a2a3b4e1d6737736956b36186bdd223ecda",
+        "rev": "805c8f56e8ebac1527176fc9d551f73c4cd886f6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                          | Message                                                                         |
| --------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------- |
| [`805c8f56`](https://github.com/0xc000022070/zen-browser-flake/commit/805c8f56e8ebac1527176fc9d551f73c4cd886f6) | `` feat: allow policies.json management via unwrapped package override (#49) `` |