### PR TITLE
chore(flake/zen-browser): `8c6b498a` -> `1deda743`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -896,11 +896,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1745012451,
-        "narHash": "sha256-whHhTy0G0AlEgfJ6m+dfv3n2Fymg1qZ/cvV/nCWzQns=",
+        "lastModified": 1745024215,
+        "narHash": "sha256-0KJ2dT/8uJG4mlyd4htjff5habh/AzP0CK8lcz1A9Oc=",
         "owner": "0xc000022070",
         "repo": "zen-browser-flake",
-        "rev": "8c6b498af3776c49698b99bae05c2ae593bcadf1",
+        "rev": "1deda743758f6e6a1ef85fdee5ede2af9bbd519e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                          | Message                                                        |
| --------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------- |
| [`1deda743`](https://github.com/0xc000022070/zen-browser-flake/commit/1deda743758f6e6a1ef85fdee5ede2af9bbd519e) | `` readme: add link to help with mkFirefoxModule docs ``       |
| [`3ac443b7`](https://github.com/0xc000022070/zen-browser-flake/commit/3ac443b7e05fe58532f51b07dd1c98e9db777877) | `` readme: add link to my rice to try to help with hm setup `` |
| [`70fde836`](https://github.com/0xc000022070/zen-browser-flake/commit/70fde8363d54c6911dc77186215f629fb8b7039f) | `` readme: renew documentation ``                              |