### PR TITLE
chore(flake/stylix): `8a35410a` -> `764fd329`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1291,11 +1291,11 @@
         "tinted-zed": "tinted-zed"
       },
       "locked": {
-        "lastModified": 1745949556,
-        "narHash": "sha256-d7ekZUqTGlX9/sNB72c+Vh6bAKKAqtsbWNaqZlceKac=",
+        "lastModified": 1745962538,
+        "narHash": "sha256-UmQxI4ocPZUVHuxtaQN3zNNBU8KLK9x2gXl2kWUhMKY=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "8a35410a28d346622936cb9f3f9d2592d71a6a9f",
+        "rev": "764fd32955e79f2742a7975f0150175f93add2fb",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                        | Message                         |
| --------------------------------------------------------------------------------------------- | ------------------------------- |
| [`764fd329`](https://github.com/danth/stylix/commit/764fd32955e79f2742a7975f0150175f93add2fb) | `` btop: add testbed (#1106) `` |