### PR TITLE
chore(flake/zen-browser): `9fc808b3` -> `855ad6c6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -956,11 +956,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1745529506,
-        "narHash": "sha256-pyhlC0vaipg2Tq1LzDuGQuOncbZ/+pJwTGJ/CCCm7sI=",
+        "lastModified": 1745550347,
+        "narHash": "sha256-y3ojr4sqs4cbtHNrzTK1JVoTFfyGzS+m8U5nzgHcj2U=",
         "owner": "0xc000022070",
         "repo": "zen-browser-flake",
-        "rev": "9fc808b3ea3fb4f3036b122a895e73c6bc1e58a7",
+        "rev": "855ad6c6bb50dc52f496375e9f031fd0305ea7b8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                          | Message                                                                 |
| --------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------- |
| [`855ad6c6`](https://github.com/0xc000022070/zen-browser-flake/commit/855ad6c6bb50dc52f496375e9f031fd0305ea7b8) | `` chore(update): twilight @ x86_64 && aarch64 to 1.11.5t#1745550111 `` |