### PR TITLE
chore(flake/thorium): `3f187b03` -> `d3b2b552`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -649,11 +649,11 @@
     },
     "nixpkgs_6": {
       "locked": {
-        "lastModified": 1745234285,
-        "narHash": "sha256-GfpyMzxwkfgRVN0cTGQSkTC0OHhEkv3Jf6Tcjm//qZ0=",
+        "lastModified": 1745391562,
+        "narHash": "sha256-sPwcCYuiEopaafePqlG826tBhctuJsLx/mhKKM5Fmjo=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "c11863f1e964833214b767f4a369c6e6a7aba141",
+        "rev": "8a2f738d9d1f1d986b5a4cd2fd2061a7127237d7",
         "type": "github"
       },
       "original": {
@@ -831,11 +831,11 @@
         "nixpkgs": "nixpkgs_6"
       },
       "locked": {
-        "lastModified": 1745353439,
-        "narHash": "sha256-pxJmQQOkXXgrlk6mpPYMdzNf+zfFx3sRl9tqfTNYrKE=",
+        "lastModified": 1745483321,
+        "narHash": "sha256-CahT0nmhscjIzeTADHWuo+FZgdwDFZO4j5anZI7EHUs=",
         "owner": "Rishabh5321",
         "repo": "thorium_flake",
-        "rev": "3f187b0390033600d787b3b61cb31a5a8600ff58",
+        "rev": "d3b2b552aa5a651d27548a5af21995a4cd775f66",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                     | Message                                          |
| ---------------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
| [`d3b2b552`](https://github.com/Rishabh5321/thorium_flake/commit/d3b2b552aa5a651d27548a5af21995a4cd775f66) | `` chore(flake/nixpkgs): c11863f1 -> 8a2f738d `` |