### PR TITLE
chore(flake/stylix): `11ceb2fd` -> `594336f4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1291,11 +1291,11 @@
         "tinted-zed": "tinted-zed"
       },
       "locked": {
-        "lastModified": 1745618823,
-        "narHash": "sha256-WGKSI0+CY3Ep2YnRASmBRU8oMIvTW4ngFyjA0dVcKgQ=",
+        "lastModified": 1745939601,
+        "narHash": "sha256-Jsgx2FlJ/qPQtL8Yxnxmn0ZwJfFJJgfenbk7Iv7zeHk=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "11ceb2fde1901dc227421bbbef2d0800339f5126",
+        "rev": "594336f425edb579f11a61d76e3d866412358486",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                        | Message                                       |
| --------------------------------------------------------------------------------------------- | --------------------------------------------- |
| [`594336f4`](https://github.com/danth/stylix/commit/594336f425edb579f11a61d76e3d866412358486) | `` stylix: switch to using treefmt (#1076) `` |