### PR TITLE
chore(flake/akuse-flake): `022c42d3` -> `7ecb80e6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -48,11 +48,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1745896156,
-        "narHash": "sha256-GqlzklAR4sPKXp8R2/y10QMMR+QFmnlfVLfQ4vGhEG8=",
+        "lastModified": 1745965338,
+        "narHash": "sha256-gstzVpT4Tsv62F2zNZJsn4oWHgTXqWN303W8kIRhnVM=",
         "owner": "Rishabh5321",
         "repo": "akuse-flake",
-        "rev": "022c42d3aba560d7330d435067d9af1d5c4d8d60",
+        "rev": "7ecb80e628c6742c7fbb56be5b8f346ea6dd3944",
         "type": "github"
       },
       "original": {
@@ -999,11 +999,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1745794561,
-        "narHash": "sha256-T36rUZHUART00h3dW4sV5tv4MrXKT7aWjNfHiZz7OHg=",
+        "lastModified": 1745930157,
+        "narHash": "sha256-y3h3NLnzRSiUkYpnfvnS669zWZLoqqI6NprtLQ+5dck=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "5461b7fa65f3ca74cef60be837fd559a8918eaa0",
+        "rev": "46e634be05ce9dc6d4db8e664515ba10b78151ae",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                   | Message                                          |
| -------------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
| [`7ecb80e6`](https://github.com/Rishabh5321/akuse-flake/commit/7ecb80e628c6742c7fbb56be5b8f346ea6dd3944) | `` chore(flake/nixpkgs): 5461b7fa -> 46e634be `` |