### PR TITLE
chore(flake/grayjay): `84accd21` -> `8d140367`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -337,11 +337,11 @@
         "nixpkgs": "nixpkgs_3"
       },
       "locked": {
-        "lastModified": 1744513122,
-        "narHash": "sha256-DPxL9yHkIvmNfpd49LeOOpT9NYrzHpgYbTO1yQg6Zh4=",
+        "lastModified": 1745022071,
+        "narHash": "sha256-1lsOIQALPkEIo13SrmeN2Ztbm5oGeKoNRZlQwVHaViI=",
         "owner": "rishabh5321",
         "repo": "grayjay-flake",
-        "rev": "84accd21a2e69709040a0eea22fccdb743c9e64c",
+        "rev": "8d140367b8124aaaaa9fa2e2876a812a45e22d72",
         "type": "github"
       },
       "original": {
@@ -512,11 +512,11 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1744463964,
-        "narHash": "sha256-LWqduOgLHCFxiTNYi3Uj5Lgz0SR+Xhw3kr/3Xd0GPTM=",
+        "lastModified": 1744932701,
+        "narHash": "sha256-fusHbZCyv126cyArUwwKrLdCkgVAIaa/fQJYFlCEqiU=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "2631b0b7abcea6e640ce31cd78ea58910d31e650",
+        "rev": "b024ced1aac25639f8ca8fdfc2f8c4fbd66c48ef",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                     | Message                                          |
| ---------------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
| [`8d140367`](https://github.com/Rishabh5321/grayjay-flake/commit/8d140367b8124aaaaa9fa2e2876a812a45e22d72) | `` chore(flake/nixpkgs): 2631b0b7 -> b024ced1 `` |