### PR TITLE
chore(flake/hyprland): `0302bfdc` -> `f5c5cfa9`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -625,11 +625,11 @@
         "xdph": "xdph"
       },
       "locked": {
-        "lastModified": 1745756886,
-        "narHash": "sha256-oXfvqaWENRd8CaxbQEHntH9PzNsjUaWalBIcG7xk/Lw=",
+        "lastModified": 1745795931,
+        "narHash": "sha256-i4zlEa2lnANuOZA1aA/X0cNGM7x9MLZqqmKP6fwfPEA=",
         "owner": "hyprwm",
         "repo": "Hyprland",
-        "rev": "0302bfdc2207f9b5482fb07aa6052e7f6cb237ca",
+        "rev": "f5c5cfa960c157c8df50b496f621290234ac4505",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                                  |
| ------------------------------------------------------------------------------------------------ | ---------------------------------------- |
| [`f5c5cfa9`](https://github.com/hyprwm/Hyprland/commit/f5c5cfa960c157c8df50b496f621290234ac4505) | `` keybindmgr: fixup bindn regression `` |