### PR TITLE
chore(flake/zen-browser): `ab0ee058` -> `a01acea9`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -896,11 +896,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1745039533,
-        "narHash": "sha256-F9VoSszqwvK6++iV3IAL7skZX/FbwD4J+aJm5zMhKf8=",
+        "lastModified": 1745040643,
+        "narHash": "sha256-QAdOWF7bDXkcJTuZ/X014tAUi9bv+DBNU33uDupzQdU=",
         "owner": "0xc000022070",
         "repo": "zen-browser-flake",
-        "rev": "ab0ee0585fedbcdec3ca31663354107fafc4f922",
+        "rev": "a01acea9d26943263e292da9fee58fe0e7824e72",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                          | Message                                                      |
| --------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------ |
| [`a01acea9`](https://github.com/0xc000022070/zen-browser-flake/commit/a01acea9d26943263e292da9fee58fe0e7824e72) | `` feat(package): add libGL as a runtime dependency (#51) `` |
| [`35bd36d5`](https://github.com/0xc000022070/zen-browser-flake/commit/35bd36d5599de9a27e41c3211e2f537d9dbe5b43) | `` readme(1password): add troubleshooting section ``         |