### PR TITLE
chore(flake/akuse-flake): `e2903e7d` -> `91550f18`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -48,11 +48,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1745504894,
-        "narHash": "sha256-hw7qshsPKeR0CgK/cVGSzU5rznU2uOLoWAkuw73Ddm4=",
+        "lastModified": 1745641634,
+        "narHash": "sha256-DM6A3+YIVUZEWJQwK+lf+FmU70saZmwgs1h5d+YIodw=",
         "owner": "Rishabh5321",
         "repo": "akuse-flake",
-        "rev": "e2903e7df5cb6b49cd8807bf5257a06a43bd7e94",
+        "rev": "91550f183c1c230414cbd5435526997df3446ab8",
         "type": "github"
       },
       "original": {
@@ -999,11 +999,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1745391562,
-        "narHash": "sha256-sPwcCYuiEopaafePqlG826tBhctuJsLx/mhKKM5Fmjo=",
+        "lastModified": 1745526057,
+        "narHash": "sha256-ITSpPDwvLBZBnPRS2bUcHY3gZSwis/uTe255QgMtTLA=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "8a2f738d9d1f1d986b5a4cd2fd2061a7127237d7",
+        "rev": "f771eb401a46846c1aebd20552521b233dd7e18b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                   | Message                                          |
| -------------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
| [`91550f18`](https://github.com/Rishabh5321/akuse-flake/commit/91550f183c1c230414cbd5435526997df3446ab8) | `` chore(flake/nixpkgs): 8a2f738d -> f771eb40 `` |