### PR TITLE
chore(flake/nixpkgs-stable): `9684b531` -> `5630cf13`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -569,11 +569,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1745279238,
-        "narHash": "sha256-AQ7M9wTa/Pa/kK5pcGTgX/DGqMHyzsyINfN7ktsI7Fo=",
+        "lastModified": 1745487689,
+        "narHash": "sha256-FQoi3R0NjQeBAsEOo49b5tbDPcJSMWc3QhhaIi9eddw=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "9684b53175fc6c09581e94cc85f05ab77464c7e3",
+        "rev": "5630cf13cceac06cefe9fc607e8dfa8fb342dde3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                 |
| ---------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------- |
| [`315b187c`](https://github.com/NixOS/nixpkgs/commit/315b187c36f6ff532a71401af179ef99eaf981d7) | `` electron-source.electron_33: 33.4.9 -> 33.4.10 ``                    |
| [`abfce4a7`](https://github.com/NixOS/nixpkgs/commit/abfce4a795bd5564ed6a6f31b3af19c8b58c8a6c) | `` electron-source.electron_34: 34.5.1 -> 34.5.2 ``                     |
| [`aa5e0e78`](https://github.com/NixOS/nixpkgs/commit/aa5e0e78a7724d7067340605d66fd5aba76f896a) | `` electron-source.electron_35: 35.1.5 -> 35.2.0 ``                     |
| [`788d2370`](https://github.com/NixOS/nixpkgs/commit/788d2370af929e708ac6f27191126073c37fbac2) | `` electron-chromedriver_33: 33.4.9 -> 33.4.10 ``                       |
| [`434dbefb`](https://github.com/NixOS/nixpkgs/commit/434dbefb5e5effd191b1ad7c38e33ebf402ca20e) | `` electron_33-bin: 33.4.9 -> 33.4.10 ``                                |
| [`048a16ff`](https://github.com/NixOS/nixpkgs/commit/048a16ffcd67830273cdc43c8efeec9c3a2012e5) | `` electron-chromedriver_34: 34.5.1 -> 34.5.2 ``                        |
| [`f9708028`](https://github.com/NixOS/nixpkgs/commit/f970802864f7375921489160f587b7b9cd1a2f8f) | `` electron_34-bin: 34.5.1 -> 34.5.2 ``                                 |
| [`16dcb918`](https://github.com/NixOS/nixpkgs/commit/16dcb918aa55bdcd8f2414da44c71531fd0c2aa7) | `` electron-chromedriver_35: 35.1.5 -> 35.2.0 ``                        |
| [`dbb7264c`](https://github.com/NixOS/nixpkgs/commit/dbb7264cdd38ad957dabf9b44462c243f0a83bcf) | `` electron_35-bin: 35.1.5 -> 35.2.0 ``                                 |
| [`fb4d7c1c`](https://github.com/NixOS/nixpkgs/commit/fb4d7c1c4ecfd80ea4fcfe6ef1f81a24e3a91e46) | `` electron-chromedriver_35: 35.1.2 -> 35.1.5 ``                        |
| [`528d0d2e`](https://github.com/NixOS/nixpkgs/commit/528d0d2ed21e4d11c546c30784a60b7b1cd92a20) | `` electron_35-bin: 35.1.2 -> 35.1.5 ``                                 |
| [`6cab41c8`](https://github.com/NixOS/nixpkgs/commit/6cab41c81ae3081eef95a3e9df2394e5abf13340) | `` electron-chromedriver_34: 34.4.1 -> 34.5.1 ``                        |
| [`83ab9d84`](https://github.com/NixOS/nixpkgs/commit/83ab9d84ac95ef925ce0035d9abf2c1503af6286) | `` electron_34-bin: 34.4.1 -> 34.5.1 ``                                 |
| [`5f6c3110`](https://github.com/NixOS/nixpkgs/commit/5f6c31107166a76b82d3541f0f85bd634ee87a24) | `` electron-chromedriver_33: 33.4.8 -> 33.4.9 ``                        |
| [`eff7c630`](https://github.com/NixOS/nixpkgs/commit/eff7c6302d74d75091f7f49f359bc6dd95d3bd9f) | `` electron_33-bin: 33.4.8 -> 33.4.9 ``                                 |
| [`c0e8c215`](https://github.com/NixOS/nixpkgs/commit/c0e8c215d553158ac030020e3f0d21823fffdf3e) | `` electron-source.electron_35: 35.1.4 -> 35.1.5 ``                     |
| [`2fa161a4`](https://github.com/NixOS/nixpkgs/commit/2fa161a4b58a498a1e56eaf2fb967be912251253) | `` electron-source.electron_34: 34.5.0 -> 34.5.1 ``                     |
| [`7989d6e1`](https://github.com/NixOS/nixpkgs/commit/7989d6e1ce17a7996301679e06fb7657cfd37f9b) | `` electron-source.electron_33: 33.4.8 -> 33.4.9 ``                     |
| [`1684051e`](https://github.com/NixOS/nixpkgs/commit/1684051e55975ecfb1783c19c8ce012e1ffc3b58) | `` nixosTests.gitlab: add minimal test for gitlab-container-registry `` |
| [`4c8bce79`](https://github.com/NixOS/nixpkgs/commit/4c8bce799462e15e87c7d9ff6e26d9407a117520) | `` nixos/gitlab: convert gitlab-registry-cert.service to oneshot ``     |
| [`2574807b`](https://github.com/NixOS/nixpkgs/commit/2574807bc63636f1f048d6b0a9a85a451e429ac3) | `` phpPackages.phpstan: 2.1.11 -> 2.1.12 ``                             |
| [`a1274f7e`](https://github.com/NixOS/nixpkgs/commit/a1274f7e3248c43cff19fff83b4b58dc641163f1) | `` inv-sig-helper: 0-unstable-2025-04-03 -> 0-unstable-2025-04-23 ``    |
| [`f2d58623`](https://github.com/NixOS/nixpkgs/commit/f2d586238d527a82de45bec3f1f6dad5666264af) | `` phpunit: 12.1.2 -> 12.1.3 ``                                         |
| [`5560ce8e`](https://github.com/NixOS/nixpkgs/commit/5560ce8e659ab8804e35856c63bbac7219da7b02) | `` tail-tray: 0.2.19 -> 0.2.20 ``                                       |
| [`9b98f664`](https://github.com/NixOS/nixpkgs/commit/9b98f6644cde291b64c423eac29bc28649481d78) | `` vscode: 1.99.2 -> 1.99.3 ``                                          |
| [`2f8641bc`](https://github.com/NixOS/nixpkgs/commit/2f8641bca47e3028a8e7a5896c483941f894a7a8) | `` vscode: 1.99.1 -> 1.99.2 ``                                          |
| [`d2db242c`](https://github.com/NixOS/nixpkgs/commit/d2db242cdee34c62b33360eb155ebf2464acbe5f) | `` vscode: 1.99.0 -> 1.99.1 ``                                          |
| [`f4fe8052`](https://github.com/NixOS/nixpkgs/commit/f4fe805299e85753a916398df7b36877faed78e2) | `` vscode: 1.98.2 -> 1.99.0 ``                                          |
| [`323cd310`](https://github.com/NixOS/nixpkgs/commit/323cd310c3f16da4a577e55187cfda3bc0216cca) | `` libblake3: 1.8.0 -> 1.8.2 (fixed nix build) ``                       |
| [`8c3d6939`](https://github.com/NixOS/nixpkgs/commit/8c3d69392e43470888f928da939453d06c61e432) | `` emacs: disable native compilation on Darwin ``                       |
| [`7ea0e842`](https://github.com/NixOS/nixpkgs/commit/7ea0e842739f5267e79d22bd7c4a87ac91907d5a) | `` libepoxy: skip test that is broken on `aarch64-darwin` too ``        |
| [`d850c18d`](https://github.com/NixOS/nixpkgs/commit/d850c18d74ec40bc1bc7bb00e15a2e8397fe4490) | `` rspamd: enable fasttext ``                                           |
| [`c4b4af1a`](https://github.com/NixOS/nixpkgs/commit/c4b4af1ab2af48c592feece94c9dc85b2bc5ac5d) | `` rspamd: fix openblas not actually being enabled ``                   |
| [`d5c0f725`](https://github.com/NixOS/nixpkgs/commit/d5c0f7253563622ccc5a33d272c20d66bb996e98) | `` anubis: 1.15.2 -> 1.16.0 (#397605) ``                                |
| [`7dcf941d`](https://github.com/NixOS/nixpkgs/commit/7dcf941dd8470c2881b9792e7b49b27ac486364e) | `` anubis: 1.15.1 -> 1.15.2 ``                                          |
| [`957ce46e`](https://github.com/NixOS/nixpkgs/commit/957ce46e2ac691470ad28ea4e9a8e4727d084aad) | `` nixos/anubis: init module ``                                         |
| [`303a6ed4`](https://github.com/NixOS/nixpkgs/commit/303a6ed4e39619db290f308980b7d672ed44a28a) | `` anubis: 1.15.0 -> 1.15.1 ``                                          |
| [`d84ae1dd`](https://github.com/NixOS/nixpkgs/commit/d84ae1dd456320a5bc67197f8cf9f8adcbf9506a) | `` anubis: add soopyc as maintainer ``                                  |
| [`853aece9`](https://github.com/NixOS/nixpkgs/commit/853aece988d5dd25c014eb0e4567858f56b4083b) | `` anubis: 1.14.2 -> 1.15.0 ``                                          |
| [`ca6b1ca8`](https://github.com/NixOS/nixpkgs/commit/ca6b1ca87a302368c7f6099314881c93e122665e) | `` anubis: init at 1.14.2 ``                                            |
| [`07223250`](https://github.com/NixOS/nixpkgs/commit/07223250e0b06a3fdcb72aca375417df9cad61ec) | `` linuxKernel.kernels.linux_lqx: 6.14.1-lqx1 -> 6.14.3-lqx1 ``         |
| [`8d7dca97`](https://github.com/NixOS/nixpkgs/commit/8d7dca973ebbe561411c3b7cbb9569f390ae535a) | `` linuxKernel.kernels.linux_zen: 6.14.1-zen1 -> 6.14.3-zen1 ``         |
| [`38f58f37`](https://github.com/NixOS/nixpkgs/commit/38f58f371ee5900c458f30693f651ffee222d865) | `` linuxKernel.kernels.linux_lqx: 6.14.0-lqx1 -> 6.14.1-lqx1 ``         |
| [`9669a45d`](https://github.com/NixOS/nixpkgs/commit/9669a45df7334fbcf41ec4160941e042ba0ceef0) | `` linuxKernel.kernels.linux_zen: 6.14.0-zen1 -> 6.14.1-zen1 ``         |
| [`1ea320ed`](https://github.com/NixOS/nixpkgs/commit/1ea320ede7e6d6c67d0abdd8b23f07cc97596238) | `` linuxKernel.kernels.linux_lqx: 6.13.8-lqx1 -> 6.14.0-lqx1 ``         |
| [`10630604`](https://github.com/NixOS/nixpkgs/commit/10630604d83e35efc119e99df80b51b1120ae4e1) | `` linuxKernel.kernels.linux_lqx: 6.13.7-lqx1 -> 6.13.8-lqx1 ``         |
| [`91c91698`](https://github.com/NixOS/nixpkgs/commit/91c9169897ef61c3109d55f50aa501dc6f043bf4) | `` linuxKernel.kernels.linux_zen: 6.13.7-zen1 -> 6.14-zen1 ``           |
| [`73fa8c12`](https://github.com/NixOS/nixpkgs/commit/73fa8c1289d22294e2f061de6d3653d338d819ae) | `` linuxKernel.kernels.linux_lqx: 6.13.5-zen1 -> 6.13.7-zen1 ``         |
| [`2cffac82`](https://github.com/NixOS/nixpkgs/commit/2cffac82ddc6fa116fb61631e3d9caf8bb1101f9) | `` linuxKernel.kernels.linux_lqx: 6.13.5-lqx1 -> 6.13.7-lqx1 ``         |
| [`342592fc`](https://github.com/NixOS/nixpkgs/commit/342592fcffa05fd222759cca74da3e080966d65c) | `` linuxKernel.kernels.linux_lqx: 6.12.16-lqx1 -> 6.13.5-lqx1 ``        |
| [`06d2f2ec`](https://github.com/NixOS/nixpkgs/commit/06d2f2ec67d6a2feefaf4015ff5cd5f83099abad) | `` linuxKernel.kernels.linux_zen: 6.13.4-zen1 -> 6.13.5-zen1 ``         |
| [`fd43ad39`](https://github.com/NixOS/nixpkgs/commit/fd43ad398ca0ef2aba6332c3b74c34634f9ea11f) | `` linuxKernel.kernels.linux_lqx: 6.12.14-lqx1 -> 6.12.16-lqx1 ``       |
| [`d4c43f11`](https://github.com/NixOS/nixpkgs/commit/d4c43f11738d4733e13da9d742c86a0136524634) | `` tone: 0.2.4 -> 0.2.5 ``                                              |
| [`5c3ce773`](https://github.com/NixOS/nixpkgs/commit/5c3ce773b1b31bb78fc7cbf5793edfab0bd3454a) | `` nixos/hyprland: fix call to wayland-session.nix ``                   |
| [`613169cb`](https://github.com/NixOS/nixpkgs/commit/613169cb5ddd222cf557872301a9c798de66e352) | `` php81Extensions.ctype: fix build ``                                  |
| [`07c9ed1d`](https://github.com/NixOS/nixpkgs/commit/07c9ed1d6d38b009ef7e8e56efd705b0d791495b) | `` borgbackup: 1.4.0 -> 1.4.1 ``                                        |
| [`2808d061`](https://github.com/NixOS/nixpkgs/commit/2808d061c983187cebe8bbe9e4de53accbfb1c91) | `` nodejs*: fix test failure on darwin on latest MacOS 15.4 ``          |
| [`a6e644be`](https://github.com/NixOS/nixpkgs/commit/a6e644beb87cdc6a325ea714a83751b94bf9e968) | `` [BACKPORT 24.11] openbao: init at 2.2.0 ``                           |
| [`3fb39300`](https://github.com/NixOS/nixpkgs/commit/3fb393006da416378af56e942ca4b3cb483329bc) | `` linuxKernel.kernels.linux_zen: 6.13.3-zen1 -> 6.13.4-zen1 ``         |
| [`e6238bc0`](https://github.com/NixOS/nixpkgs/commit/e6238bc07ff98ac753ee62ca437610a539dbb64d) | `` linuxKernel.kernels.linux_lqx: 6.12.10-lqx1 -> 6.12.14-lqx1 ``       |
| [`1fcdf1f0`](https://github.com/NixOS/nixpkgs/commit/1fcdf1f0401f7696174869a4d8e3ffecc71f752e) | `` linuxKernel.kernels.linux_zen: 6.13.1-zen1 -> 6.13.3-zen1 ``         |
| [`a5f73584`](https://github.com/NixOS/nixpkgs/commit/a5f735844ea25086708a3ae7bc4dbe3df9dc9f45) | `` linuxKernel.kernels.linux_zen: 6.12.10-zen1 -> 6.13.1-zen1 ``        |
| [`708912ee`](https://github.com/NixOS/nixpkgs/commit/708912eeba135894ff541be1720e4f6ead4d086f) | `` firefox: do not set the executable bit on desktop file ``            |
| [`323dff7d`](https://github.com/NixOS/nixpkgs/commit/323dff7db55dbdd7fa82a7c73e82731453b367e6) | `` docker: 28.0.4 -> 28.1.1 ``                                          |
| [`5732c0f6`](https://github.com/NixOS/nixpkgs/commit/5732c0f6dbcc884867724c9de71e63651810ccf3) | `` docs/autoPatchcilHook: init ``                                       |
| [`6827c45f`](https://github.com/NixOS/nixpkgs/commit/6827c45ff41631b673ea225484cd0128f9365b14) | `` dotnetCorePackages.autoPatchcilHook: init ``                         |
| [`34b7a066`](https://github.com/NixOS/nixpkgs/commit/34b7a066f2349ac6701e01e33b2f00a618359b56) | `` patchcil: init at 0.2.2 ``                                           |
| [`9ac27b56`](https://github.com/NixOS/nixpkgs/commit/9ac27b56d8ba81cdc3467457a0a457a635a05c18) | `` grafanaPlugin.grafana-lokiexplore-app: init at 1.0.10 ``             |
| [`e3833676`](https://github.com/NixOS/nixpkgs/commit/e3833676cf66315cef45bae7fec5a89569915c28) | `` nextcloud31: 31.0.3 -> 31.0.4 ``                                     |
| [`a1a04c27`](https://github.com/NixOS/nixpkgs/commit/a1a04c270b8a25419681633175e0587b1ce58e68) | `` nextcloud30: 30.0.9 -> 30.0.10 ``                                    |
| [`6ab6ad84`](https://github.com/NixOS/nixpkgs/commit/6ab6ad84bf23e763079f22f6b0b640c1faba5a7b) | `` nextcloud29: 29.0.15 -> 29.0.16 ``                                   |
| [`ed6a52ce`](https://github.com/NixOS/nixpkgs/commit/ed6a52ce6361ac4bd773373c5f4889cd28bf3ae2) | `` slurm: 24.05.4.1 -> 24.05.7.1 ``                                     |
| [`6f9698ac`](https://github.com/NixOS/nixpkgs/commit/6f9698ace9bd3902a0f000f83329a77cd97c4174) | `` rdma-core: 54.0 -> 54.2 ``                                           |
| [`da70609f`](https://github.com/NixOS/nixpkgs/commit/da70609f88de31528fc136b72694fcc00fbb4f29) | `` naps2: 7.4.3 -> 7.5.3 and use non-EOL dotnet ``                      |
| [`6f156e78`](https://github.com/NixOS/nixpkgs/commit/6f156e78a635a5813c854f39c2775e08008f47c5) | `` vivaldi: 7.3.3635.4 -> 7.3.3635.7 ``                                 |
| [`5d12ef59`](https://github.com/NixOS/nixpkgs/commit/5d12ef5984ebc13c6948dcdcfd4070e174e5473a) | `` vivaldi: 7.1.3570.60 -> 7.3.3635.4 ``                                |
| [`c017da2f`](https://github.com/NixOS/nixpkgs/commit/c017da2f34bd611bcec320bab431a8859b117b69) | `` vivaldi: 7.1.3570.58 -> 7.1.3570.60 ``                               |
| [`aa6eb22f`](https://github.com/NixOS/nixpkgs/commit/aa6eb22f798445688ba1eef1641a892eba3ad09c) | `` vivaldi: 7.1.3570.54 -> 7.1.3570.58 ``                               |