### PR TITLE
chore(flake/hyprland): `94bc1320` -> `ae1fe860`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -625,11 +625,11 @@
         "xdph": "xdph"
       },
       "locked": {
-        "lastModified": 1745952553,
-        "narHash": "sha256-Ug1VYLD2ISBLHPiD9uBdVF5ozBvtGAUWIAIBw1LnkyI=",
+        "lastModified": 1745957354,
+        "narHash": "sha256-rYRPfNYK36+Za4hzhjrM/BgWgNYOteeVZ3VVPFrNDzU=",
         "owner": "hyprwm",
         "repo": "Hyprland",
-        "rev": "94bc1320843e4f45c4b8d3fd3cd08f8914b5fa13",
+        "rev": "ae1fe860ff73071cd14803c4495049a8969bb8f9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                                                      |
| ------------------------------------------------------------------------------------------------ | ------------------------------------------------------------ |
| [`ae1fe860`](https://github.com/hyprwm/Hyprland/commit/ae1fe860ff73071cd14803c4495049a8969bb8f9) | `` renderer: add render:send_content_type setting (#9851) `` |
| [`49974d5e`](https://github.com/hyprwm/Hyprland/commit/49974d5e34292ede24351c8638fe060b382bbda0) | `` cm: Use precomputed primaries conversion (#9814) ``       |