### PR TITLE
chore(flake/home-manager): `ca39b348` -> `d2b3e6c8`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -496,11 +496,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1745986532,
-        "narHash": "sha256-1ReJZBsXZLmEn4Wyc0dMICVoUZhq2f7z/E31idnAWmg=",
+        "lastModified": 1745987135,
+        "narHash": "sha256-8Up4QPuMZEJBU0eefAY+nUe7DYKQQzvaHnMpNdwRgKA=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "ca39b348299bb772a7cca2271cef9b91845a390a",
+        "rev": "d2b3e6c83d457aa0e7f9344c61c3fed32bad0f7e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                          |
| ----------------------------------------------------------------------------------------------------------- | -------------------------------- |
| [`d2b3e6c8`](https://github.com/nix-community/home-manager/commit/d2b3e6c83d457aa0e7f9344c61c3fed32bad0f7e) | `` flake.lock: Update (#6937) `` |