### PR TITLE
chore(flake/home-manager): `b7527e2d` -> `6d1f834c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -357,11 +357,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1745421701,
-        "narHash": "sha256-mZoVHMwj8uF1nnd8nHGzcTzTcVNApymIoo4NemJjnzU=",
+        "lastModified": 1745427103,
+        "narHash": "sha256-J4v65MKoXt95nmCYr6a7Cdiyl9QmPp6u3+7aJ71zxbk=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "b7527e2daf755437a2948f09761a8ed07debd075",
+        "rev": "6d1f834ca63700604a96d8c38aa8ac272d95071a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                                   |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------- |
| [`6d1f834c`](https://github.com/nix-community/home-manager/commit/6d1f834ca63700604a96d8c38aa8ac272d95071a) | `` fcitx5: add upstream options (#6892) ``                                |
| [`59de2dfb`](https://github.com/nix-community/home-manager/commit/59de2dfb0a08ebcbc73e3bb8488d2c23057e6ad8) | `` workflows: only run conflicts and update flake on main repo (#6893) `` |