### PR TITLE
chore(flake/home-manager): `abfad3d2` -> `98f4fef7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -425,11 +425,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1745494811,
-        "narHash": "sha256-YZCh2o9Ua1n9uCvrvi5pRxtuVNml8X2a03qIFfRKpFs=",
+        "lastModified": 1745555634,
+        "narHash": "sha256-lhVyVn1utb2UVTbyKJ6mfKB7wLTjrj14OlebvO0WU2s=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "abfad3d2958c9e6300a883bd443512c55dfeb1be",
+        "rev": "98f4fef7fd7b4a77245db12e33616023162bc6d9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                                    |
| ----------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------- |
| [`98f4fef7`](https://github.com/nix-community/home-manager/commit/98f4fef7fd7b4a77245db12e33616023162bc6d9) | `` format: Fix failing due to no cache access ``                           |
| [`dedfde15`](https://github.com/nix-community/home-manager/commit/dedfde15f6ad102596d0a3110f9f2852063cbc35) | `` format: Set {,XDG_CONFIG_}HOME to empty dir rather than empty string `` |