### PR TITLE
chore(flake/better-control): `1418d3fc` -> `f2808a47`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -91,11 +91,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1745352777,
-        "narHash": "sha256-HlS7w937EdoZC7zO0mdEFibqRPPbdBXjGNtrBASJGvk=",
+        "lastModified": 1745379965,
+        "narHash": "sha256-8G6kFNZ9l+fWseZ9O6HOGjBqhhGxsqF4sToilkuAjEE=",
         "owner": "rishabh5321",
         "repo": "better-control-flake",
-        "rev": "1418d3fc014bf05cfde3a32f2b88b28463e09e00",
+        "rev": "f2808a47cadecab46e96f4da6a1a6ce4c604ee69",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                            | Message                                            |
| ----------------------------------------------------------------------------------------------------------------- | -------------------------------------------------- |
| [`f2808a47`](https://github.com/Rishabh5321/better-control-flake/commit/f2808a47cadecab46e96f4da6a1a6ce4c604ee69) | `` feat: Update better-control to v6.10.6 (#78) `` |