### PR TITLE
chore(flake/thorium): `c8e910a8` -> `9574c3c1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -576,11 +576,11 @@
     },
     "nixpkgs_7": {
       "locked": {
-        "lastModified": 1744463964,
-        "narHash": "sha256-LWqduOgLHCFxiTNYi3Uj5Lgz0SR+Xhw3kr/3Xd0GPTM=",
+        "lastModified": 1744932701,
+        "narHash": "sha256-fusHbZCyv126cyArUwwKrLdCkgVAIaa/fQJYFlCEqiU=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "2631b0b7abcea6e640ce31cd78ea58910d31e650",
+        "rev": "b024ced1aac25639f8ca8fdfc2f8c4fbd66c48ef",
         "type": "github"
       },
       "original": {
@@ -773,11 +773,11 @@
         "nixpkgs": "nixpkgs_7"
       },
       "locked": {
-        "lastModified": 1744513074,
-        "narHash": "sha256-rDfBJaUWJyh1hO4wKvLihYn0kQ3qnyNUECizEMUyBas=",
+        "lastModified": 1744989706,
+        "narHash": "sha256-/9tYuFye0Y2rlQFQF6X+ToqJzODpgVLPnm+ntOZlFuY=",
         "owner": "Rishabh5321",
         "repo": "thorium_flake",
-        "rev": "c8e910a8b5e4c7a865792633e04f5bde49052860",
+        "rev": "9574c3c191eae4b5e417a27934946375e2c9fd40",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                     | Message                                          |
| ---------------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
| [`9574c3c1`](https://github.com/Rishabh5321/thorium_flake/commit/9574c3c191eae4b5e417a27934946375e2c9fd40) | `` chore(flake/nixpkgs): 2631b0b7 -> b024ced1 `` |