### PR TITLE
chore(flake/seanime): `1378bc9b` -> `e2dc44d4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1110,11 +1110,11 @@
     },
     "nixpkgs_6": {
       "locked": {
-        "lastModified": 1745794561,
-        "narHash": "sha256-T36rUZHUART00h3dW4sV5tv4MrXKT7aWjNfHiZz7OHg=",
+        "lastModified": 1745930157,
+        "narHash": "sha256-y3h3NLnzRSiUkYpnfvnS669zWZLoqqI6NprtLQ+5dck=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "5461b7fa65f3ca74cef60be837fd559a8918eaa0",
+        "rev": "46e634be05ce9dc6d4db8e664515ba10b78151ae",
         "type": "github"
       },
       "original": {
@@ -1233,11 +1233,11 @@
         "nixpkgs": "nixpkgs_6"
       },
       "locked": {
-        "lastModified": 1745893524,
-        "narHash": "sha256-HJGKTXmwxp5hTU8WSjMS+MHyJn5fC9+RTJAbU+Bqlls=",
+        "lastModified": 1745964582,
+        "narHash": "sha256-VCL8x/7jTBBaHGY4Vxq0Srk28GXLTifqde9mRcdkfFc=",
         "owner": "rishabh5321",
         "repo": "seanime-flake",
-        "rev": "1378bc9ba8a1ff31ee8b930167cb76f821e5a3b3",
+        "rev": "e2dc44d4160cc34569b75f2c15947ab5ac42a7f8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                     | Message                                          |
| ---------------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
| [`e2dc44d4`](https://github.com/Rishabh5321/seanime-flake/commit/e2dc44d4160cc34569b75f2c15947ab5ac42a7f8) | `` chore(flake/nixpkgs): 5461b7fa -> 46e634be `` |