### PR TITLE
chore(flake/nixpkgs): `c11863f1` -> `8a2f738d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -617,11 +617,11 @@
     },
     "nixpkgs_4": {
       "locked": {
-        "lastModified": 1745234285,
-        "narHash": "sha256-GfpyMzxwkfgRVN0cTGQSkTC0OHhEkv3Jf6Tcjm//qZ0=",
+        "lastModified": 1745391562,
+        "narHash": "sha256-sPwcCYuiEopaafePqlG826tBhctuJsLx/mhKKM5Fmjo=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "c11863f1e964833214b767f4a369c6e6a7aba141",
+        "rev": "8a2f738d9d1f1d986b5a4cd2fd2061a7127237d7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                   |
| ---------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------- |
| [`37e1c3f7`](https://github.com/NixOS/nixpkgs/commit/37e1c3f76fc9ab398ac90c238114adc0bb95ef8a) | `` python312Packages.lib4package: 0.3.1 -> 0.3.2 ``                                       |
| [`ed3789c0`](https://github.com/NixOS/nixpkgs/commit/ed3789c02b5eb3544af1ad6e1ecd1ea702e9f507) | `` duply: 2.4 -> 2.5.5 ``                                                                 |
| [`4c38c704`](https://github.com/NixOS/nixpkgs/commit/4c38c704aacd3b89c54fff2998354e5513363e76) | `` Revert "mongoc: 1.30.2 -> 2.0.0" ``                                                    |
| [`8923784c`](https://github.com/NixOS/nixpkgs/commit/8923784c1365ed59297104df16dd8e2a310f9a28) | `` mcpelauncher-ui-qt: fix build on Qt 6.9 ``                                             |
| [`21f623d6`](https://github.com/NixOS/nixpkgs/commit/21f623d62d0af0381e7a143db89597eaefd42644) | `` maintainers: awwpotato add matrix ``                                                   |
| [`465759d4`](https://github.com/NixOS/nixpkgs/commit/465759d454d40d1708ca769f1bf9a50002073eaa) | `` fooyin: fix build, add libebur128 for ReplayGain ``                                    |
| [`b823d772`](https://github.com/NixOS/nixpkgs/commit/b823d7721f174ac9094f0eeb666f6180a6486d75) | `` python312Packages.vector: 1.6.1 -> 1.6.2 (#400912) ``                                  |
| [`1f0c0201`](https://github.com/NixOS/nixpkgs/commit/1f0c0201d1aab1721b25ff75614c065962de89dd) | `` blender: 4.4.0 -> 4.4.1 (#399292) ``                                                   |
| [`2152f51e`](https://github.com/NixOS/nixpkgs/commit/2152f51ec73f4c7e18202b1846ac35a59c21f620) | `` chamber: 3.1.1 -> 3.1.2 ``                                                             |
| [`8e00b8a6`](https://github.com/NixOS/nixpkgs/commit/8e00b8a60022155759f4e79d53383f035d5a2e78) | `` python312Packages.docling-serve: 0.7.0 -> 0.8.0 ``                                     |
| [`3204bcc7`](https://github.com/NixOS/nixpkgs/commit/3204bcc765a2ef97cc0c8655fc4cb1044caed463) | `` allure: 2.33.0 -> 2.34.0 ``                                                            |
| [`cc83e5d5`](https://github.com/NixOS/nixpkgs/commit/cc83e5d5a0bc37c3c75c63f53b3cd22e3744adae) | `` yaziPlugins.starship: 25.4.8-unstable-2025-04-09 -> 25.4.8-unstable-2025-04-20 ``      |
| [`5df569cf`](https://github.com/NixOS/nixpkgs/commit/5df569cff455d56fedc90350260fe87649e5b392) | `` yaziPlugins.duckdb: 25.4.8-unstable-2025-04-09 -> 25.4.8-unstable-2025-04-20 ``        |
| [`e76b49e8`](https://github.com/NixOS/nixpkgs/commit/e76b49e83ecc46fad3bcb18819921a3a4528ad0e) | `` yaziPlugins.rich-preview: 0-unstable-2025-01-18 -> 0-unstable-2025-04-22 ``            |
| [`43429d17`](https://github.com/NixOS/nixpkgs/commit/43429d17c10b287eeb506924883b67b29a5c90c1) | `` yaziPlugins.toggle-pane: 25.2.26-unstable-2025-03-19 -> 25.2.26-unstable-2025-04-21 `` |
| [`653797d4`](https://github.com/NixOS/nixpkgs/commit/653797d4e61603df11714c041407e3060a433531) | `` glance: 0.7.12 -> 0.7.13 ``                                                            |
| [`e88a9b66`](https://github.com/NixOS/nixpkgs/commit/e88a9b669c25bcebce56cb666d9e78566dee4c70) | `` weaviate: 1.29.1 -> 1.30.1 ``                                                          |
| [`9b5e54fa`](https://github.com/NixOS/nixpkgs/commit/9b5e54fa653ad6ce03edb1c162aeea41dba64e98) | `` beeper: fix desktop entry copy ``                                                      |
| [`1fab1498`](https://github.com/NixOS/nixpkgs/commit/1fab1498a5a4875d203980fab8395b847aaf5acc) | `` beyond-all-reason: init at 1.2988.0 ``                                                 |
| [`5aa70730`](https://github.com/NixOS/nixpkgs/commit/5aa70730efad266bf1e5b55b27d30ce2744df7bf) | `` angryoxide: init at 0.8.32 ``                                                          |
| [`fee2c0bc`](https://github.com/NixOS/nixpkgs/commit/fee2c0bcb434f74b4abd3b303ddcb2534e0846a3) | `` maintainers: add fvckgrimm ``                                                          |
| [`a09871dc`](https://github.com/NixOS/nixpkgs/commit/a09871dc983587be9e12490ddf849ba9ca75f27a) | `` mongodb-atlas-cli: init at 1.42.0 ``                                                   |
| [`09787fba`](https://github.com/NixOS/nixpkgs/commit/09787fba34015ffec55ffac5e1f3956f5fd23217) | `` traefik: remove with lib from meta ``                                                  |
| [`630d9199`](https://github.com/NixOS/nixpkgs/commit/630d9199748f1cf6f4b5b6eac33ee89923d32d8f) | `` packages-config: remove zabbix50 ``                                                    |
| [`9a10be54`](https://github.com/NixOS/nixpkgs/commit/9a10be54058e718de9b5e1447d3783bf721d69c3) | `` traefik:  use finalAttrs pattern ``                                                    |
| [`11effb9b`](https://github.com/NixOS/nixpkgs/commit/11effb9b9872bceb35c24e8284cedca92cc18679) | `` slurm-nm: declare all unix platforms as officially supported ``                        |
| [`b5443450`](https://github.com/NixOS/nixpkgs/commit/b544345095d55ec9f0423709a2ce9aab6e765c41) | `` phpExtensions.phalcon: 5.9.2 -> 5.9.3 ``                                               |
| [`8965dab3`](https://github.com/NixOS/nixpkgs/commit/8965dab3a763b598f530122ba8a450af4c2447eb) | `` python312Packages.bash-kernel: cleanup, fix on darwin ``                               |
| [`75016788`](https://github.com/NixOS/nixpkgs/commit/750167887ed3c6fa27bd35fc118fa327943abef7) | `` python312Packages.papermill: fix, cleanup ``                                           |
| [`70566d84`](https://github.com/NixOS/nixpkgs/commit/70566d844ea43f614e99d946eb61a576ab5f2dc4) | `` phpPackages.phpstan: 2.1.11 -> 2.1.12 ``                                               |
| [`576ab066`](https://github.com/NixOS/nixpkgs/commit/576ab0667b5c06a63f2ea291596b0074df95b7be) | `` nix-search-tv: 2.1.5 -> 2.1.6 ``                                                       |
| [`b29c6561`](https://github.com/NixOS/nixpkgs/commit/b29c65613c8e5b24520e41f9c8514c4a32b8257b) | `` various: remove linuxmobile as maintainer ``                                           |
| [`c722b52f`](https://github.com/NixOS/nixpkgs/commit/c722b52fae28176ab116a6de96c56cda6073a72d) | `` minio-warp: 1.1.1 -> 1.1.2 ``                                                          |
| [`c7ddb3d6`](https://github.com/NixOS/nixpkgs/commit/c7ddb3d6ce563cc2835ef0f7ea5be0e3178c4c73) | `` syndicate_utils: 20250110 -> 20250422 ``                                               |
| [`bb3e5ad5`](https://github.com/NixOS/nixpkgs/commit/bb3e5ad57cb21336e1ce1085414c5255873c1433) | `` nim-2_0: 2.0.12 -> 2.0.16 ``                                                           |
| [`e09224ce`](https://github.com/NixOS/nixpkgs/commit/e09224ce6262bac5bca621008d36216534bd22fb) | `` nim-unwrapped: 2.2.2 -> 2.2.4 ``                                                       |
| [`e9e3701b`](https://github.com/NixOS/nixpkgs/commit/e9e3701b5f980e2d8fd546e2a4d589418cd8f779) | `` python313Packages.pytibber: 0.31.0 -> 0.31.1 ``                                        |
| [`eb6ada29`](https://github.com/NixOS/nixpkgs/commit/eb6ada290ba80d587280b31d16180005289a0b3a) | `` python3Packages.empy: fix license ``                                                   |
| [`5917b567`](https://github.com/NixOS/nixpkgs/commit/5917b567ff1df7c419019d981433bd648d0e8219) | `` quill-log: 9.0.1 -> 9.0.2 ``                                                           |
| [`896cb724`](https://github.com/NixOS/nixpkgs/commit/896cb724decc16528b7372e3beee77ffa85b68c0) | `` php81Extensions.ctype: fix build ``                                                    |
| [`3dfffb74`](https://github.com/NixOS/nixpkgs/commit/3dfffb742583d8391ed5e32f4913f80e8f1c4653) | `` evcc: 0.203.1 -> 0.203.2 ``                                                            |
| [`96f49687`](https://github.com/NixOS/nixpkgs/commit/96f4968703d18f8c4a2ebc28fa70dfd3dc190f10) | `` python312Packages.botocore-stubs: 1.37.37 -> 1.37.38 ``                                |
| [`1e08d9e6`](https://github.com/NixOS/nixpkgs/commit/1e08d9e6a0f767f26f34e7b06b667d2f1fe5b6c0) | `` python312Packages.boto3-stubs: 1.37.37 -> 1.37.38 ``                                   |
| [`1642cac9`](https://github.com/NixOS/nixpkgs/commit/1642cac9ec2d541d7e3e8cbf9b3f229c1096c1df) | `` dalphaball: init at 0-unstable-2023-06-15 ``                                           |
| [`902d4f60`](https://github.com/NixOS/nixpkgs/commit/902d4f604ffc001a3852f0a42f6adb6bd8f16465) | `` buildGoModule: add goSum attribute to make goModules rebuild (#399532) ``              |
| [`5b2a4299`](https://github.com/NixOS/nixpkgs/commit/5b2a4299660a09ebac2ea66fc1f29a9c2e759822) | `` deconz: 2.28.1 -> 2.29.5 ``                                                            |
| [`3901d159`](https://github.com/NixOS/nixpkgs/commit/3901d15967d439f348b935fc29c3f2f72d6defe6) | `` maintainers: add aschleck ``                                                           |
| [`ebf939da`](https://github.com/NixOS/nixpkgs/commit/ebf939da4f6b388a17f1bfd292cee2d3e9f22490) | `` redeclipse: add missing libGL dependency ``                                            |
| [`492248f5`](https://github.com/NixOS/nixpkgs/commit/492248f5364b9c4ae1a137e347c815974eba8cee) | `` commitizen: 4.5.0 -> 4.6.0 ``                                                          |
| [`c28f36f0`](https://github.com/NixOS/nixpkgs/commit/c28f36f0f8d78e29c5040c1ad899d66e395f0dcc) | `` cdncheck: 1.1.14 -> 1.1.15 ``                                                          |
| [`b24513b5`](https://github.com/NixOS/nixpkgs/commit/b24513b56e0ca28a14f8759557544e4ffb172d54) | `` [python313Packages.]scspell: init at 2.3 ``                                            |
| [`0bb30232`](https://github.com/NixOS/nixpkgs/commit/0bb3023251ec2d2a6edcf820d999500ecb1b42e4) | `` python312Packages.plaid-python: 29.1.0 -> 30.0.0 ``                                    |
| [`1e8fd71b`](https://github.com/NixOS/nixpkgs/commit/1e8fd71b3c2380f17d81cfb071a6d105d7c07bb0) | `` python312Packages.fedora-messaging: 3.7.0 -> 3.7.1 ``                                  |
| [`66b8619c`](https://github.com/NixOS/nixpkgs/commit/66b8619cc73ae854a3d64eba7421fb67e09f5088) | `` gtree: 1.11.3 -> 1.11.4 ``                                                             |
| [`877c0c5f`](https://github.com/NixOS/nixpkgs/commit/877c0c5fd18335f93aa4154d527da154a36e31a1) | `` pdfcpu: 0.9.1 -> 0.10.1 ``                                                             |
| [`d080e470`](https://github.com/NixOS/nixpkgs/commit/d080e470f73a7711b06086f71465b701aae99d38) | `` pdfcpu: Use a grep-less version parts identification ``                                |
| [`43902beb`](https://github.com/NixOS/nixpkgs/commit/43902beb574b5af8edeed554d5ee175fee4447e3) | `` Revert "alpaca: 5.2.0 -> 5.3.0" ``                                                     |
| [`d6b65b5c`](https://github.com/NixOS/nixpkgs/commit/d6b65b5c99d36f6580e1451ca1bc129def861cce) | `` pdfcpu: use writableTmpDirAsHomeHook ``                                                |
| [`ff1812f7`](https://github.com/NixOS/nixpkgs/commit/ff1812f73cc59a2d902780018af2a57eae7edf68) | `` clapper-unwrapped: fix cross compilation ``                                            |
| [`ec9582b0`](https://github.com/NixOS/nixpkgs/commit/ec9582b0c98f68ebd86fc57600602153ba5cd1cb) | `` python312Packages.sentry-sdk: disable test on darwin ``                                |
| [`3ae70f36`](https://github.com/NixOS/nixpkgs/commit/3ae70f3682209eb4c4f1c807dbdad819827edfe9) | `` prometheus-smartctl-exporter: 0.13.0 -> 0.14.0 ``                                      |
| [`afdf5aaa`](https://github.com/NixOS/nixpkgs/commit/afdf5aaaadf616ad30a6cc9deb48282435381a38) | `` python312Packages.pettingzoo: 1.25.1 -> 1.25.0 ``                                      |
| [`bc753342`](https://github.com/NixOS/nixpkgs/commit/bc75334210f6b14b1126160c42bd59e42695eccb) | `` linuxPackages_latest.prl-tools: 20.2.2-55879 -> 20.3.0-55895 ``                        |
| [`e7bc4319`](https://github.com/NixOS/nixpkgs/commit/e7bc43198684a6302640039679f8bf7bebbfd691) | `` python312Packages.pylacus: 1.13.2 -> 1.14.0 ``                                         |
| [`7c1ef2ca`](https://github.com/NixOS/nixpkgs/commit/7c1ef2ca629a13e772f8903236a56330fc0734a0) | `` coqPackages_8_20.coq-hammer: init at v1.3.2 ``                                         |
| [`3fcd89aa`](https://github.com/NixOS/nixpkgs/commit/3fcd89aa6c166b1edb89a415aad5a63baabb5242) | `` python312Packages.pybase64: 1.4.0 -> 1.4.1 ``                                          |
| [`c0768798`](https://github.com/NixOS/nixpkgs/commit/c07687986badb7930cad566cab2c4d42d877f4ef) | `` python312Packages.aioairzone-cloud: 0.6.11 -> 0.6.12 ``                                |
| [`14d62629`](https://github.com/NixOS/nixpkgs/commit/14d626295851c1bb3513bd101edae6b694d6cba0) | `` uv: 0.6.14 -> 0.6.16 ``                                                                |
| [`4a75d43c`](https://github.com/NixOS/nixpkgs/commit/4a75d43c310389e59aea0c77950907086a8ba144) | `` nixos/doc/rl2505: Fix a typo ``                                                        |
| [`301e9a34`](https://github.com/NixOS/nixpkgs/commit/301e9a34a1728bf4dbcf994f98df202af41baad7) | `` pkgsStatic.bcachefs-tools: fix build ``                                                |
| [`cbfa0a9b`](https://github.com/NixOS/nixpkgs/commit/cbfa0a9bcb643aedb972d4e1d0561e0a3c4ca811) | `` python3Packages.dep-logic: add misilelab to maintainers ``                             |
| [`f0887fbd`](https://github.com/NixOS/nixpkgs/commit/f0887fbd7fd6c4eb22defcaaba4ef7a1b6c8b6cc) | `` keymapp: 1.3.5 -> 1.3.6 ``                                                             |
| [`de199835`](https://github.com/NixOS/nixpkgs/commit/de199835d04653a461960f5821a30c34dc06c597) | `` mariadb_105: remove due to EOL ``                                                      |
| [`9f90ef1f`](https://github.com/NixOS/nixpkgs/commit/9f90ef1f5cb8c2a5d43c9c6467f180e249bf5be6) | `` wsrepl: cleanup, fix ``                                                                |
| [`76f3fb0d`](https://github.com/NixOS/nixpkgs/commit/76f3fb0d8807c6d4858a80a0c4457c499171c451) | `` seagoat: 0.54.6 -> 0.54.9 ``                                                           |
| [`c7dd612b`](https://github.com/NixOS/nixpkgs/commit/c7dd612b983d8a2c835360f29b0a9dfe809992f1) | `` gopass-hibp: 1.15.15 -> 1.15.16 ``                                                     |
| [`4e6de406`](https://github.com/NixOS/nixpkgs/commit/4e6de4065092890204c7678ce92cf32d6e410038) | `` rich-cli: fix build ``                                                                 |
| [`00a57910`](https://github.com/NixOS/nixpkgs/commit/00a57910300c595637ddbf971b0324ad08059939) | `` make-bootstrap-tools-cross: add loongarch64-unknown-linux-gnu ``                       |
| [`b814e3d9`](https://github.com/NixOS/nixpkgs/commit/b814e3d946ae088ef4b49fe79029c116e3e7eb99) | `` stdenv-bootstrap-tools: use bashNonInteractive ``                                      |
| [`81df2570`](https://github.com/NixOS/nixpkgs/commit/81df2570ee8fd4ea947b3c93212d6ef412d6e353) | `` stdenv-bootstrap-tools: don't copy obsolete libutil from glibc ``                      |
| [`d5b9cf4f`](https://github.com/NixOS/nixpkgs/commit/d5b9cf4f81f555036651e824a7691369c5a7c679) | `` electron-source.electron_33: 33.4.9 -> 33.4.10 ``                                      |
| [`557ad0b3`](https://github.com/NixOS/nixpkgs/commit/557ad0b3f71b4038e5a0616d9fc3e92a15a2210b) | `` electron-source.electron_34: 34.5.1 -> 34.5.2 ``                                       |