### PR TITLE
chore(flake/better-control): `f2808a47` -> `d73663f0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -91,11 +91,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1745379965,
-        "narHash": "sha256-8G6kFNZ9l+fWseZ9O6HOGjBqhhGxsqF4sToilkuAjEE=",
+        "lastModified": 1745383949,
+        "narHash": "sha256-C8O3+d6WUb/2NfcQ5rjae9MM6yhLn5BVEu4zR1HDmFA=",
         "owner": "rishabh5321",
         "repo": "better-control-flake",
-        "rev": "f2808a47cadecab46e96f4da6a1a6ce4c604ee69",
+        "rev": "d73663f07f30e29600f7ad29606a016b722cb7a7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                            | Message                                                                       |
| ----------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------- |
| [`d73663f0`](https://github.com/Rishabh5321/better-control-flake/commit/d73663f07f30e29600f7ad29606a016b722cb7a7) | `` feat: enhance flake check workflow with detailed Telegram notifications `` |
| [`08a1c4a5`](https://github.com/Rishabh5321/better-control-flake/commit/08a1c4a5a01c980c0ae0294ae5d0836f890e4a49) | `` refactor: rename workflow and streamline flake check process ``            |
| [`a80e44fe`](https://github.com/Rishabh5321/better-control-flake/commit/a80e44fe2ba675778209e1c4b1d7cbf85ebf1e9b) | `` refactor: improve flake check workflow logging and error handling ``       |
| [`ed768b5e`](https://github.com/Rishabh5321/better-control-flake/commit/ed768b5eb2339f61fb1cb1bfc933994d2dbcaec8) | `` feat: enable platforms field in package.nix for better compatibility ``    |
| [`649247a7`](https://github.com/Rishabh5321/better-control-flake/commit/649247a7e49c26a9ffca996b240907a26bc8c0e5) | `` chore: comment out platforms field in package.nix ``                       |