### PR TITLE
chore(flake/spicetify-nix): `9e5c7a2e` -> `24e8c27b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1233,11 +1233,11 @@
         "systems": "systems_4"
       },
       "locked": {
-        "lastModified": 1745727291,
-        "narHash": "sha256-YW/V93WgJur6a3BVa1jynlKr2pyZlEpiXXjQjpSHc5s=",
+        "lastModified": 1745802398,
+        "narHash": "sha256-9Y1EYqqrwE0h2BUu+5xD+0hhrN2N6CM87WdpbzC2DUQ=",
         "owner": "Gerg-L",
         "repo": "spicetify-nix",
-        "rev": "9e5c7a2e7f1ab3118ec9b7179eb28667a3575f0e",
+        "rev": "24e8c27b60856ee6d812757be078ec6c95bc36af",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                               |
| ----------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------- |
| [`24e8c27b`](https://github.com/Gerg-L/spicetify-nix/commit/24e8c27b60856ee6d812757be078ec6c95bc36af) | `` fix: only override fixupPhase on linux ``                          |
| [`cbb1d769`](https://github.com/Gerg-L/spicetify-nix/commit/cbb1d769959c52077bf80a4a2bff3a50bfd78bae) | `` feat: wayland option ``                                            |
| [`4d19e41d`](https://github.com/Gerg-L/spicetify-nix/commit/4d19e41d38d92242bdf898840d3108983f03a640) | `` feat: don't clobber color.ini if custom color scheme is defined `` |