### PR TITLE
chore(flake/nixpkgs-stable): `1eae3268` -> `9684b531`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -480,11 +480,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1744917357,
-        "narHash": "sha256-1Sj8MToixDwakJYNMYBS/PYbg8Oa4CAxreXraMHB5qg=",
+        "lastModified": 1745279238,
+        "narHash": "sha256-AQ7M9wTa/Pa/kK5pcGTgX/DGqMHyzsyINfN7ktsI7Fo=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "1eae3268880484be84199bdb77941c09bb4a97ba",
+        "rev": "9684b53175fc6c09581e94cc85f05ab77464c7e3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                              |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------ |
| [`735ca2b3`](https://github.com/NixOS/nixpkgs/commit/735ca2b3a4c57206d3cfaac93257baaf84c7226e) | `` necesse-server: add udpate script ``                                              |
| [`5b422423`](https://github.com/NixOS/nixpkgs/commit/5b422423ff67d4bcf0421a3162fa9007022b4c33) | `` necesse-server: 0.31.1-17664948 -> 0.32.1-18110069 ``                             |
| [`8391968c`](https://github.com/NixOS/nixpkgs/commit/8391968c0f2d336ee19c7db2c62741032eb0c4ac) | `` pnpm_10: 10.8.1 -> 10.9.0 ``                                                      |
| [`2e15940b`](https://github.com/NixOS/nixpkgs/commit/2e15940bbe0a0be6b9d977d9d4368bc64e1aced6) | `` doc: do not reuse `pname` ``                                                      |
| [`e770ce47`](https://github.com/NixOS/nixpkgs/commit/e770ce47b6b990e9d7dbeb0aefd74e3a891887af) | `` doc: replace `rev` with `tag` ``                                                  |
| [`c084f8dc`](https://github.com/NixOS/nixpkgs/commit/c084f8dc6c67c937f69099efdfb6a7ffbf082895) | `` doc: remove useless `rec` ``                                                      |
| [`9761d7f8`](https://github.com/NixOS/nixpkgs/commit/9761d7f89fb73feef3849fca6c0bcd16b1bc0a01) | `` doc: use `finalAttrs` pattern ``                                                  |
| [`46a181a2`](https://github.com/NixOS/nixpkgs/commit/46a181a27b9fd741d11cd340d7d4b92a065e143f) | `` doc: add missing phase hooks ``                                                   |
| [`f1d9d0bd`](https://github.com/NixOS/nixpkgs/commit/f1d9d0bdd63e0595c9bca5a91be7c3ba47a3fcd2) | `` doc: use `writableTmpDirAsHomeHook` ``                                            |
| [`206a616b`](https://github.com/NixOS/nixpkgs/commit/206a616bbe32423a9a11791a9316fa6b2168a1ac) | `` linux_6_12: 6.12.23 -> 6.12.24 ``                                                 |
| [`a99b2866`](https://github.com/NixOS/nixpkgs/commit/a99b2866dd7878c7208cdaa346fa93bd1a18b02f) | `` linux_6_13: 6.13.11 -> 6.13.12 ``                                                 |
| [`556b76e7`](https://github.com/NixOS/nixpkgs/commit/556b76e7684134e845ce38e7addc297f3f2c37b8) | `` linux_6_14: 6.14.2 -> 6.14.3 ``                                                   |
| [`bee69807`](https://github.com/NixOS/nixpkgs/commit/bee6980740ddd9dce3d3b7da0b7605cb20081efa) | `` linux_testing: 6.15-rc1 -> 6.15-rc2 ``                                            |
| [`b69bd9e2`](https://github.com/NixOS/nixpkgs/commit/b69bd9e228e3a944077d73972478eb40c86cc4d0) | `` doc: update Nix code snippets format ``                                           |
| [`51ffa11b`](https://github.com/NixOS/nixpkgs/commit/51ffa11b12f57b9a0289f08d8ace2319a8a20937) | `` doc: fix various nix snippets ``                                                  |
| [`64a347a0`](https://github.com/NixOS/nixpkgs/commit/64a347a04dae0aa9fb4901a90787b66485b806b1) | `` {nixpkgs-manual, nixos-manual}: add new test `check-nix-code-blocks` ``           |
| [`36666805`](https://github.com/NixOS/nixpkgs/commit/366668051e3a77072da8fda09cc5d9fac7c04a75) | `` markdown-code-runner: init at 0-unstable-2025-04-13 ``                            |
| [`02725fdd`](https://github.com/NixOS/nixpkgs/commit/02725fdd2e86e0a3e9000d10f54247d4ace22c82) | `` mautrix-signal: 0.8.1 -> 0.8.2 ``                                                 |
| [`4d36e502`](https://github.com/NixOS/nixpkgs/commit/4d36e502fd41752dcbb75ec8f76f5a8b9e59b0fc) | `` libsignal-ffi: 0.67.4 -> 0.70.0 ``                                                |
| [`a01df831`](https://github.com/NixOS/nixpkgs/commit/a01df831705215ecbe674cac51af09dd4329724a) | `` mautrix-whatsapp: 0.11.4 -> 0.12.0 ``                                             |
| [`96c3c1fd`](https://github.com/NixOS/nixpkgs/commit/96c3c1fdcaf6dbaadcce64b0901fe70f5b459e58) | `` mysql84: 8.4.4 -> 8.4.5 ``                                                        |
| [`5d715c6b`](https://github.com/NixOS/nixpkgs/commit/5d715c6b6fa2121ad489b4703dab45d6adaf3cad) | `` mysql80: 8.0.41 -> 8.0.42 ``                                                      |
| [`41c7c5e2`](https://github.com/NixOS/nixpkgs/commit/41c7c5e2945d767d742a6085249690a62ba44686) | `` mate.libmateweather: disable location compression to fix loading data ``          |
| [`8796b128`](https://github.com/NixOS/nixpkgs/commit/8796b1285d7ae58477733c1c9eff7cde6880ee56) | `` pantheon.appcenter: Do not use compressed appstream metadata ``                   |
| [`0c9b3c1b`](https://github.com/NixOS/nixpkgs/commit/0c9b3c1b94409d8cd934fb85b63b5ec32389a7a6) | `` monado: 24.0.0 -> 25.0.0 ``                                                       |
| [`92d8c22b`](https://github.com/NixOS/nixpkgs/commit/92d8c22b354c5ee07f6ae718a20eb081d799bc63) | `` batman-adv: 2025.0 -> 2025.1 ``                                                   |
| [`df2a272d`](https://github.com/NixOS/nixpkgs/commit/df2a272d41983ebb4014345a3183029538723ece) | `` forgejo: 10.0.3 -> 11.0.0 ``                                                      |
| [`eee86cc5`](https://github.com/NixOS/nixpkgs/commit/eee86cc546f9f833919ae7a6e70fa15655b0a067) | `` heroic: take NIXOS_OZONE_WL into account ``                                       |
| [`675d1a9c`](https://github.com/NixOS/nixpkgs/commit/675d1a9cb9a100e43ddd24e60bb498c9a5e3147c) | `` element-desktop: 1.11.96 -> 1.11.97 ``                                            |
| [`81afbe6a`](https://github.com/NixOS/nixpkgs/commit/81afbe6a21f2de8685751af15e302f8468bb8f28) | `` element-web: 1.11.96 -> 1.11.97 ``                                                |
| [`1e8ea80c`](https://github.com/NixOS/nixpkgs/commit/1e8ea80c0cf4a966970c1145fcfee408e5412ce7) | `` mattermostLatest: 10.4.4 -> 10.6.1 ``                                             |
| [`288b1da0`](https://github.com/NixOS/nixpkgs/commit/288b1da000dc9845799e816231c8fc89aa588c3e) | `` tests.importCargoLock.gitDependencyWorkspaceInheritance: fix build ``             |
| [`67652478`](https://github.com/NixOS/nixpkgs/commit/67652478eb2e61df8f5a8b041ca4f3d166b5695e) | `` tests.importCargoLock.gitDependencyRevNonWorkspaceNestedCrate: use system zlib `` |
| [`cf211afd`](https://github.com/NixOS/nixpkgs/commit/cf211afdc427897527a0137553fb61205b9a9b6e) | `` palemoon-bin: Pin ffmpeg to ffmpeg_6 ``                                           |
| [`b0a6d2cb`](https://github.com/NixOS/nixpkgs/commit/b0a6d2cbfd2aedd78d590803faa3d8f026554e6e) | `` palemoon-bin: 33.6.1 -> 33.7.0 ``                                                 |
| [`981d5a7c`](https://github.com/NixOS/nixpkgs/commit/981d5a7ce30f8ff043ce64169369e5168a210c79) | `` teleport_17: 17.4.1 -> 17.4.2 ``                                                  |
| [`518b1410`](https://github.com/NixOS/nixpkgs/commit/518b1410e1b4dcc692d0752ac63300809817a1b8) | `` teleport_17: 17.4.0 -> 17.4.1 ``                                                  |
| [`7e5d1fe5`](https://github.com/NixOS/nixpkgs/commit/7e5d1fe57ba70606e4651b63a8a0ac64e76b06b5) | `` teleport_16: 16.4.18 -> 16.5.0 ``                                                 |
| [`fe5f529c`](https://github.com/NixOS/nixpkgs/commit/fe5f529c0290a6a737059baadfff90295ef40171) | `` teleport_17: 17.3.3 -> 17.4.0 ``                                                  |
| [`f8203ae0`](https://github.com/NixOS/nixpkgs/commit/f8203ae0298c5f7c5a13241e5f7f5ea06849b75f) | `` teleport_16: 16.4.17 -> 16.4.18 ``                                                |
| [`193d5aea`](https://github.com/NixOS/nixpkgs/commit/193d5aea90fa1717157c94625cc9a7163fa49d91) | `` teleport_15: 15.4.29 -> 15.4.30 ``                                                |
| [`07be1229`](https://github.com/NixOS/nixpkgs/commit/07be12297d775f942a969727e68f4ba9f0a578ec) | `` teleport_16: 16.4.16 -> 16.4.17 ``                                                |
| [`2a598f26`](https://github.com/NixOS/nixpkgs/commit/2a598f261f2a23d5d7d9befe3fd3ef3e61945589) | `` teleport_17: 17.2.9 -> 17.3.3 ``                                                  |