### PR TITLE
chore(flake/zen-browser): `855ad6c6` -> `4ca970a3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1529,11 +1529,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1745550347,
-        "narHash": "sha256-y3ojr4sqs4cbtHNrzTK1JVoTFfyGzS+m8U5nzgHcj2U=",
+        "lastModified": 1745673518,
+        "narHash": "sha256-hIay3kpw5bKdfOT383/xzSsffSQTdvM8SHUoZFeXQ/s=",
         "owner": "0xc000022070",
         "repo": "zen-browser-flake",
-        "rev": "855ad6c6bb50dc52f496375e9f031fd0305ea7b8",
+        "rev": "4ca970a32c426a4d65b7432ca5d028f9a791e18d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                          | Message                                                      |
| --------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------ |
| [`4ca970a3`](https://github.com/0xc000022070/zen-browser-flake/commit/4ca970a32c426a4d65b7432ca5d028f9a791e18d) | `` ci(style): workflow will only run if nix files are mod `` |
| [`8bc1df0f`](https://github.com/0xc000022070/zen-browser-flake/commit/8bc1df0f27413ef630ad114ebf6d4cf1193256ff) | `` readme: add advice about `twilight-official` usage ``     |