### PR TITLE
chore(flake/nixpkgs-stable): `5630cf13` -> `26245db0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1030,11 +1030,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1745487689,
-        "narHash": "sha256-FQoi3R0NjQeBAsEOo49b5tbDPcJSMWc3QhhaIi9eddw=",
+        "lastModified": 1745742390,
+        "narHash": "sha256-1rqa/XPSJqJg21BKWjzJZC7yU0l/YTVtjRi0RJmipus=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "5630cf13cceac06cefe9fc607e8dfa8fb342dde3",
+        "rev": "26245db0cb552047418cfcef9a25da91b222d6c7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                          |
| ---------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------- |
| [`8ad8b9d6`](https://github.com/NixOS/nixpkgs/commit/8ad8b9d65444c358b86bf75f73a036b3fd35bce4) | `` qt6.qtdeclarative: add sigtool on Darwin ``                                   |
| [`25f0e7ca`](https://github.com/NixOS/nixpkgs/commit/25f0e7cae1e3ba483a1326ecd6931f0aa8d7e038) | `` stats: 2.11.36 -> 2.11.41 ``                                                  |
| [`e8c345a5`](https://github.com/NixOS/nixpkgs/commit/e8c345a5a781d25725a65be29c85b46a0f75c968) | `` stats: 2.11.35 -> 2.11.36 ``                                                  |
| [`83bf6dfc`](https://github.com/NixOS/nixpkgs/commit/83bf6dfc8f0105c14808f84e2ac3c389bd870407) | `` stats: 2.11.32 -> 2.11.35 ``                                                  |
| [`f6770dde`](https://github.com/NixOS/nixpkgs/commit/f6770dde2fe141c89c4946cba68d0539763aeaf5) | `` stats: 2.11.31 -> 2.11.32 ``                                                  |
| [`267d13ca`](https://github.com/NixOS/nixpkgs/commit/267d13ca90d1985ed6b1ae2f222ae7d7c8ccd974) | `` stats: 2.11.30 -> 2.11.31 ``                                                  |
| [`f3d8722a`](https://github.com/NixOS/nixpkgs/commit/f3d8722a61377e767c26cc5a913ca2697d0a9fb3) | `` stats: 2.11.26 -> 2.11.30 ``                                                  |
| [`c4bb48f5`](https://github.com/NixOS/nixpkgs/commit/c4bb48f5ce6340af794cf105833ec9f52cd1bf5b) | `` stats: 2.11.23 -> 2.11.26 ``                                                  |
| [`a20476b5`](https://github.com/NixOS/nixpkgs/commit/a20476b54465e4cbab22cc4d81faabd943008f7b) | `` stats: 2.11.22 -> 2.11.23 ``                                                  |
| [`29730444`](https://github.com/NixOS/nixpkgs/commit/297304449dc84a094a1bc286ba4948b86077a8c2) | `` stats: 2.11.21 -> 2.11.22 ``                                                  |
| [`0383abee`](https://github.com/NixOS/nixpkgs/commit/0383abee3dec29446530076cbc4bd8ebfadd3850) | `` qpwgraph: 0.8.3 -> 0.9.0 ``                                                   |
| [`8869ee4d`](https://github.com/NixOS/nixpkgs/commit/8869ee4d5c2f957efa230a11b30df723f943e5ef) | `` qt6.qtdeclarative: nixfmt ``                                                  |
| [`0b72d8ac`](https://github.com/NixOS/nixpkgs/commit/0b72d8acef12879487f57a7c7127cc817462ab5a) | `` clash-verge: mark as insecure ``                                              |
| [`68655875`](https://github.com/NixOS/nixpkgs/commit/686558754a84af32332522973fe316659bb5c3f4) | `` meshcentral: 1.1.43 -> 1.1.44 ``                                              |
| [`e2b10cdb`](https://github.com/NixOS/nixpkgs/commit/e2b10cdbc01bc9bb48fa64ac45d6e6665fc3e63d) | `` qt6.qtdeclarative: fix code-signing on Darwin ``                              |
| [`c80556f3`](https://github.com/NixOS/nixpkgs/commit/c80556f3ae427a0e8cb7a4999a0bc2c6e949c265) | `` workflows: make requested permissions explicit for create-github-app-token `` |
| [`9f711dc6`](https://github.com/NixOS/nixpkgs/commit/9f711dc6ae6236d895e888a1aad0471add20a573) | `` element-web: 1.11.97 -> 1.11.99 ``                                            |
| [`b43e189f`](https://github.com/NixOS/nixpkgs/commit/b43e189fd00d83d4cf6eb9b9e8e4f1fba528bf5b) | `` element-desktop: 1.11.97 -> 1.11.99 ``                                        |
| [`7fde7112`](https://github.com/NixOS/nixpkgs/commit/7fde7112382763cd2dd50c7be72ce3ca1206abcf) | `` domination: 1.3.1 -> 1.3.3 ``                                                 |
| [`8aa8577d`](https://github.com/NixOS/nixpkgs/commit/8aa8577d59f487cf9ca7a8a7d27feb108e2ab17b) | `` domination: add updateScript ``                                               |
| [`456f1f87`](https://github.com/NixOS/nixpkgs/commit/456f1f87f2499a2323dc9b9eee1157d242f9d4f8) | `` linux_6_1: 6.1.134 -> 6.1.135 ``                                              |
| [`2e44b492`](https://github.com/NixOS/nixpkgs/commit/2e44b49239a3531816340187e9b97f32b9ba7134) | `` linux_6_6: 6.6.87 -> 6.6.88 ``                                                |
| [`127973da`](https://github.com/NixOS/nixpkgs/commit/127973da529d9ea0b302685cb90cf9d88126bf4f) | `` linux_6_12: 6.12.24 -> 6.12.25 ``                                             |
| [`69c28144`](https://github.com/NixOS/nixpkgs/commit/69c281448213cfcaa960a41cfbd9410d2f52b377) | `` linux_6_14: 6.14.3 -> 6.14.4 ``                                               |
| [`9ec836e9`](https://github.com/NixOS/nixpkgs/commit/9ec836e9807af55babc181ffadce44e0e68d2800) | `` linux_testing: 6.15-rc2 -> 6.15-rc3 ``                                        |
| [`9bff7ab2`](https://github.com/NixOS/nixpkgs/commit/9bff7ab28852dba3f5eefbc290bca6ba1a7372fd) | `` linux_xanmod_latest: 6.13.11 -> 6.13.12 ``                                    |
| [`641a3407`](https://github.com/NixOS/nixpkgs/commit/641a34077e07746a66e912f2b6446a50bc7bfbdc) | `` linux_xanmod: 6.12.23 -> 6.12.24 ``                                           |
| [`98e9ae8c`](https://github.com/NixOS/nixpkgs/commit/98e9ae8c5d42ee68ab0cb0821c6a6e2cdaaa1266) | `` jdk17: 17.0.13+11 -> 17.0.14+7 ``                                             |
| [`b01fdeed`](https://github.com/NixOS/nixpkgs/commit/b01fdeedddd89195244694e6071c921c5c976fff) | `` jdk11: 11.0.25+9 -> 11.0.26+4 ``                                              |
| [`2c55d849`](https://github.com/NixOS/nixpkgs/commit/2c55d849523f16afb116b50e46c76580edce71c0) | `` jdk8: 8u432-b06 -> 8u442-b06 ``                                               |
| [`0e361530`](https://github.com/NixOS/nixpkgs/commit/0e3615307fcdc78b173046af9accf2920012b0d7) | `` grafana: 11.3.5 -> 11.3.6 ``                                                  |
| [`ae9f4ebf`](https://github.com/NixOS/nixpkgs/commit/ae9f4ebf1cb80ef407a0c8dda8b9db493d684532) | `` lockbook: 0.9.21 -> 0.9.22 ``                                                 |
| [`200d39c1`](https://github.com/NixOS/nixpkgs/commit/200d39c1eabe348498278bdddbcb48ee83325ae5) | `` lockbook-desktop: 0.9.21 -> 0.9.22 ``                                         |
| [`e309d713`](https://github.com/NixOS/nixpkgs/commit/e309d71311bcf43c7b69e8463cf99c7b52e1cc8d) | `` brave: 1.77.97 -> 1.77.101 ``                                                 |
| [`30157437`](https://github.com/NixOS/nixpkgs/commit/301574372d6ae4959b3364a40745bd4d665b6037) | `` nixos/home-assistant: add custom components to used components query ``       |
| [`07d62fef`](https://github.com/NixOS/nixpkgs/commit/07d62fef1aa3b758dc0455d991bdccf637ac6628) | `` home-assistant-custom-components.benqprojector: init at 0.1.3 ``              |
| [`118abb46`](https://github.com/NixOS/nixpkgs/commit/118abb46f8497ee430d36c0a409449d30f3f08cf) | `` python313Packages.benqprojector: init at 0.1.6 ``                             |
| [`64150aad`](https://github.com/NixOS/nixpkgs/commit/64150aaddcb36983292c8937dae71e91388ca7d7) | `` ungoogled-chromium: 135.0.7049.95-1 -> 135.0.7049.114-1 ``                    |
| [`84707a56`](https://github.com/NixOS/nixpkgs/commit/84707a560883362301ca2670bb5cc73d8d96dbe4) | `` miniflux: 2.2.7 -> 2.2.8 ``                                                   |
| [`ed48aeae`](https://github.com/NixOS/nixpkgs/commit/ed48aeaedb3d2dd11b7b154bce5a016c58dc4dc6) | `` gitlab-container-registry: 4.19.0 -> 4.20.0 ``                                |
| [`2ad56c47`](https://github.com/NixOS/nixpkgs/commit/2ad56c474fe24a30230cbf9ee28836af0a61f1f4) | `` amazon-q-cli: 1.7.3 -> 1.8.0 ``                                               |
| [`3f91b780`](https://github.com/NixOS/nixpkgs/commit/3f91b780c6f1b594cfeb1f64cd134542e4458275) | `` jetbrains-toolbox: 2.5.4.38621 -> 2.6.1.40902 ``                              |
| [`77070abb`](https://github.com/NixOS/nixpkgs/commit/77070abb9edb99d225201d966b70ebf20be0720c) | `` jetbrains-toolbox: support more platforms ``                                  |
| [`13e5e68f`](https://github.com/NixOS/nixpkgs/commit/13e5e68f9425268c161978205e97e1a9308158c5) | `` jetbrains-toolbox: 2.5.3.37797 -> 2.5.4.38621 ``                              |
| [`b666152b`](https://github.com/NixOS/nixpkgs/commit/b666152be4e9d83dd3b94c50528cc5230c7bc644) | `` jetbrains-toolbox: 2.5.1.34629 -> 2.5.3.37797 ``                              |
| [`04d5f166`](https://github.com/NixOS/nixpkgs/commit/04d5f166315ec4b7630137d7667d4543e62e09e1) | `` jetbrains-toolbox: fix update script ``                                       |
| [`0f7637f1`](https://github.com/NixOS/nixpkgs/commit/0f7637f12e2d208a55bdbfe622f06c14fe5ffb1d) | `` jetbrains-toolbox: format ``                                                  |
| [`416da07b`](https://github.com/NixOS/nixpkgs/commit/416da07bfeba4445c3d29a227c638c5fbc19516d) | `` osu-lazer: 2025.420.0 -> 2025.424.0 ``                                        |
| [`7878cc9d`](https://github.com/NixOS/nixpkgs/commit/7878cc9de4dab2892baf20a71ff41beddb0f0f65) | `` osu-lazer-bin: 2025.420.0 -> 2025.424.0 ``                                    |
| [`3c7c3ee5`](https://github.com/NixOS/nixpkgs/commit/3c7c3ee51b8f74a901e9f86d8a2cb6d020a788c0) | `` gitlab: 17.10.4 -> 17.11.1 ``                                                 |
| [`9f103de5`](https://github.com/NixOS/nixpkgs/commit/9f103de50eb0e67008f76367abc24bda9567aacc) | `` gitlab: Reformat gemset.nix after updating with update.py ``                  |
| [`2fea8a13`](https://github.com/NixOS/nixpkgs/commit/2fea8a134198cba8cc0b2ade267a7b1b902da7ba) | `` gitlab: Repair --commit functionality in update.py ``                         |
| [`f78d65a2`](https://github.com/NixOS/nixpkgs/commit/f78d65a25635219301218aa078c889b4705d93b8) | `` koreader: 2024.11 -> 2025.04 ``                                               |
| [`b7bbc243`](https://github.com/NixOS/nixpkgs/commit/b7bbc243a0e1a85d3e55f1c41e8255eb63a9d263) | `` rundeck: 5.10 -> 5.11.1 ``                                                    |
| [`e1565fdf`](https://github.com/NixOS/nixpkgs/commit/e1565fdf964d3f8899c060479b9c56448ce46ea8) | `` mattermostLatest: 10.7.0 -> 10.7.1 ``                                         |
| [`cde57dff`](https://github.com/NixOS/nixpkgs/commit/cde57dffac720c387f272d4873b8b516dfc04a6b) | `` google-chrome: 135.0.7049.84 -> 135.0.7049.114 ``                             |
| [`360e07e5`](https://github.com/NixOS/nixpkgs/commit/360e07e592c6b3b32c56f7fa1be432136aa916b2) | `` junction: 1.8 -> 1.9 ``                                                       |
| [`19c3bbdd`](https://github.com/NixOS/nixpkgs/commit/19c3bbddf489377ce25a82614e549220bd826dd2) | `` refine: 0.5.6 -> 0.5.7 ``                                                     |
| [`16c02b91`](https://github.com/NixOS/nixpkgs/commit/16c02b918569a95766e692f42852f98853b35817) | `` home-assistant-custom-components.sun2: init at 3.3.5 ``                       |
| [`7f6bda8d`](https://github.com/NixOS/nixpkgs/commit/7f6bda8d59ade39630267e7c5630fa0bde6982e4) | `` open-policy-agent: enable __darwinAllowLocalNetworking ``                     |
| [`96001836`](https://github.com/NixOS/nixpkgs/commit/960018361afc51a7051f87ba0df71291ea367282) | `` open-policy-agent: skip tests that require network ``                         |
| [`8d595f10`](https://github.com/NixOS/nixpkgs/commit/8d595f10e3ceba90472acdca7d5e57b80d9e5849) | `` open-policy-agent: 1.2.0 -> 1.3.0 ``                                          |
| [`00620789`](https://github.com/NixOS/nixpkgs/commit/006207892fd6b6cb4625f5f30fb8ab4b42070bc4) | `` freetube: 0.23.3 -> 0.23.4 ``                                                 |
| [`113fb835`](https://github.com/NixOS/nixpkgs/commit/113fb835107966711a33b36935195c6e84a66d06) | `` nix: fix system/user registries ``                                            |
| [`70365f06`](https://github.com/NixOS/nixpkgs/commit/70365f06c6c799019765af1071c9c02618b92878) | `` pngout: 20200115 -> 20230322 ``                                               |
| [`f51f975f`](https://github.com/NixOS/nixpkgs/commit/f51f975fd6b39a561d9ea627891d060e12f32420) | `` paretosecurity: 0.1.3 -> 0.1.4 ``                                             |
| [`59a364d1`](https://github.com/NixOS/nixpkgs/commit/59a364d1d8f83e3496f1b705c06e3f3cda39f6bc) | `` thunderbird-latest-unwrapped: 137.0.1 -> 137.0.2 ``                           |
| [`8673e8d7`](https://github.com/NixOS/nixpkgs/commit/8673e8d76b8c76d3e401aac278388bc9c567a532) | `` fcgi: 2.4.4 -> 2.4.5 ``                                                       |
| [`d818dad5`](https://github.com/NixOS/nixpkgs/commit/d818dad56d0d6a2ec9802d37f368e751f244c09d) | `` fcgi: 2.4.3 -> 2.4.4 ``                                                       |
| [`99f1c246`](https://github.com/NixOS/nixpkgs/commit/99f1c24650236225e52ed21e616fdb5c9a8556e7) | `` fcgi: 2.4.2 -> 2.4.3 ``                                                       |
| [`e1f3f2f8`](https://github.com/NixOS/nixpkgs/commit/e1f3f2f83a61535c04a3fc44e31fd10141810110) | `` fedifetcher: 7.1.15 -> 7.1.16 ``                                              |
| [`3b1b8933`](https://github.com/NixOS/nixpkgs/commit/3b1b89339fa58597f2f5e894483f42b733e7271d) | `` chromium,chromedriver: 135.0.7049.95 -> 135.0.7049.114 ``                     |
| [`bbd437c8`](https://github.com/NixOS/nixpkgs/commit/bbd437c81b5b8b1ad329f3390d4faf1e6dd66a62) | `` firefox-devedition-bin-unwrapped: 137.0b10 -> 138.0b7 ``                      |
| [`cc0fbf4e`](https://github.com/NixOS/nixpkgs/commit/cc0fbf4e86ec0468c8a98a3537db7befc5a50b54) | `` vivaldi: 7.3.3635.7 -> 7.3.3635.11 ``                                         |
| [`b6c4e78c`](https://github.com/NixOS/nixpkgs/commit/b6c4e78c491a0460093dd8a360ddbaf03c5557c9) | `` gotosocial: 0.18.3 -> 0.19.0 ``                                               |
| [`c457d4fc`](https://github.com/NixOS/nixpkgs/commit/c457d4fcad2337ebb3a1dc89097f70e92bf5b6cf) | `` sdl3-image: add updateScript ``                                               |
| [`346c458f`](https://github.com/NixOS/nixpkgs/commit/346c458f94b5545080dbad9b4053911689ff9152) | `` sdl3-image: remove uses of 'with' ``                                          |
| [`98696a15`](https://github.com/NixOS/nixpkgs/commit/98696a157de782f58d13d77baabe3f802b15cc2b) | `` sdl3-image: remove usage of apple_sdk ``                                      |
| [`df6236e2`](https://github.com/NixOS/nixpkgs/commit/df6236e24aba434d5f0df53edf3795eb19fafbe1) | `` sld3-image: add option to disable stb ``                                      |
| [`25133997`](https://github.com/NixOS/nixpkgs/commit/251339979bc0dd3f9640e2f9cad8602b0eef0a16) | `` sdl3-image: init at 3.2.4 ``                                                  |
| [`e0758500`](https://github.com/NixOS/nixpkgs/commit/e075850057647efd9399e53fd57f88acf9bf9da2) | `` maintainers: add evythedemon ``                                               |
| [`8c88e026`](https://github.com/NixOS/nixpkgs/commit/8c88e0264bf8860dd6d816637ae6d3d9577c5e23) | `` netbox_4_1: 4.1.7 -> 4.1.11 ``                                                |
| [`23872a9a`](https://github.com/NixOS/nixpkgs/commit/23872a9a0bebe3249c5df62b45cc56ce8de48ab1) | `` nixVersions.nix_2_28: 2.28.1 -> 2.28.2 ``                                     |
| [`4f2ffb6d`](https://github.com/NixOS/nixpkgs/commit/4f2ffb6dc9e066a6167f5eb3134dcf1efe3fa5bd) | `` nixos/nextcloud: S3: Rename autocreate (a no-op) to verify_bucket_exists ``   |
| [`6eae6782`](https://github.com/NixOS/nixpkgs/commit/6eae678208a110007f020ec2e1f607ee93e6eb0b) | `` gpredict-unstable: init at 2.4.0-unstable-2024-09-17 ``                       |
| [`89c06632`](https://github.com/NixOS/nixpkgs/commit/89c06632d230b9bdcd36274b30877056c416ff1b) | `` gpredict: fix license ``                                                      |
| [`f29ffab1`](https://github.com/NixOS/nixpkgs/commit/f29ffab1c482154b898b39b62a4af039e203e244) | `` goocanvas3: fix license ``                                                    |
| [`d474f7f6`](https://github.com/NixOS/nixpkgs/commit/d474f7f65d6172c7f6a594545f45b942652a73d6) | `` gpredict: add pandapip1 to maintainers ``                                     |
| [`c2bf4000`](https://github.com/NixOS/nixpkgs/commit/c2bf4000f2b8b84612dbe04e6e290f8eddfa4555) | `` goocanvas3: add pandapip1 to maintainers ``                                   |
| [`80a5e06e`](https://github.com/NixOS/nixpkgs/commit/80a5e06e49bb53b866f324864f4aa5fa9ce45c97) | `` gpredict: switch to fetchFromGithub tag ``                                    |
| [`3f598e7f`](https://github.com/NixOS/nixpkgs/commit/3f598e7f33684ca80c348445949c505139180d9d) | `` gpredict: move to by-name ``                                                  |
| [`93822b8d`](https://github.com/NixOS/nixpkgs/commit/93822b8df3b1020931600afecab9a3efa6090e8a) | `` gpredict: switch to finalAttrs ``                                             |
| [`ab9ea0a1`](https://github.com/NixOS/nixpkgs/commit/ab9ea0a179da71cfe126e9e44df7b8e9a5469165) | `` goocanvas3: remove with lib ``                                                |
| [`8cc28aca`](https://github.com/NixOS/nixpkgs/commit/8cc28aca15b2ce454c4491760617533592e0d948) | `` goocanvas3: switch to finalAttrs ``                                           |
| [`37cec38a`](https://github.com/NixOS/nixpkgs/commit/37cec38ac795713a8947d2dbc87135accbbf776b) | `` goocanvas3: fix build for gcc 15 ``                                           |
| [`fbb1a1f4`](https://github.com/NixOS/nixpkgs/commit/fbb1a1f4acebc030b96c384e5c77a8d74c411855) | `` mattermostLatest: 10.6.1 -> 10.7.0 ``                                         |
| [`0cd14f92`](https://github.com/NixOS/nixpkgs/commit/0cd14f92722615a3b38bd640cf9734d161e84f06) | `` osu-lazer-bin: 2025.418.1 -> 2025.420.0 ``                                    |
| [`61907207`](https://github.com/NixOS/nixpkgs/commit/61907207b8c18beda291910f3d17651aedaa63c0) | `` osu-lazer: 2025.418.1 -> 2025.420.0 ``                                        |
| [`593828c1`](https://github.com/NixOS/nixpkgs/commit/593828c17b543cb0071e016b1a79d256a9652d0a) | `` discord: 0.0.89 -> 0.0.91 ``                                                  |
| [`853d5184`](https://github.com/NixOS/nixpkgs/commit/853d5184fd386f368da7f7cdd33f3f888e762f93) | `` grafanaPlugin.victoriametrics-metrics-datasource: 0.13.1 -> 0.14.0 ``         |
| [`595ceb98`](https://github.com/NixOS/nixpkgs/commit/595ceb9841dafcef30a10a45932e2617ebee2aaa) | `` grafanaPlugin.victoriametrics-logs-datasource: 0.14.3 -> 0.16.3 ``            |
| [`bedc4918`](https://github.com/NixOS/nixpkgs/commit/bedc4918c549bfaa26bb4002763fc413204bf515) | `` osu-lazer: remove unnecessary runtimeconfig.json ``                           |
| [`a61f5a77`](https://github.com/NixOS/nixpkgs/commit/a61f5a77c79e09723e7ac3e6b2cde7ac5543cbce) | `` osu-lazer: simpler update script ``                                           |
| [`3df91559`](https://github.com/NixOS/nixpkgs/commit/3df91559206862685aee3e108a70166b686e4957) | `` osu-lazer: 2025.321.0 -> 2025.418.1 ``                                        |
| [`b40bcf67`](https://github.com/NixOS/nixpkgs/commit/b40bcf67c72661414c2773d9a47746fa3fc12932) | `` osu-lazer-bin: 2025.321.0 -> 2025.418.1 ``                                    |
| [`72d6dc98`](https://github.com/NixOS/nixpkgs/commit/72d6dc982dd50308829c42e44045c7504bfdb6f9) | `` osu-lazer-bin: 2025.316.0 -> 2025.321.0 ``                                    |
| [`8f9876a4`](https://github.com/NixOS/nixpkgs/commit/8f9876a4cee60dc05275eb54f50d71282972628d) | `` osu-lazer: 2025.316.0 -> 2025.321.0 ``                                        |
| [`5b990c30`](https://github.com/NixOS/nixpkgs/commit/5b990c30a2274a7024b962b15a8b8c1b268be566) | `` Revert "[Backport release-24.11] fastlane: 2.220.0 -> 2.227.0" ``             |
| [`e849a60b`](https://github.com/NixOS/nixpkgs/commit/e849a60bafb1884cb4fb083a3884ff7f59db183a) | `` garnet: 1.0.61 -> 1.0.63 ``                                                   |
| [`c997e521`](https://github.com/NixOS/nixpkgs/commit/c997e52183109cb183356072e89f2dfb2f2b0a39) | `` pnpm.fetchDeps: fix use for cross ``                                          |
| [`8b47172a`](https://github.com/NixOS/nixpkgs/commit/8b47172aff51feae877cc97a6b576726029fcea6) | `` sql-formatter: 15.4.3 -> 15.4.9 ``                                            |
| [`3cc8d62a`](https://github.com/NixOS/nixpkgs/commit/3cc8d62ae06cf0503cbb894a7f97267ea6e6fb65) | `` webkitgtk_6_0: 2.48.0 → 2.48.1 ``                                             |
| [`b6d66f03`](https://github.com/NixOS/nixpkgs/commit/b6d66f03f304349856d9fcf4cac6b8c75163295d) | `` uair: 0.6.2 -> 0.6.3 ``                                                       |
| [`bf9258e1`](https://github.com/NixOS/nixpkgs/commit/bf9258e1bd9000bfd48df6ccfd804a8c603827bc) | `` pnpm.configHook: improve error message when install fails due to old hash ``  |
| [`1fa1bc72`](https://github.com/NixOS/nixpkgs/commit/1fa1bc7206d1c36c85c9304cab0d1a19050abf27) | `` pdm: fix AGPL issues (#390944) ``                                             |
| [`ecf1a6a1`](https://github.com/NixOS/nixpkgs/commit/ecf1a6a16b7abf300b3931b44dee82b09710dee5) | `` ceph: 19.2.1 -> 19.2.2 ``                                                     |
| [`a2146d0f`](https://github.com/NixOS/nixpkgs/commit/a2146d0faa25ae734495ecb74ecfc8001e2683ba) | `` [Backport release-24.11] authentik: Add missing dependency on bash ``         |
| [`7d2988ac`](https://github.com/NixOS/nixpkgs/commit/7d2988ac4f6bc677788277ce4f5a153ab3af1f85) | `` knot-dns: 3.4.5 -> 3.4.6 ``                                                   |
| [`672d6e66`](https://github.com/NixOS/nixpkgs/commit/672d6e664d404e9a4b7e200a07d33f6f5c6003fc) | `` boatswain: modernize and clean up deps ``                                     |
| [`dc2a7286`](https://github.com/NixOS/nixpkgs/commit/dc2a7286caa7a696b562743fc429c302a7d70b0b) | `` boatswain: 0.4.0 -> 5.0 ``                                                    |
| [`5f872dce`](https://github.com/NixOS/nixpkgs/commit/5f872dceb6ca6b3fa53c7af74be39e5132260401) | `` nixos/immich: restrict filesystem permissions ``                              |
| [`58d59114`](https://github.com/NixOS/nixpkgs/commit/58d5911464059eb1768d5b6dbce20cea00c0aa94) | `` immich: 1.131.2 -> 1.131.3 (#395524) ``                                       |
| [`b26757f8`](https://github.com/NixOS/nixpkgs/commit/b26757f87654324f4d612d1485676cf14aea8eb2) | `` nano: 8.2 -> 8.4 ``                                                           |
| [`4e543d71`](https://github.com/NixOS/nixpkgs/commit/4e543d7100d9a2da6bc8d58463c8e376afdcb325) | `` [Backport release-24.11] bibata-cursors: 2.0.6 → 2.0.7 ``                     |