### PR TITLE
chore(flake/nixpkgs-stable): `26245db0` -> `330d0a41`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1030,11 +1030,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1745742390,
-        "narHash": "sha256-1rqa/XPSJqJg21BKWjzJZC7yU0l/YTVtjRi0RJmipus=",
+        "lastModified": 1745868005,
+        "narHash": "sha256-hZScOyQphT4RUmSEJX+2OxjIlGgLwSd8iW1LNtAWIOs=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "26245db0cb552047418cfcef9a25da91b222d6c7",
+        "rev": "330d0a4167924b43f31cc9406df363f71b768a02",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                              |
| ---------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------- |
| [`7165df87`](https://github.com/NixOS/nixpkgs/commit/7165df87d1c2dcca37c02b70768907bac666e0ad) | `` pnpm: 10.9.0 -> 10.10.0 ``                                                                        |
| [`038710e9`](https://github.com/NixOS/nixpkgs/commit/038710e961cdd741620e14d1eb9cf3a726fcbe46) | `` webcord-vencord: bump electron version ``                                                         |
| [`a4d07932`](https://github.com/NixOS/nixpkgs/commit/a4d07932e6aaf3e10cfd71559417bd8d5e93a983) | `` gotosocial: move to codeberg ``                                                                   |
| [`c9b28660`](https://github.com/NixOS/nixpkgs/commit/c9b28660f8242974579ed71fbd3929c963f0ba21) | `` librewolf-unwrapped: 137.0.1-1 -> 137.0.2-1 ``                                                    |
| [`542e9320`](https://github.com/NixOS/nixpkgs/commit/542e9320b45be199df80329f9dfc063753ad64f0) | `` discord-canary: 0.0.621 -> 0.0.649 ``                                                             |
| [`b9222e4d`](https://github.com/NixOS/nixpkgs/commit/b9222e4dc78da24e2068ec50baa074bf33ec7d65) | `` opera: 117.0.5408.197 -> 118.0.5461.60 ``                                                         |
| [`edfebe1a`](https://github.com/NixOS/nixpkgs/commit/edfebe1a45f8dc25fa84fda1babe96207c27612c) | `` opera: 117.0.5408.93 -> 117.0.5408.197 ``                                                         |
| [`984ecb5a`](https://github.com/NixOS/nixpkgs/commit/984ecb5afc160dcde5bd1596b8a04f33290ff4e3) | `` opera: 117.0.5408.32 -> 117.0.5408.93 ``                                                          |
| [`e1e65656`](https://github.com/NixOS/nixpkgs/commit/e1e65656455b264ae20c4720698cc5207fa0c183) | `` opera: 116.0.5366.71 -> 117.0.5408.32 ``                                                          |
| [`55541366`](https://github.com/NixOS/nixpkgs/commit/5554136642dfa9b559e3fa9011be5b9ff77cea41) | `` opera: 115.0.5322.119 -> 116.0.5366.71 ``                                                         |
| [`47c83b34`](https://github.com/NixOS/nixpkgs/commit/47c83b343de8684ec348f39936da9d47f2d9a81e) | `` opera: 115.0.5322.77 -> 115.0.5322.119 ``                                                         |
| [`c2fcb4fd`](https://github.com/NixOS/nixpkgs/commit/c2fcb4fd368648de581a8dca346f5d2abc87858f) | `` microsoft-edge: 135.0.3179.54 -> 135.0.3179.85 ``                                                 |
| [`3d787f5b`](https://github.com/NixOS/nixpkgs/commit/3d787f5bee8b141174627c75b82a8f88927ac37b) | `` gitlab-runner: Add main program, version check hook, and Nix update script. Fix Darwin builds. `` |
| [`7f751922`](https://github.com/NixOS/nixpkgs/commit/7f751922219f9660c8e3b462b15db817a85e1140) | `` vencord: fixup cp order,  does not exist ``                                                       |
| [`e7fab714`](https://github.com/NixOS/nixpkgs/commit/e7fab7148022d79dc3ed2e2ae2f6ea9db4e4ff15) | `` vencord: include `package.json` checked by Vesktop ``                                             |
| [`f0afe1f1`](https://github.com/NixOS/nixpkgs/commit/f0afe1f147cf4682f45da64b8ba04be5bb204409) | `` valkey: 8.0.2 -> 8.0.3 ``                                                                         |
| [`ff5bf1bb`](https://github.com/NixOS/nixpkgs/commit/ff5bf1bb9b4048209e6a87b9e6c0993a5b771942) | `` teleport_15: 15.4.31 -> 15.4.33 ``                                                                |
| [`ac2b6f73`](https://github.com/NixOS/nixpkgs/commit/ac2b6f73361656fac169a6f89cf38e50b5dac0e9) | `` teleport_16: 16.5.1 -> 16.5.3 ``                                                                  |
| [`d95d98cf`](https://github.com/NixOS/nixpkgs/commit/d95d98cf162669ae6474263f554f76ffc639a659) | `` teleport_17: 17.4.3 -> 17.4.5 ``                                                                  |
| [`4287d4e6`](https://github.com/NixOS/nixpkgs/commit/4287d4e68a19a95ceb101800029aa1a8c08b4ba1) | `` teleport_17: 17.4.2 -> 17.4.3; teleport_16: 16.5.0 -> 16.5.1; ``                                  |
| [`085c68f2`](https://github.com/NixOS/nixpkgs/commit/085c68f2c8b0615e542bc2b37b81158f4ca44ccf) | `` ed-odyssey-materials-helper: init at 2.156 ``                                                     |
| [`de32d29f`](https://github.com/NixOS/nixpkgs/commit/de32d29fe878703eceb80e87c70877a55719ae33) | `` maintainers: add elfenermarcell ``                                                                |
| [`27c10173`](https://github.com/NixOS/nixpkgs/commit/27c1017392f07960f6e0a1e0640b570975f2ac13) | `` trafficserver: 9.2.7 -> 9.2.9 ``                                                                  |
| [`26a02db0`](https://github.com/NixOS/nixpkgs/commit/26a02db0c5a595dd53ba99c34ade10681f3ec9d6) | `` libadwaita: 1.6.3 -> 1.6.4 ``                                                                     |
| [`5b077993`](https://github.com/NixOS/nixpkgs/commit/5b077993cb00ea226fc7efce4aeac534c02a72a4) | `` libadwaita: 1.6.2 → 1.6.3 ``                                                                      |
| [`e3b4e484`](https://github.com/NixOS/nixpkgs/commit/e3b4e484e5ab4e93696926459cf4fbcaf8d88b1e) | `` dependency-track: 4.12.6 -> 4.12.7 ``                                                             |