### PR TITLE
chore(flake/home-manager): `342b3e3e` -> `c9433ae6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -357,11 +357,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1745335336,
-        "narHash": "sha256-T/h5/oa9xsggWV1LfwTWfpRGuKdtS9xM0WIgq/dYptM=",
+        "lastModified": 1745340124,
+        "narHash": "sha256-zQTOl/JPGjiAQoU1yraCGfPBg7yr4nlHNdbZy8Ebrl4=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "342b3e3e6df239dc972372e6a641acf052ff74aa",
+        "rev": "c9433ae62fbb4bd09609e242569edc3b551e21a9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                    |
| ----------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------- |
| [`c9433ae6`](https://github.com/nix-community/home-manager/commit/c9433ae62fbb4bd09609e242569edc3b551e21a9) | `` keepassxc: register as native messaging host (#6879) `` |
| [`b925865c`](https://github.com/nix-community/home-manager/commit/b925865c74a783c2fd42f0f340f18f2276baa316) | `` ci: label msmtp changes with "mail" (#6881) ``          |