### PR TITLE
chore(flake/home-manager): `22b326b4` -> `81541ea3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -357,11 +357,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1745256380,
-        "narHash": "sha256-hJH1S5Xy0K2J6eT22AMDIcQ07E8XYC1t7DnXUr2llEM=",
+        "lastModified": 1745272532,
+        "narHash": "sha256-+sFbKw1vFkulKYxsAbz84N0V/goSg808IgFh8iWe/As=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "22b326b42bf42973d5e4fe1044591fb459e6aeac",
+        "rev": "81541ea36d1fead4be7797e826ee325d4c19308b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                          |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
| [`81541ea3`](https://github.com/nix-community/home-manager/commit/81541ea36d1fead4be7797e826ee325d4c19308b) | `` lorri: fix missing makeSearchPath (#6875) ``  |
| [`42d90297`](https://github.com/nix-community/home-manager/commit/42d90297b38424a62235550a191fca875913e2f7) | `` git: support maintenance on darwin (#6868) `` |