### PR TITLE
chore(flake/zen-browser): `a01acea9` -> `55681a87`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -896,11 +896,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1745040643,
-        "narHash": "sha256-QAdOWF7bDXkcJTuZ/X014tAUi9bv+DBNU33uDupzQdU=",
+        "lastModified": 1745079747,
+        "narHash": "sha256-Xg1C41ynxxljEyGqGDyFJ5c3i6p6GTSKMuAZQB/W2rA=",
         "owner": "0xc000022070",
         "repo": "zen-browser-flake",
-        "rev": "a01acea9d26943263e292da9fee58fe0e7824e72",
+        "rev": "55681a87d6e094fa93d260993e8c154208e70a69",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                          | Message                                                                 |
| --------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------- |
| [`55681a87`](https://github.com/0xc000022070/zen-browser-flake/commit/55681a87d6e094fa93d260993e8c154208e70a69) | `` chore(update): twilight @ x86_64 && aarch64 to 1.11.5t#1745077849 `` |