### PR TITLE
chore(flake/home-manager): `f98314bb` -> `22b326b4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -357,11 +357,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1745128386,
-        "narHash": "sha256-xnNxL9lZC5Ez8AxTgHZZu8pYSNM34+5GD5jGSs8Vq4M=",
+        "lastModified": 1745256380,
+        "narHash": "sha256-hJH1S5Xy0K2J6eT22AMDIcQ07E8XYC1t7DnXUr2llEM=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "f98314bb064cf8f8446c44afbadaaad2505875a7",
+        "rev": "22b326b42bf42973d5e4fe1044591fb459e6aeac",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                        |
| ----------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------- |
| [`22b326b4`](https://github.com/nix-community/home-manager/commit/22b326b42bf42973d5e4fe1044591fb459e6aeac) | `` television: add module (#6866) ``                           |
| [`be4e5ec6`](https://github.com/nix-community/home-manager/commit/be4e5ec62ce5703a00e40668f7a1a79d04c2195d) | `` nix-init: add module (#6864) ``                             |
| [`08b85bd0`](https://github.com/nix-community/home-manager/commit/08b85bd0002c7ac500b8d9ac0112467885712b1f) | `` vesktop: add support for multiple themes (#6860) ``         |
| [`ca836711`](https://github.com/nix-community/home-manager/commit/ca8367117a20e11139b6b887aa19cb5d48dc1075) | `` atuin: Fix deprecated string type warning (#6861) ``        |
| [`ddda2b1f`](https://github.com/nix-community/home-manager/commit/ddda2b1f20ffc92b803fc5c8c0d80bbfb54cd478) | `` direnv: only set sessionVariable for old version (#6842) `` |
| [`82ee14ff`](https://github.com/nix-community/home-manager/commit/82ee14ff60611b46588ea852f267aafcc117c8c8) | `` treewide: remove with lib (#6871) ``                        |
| [`6695b1d4`](https://github.com/nix-community/home-manager/commit/6695b1d477246e30a3f14a7084c82775b30c09c1) | `` kconfig: escape arguments properly (#6867) ``               |
| [`3fbe9a2b`](https://github.com/nix-community/home-manager/commit/3fbe9a2b76ff5c4dcb2a2a2027dac31cfc993c8c) | `` tests/ranger: null package ``                               |
| [`63bfbf55`](https://github.com/nix-community/home-manager/commit/63bfbf55b6e561f5c517a29f9bf9157ff9dd8c87) | `` ranger: nullable package support ``                         |
| [`14eda3db`](https://github.com/nix-community/home-manager/commit/14eda3db4e0347bb03f0d2e32f28f4467744abe1) | `` clock-rs: add module ``                                     |
| [`ac21ae37`](https://github.com/nix-community/home-manager/commit/ac21ae37168f339cccfd7002039314aeb3829bf6) | `` maintainers: add Oughie ``                                  |
| [`b0cc0924`](https://github.com/nix-community/home-manager/commit/b0cc092405da805da6fa964f5a178343658ceaf0) | `` shikane: init module (#4096) ``                             |
| [`496fa9c0`](https://github.com/nix-community/home-manager/commit/496fa9c054d3a212c8bcb3ac80ab310841eed361) | `` PR_TEMPLATE: mention nix fmt (#6859) ``                     |
| [`b71ca269`](https://github.com/nix-community/home-manager/commit/b71ca269615b0837724dac13358a2f0d6816d372) | `` uv: nullable package support ``                             |
| [`1d2d6b95`](https://github.com/nix-community/home-manager/commit/1d2d6b95688a6cb7555e2d50ba6ef1ebaa916546) | `` uv: init module ``                                          |
| [`a0461b67`](https://github.com/nix-community/home-manager/commit/a0461b67ff657b6b6e51bb4a547ad98907d28dc8) | `` vesktop: created module ``                                  |
| [`3cecde80`](https://github.com/nix-community/home-manager/commit/3cecde80a57211a05972aad49dab3ab4957178ae) | `` maintainers: added lilleaila ``                             |
| [`642d3e3b`](https://github.com/nix-community/home-manager/commit/642d3e3bad75f688fa68edc01f2c3c8fe9833737) | `` atuin: add support for str + path themes (#6849) ``         |
| [`6a676ee4`](https://github.com/nix-community/home-manager/commit/6a676ee476543fcaea916d3b7a6e130112c44603) | `` wallust: null package support ``                            |
| [`aa2c7ac4`](https://github.com/nix-community/home-manager/commit/aa2c7ac40455ba98a106b9b5b22959a19e05a629) | `` wallust: add module ``                                      |
| [`48bbe7bc`](https://github.com/nix-community/home-manager/commit/48bbe7bc4895a976e563b559316e8b178d474a0c) | `` maintainers: add kiara ``                                   |