### PR TITLE
chore(flake/akuse-flake): `c7189595` -> `e2bc22e9`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -5,11 +5,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1744513976,
-        "narHash": "sha256-fwxFaM+YaKd5jGeyrjdkLqDe0iSkIT8mG+1FKp3p674=",
+        "lastModified": 1744989821,
+        "narHash": "sha256-ENCgJVdXkqzdc55DbWewVUSYrq9LV2JegjyOk+d3Cao=",
         "owner": "Rishabh5321",
         "repo": "akuse-flake",
-        "rev": "c7189595c06dd05369e5159c76fe26e9d2b2e07f",
+        "rev": "e2bc22e941b8ed644777973d669ad1b2e271267a",
         "type": "github"
       },
       "original": {
@@ -449,11 +449,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1744463964,
-        "narHash": "sha256-LWqduOgLHCFxiTNYi3Uj5Lgz0SR+Xhw3kr/3Xd0GPTM=",
+        "lastModified": 1744932701,
+        "narHash": "sha256-fusHbZCyv126cyArUwwKrLdCkgVAIaa/fQJYFlCEqiU=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "2631b0b7abcea6e640ce31cd78ea58910d31e650",
+        "rev": "b024ced1aac25639f8ca8fdfc2f8c4fbd66c48ef",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                   | Message                                          |
| -------------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
| [`e2bc22e9`](https://github.com/Rishabh5321/akuse-flake/commit/e2bc22e941b8ed644777973d669ad1b2e271267a) | `` chore(flake/nixpkgs): 2631b0b7 -> b024ced1 `` |