### PR TITLE
chore(flake/home-manager): `0fbd8207` -> `7b2aae3f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -496,11 +496,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1745771770,
-        "narHash": "sha256-kC1yYNAO69i0Q9nnQFTxu5kdwcoHRE7x4jtJyIB5QSg=",
+        "lastModified": 1745782215,
+        "narHash": "sha256-mx27J2HYQT+nGXTyUWKrUuxRzpr1FVVr59ZH4oNzOyw=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "0fbd8207e913b2d1660a7662f9ae80e5e639de65",
+        "rev": "7b2aae3fb39928aecc5e41c10a9c87c4881614d5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                   |
| ----------------------------------------------------------------------------------------------------------- | --------------------------------------------------------- |
| [`7b2aae3f`](https://github.com/nix-community/home-manager/commit/7b2aae3fb39928aecc5e41c10a9c87c4881614d5) | `` eza: add tests ``                                      |
| [`edaeeda2`](https://github.com/nix-community/home-manager/commit/edaeeda26429aa3d25b9119f358075813bd9d4ba) | `` eza: default disable nushell integration again ``      |
| [`2a264c17`](https://github.com/nix-community/home-manager/commit/2a264c17d5fb3673eeec891ea4a82027a41addc3) | `` zsh: add type to zprof.enable option (#6916) ``        |
| [`adb3fbc5`](https://github.com/nix-community/home-manager/commit/adb3fbc58455de60ad4131c6e59d596ea2bb105f) | `` neomutt: use correct neomutt in config file (#6915) `` |