### PR TITLE
chore(flake/seanime): `42d816d8` -> `1378bc9b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1110,11 +1110,11 @@
     },
     "nixpkgs_6": {
       "locked": {
-        "lastModified": 1745526057,
-        "narHash": "sha256-ITSpPDwvLBZBnPRS2bUcHY3gZSwis/uTe255QgMtTLA=",
+        "lastModified": 1745794561,
+        "narHash": "sha256-T36rUZHUART00h3dW4sV5tv4MrXKT7aWjNfHiZz7OHg=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "f771eb401a46846c1aebd20552521b233dd7e18b",
+        "rev": "5461b7fa65f3ca74cef60be837fd559a8918eaa0",
         "type": "github"
       },
       "original": {
@@ -1233,11 +1233,11 @@
         "nixpkgs": "nixpkgs_6"
       },
       "locked": {
-        "lastModified": 1745811307,
-        "narHash": "sha256-J7boNhCwIWX9Epquk9N90iPdFiulp5VK8ub4cvBGaa0=",
+        "lastModified": 1745893524,
+        "narHash": "sha256-HJGKTXmwxp5hTU8WSjMS+MHyJn5fC9+RTJAbU+Bqlls=",
         "owner": "rishabh5321",
         "repo": "seanime-flake",
-        "rev": "42d816d814067679911a80d55a20405cdf7583f8",
+        "rev": "1378bc9ba8a1ff31ee8b930167cb76f821e5a3b3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                     | Message                                          |
| ---------------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
| [`1378bc9b`](https://github.com/Rishabh5321/seanime-flake/commit/1378bc9ba8a1ff31ee8b930167cb76f821e5a3b3) | `` chore(flake/nixpkgs): f771eb40 -> 5461b7fa `` |