### PR TITLE
chore(flake/akuse-flake): `e2bc22e9` -> `efa4f8e4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -5,11 +5,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1744989821,
-        "narHash": "sha256-ENCgJVdXkqzdc55DbWewVUSYrq9LV2JegjyOk+d3Cao=",
+        "lastModified": 1745353568,
+        "narHash": "sha256-SXEjrddNh1Ryuu0U7uZPtTj2yKn4sa0OKLG2T6MatJQ=",
         "owner": "Rishabh5321",
         "repo": "akuse-flake",
-        "rev": "e2bc22e941b8ed644777973d669ad1b2e271267a",
+        "rev": "efa4f8e4c07ba80f6dd3ee0c026445f45fca0933",
         "type": "github"
       },
       "original": {
@@ -449,11 +449,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1744932701,
-        "narHash": "sha256-fusHbZCyv126cyArUwwKrLdCkgVAIaa/fQJYFlCEqiU=",
+        "lastModified": 1745234285,
+        "narHash": "sha256-GfpyMzxwkfgRVN0cTGQSkTC0OHhEkv3Jf6Tcjm//qZ0=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "b024ced1aac25639f8ca8fdfc2f8c4fbd66c48ef",
+        "rev": "c11863f1e964833214b767f4a369c6e6a7aba141",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                   | Message                                          |
| -------------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
| [`efa4f8e4`](https://github.com/Rishabh5321/akuse-flake/commit/efa4f8e4c07ba80f6dd3ee0c026445f45fca0933) | `` chore(flake/nixpkgs): b024ced1 -> c11863f1 `` |