### PR TITLE
chore(flake/spicetify-nix): `d9ca0f8a` -> `8e05ca5d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1254,11 +1254,11 @@
         "systems": "systems_4"
       },
       "locked": {
-        "lastModified": 1745832939,
-        "narHash": "sha256-uyb3vhSAD8G0gnX5dsnvoEncnm4tvK7kvC0vT+kOYT8=",
+        "lastModified": 1745876380,
+        "narHash": "sha256-rn8LzSWtOpcvIB8JJ+UX5YtIAkH0vjF9EZfo7U9QGyQ=",
         "owner": "Gerg-L",
         "repo": "spicetify-nix",
-        "rev": "d9ca0f8a3d97b94a7a8225152fafb1805477df52",
+        "rev": "8e05ca5d733b41d9f576076bd268a79ce3f975ee",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                           |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------- |
| [`8e05ca5d`](https://github.com/Gerg-L/spicetify-nix/commit/8e05ca5d733b41d9f576076bd268a79ce3f975ee) | `` fix: set default value to program.spicetify `` |
| [`eb5fa468`](https://github.com/Gerg-L/spicetify-nix/commit/eb5fa46832c6386f633503ecfc432b22a42da0c3) | `` fix: correct spotify darwin path? ``           |