### PR TITLE
chore(flake/zen-browser): `55681a87` -> `67df3e64`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -896,11 +896,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1745079747,
-        "narHash": "sha256-Xg1C41ynxxljEyGqGDyFJ5c3i6p6GTSKMuAZQB/W2rA=",
+        "lastModified": 1745111733,
+        "narHash": "sha256-FVsS0LcSYwt4qiw1inlI8F9dc7PZaRaWAr4vqvvnekg=",
         "owner": "0xc000022070",
         "repo": "zen-browser-flake",
-        "rev": "55681a87d6e094fa93d260993e8c154208e70a69",
+        "rev": "67df3e64a216db8ac3c8bc669143af090bf4e6ad",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                          | Message                                                  |
| --------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------- |
| [`67df3e64`](https://github.com/0xc000022070/zen-browser-flake/commit/67df3e64a216db8ac3c8bc669143af090bf4e6ad) | `` chore(update): beta @ x86_64 && aarch64 to 1.11.5b `` |