### PR TITLE
chore(flake/hyprland): `41f5f67f` -> `742bce01`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -625,11 +625,11 @@
         "xdph": "xdph"
       },
       "locked": {
-        "lastModified": 1745541469,
-        "narHash": "sha256-M4eoWX2yBwVwYtp2rNNTvudnPdZuGKiJWQYTU5s9g1E=",
+        "lastModified": 1745593751,
+        "narHash": "sha256-TJ/Nijr83ydAi473NGeazYqcQ0t8lCPU7aaQv98oGg8=",
         "owner": "hyprwm",
         "repo": "Hyprland",
-        "rev": "41f5f67f6c8675ec48d893007ca93f8bf6c0049a",
+        "rev": "742bce016cb848d222fbfcfcf8d3894ea3fdaeff",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                                                            |
| ------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------ |
| [`742bce01`](https://github.com/hyprwm/Hyprland/commit/742bce016cb848d222fbfcfcf8d3894ea3fdaeff) | `` decorationPositioner: update posinfo on window update ``        |
| [`4cf62c11`](https://github.com/hyprwm/Hyprland/commit/4cf62c114e8fd2cc4fa47d07459e00c52f6dc1d3) | `` layerrules: add abovelock to render above lockscreen (#9793) `` |