### PR TITLE
chore(flake/stylix): `245a167c` -> `11ceb2fd`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1270,11 +1270,11 @@
         "tinted-zed": "tinted-zed"
       },
       "locked": {
-        "lastModified": 1745584517,
-        "narHash": "sha256-vk5fMNU/U+T9hHPPy7MvZbEHcgJ+XN2KTX3awc3ubJ4=",
+        "lastModified": 1745618823,
+        "narHash": "sha256-WGKSI0+CY3Ep2YnRASmBRU8oMIvTW4ngFyjA0dVcKgQ=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "245a167c75a221e5692c08b8a4aa15c76e32c041",
+        "rev": "11ceb2fde1901dc227421bbbef2d0800339f5126",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                        | Message                            |
| --------------------------------------------------------------------------------------------- | ---------------------------------- |
| [`11ceb2fd`](https://github.com/danth/stylix/commit/11ceb2fde1901dc227421bbbef2d0800339f5126) | `` spotify-player: init (#1177) `` |