### PR TITLE
chore(flake/home-manager): `d0d9d0a1` -> `1ad12323`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -496,11 +496,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1745858959,
-        "narHash": "sha256-B1FQwPCFLL3cbHc2nxT3/UI1uprHp2h1EA6M2JVe0oQ=",
+        "lastModified": 1745894335,
+        "narHash": "sha256-m47zhftaod/oHOwoVT25jstdcVLhkrVGyvEHKjbnFHI=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "d0d9d0a1454d5a0200693570618084d80a8b336c",
+        "rev": "1ad123239957d40e11ef66c203d0a7e272eb48aa",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                     |
| ----------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------- |
| [`1ad12323`](https://github.com/nix-community/home-manager/commit/1ad123239957d40e11ef66c203d0a7e272eb48aa) | `` rclone: make secret injection non-interactive (#6919) `` |
| [`c803a389`](https://github.com/nix-community/home-manager/commit/c803a38927b9b3b15dc83aecae27af3172be5ee2) | `` nh: add path option for flake (#6898) ``                 |
| [`4d2baba7`](https://github.com/nix-community/home-manager/commit/4d2baba75e9de32f6f552fe02797f46cd6f46bd9) | `` espanso: fix alias in news (#6931) ``                    |