### PR TITLE
chore(flake/akuse-flake): `91550f18` -> `022c42d3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -48,11 +48,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1745641634,
-        "narHash": "sha256-DM6A3+YIVUZEWJQwK+lf+FmU70saZmwgs1h5d+YIodw=",
+        "lastModified": 1745896156,
+        "narHash": "sha256-GqlzklAR4sPKXp8R2/y10QMMR+QFmnlfVLfQ4vGhEG8=",
         "owner": "Rishabh5321",
         "repo": "akuse-flake",
-        "rev": "91550f183c1c230414cbd5435526997df3446ab8",
+        "rev": "022c42d3aba560d7330d435067d9af1d5c4d8d60",
         "type": "github"
       },
       "original": {
@@ -999,11 +999,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1745526057,
-        "narHash": "sha256-ITSpPDwvLBZBnPRS2bUcHY3gZSwis/uTe255QgMtTLA=",
+        "lastModified": 1745794561,
+        "narHash": "sha256-T36rUZHUART00h3dW4sV5tv4MrXKT7aWjNfHiZz7OHg=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "f771eb401a46846c1aebd20552521b233dd7e18b",
+        "rev": "5461b7fa65f3ca74cef60be837fd559a8918eaa0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                   | Message                                          |
| -------------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
| [`022c42d3`](https://github.com/Rishabh5321/akuse-flake/commit/022c42d3aba560d7330d435067d9af1d5c4d8d60) | `` chore(flake/nixpkgs): f771eb40 -> 5461b7fa `` |