### PR TITLE
chore(flake/better-control): `c72863ff` -> `1418d3fc`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -91,11 +91,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1745341081,
-        "narHash": "sha256-gxJ/YD8SehP194gUI7cMx5hCCqgqSTZziPjSBp4Ltdc=",
+        "lastModified": 1745352777,
+        "narHash": "sha256-HlS7w937EdoZC7zO0mdEFibqRPPbdBXjGNtrBASJGvk=",
         "owner": "rishabh5321",
         "repo": "better-control-flake",
-        "rev": "c72863ff88504d2ae0c3cdaff8b7286edfa8929f",
+        "rev": "1418d3fc014bf05cfde3a32f2b88b28463e09e00",
         "type": "github"
       },
       "original": {
@@ -496,11 +496,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1744932701,
-        "narHash": "sha256-fusHbZCyv126cyArUwwKrLdCkgVAIaa/fQJYFlCEqiU=",
+        "lastModified": 1745234285,
+        "narHash": "sha256-GfpyMzxwkfgRVN0cTGQSkTC0OHhEkv3Jf6Tcjm//qZ0=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "b024ced1aac25639f8ca8fdfc2f8c4fbd66c48ef",
+        "rev": "c11863f1e964833214b767f4a369c6e6a7aba141",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                            | Message                                          |
| ----------------------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
| [`1418d3fc`](https://github.com/Rishabh5321/better-control-flake/commit/1418d3fc014bf05cfde3a32f2b88b28463e09e00) | `` chore(flake/nixpkgs): b024ced1 -> c11863f1 `` |