### PR TITLE
chore(flake/home-manager): `b99e3e46` -> `97a62d8e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -357,11 +357,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1745362344,
-        "narHash": "sha256-R4d7j2urn/W+K9crKJaxJvZOsVX5v7uCAymaDBq97SE=",
+        "lastModified": 1745375834,
+        "narHash": "sha256-/MXB13Ua92tlnN30T0Tu07qzhMReicc8vw2pA7ahOFM=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "b99e3e46b86aefc01f229e0a29d0c03c1079aaed",
+        "rev": "97a62d8eef74ab06b20152be0b323292dfe03c88",
         "type": "github"
       },
       "original": {

--- a/modules/user/zsh.nix
+++ b/modules/user/zsh.nix
@@ -1,5 +1,6 @@
 { username
 , wallpaper
+, lib
 , ...
 }: {
   programs.zsh = {
@@ -13,7 +14,7 @@
       plugins = [ "git" ];
       theme = "intheloop";
     };
-    initExtraFirst = ''
+    initContent = lib.mkBefore ''
       export PATH=$PATH:/run/current-system/sw/bin
       HISTFILE=~/.histfile
       HISTSIZE=1000
@@ -22,9 +23,6 @@
       unsetopt beep extendedglob notify
       autoload -Uz compinit
       compinit
-    '';
-
-    initExtra = ''
       zstyle ":completion:*" menu select
       zstyle ":completion:*" matcher-list "" "m:{a-z0A-Z}={A-Za-z}" "r:|=*" "l:|=* r:|=*"
       if type nproc &>/dev/null; then


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                                   |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------- |
| [`97a62d8e`](https://github.com/nix-community/home-manager/commit/97a62d8eef74ab06b20152be0b323292dfe03c88) | `` tests/default: add zoxide darwin stub (#6888) ``                       |
| [`68bc080c`](https://github.com/nix-community/home-manager/commit/68bc080cdf00b1ec65f78c1d1e65e9828904cd22) | `` fcitx5: refactor logic (#6886) ``                                      |
| [`f1aabf1d`](https://github.com/nix-community/home-manager/commit/f1aabf1deb6981176b7608cdf67140519a3d442b) | `` zsh: deprecate initLocation options in favor of initContent (#6841) `` |
| [`c42f04c8`](https://github.com/nix-community/home-manager/commit/c42f04c83f866e3ad7d285072b253dffdabad6fe) | `` mkFirefoxModule: revert userChrome changes (#6887) ``                  |