### PR TITLE
chore(flake/home-manager): `f98314bb` -> `3fbe9a2b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -357,11 +357,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1745128386,
-        "narHash": "sha256-xnNxL9lZC5Ez8AxTgHZZu8pYSNM34+5GD5jGSs8Vq4M=",
+        "lastModified": 1745205007,
+        "narHash": "sha256-k67bEcLkSo13TIBfs0CGYkJjG12aaikabMtxWbSeqr0=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "f98314bb064cf8f8446c44afbadaaad2505875a7",
+        "rev": "3fbe9a2b76ff5c4dcb2a2a2027dac31cfc993c8c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------------ |
| [`3fbe9a2b`](https://github.com/nix-community/home-manager/commit/3fbe9a2b76ff5c4dcb2a2a2027dac31cfc993c8c) | `` tests/ranger: null package ``                       |
| [`63bfbf55`](https://github.com/nix-community/home-manager/commit/63bfbf55b6e561f5c517a29f9bf9157ff9dd8c87) | `` ranger: nullable package support ``                 |
| [`14eda3db`](https://github.com/nix-community/home-manager/commit/14eda3db4e0347bb03f0d2e32f28f4467744abe1) | `` clock-rs: add module ``                             |
| [`ac21ae37`](https://github.com/nix-community/home-manager/commit/ac21ae37168f339cccfd7002039314aeb3829bf6) | `` maintainers: add Oughie ``                          |
| [`b0cc0924`](https://github.com/nix-community/home-manager/commit/b0cc092405da805da6fa964f5a178343658ceaf0) | `` shikane: init module (#4096) ``                     |
| [`496fa9c0`](https://github.com/nix-community/home-manager/commit/496fa9c054d3a212c8bcb3ac80ab310841eed361) | `` PR_TEMPLATE: mention nix fmt (#6859) ``             |
| [`b71ca269`](https://github.com/nix-community/home-manager/commit/b71ca269615b0837724dac13358a2f0d6816d372) | `` uv: nullable package support ``                     |
| [`1d2d6b95`](https://github.com/nix-community/home-manager/commit/1d2d6b95688a6cb7555e2d50ba6ef1ebaa916546) | `` uv: init module ``                                  |
| [`a0461b67`](https://github.com/nix-community/home-manager/commit/a0461b67ff657b6b6e51bb4a547ad98907d28dc8) | `` vesktop: created module ``                          |
| [`3cecde80`](https://github.com/nix-community/home-manager/commit/3cecde80a57211a05972aad49dab3ab4957178ae) | `` maintainers: added lilleaila ``                     |
| [`642d3e3b`](https://github.com/nix-community/home-manager/commit/642d3e3bad75f688fa68edc01f2c3c8fe9833737) | `` atuin: add support for str + path themes (#6849) `` |
| [`6a676ee4`](https://github.com/nix-community/home-manager/commit/6a676ee476543fcaea916d3b7a6e130112c44603) | `` wallust: null package support ``                    |
| [`aa2c7ac4`](https://github.com/nix-community/home-manager/commit/aa2c7ac40455ba98a106b9b5b22959a19e05a629) | `` wallust: add module ``                              |
| [`48bbe7bc`](https://github.com/nix-community/home-manager/commit/48bbe7bc4895a976e563b559316e8b178d474a0c) | `` maintainers: add kiara ``                           |