### PR TITLE
chore(flake/hyprland): `208f4c48` -> `72cb5d24`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -625,11 +625,11 @@
         "xdph": "xdph"
       },
       "locked": {
-        "lastModified": 1745968247,
-        "narHash": "sha256-qSsoBlL50+a8z7WhF2TR4Bgo+RIgWE679UrL97+BYxk=",
+        "lastModified": 1745969732,
+        "narHash": "sha256-OUQ6QeZIf518LtkizIYHRo7FHRpuh3zd28bJV7WSiSg=",
         "owner": "hyprwm",
         "repo": "Hyprland",
-        "rev": "208f4c48dbe081b00262a834e083bab1b0c9fbf8",
+        "rev": "72cb5d24b6894334da021157c626556a8e99b6ff",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                                                                |
| ------------------------------------------------------------------------------------------------ | ---------------------------------------------------------------------- |
| [`72cb5d24`](https://github.com/hyprwm/Hyprland/commit/72cb5d24b6894334da021157c626556a8e99b6ff) | `` permissions: disable automatic reloading of permissions from cfg `` |
| [`9868b183`](https://github.com/hyprwm/Hyprland/commit/9868b18378e99c8123a24fa4b152a58d5c0bfe67) | `` input: don't use pointer hold logic for unmapped surfs ``           |