### PR TITLE
chore(flake/home-manager): `5e6a8203` -> `fc09cb7a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -357,11 +357,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1744987093,
-        "narHash": "sha256-IVioWVz5qVtHiqosesW7CJW//m/yADr7cVdgF1P4N8s=",
+        "lastModified": 1745001336,
+        "narHash": "sha256-R4HuzrgYtOYBNmB3lfRxcieHEBO4uSfgHNz4MzWkZ5M=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "5e6a8203cee7cc33b2e0d9a0adb7268f46447292",
+        "rev": "fc09cb7aaadb70d6c4898654ffc872f0d2415df9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                   |
| ----------------------------------------------------------------------------------------------------------- | ----------------------------------------- |
| [`fc09cb7a`](https://github.com/nix-community/home-manager/commit/fc09cb7aaadb70d6c4898654ffc872f0d2415df9) | `` tests/labwc: fix autostart ``          |
| [`4d6a8f59`](https://github.com/nix-community/home-manager/commit/4d6a8f590e46e62075e6787860f0ea030bab7651) | `` keepassxc: nullable package support `` |
| [`54b494a7`](https://github.com/nix-community/home-manager/commit/54b494a77fb9fa68b0ebd7f75a8179cca0b286cd) | `` keepassxc: add module ``               |