### PR TITLE
chore(flake/home-manager): `814521fd` -> `6c132a09`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -357,11 +357,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1745414626,
-        "narHash": "sha256-c3M+Zq11JgiPq76H0fpLGnoWsGu9cbB/FGPoT8PpWm8=",
+        "lastModified": 1745416071,
+        "narHash": "sha256-L8mEeVZvS1e0XaEDsibClr4MhBzqrxhUDiiAIbDnZGM=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "814521fdc16813b036415edb4bb42a8733729dd5",
+        "rev": "6c132a098e61163fb559db986efe913acd3df4e7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                         |
| ----------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------- |
| [`6c132a09`](https://github.com/nix-community/home-manager/commit/6c132a098e61163fb559db986efe913acd3df4e7) | `` tests/darwinScrublist: add more darwin stubs ``              |
| [`a3e713cb`](https://github.com/nix-community/home-manager/commit/a3e713cb82af628105480ae54dc7500b5ec8ebd1) | `` tests/darwinScrublist: move darwin scrub list to new file `` |
| [`b01a9411`](https://github.com/nix-community/home-manager/commit/b01a94118403af8a3ce646b3d703ba3d18bed042) | `` tests/default: add more darwin stubs ``                      |