### PR TITLE
chore(flake/home-manager): `81541ea3` -> `ce8dc1f7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -357,11 +357,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1745272532,
-        "narHash": "sha256-+sFbKw1vFkulKYxsAbz84N0V/goSg808IgFh8iWe/As=",
+        "lastModified": 1745325289,
+        "narHash": "sha256-RKLaR/x3jsc57lu+giaSa+3xXwky/IZMJ/f8RB+XPWs=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "81541ea36d1fead4be7797e826ee325d4c19308b",
+        "rev": "ce8dc1f77ada561f4deee2c76f7cd6f6c7b8feec",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                     |
| ----------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------- |
| [`ce8dc1f7`](https://github.com/nix-community/home-manager/commit/ce8dc1f77ada561f4deee2c76f7cd6f6c7b8feec) | `` xsettingsd: Remove erroneous `lib.` insertion (#6877) `` |