### PR TITLE
chore(flake/home-manager): `20705949` -> `f98314bb`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -357,11 +357,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1745125917,
-        "narHash": "sha256-UIfoCpTYnt9eigHFKV8UmQ/h5UAbFc9adYBaOEBaYYk=",
+        "lastModified": 1745128386,
+        "narHash": "sha256-xnNxL9lZC5Ez8AxTgHZZu8pYSNM34+5GD5jGSs8Vq4M=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "20705949f101952182694be8e7ccd890f61824c2",
+        "rev": "f98314bb064cf8f8446c44afbadaaad2505875a7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                                         |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------- |
| [`f98314bb`](https://github.com/nix-community/home-manager/commit/f98314bb064cf8f8446c44afbadaaad2505875a7) | `` restic: init module (#6729) ``                                               |
| [`bb8d2866`](https://github.com/nix-community/home-manager/commit/bb8d286649e97b89ad7dedae90418ff78f028c9d) | `` zed-editor: add themes option (#6832) ``                                     |
| [`e8b68f99`](https://github.com/nix-community/home-manager/commit/e8b68f99c6921c3ea8a79df85a2e980a71b17bfb) | `` eza: add theme option (#6850) ``                                             |
| [`f6d295ce`](https://github.com/nix-community/home-manager/commit/f6d295cee3f6c9f8e968e1bfa4fda29bf9314bc5) | `` flake.lock: Update (#6854) ``                                                |
| [`b8d186ab`](https://github.com/nix-community/home-manager/commit/b8d186abf8e14b3cffc8e0aee6459a323bc83eb0) | `` fish: allow multiple commands for command option in abbreviations (#6851) `` |