### PR TITLE
chore(flake/hyprland): `f5c5cfa9` -> `c505eb55`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -625,11 +625,11 @@
         "xdph": "xdph"
       },
       "locked": {
-        "lastModified": 1745795931,
-        "narHash": "sha256-i4zlEa2lnANuOZA1aA/X0cNGM7x9MLZqqmKP6fwfPEA=",
+        "lastModified": 1745867882,
+        "narHash": "sha256-kIdHBL/FUJGdnxqsZDggofW6slbfM7OciOiDEOqnfDI=",
         "owner": "hyprwm",
         "repo": "Hyprland",
-        "rev": "f5c5cfa960c157c8df50b496f621290234ac4505",
+        "rev": "c505eb55ff967f2a0474e88a50803412ba550a61",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                                                        |
| ------------------------------------------------------------------------------------------------ | -------------------------------------------------------------- |
| [`c505eb55`](https://github.com/hyprwm/Hyprland/commit/c505eb55ff967f2a0474e88a50803412ba550a61) | `` screencopy: support hw cursors while sharing with cursor `` |