### PR TITLE
chore(flake/home-manager): `6c132a09` -> `b7527e2d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -357,11 +357,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1745416071,
-        "narHash": "sha256-L8mEeVZvS1e0XaEDsibClr4MhBzqrxhUDiiAIbDnZGM=",
+        "lastModified": 1745421701,
+        "narHash": "sha256-mZoVHMwj8uF1nnd8nHGzcTzTcVNApymIoo4NemJjnzU=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "6c132a098e61163fb559db986efe913acd3df4e7",
+        "rev": "b7527e2daf755437a2948f09761a8ed07debd075",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                       |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------- |
| [`b7527e2d`](https://github.com/nix-community/home-manager/commit/b7527e2daf755437a2948f09761a8ed07debd075) | `` vesktop: only generate settings when configured (#6897) `` |
| [`ff6adf83`](https://github.com/nix-community/home-manager/commit/ff6adf83b9cfdc88dc0b035a608e08d3eb674b3a) | `` input-method: fix enable condition (#6896) ``              |