### PR TITLE
chore(flake/hyprpanel): `42943b3d` -> `0c82ce97`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -822,11 +822,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1744513377,
-        "narHash": "sha256-2ocy+qAVxTBmaK8MpAy7mpKIH+DYEzwf+KzXZX83oZ4=",
+        "lastModified": 1745885816,
+        "narHash": "sha256-yuIb6/gGcII+2YgtTLcYdga0pcL63B18xQ/oitOhg7k=",
         "owner": "Jas-SinghFSU",
         "repo": "HyprPanel",
-        "rev": "42943b3def85d8787d703778951944c8e791202b",
+        "rev": "0c82ce9704c8063be8d8f60443071c91943eb68c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                  | Message                                              |
| ------------------------------------------------------------------------------------------------------- | ---------------------------------------------------- |
| [`0c82ce97`](https://github.com/Jas-SinghFSU/HyprPanel/commit/0c82ce9704c8063be8d8f60443071c91943eb68c) | `` Fix wallpaper path handling with spaces (#908) `` |
| [`07a990f1`](https://github.com/Jas-SinghFSU/HyprPanel/commit/07a990f1f86341a45acd7f613a924dd75dd431ae) | `` better runUpdates script for arch users (#909) `` |