### PR TITLE
chore(flake/akuse-flake): `49f618d8` -> `e2903e7d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -48,11 +48,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1745483460,
-        "narHash": "sha256-ZNRnNHaJ+3iryCdKW9O2uCHg6EoC6xjVipZj/161zW0=",
+        "lastModified": 1745504894,
+        "narHash": "sha256-hw7qshsPKeR0CgK/cVGSzU5rznU2uOLoWAkuw73Ddm4=",
         "owner": "Rishabh5321",
         "repo": "akuse-flake",
-        "rev": "49f618d8795ff2cf692b5be295a85de8d678898d",
+        "rev": "e2903e7df5cb6b49cd8807bf5257a06a43bd7e94",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                   | Message                                                           |
| -------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------- |
| [`602c47a6`](https://github.com/Rishabh5321/akuse-flake/commit/602c47a64b3c264cf48066e9e40e779b545595b3) | `` chore(github): bump DeterminateSystems/nix-installer-action `` |