### PR TITLE
chore(flake/home-manager): `991a4804` -> `ae84885d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -357,11 +357,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1745024268,
-        "narHash": "sha256-bcVWOqJ1sDgHmwNvPrdJrF4H659rq7nno1w632BToas=",
+        "lastModified": 1745033012,
+        "narHash": "sha256-KjBMsjCzIOWgDqTZMYIriPFmHiQcCb2RhuDh5JF0VVc=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "991a4804720669220f7cbba078a2a27e2496eb69",
+        "rev": "ae84885d9b6b62dc58ccd300e9ab321a3fd9f9c7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                 |
| ----------------------------------------------------------------------------------------------------------- | --------------------------------------- |
| [`ae84885d`](https://github.com/nix-community/home-manager/commit/ae84885d9b6b62dc58ccd300e9ab321a3fd9f9c7) | `` workflows/conflicts: init (#6845) `` |
| [`307281bf`](https://github.com/nix-community/home-manager/commit/307281bfda7f3e3469234a03a7dd9d0026bf9f36) | `` labeler: expand labels (#6846) ``    |