### PR TITLE
chore(flake/hyprland): `742bce01` -> `4f868a1f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -625,11 +625,11 @@
         "xdph": "xdph"
       },
       "locked": {
-        "lastModified": 1745593751,
-        "narHash": "sha256-TJ/Nijr83ydAi473NGeazYqcQ0t8lCPU7aaQv98oGg8=",
+        "lastModified": 1745705220,
+        "narHash": "sha256-8+R5/w7QZ6c29gAY+bGWgwiqOb6Y57sgkBlLvehu5tY=",
         "owner": "hyprwm",
         "repo": "Hyprland",
-        "rev": "742bce016cb848d222fbfcfcf8d3894ea3fdaeff",
+        "rev": "4f868a1f3c1edfc1f5998f7d21e46e7c23aeb02f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                                                                    |
| ------------------------------------------------------------------------------------------------ | -------------------------------------------------------------------------- |
| [`4f868a1f`](https://github.com/hyprwm/Hyprland/commit/4f868a1f3c1edfc1f5998f7d21e46e7c23aeb02f) | `` SECURITY: init security policy ``                                       |
| [`94c55fe9`](https://github.com/hyprwm/Hyprland/commit/94c55fe9091078f56acfcff00c4287226b710511) | `` helpers: properly support next/prev for workspace switching (#10074) `` |