### PR TITLE
chore(flake/zen-browser): `787480b8` -> `8c6b498a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -896,11 +896,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1745008338,
-        "narHash": "sha256-fm42BFmVRoKQhxtGKY/PjrgHJfDWJA2itA/QcOaVitc=",
+        "lastModified": 1745012451,
+        "narHash": "sha256-whHhTy0G0AlEgfJ6m+dfv3n2Fymg1qZ/cvV/nCWzQns=",
         "owner": "0xc000022070",
         "repo": "zen-browser-flake",
-        "rev": "787480b8179a8536e25107bf4b3e7edb0bae13a3",
+        "rev": "8c6b498af3776c49698b99bae05c2ae593bcadf1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                          | Message                            |
| --------------------------------------------------------------------------------------------------------------- | ---------------------------------- |
| [`8c6b498a`](https://github.com/0xc000022070/zen-browser-flake/commit/8c6b498af3776c49698b99bae05c2ae593bcadf1) | `` fix: policies handling (#50) `` |