### PR TITLE
chore(flake/better-control): `1774c76f` -> `2ee5a9e8`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -177,11 +177,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1745415990,
-        "narHash": "sha256-XuFjHcsgUJnihT/lJk2jeiOLthMCYjtY708N05YLrDw=",
+        "lastModified": 1745482548,
+        "narHash": "sha256-IEywhI6Z43aIUwilOK7CPjrl9TfkZoSA4mIDowxYnvU=",
         "owner": "rishabh5321",
         "repo": "better-control-flake",
-        "rev": "1774c76fa17f7774929e0db059dba182136531e0",
+        "rev": "2ee5a9e8488395a6ed02c7744cfa3bad02df7c8c",
         "type": "github"
       },
       "original": {
@@ -585,11 +585,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1745234285,
-        "narHash": "sha256-GfpyMzxwkfgRVN0cTGQSkTC0OHhEkv3Jf6Tcjm//qZ0=",
+        "lastModified": 1745391562,
+        "narHash": "sha256-sPwcCYuiEopaafePqlG826tBhctuJsLx/mhKKM5Fmjo=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "c11863f1e964833214b767f4a369c6e6a7aba141",
+        "rev": "8a2f738d9d1f1d986b5a4cd2fd2061a7127237d7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                            | Message                                          |
| ----------------------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
| [`2ee5a9e8`](https://github.com/Rishabh5321/better-control-flake/commit/2ee5a9e8488395a6ed02c7744cfa3bad02df7c8c) | `` chore(flake/nixpkgs): c11863f1 -> 8a2f738d `` |