### PR TITLE
chore(flake/stylix): `3194470d` -> `4846adbc`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -768,11 +768,11 @@
         "tinted-zed": "tinted-zed"
       },
       "locked": {
-        "lastModified": 1745511266,
-        "narHash": "sha256-W68rSRTGhRF22nDzJgq2ffQwI/4k+4jMs84Mpj38aOI=",
+        "lastModified": 1745541960,
+        "narHash": "sha256-CnkPq3sjuxB2HC93JVSotfMCF3dDrdKo3e4JOImKiLs=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "3194470d07d2885da178a6baca10a91ea1068e1b",
+        "rev": "4846adbc2a0334687c024aed0ca77ecd93ccdb0d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                        | Message                                                              |
| --------------------------------------------------------------------------------------------- | -------------------------------------------------------------------- |
| [`4846adbc`](https://github.com/danth/stylix/commit/4846adbc2a0334687c024aed0ca77ecd93ccdb0d) | `` vesktop: use upstream options (#1150) ``                          |
| [`21774695`](https://github.com/danth/stylix/commit/21774695205278373f67de5540bd08fea376895c) | `` ci: bump DeterminateSystems/nix-installer-action from 16 to 17 `` |