### PR TITLE
chore(flake/spicetify-nix): `02098a8c` -> `c9093f2d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -673,11 +673,11 @@
         "systems": "systems_2"
       },
       "locked": {
-        "lastModified": 1745015891,
-        "narHash": "sha256-8vjI6kktMA0hWYQbYH63+YV7j9QFotVZSQzk8FnnrDg=",
+        "lastModified": 1745073200,
+        "narHash": "sha256-9BdXrdvR4ewdRMbvTRKABrJfuhcH1xxin2OR89MhMNY=",
         "owner": "Gerg-L",
         "repo": "spicetify-nix",
-        "rev": "02098a8c4f373cb0b2f6691bab1fa2e921d6c123",
+        "rev": "c9093f2d516c5b62461844c06bf362db8e230ff9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                    |
| ----------------------------------------------------------------------------------------------------- | -------------------------- |
| [`c9093f2d`](https://github.com/Gerg-L/spicetify-nix/commit/c9093f2d516c5b62461844c06bf362db8e230ff9) | `` feat: add checks ``     |
| [`85a8af65`](https://github.com/Gerg-L/spicetify-nix/commit/85a8af6502bf857818e4336d5710a8d54e4b059e) | `` feat: use submodules `` |