### PR TITLE
chore(flake/home-manager): `97a62d8e` -> `1d0e1390`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -357,11 +357,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1745375834,
-        "narHash": "sha256-/MXB13Ua92tlnN30T0Tu07qzhMReicc8vw2pA7ahOFM=",
+        "lastModified": 1745380081,
+        "narHash": "sha256-bUy25YkdRfdWPxSyx22igWi6g3rd3HXKFg+yL4dfBPY=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "97a62d8eef74ab06b20152be0b323292dfe03c88",
+        "rev": "1d0e13904bd8c444ab1595f686ede5eff377e881",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------------ |
| [`1d0e1390`](https://github.com/nix-community/home-manager/commit/1d0e13904bd8c444ab1595f686ede5eff377e881) | `` i18n.inputMethod: add awwpotato as maintainer ``    |
| [`585bae4b`](https://github.com/nix-community/home-manager/commit/585bae4bbb48789ece06f4b18cb373651760c4ab) | `` i18n.inputMethod: align enable option with nixos `` |
| [`7ef31370`](https://github.com/nix-community/home-manager/commit/7ef3137035deca91854c38c114eeaf611707b005) | `` vesktop: fix config path on darwin (#6889) ``       |