### PR TITLE
chore(flake/spicetify-nix): `c9093f2d` -> `1dd4328f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -673,11 +673,11 @@
         "systems": "systems_2"
       },
       "locked": {
-        "lastModified": 1745073200,
-        "narHash": "sha256-9BdXrdvR4ewdRMbvTRKABrJfuhcH1xxin2OR89MhMNY=",
+        "lastModified": 1745151211,
+        "narHash": "sha256-qFXfTdO1yvW6DmUPfVLIJgDHfkSd5yimZWvBMrlP/ow=",
         "owner": "Gerg-L",
         "repo": "spicetify-nix",
-        "rev": "c9093f2d516c5b62461844c06bf362db8e230ff9",
+        "rev": "1dd4328f82115887901a685ecd9fa6e1d1db2d0c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                       |
| ----------------------------------------------------------------------------------------------------- | --------------------------------------------- |
| [`1dd4328f`](https://github.com/Gerg-L/spicetify-nix/commit/1dd4328f82115887901a685ecd9fa6e1d1db2d0c) | `` CI update 2025-04-20 ``                    |
| [`2a659a51`](https://github.com/Gerg-L/spicetify-nix/commit/2a659a5123cff72007eab6a688dab69989544a5d) | `` fix: remove spicetify-cli from workflow `` |