### PR TITLE
chore(flake/home-manager): `fc09cb7a` -> `67f60ebc`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -357,11 +357,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1745001336,
-        "narHash": "sha256-R4HuzrgYtOYBNmB3lfRxcieHEBO4uSfgHNz4MzWkZ5M=",
+        "lastModified": 1745016969,
+        "narHash": "sha256-nDK8Z+LsNWrUsQ1JjnndNB57lvCmvy2QZUoCakoJCcI=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "fc09cb7aaadb70d6c4898654ffc872f0d2415df9",
+        "rev": "67f60ebce88a89939fb509f304ac554bcdc5bfa6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                     |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------- |
| [`67f60ebc`](https://github.com/nix-community/home-manager/commit/67f60ebce88a89939fb509f304ac554bcdc5bfa6) | `` tests/home-cursor: don't use realPkgs `` |
| [`4bc9b08c`](https://github.com/nix-community/home-manager/commit/4bc9b08c330842cb6e0cdafdb3c3b900cdde111a) | `` tests/broot: stub broot ``               |
| [`39037b08`](https://github.com/nix-community/home-manager/commit/39037b08f11ed034f4e0649aadbcdd856fab0ced) | `` tests: darwin stub hjson-go ``           |
| [`412eb166`](https://github.com/nix-community/home-manager/commit/412eb166eb6725549c7e6b317eb48dc2bc648e39) | `` tests/thunderbird: dont use realPkgs ``  |