### PR TITLE
chore(flake/better-control): `0c448062` -> `9fb7218d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -91,11 +91,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1744989088,
-        "narHash": "sha256-j3HCGYdauq74hZzlgsDpQKx8rKLRX2oNhrsS8Jr8ZE8=",
+        "lastModified": 1745212446,
+        "narHash": "sha256-f0VfqsGXYmzoWMiYXHrzU7mBTxzs7Okeok6grgU44/0=",
         "owner": "rishabh5321",
         "repo": "better-control-flake",
-        "rev": "0c4480620461c1b5d8bcf1112b915be5a26f8308",
+        "rev": "9fb7218da5b761fecfa9e6ecc9d10371e182da9a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                            | Message                                            |
| ----------------------------------------------------------------------------------------------------------------- | -------------------------------------------------- |
| [`9fb7218d`](https://github.com/Rishabh5321/better-control-flake/commit/9fb7218da5b761fecfa9e6ecc9d10371e182da9a) | `` feat: Update better-control to v6.10.4 (#75) `` |