### PR TITLE
chore(flake/zen-browser): `09eb9216` -> `624bf6dc`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1529,11 +1529,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1745785184,
-        "narHash": "sha256-cZgkg0CyuaPRsUxfvXOLSc5lhvMxt5MGkdMglkm3GPE=",
+        "lastModified": 1745804336,
+        "narHash": "sha256-zm3X7RUY5Zi1i4GJ6twjDm6y/AsaMKPvusOQsnwh+Yo=",
         "owner": "0xc000022070",
         "repo": "zen-browser-flake",
-        "rev": "09eb9216ad6000e68eaa3ae5c77fb63019c4302a",
+        "rev": "624bf6dc55d5b3e4e3bc71e55673e2b6f35d7f52",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                          | Message                                                                 |
| --------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------- |
| [`624bf6dc`](https://github.com/0xc000022070/zen-browser-flake/commit/624bf6dc55d5b3e4e3bc71e55673e2b6f35d7f52) | `` chore(update): twilight @ x86_64 && aarch64 to 1.11.5t#1745801781 `` |
| [`ebd8b381`](https://github.com/0xc000022070/zen-browser-flake/commit/ebd8b381387e314bc9f199ec5a261dbda6e15a5d) | `` readme: removed leading period in features section ``                |