### PR TITLE
chore(flake/nixpkgs-stable): `26d499fc` -> `1eae3268`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -480,11 +480,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1744440957,
-        "narHash": "sha256-FHlSkNqFmPxPJvy+6fNLaNeWnF1lZSgqVCl/eWaJRc4=",
+        "lastModified": 1744917357,
+        "narHash": "sha256-1Sj8MToixDwakJYNMYBS/PYbg8Oa4CAxreXraMHB5qg=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "26d499fc9f1d567283d5d56fcf367edd815dba1d",
+        "rev": "1eae3268880484be84199bdb77941c09bb4a97ba",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                           |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------- |
| [`e03df76c`](https://github.com/NixOS/nixpkgs/commit/e03df76c3a8ac2119f45ff18c9b994513dbb7a4c) | `` linux_xanmod, linux_xanmod_latest: 2025-04-10 (#397468) ``                                     |
| [`73b4986f`](https://github.com/NixOS/nixpkgs/commit/73b4986fe2301a705174a8956417224f67e2541a) | `` mullvad-browser: 14.0.9 -> 14.5 ``                                                             |
| [`0849c41e`](https://github.com/NixOS/nixpkgs/commit/0849c41e9570f12fb7de798e4962f4c705dbe6ed) | `` tor-browser: 14.0.9 -> 14.5 ``                                                                 |
| [`cf45a63f`](https://github.com/NixOS/nixpkgs/commit/cf45a63ff1c29cc759213c5dbe9ced255a6e39d1) | `` erlang_27: 27.3.2 -> 27.3.3 ``                                                                 |
| [`a08b5fbc`](https://github.com/NixOS/nixpkgs/commit/a08b5fbc7f4d00bd6578fa2a330d08e89e41da7a) | `` erlang_26: 26.2.5.10 -> 26.2.5.11 ``                                                           |
| [`84c1ad19`](https://github.com/NixOS/nixpkgs/commit/84c1ad19431ad55fbfb5383e344a7ff142661599) | `` erlang_24: mark end of life ``                                                                 |
| [`847c62ac`](https://github.com/NixOS/nixpkgs/commit/847c62ac4058df2f39766af607aa0c9b718425c9) | `` erlang_25: 25.3.2.19 -> 25.3.2.20 ``                                                           |
| [`83fbd758`](https://github.com/NixOS/nixpkgs/commit/83fbd758e1630c8b1920bb8dc00957f6f43fda15) | `` ungoogled-chromium: 135.0.7049.84-1 -> 135.0.7049.95-1 ``                                      |
| [`05931b13`](https://github.com/NixOS/nixpkgs/commit/05931b13e957d746453db84269d5cab730e6d502) | `` raycast: 1.95.0 -> 1.96.0 ``                                                                   |
| [`5dca6997`](https://github.com/NixOS/nixpkgs/commit/5dca69972662e61d17faccf1fa41dac94168f020) | `` chromium,chromedriver: 135.0.7049.84 -> 135.0.7049.95 ``                                       |
| [`8fe61a4a`](https://github.com/NixOS/nixpkgs/commit/8fe61a4a07166a4c5c5147db047b0d74338c1cc3) | `` yelp-xsl: fix for CVE-2025-3155 ``                                                             |
| [`63641a3b`](https://github.com/NixOS/nixpkgs/commit/63641a3b19e44924bbe6731c0321bbb9c2b36f0e) | `` yelp: fix for CVE-2025-3155 ``                                                                 |
| [`b92a6949`](https://github.com/NixOS/nixpkgs/commit/b92a69497b70fffdeeee920587a915406134da18) | `` pnpm_10: 10.8.0 -> 10.8.1 ``                                                                   |
| [`a75fd524`](https://github.com/NixOS/nixpkgs/commit/a75fd524834f3452fd1aec76f4d6f7cf9b3dda39) | `` vesktop: 1.5.5 -> 1.5.6 ``                                                                     |
| [`6dcb23b5`](https://github.com/NixOS/nixpkgs/commit/6dcb23b523504fb79f3340b7f92d3d1b86ec9526) | `` pyfa: 2.62.2 -> 2.62.3 ``                                                                      |
| [`293f26f7`](https://github.com/NixOS/nixpkgs/commit/293f26f70d42b0a274301a3e8c744129c686d0e7) | `` microsoft-edge: 134.0.3124.95 -> 135.0.3179.54 ``                                              |
| [`43de5ad7`](https://github.com/NixOS/nixpkgs/commit/43de5ad76d13b90ea5f9c6a8d6bd96102c8020dd) | `` amazon-q-cli: 1.7.2 -> 1.7.3 ``                                                                |
| [`dfb90afc`](https://github.com/NixOS/nixpkgs/commit/dfb90afc608f722f7b8d14381d5422ad727819e9) | `` brave: 1.77.95 -> 1.77.97 ``                                                                   |
| [`71ab7e90`](https://github.com/NixOS/nixpkgs/commit/71ab7e9098b9308c4b9aba4cfe4eb37177a982aa) | `` ruby_3_4: 3.4.1 -> 3.4.3 ``                                                                    |
| [`1aaf61fe`](https://github.com/NixOS/nixpkgs/commit/1aaf61fe75aed0bdf65e7f9a84512b8162860814) | `` portunus: 2.1.1 -> 2.1.2 ``                                                                    |
| [`dce3f019`](https://github.com/NixOS/nixpkgs/commit/dce3f0197d214a9febe2433e322a973985068da4) | `` go_1_24: 1.24.1 -> 1.24.2 ``                                                                   |
| [`7f1f7f56`](https://github.com/NixOS/nixpkgs/commit/7f1f7f56cb38c2d3ac4f966a5dd21fcf5d02a271) | `` go_1_24: 1.24.0 -> 1.24.1 ``                                                                   |
| [`e434e79e`](https://github.com/NixOS/nixpkgs/commit/e434e79ed41df38dcc99f1754d55c4f36bae1ff6) | `` go_1_24: 1.24rc3 -> 1.24.0 ``                                                                  |
| [`6733e010`](https://github.com/NixOS/nixpkgs/commit/6733e010fb95eb4f8e6b171a2f8733f50cbfeef4) | `` go_1_24: rc2 -> rc3 ``                                                                         |
| [`7a98de45`](https://github.com/NixOS/nixpkgs/commit/7a98de45a77f1953db9ebc640b6feee175497515) | `` go_1_24: 1.24rc1 -> 1.24rc2 ``                                                                 |
| [`ea9e2c26`](https://github.com/NixOS/nixpkgs/commit/ea9e2c26615462f7c702f92cf7b7d8480c3ad039) | `` go_1_24: init at 1.24rc1 ``                                                                    |
| [`e9d29300`](https://github.com/NixOS/nixpkgs/commit/e9d29300cb39ac93fe0f7e9e419c32cbd83017b3) | `` lib/modules: add `class` to `specialArgs` ``                                                   |
| [`18157a99`](https://github.com/NixOS/nixpkgs/commit/18157a99d0df5bc1a66e77b7788fcab55ba514dc) | `` gitlab: 17.10.1 -> 17.10.4 ``                                                                  |
| [`ed0f4c46`](https://github.com/NixOS/nixpkgs/commit/ed0f4c46dec9d8c67738d456e18240525bdd3f33) | `` gitlab: fix update script after global reformatting ``                                         |
| [`0c115ba2`](https://github.com/NixOS/nixpkgs/commit/0c115ba27334c15e3eb37da082f90be228799fe3) | `` vscode-extensions.woberg.godot-dotnet-tools: init 0.5.1 ``                                     |
| [`5230a1a6`](https://github.com/NixOS/nixpkgs/commit/5230a1a67667f03b55b3097e13c5b103c5c416d9) | `` firefox-bin-unwrapped: 137.0.1 -> 137.0.2 ``                                                   |
| [`1689e1d7`](https://github.com/NixOS/nixpkgs/commit/1689e1d7a71b4997bdf478bf25ecdffba2e868a5) | `` firefox-unwrapped: 137.0.1 -> 137.0.2 ``                                                       |
| [`16788414`](https://github.com/NixOS/nixpkgs/commit/167884140720b1bf6eb9f319ce1344a340c26d27) | `` buildbox: Simplify wrapper for `buildbox-run` ``                                               |
| [`7ba535b8`](https://github.com/NixOS/nixpkgs/commit/7ba535b8e679c8a6f8e2b1c72b924387ad519e31) | `` nm-file-secret-agent: update canonical repo location ``                                        |
| [`3938ce72`](https://github.com/NixOS/nixpkgs/commit/3938ce72da3ff10d0ceebc425feb7c97a30ccc43) | `` nm-file-secret-agent: v1.0.1 -> v1.1.0 ``                                                      |
| [`f1f0a6fd`](https://github.com/NixOS/nixpkgs/commit/f1f0a6fdfec353d6a6fde4bc41a0d7de6e1ed46a) | `` phpunit: 12.1.0 -> 12.1.2 ``                                                                   |
| [`706209a6`](https://github.com/NixOS/nixpkgs/commit/706209a65a7ca7ea829454dd9c40a80dc3eb0074) | `` gitlab: 17.9.3 -> 17.10.1 ``                                                                   |
| [`8a38cf49`](https://github.com/NixOS/nixpkgs/commit/8a38cf497881a030827516b9491ab5b58a4aa646) | `` opencore-amr: adjust homepage to have index-able URL ``                                        |
| [`cc3f0935`](https://github.com/NixOS/nixpkgs/commit/cc3f093570a48f18421d944598e95a48c5be532c) | `` php84Extensions.ctype: remove flaky test for `aarch64-darwin` ``                               |
| [`8c1f7255`](https://github.com/NixOS/nixpkgs/commit/8c1f725506c76d11e5deb16307fd0d31384537bc) | `` vencord: 1.11.8 -> 1.11.9 ``                                                                   |
| [`3c1890e3`](https://github.com/NixOS/nixpkgs/commit/3c1890e34734a5d1dadb90cc38c6b8eb643e91af) | `` nixVersions.nixComponents_2_27: fix error message ``                                           |
| [`445c6b84`](https://github.com/NixOS/nixpkgs/commit/445c6b84eb90acf19ab93b21098a8c8e3c55c0a6) | `` stdenv/darwin: disable `gnugrep` tests in early bootstrap ``                                   |
| [`1cd8c7fc`](https://github.com/NixOS/nixpkgs/commit/1cd8c7fcfe299bea33c7d1395b1c59d6bb444087) | `` nixos/shutdown: Create /run/initramfs with mode 0700 ``                                        |
| [`098fb93e`](https://github.com/NixOS/nixpkgs/commit/098fb93ebdb56b0be422ffe88345b6f70dab0382) | `` make-initrd-ng: Restore stripped file permissions ``                                           |
| [`45388e9b`](https://github.com/NixOS/nixpkgs/commit/45388e9bf23305b8baf54b5483440a24853674d9) | `` perl: apply patch for CVE-2024-56406 ``                                                        |
| [`c54b1288`](https://github.com/NixOS/nixpkgs/commit/c54b12884aabaa153e338184bded02111aea7161) | `` librewolf-unwrapped: 137.0-3 -> 137.0.1-1 ``                                                   |
| [`5fa7fe9d`](https://github.com/NixOS/nixpkgs/commit/5fa7fe9dec25685a057c938b7b302f25f9212a62) | `` prismlauncher: 9.3 -> 9.4 ``                                                                   |
| [`474067eb`](https://github.com/NixOS/nixpkgs/commit/474067ebeb9da72ca08c76aabc2af5ad7357dff3) | `` prismlauncher: 9.2 -> 9.3 ``                                                                   |
| [`10618401`](https://github.com/NixOS/nixpkgs/commit/1061840133b7bc5c0ec42bb6868030a5e12a5d37) | `` rmapi: 0.0.27.1 -> 0.0.28 ``                                                                   |
| [`d91e164c`](https://github.com/NixOS/nixpkgs/commit/d91e164c74711d11efe0b9f82da775cb5a42222d) | `` phpPackages.phive: 0.15.3 -> 0.16.0 ``                                                         |
| [`ceec6c1e`](https://github.com/NixOS/nixpkgs/commit/ceec6c1e52087619a04a55d45b8e9fcfd59e5ce9) | `` phpPackages.php-codesniffer: 3.12.0 -> 3.12.2 ``                                               |
| [`682c430b`](https://github.com/NixOS/nixpkgs/commit/682c430bfa7f9feae4ffa3162a69c07431cd34e9) | `` wlx-overlay-s: 25.4.0 -> 25.4.2 ``                                                             |
| [`3a41a2a5`](https://github.com/NixOS/nixpkgs/commit/3a41a2a5e2a4b2efae8f721dfe75c349d556949f) | `` wlx-overlay-s: 25.3.0 -> 25.4.0 ``                                                             |
| [`347cb928`](https://github.com/NixOS/nixpkgs/commit/347cb928a82d8381cb8107d2a5e2ebc56c798e39) | `` mediawiki: 1.42.3 -> 1.42.6 ``                                                                 |
| [`5b838dfd`](https://github.com/NixOS/nixpkgs/commit/5b838dfdae8d9cac634af744a591faab0737d7e0) | `` dotnetCorePackages.sdk_10_0-bin: 10.0.100-preview.2.25164.34 -> 10.0.100-preview.3.25201.16 `` |
| [`985c222d`](https://github.com/NixOS/nixpkgs/commit/985c222d32a3fd37ae746cf368912254a11c8b0b) | `` dotnetCorePackages.dotnet_10.vmr: 10.0.0-preview.2 -> 10.0.0-preview.3 ``                      |
| [`8a26f091`](https://github.com/NixOS/nixpkgs/commit/8a26f0919a768b1b73532342cec851d7e2072cf6) | `` dotnetCorePackages.dotnet_9.vmr: 9.0.3 -> 9.0.4 ``                                             |
| [`6a297b0c`](https://github.com/NixOS/nixpkgs/commit/6a297b0ce9f21b70b08409eb80ad5a40cf7f513a) | `` dotnetCorePackages.dotnet_8.vmr: 8.0.14 -> 8.0.15 ``                                           |
| [`44452534`](https://github.com/NixOS/nixpkgs/commit/44452534ebe84fe8d5a9e38d677d685e3cf73553) | `` dotnetCorePackages.sdk_8_0-bin: 8.0.407 -> 8.0.408 ``                                          |
| [`bf224050`](https://github.com/NixOS/nixpkgs/commit/bf2240508c0da23117713c82d0366910e838bde5) | `` dotnetCorePackages.sdk_9_0-bin: 9.0.202 -> 9.0.203 ``                                          |
| [`89a973a3`](https://github.com/NixOS/nixpkgs/commit/89a973a322935b6ce3d91b279ec9d7197bb7cbb8) | `` dotnetCorePackages.dotnet_{8,9,10}.aspnetcore: copy App package only ``                        |
| [`353dff03`](https://github.com/NixOS/nixpkgs/commit/353dff03e32e5aa9559cc9f21ce8de471af0020d) | `` dotent/update.sh: ignore new apphost-pack and targeting-pack releases ``                       |
| [`0cdacffe`](https://github.com/NixOS/nixpkgs/commit/0cdacffe66a8460bc16c18e79439d408eff90e16) | `` dotnet/update.sh: set inherit_errexit ``                                                       |
| [`55a8c9bd`](https://github.com/NixOS/nixpkgs/commit/55a8c9bd4553daae6d3cf15bc56b41c6d3bdc19a) | `` garnet: use target packages from sdk ``                                                        |
| [`e0469d1f`](https://github.com/NixOS/nixpkgs/commit/e0469d1f7066d9a38d6cc1677f0cc2d81a5d76e5) | `` php83: 8.3.19 -> 8.3.20 ``                                                                     |
| [`e6d3d745`](https://github.com/NixOS/nixpkgs/commit/e6d3d745a739f2f5bc9809644f26ec11fca6ea42) | `` php: 8.4.5 -> 8.4.6 ``                                                                         |
| [`a4cee02d`](https://github.com/NixOS/nixpkgs/commit/a4cee02d2bff80800faf2159a7e6549b321a9132) | `` thunderbird-bin-unwrapped: 128.8.1esr -> 128.9.1esr ``                                         |
| [`b0ca7e88`](https://github.com/NixOS/nixpkgs/commit/b0ca7e884a6080dc4dcff9840901ef28c3eed3ac) | `` patchelfUnstable: 0.18.0-unstable-2024-06-15 -> 0.18.0-unstable-2025-01-07 ``                  |
| [`22b3c4a1`](https://github.com/NixOS/nixpkgs/commit/22b3c4a1cddf2b97f1b72fdb3c559dd55872c91f) | `` morphosis: 1.4.1 -> 48.1 ``                                                                    |
| [`70c6677b`](https://github.com/NixOS/nixpkgs/commit/70c6677b3d3b88b1ee33380d7efb24bbae8c9f4b) | `` textpieces: 4.1.1-1 -> 4.2.0 ``                                                                |
| [`c79af6cb`](https://github.com/NixOS/nixpkgs/commit/c79af6cb6d2c396c39df58d1209aa402b3dbb2a4) | `` pcloud: use patchelfUnstable ``                                                                |
| [`f24e317e`](https://github.com/NixOS/nixpkgs/commit/f24e317e0e2efc639d078c5810c59c43251a8d94) | `` sydbox: 3.32.6 -> 3.32.7 ``                                                                    |
| [`2adb5dc5`](https://github.com/NixOS/nixpkgs/commit/2adb5dc5a42597abd31617a961433a50075e3ec3) | `` bird2: 2.16.1 -> 2.17 ``                                                                       |
| [`99647a2c`](https://github.com/NixOS/nixpkgs/commit/99647a2c134f21bc43a204dea1a4ce21553af10b) | `` brave: 1.76.81 -> 1.77.95 ``                                                                   |
| [`dbd58ec2`](https://github.com/NixOS/nixpkgs/commit/dbd58ec253d702b60c6bc77d841a2f6f4effe007) | `` thunderbird-latest-unwrapped: 136.0.1 -> 137.0.1 ``                                            |
| [`7a492900`](https://github.com/NixOS/nixpkgs/commit/7a492900a3935275afe22c0f801caee07c8e446d) | `` amazon-q-cli: init at 1.7.2 ``                                                                 |
| [`81eb3b49`](https://github.com/NixOS/nixpkgs/commit/81eb3b492bc70c88d999f6fb0ebe4433e4bc0450) | `` maintainers: add jamesward ``                                                                  |
| [`cf4f31b7`](https://github.com/NixOS/nixpkgs/commit/cf4f31b755503eaf0ee8da8f61e2205a057b258e) | `` mcaselector: 2.5 -> 2.5.1 ``                                                                   |
| [`d7010f0f`](https://github.com/NixOS/nixpkgs/commit/d7010f0f63206c8c836c78270abad4cb2551a187) | `` mcaselector: 2.4.2 -> 2.5 ``                                                                   |
| [`876840cf`](https://github.com/NixOS/nixpkgs/commit/876840cf0f1e3d521bdee1dd21418e298260f803) | `` openvpn: 2.6.13 -> 2.6.14 ``                                                                   |
| [`4201aa8f`](https://github.com/NixOS/nixpkgs/commit/4201aa8f0c538a7b520b9c09cf69f24111f87c20) | `` openvpn: 2.6.12 -> 2.6.13 ``                                                                   |
| [`aa04087c`](https://github.com/NixOS/nixpkgs/commit/aa04087ce32ac7999c2bdb27eb76fa8aa9c8e549) | `` kismet: 2023-07-R1 -> 2023-07-R2; adopt ``                                                     |
| [`33943c19`](https://github.com/NixOS/nixpkgs/commit/33943c19c2e2cb9f876314673742fe8d3993080d) | `` cinny-desktop: 4.5.1 -> 4.6.0 ``                                                               |
| [`1ab69d0c`](https://github.com/NixOS/nixpkgs/commit/1ab69d0c19dd07c94a0ffc6a6366fa2e6e142e47) | `` cinny-unwrapped: 4.5.1 -> 4.6.0 ``                                                             |
| [`9d7bb8d9`](https://github.com/NixOS/nixpkgs/commit/9d7bb8d9a4be540b014d7d5cb8aab753b9dc8179) | `` cargo-auditable: format ``                                                                     |
| [`529d2793`](https://github.com/NixOS/nixpkgs/commit/529d2793d3dff9f4d3d9111aec2b3d6a468e2e4f) | `` cargo-auditable: 0.6.2 -> 0.6.5 ``                                                             |
| [`daa477e0`](https://github.com/NixOS/nixpkgs/commit/daa477e013dd736c939fcc111dc4dd889bc17c94) | `` go_1_23: 1.23.7 -> 1.23.8 ``                                                                   |
| [`4c1e13d7`](https://github.com/NixOS/nixpkgs/commit/4c1e13d740f6c69688579928da33b4413d8d979d) | `` ruby_3_3: 3.3.6 -> 3.3.7 ``                                                                    |
| [`a5508e29`](https://github.com/NixOS/nixpkgs/commit/a5508e29a40d7b15d82dabdf5c05d120039e66db) | `` ruby_3_2: 3.2.6 -> 3.2.8 ``                                                                    |
| [`bc2fd9c9`](https://github.com/NixOS/nixpkgs/commit/bc2fd9c972f9d6b4a3a5ae9a9c8ae1902b1ec166) | `` ruby_3_1: 3.1.6 -> 3.1.7 ``                                                                    |
| [`ae711c3e`](https://github.com/NixOS/nixpkgs/commit/ae711c3e33a9143e92cb1108b537321a365947f6) | `` nixos/wayland-session: fix conflicts between users ``                                          |
| [`7eebbccf`](https://github.com/NixOS/nixpkgs/commit/7eebbccf7b15e3c40da5cf9a139e6ea8498404d2) | `` mautrix-signal: 0.8.0 -> 0.8.1 ``                                                              |
| [`8816db8f`](https://github.com/NixOS/nixpkgs/commit/8816db8f26dd39f4615c8ed04d95be889dc23056) | `` qt6: 6.8.2 -> 6.8.3 ``                                                                         |
| [`d202afb5`](https://github.com/NixOS/nixpkgs/commit/d202afb598eed0963258fb5bfc34ce5159743770) | `` webkitgtk_6_0: 2.46.6 → 2.48.0 ``                                                              |