### PR TITLE
chore(flake/stylix): `758fe634` -> `039e938b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -710,11 +710,11 @@
         "tinted-zed": "tinted-zed"
       },
       "locked": {
-        "lastModified": 1745156230,
-        "narHash": "sha256-8Oeww77z62PVy4xmyH6UHFxRoZfKgXkSSyKQpIWMTyQ=",
+        "lastModified": 1745197327,
+        "narHash": "sha256-67BDvZBfS+IGM/onh7FgjSo1B+oeh6tewDCFvwrDzvs=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "758fe63490093650075ec7587b7a6eb38614a4dd",
+        "rev": "039e938b29ce870ba326be1d60ae6d7c0a58f84e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                        | Message                                              |
| --------------------------------------------------------------------------------------------- | ---------------------------------------------------- |
| [`039e938b`](https://github.com/danth/stylix/commit/039e938b29ce870ba326be1d60ae6d7c0a58f84e) | `` doc: promote lib.singleton in testbeds (#1148) `` |
| [`179220cf`](https://github.com/danth/stylix/commit/179220cfc24b77e206fe240fac76d7974c32c8d4) | `` gitui: switch from rgb to hex (#1144) ``          |