### PR TITLE
chore(flake/nixpkgs-stable): `330d0a41` -> `b000159b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1030,11 +1030,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1745868005,
-        "narHash": "sha256-hZScOyQphT4RUmSEJX+2OxjIlGgLwSd8iW1LNtAWIOs=",
+        "lastModified": 1745921652,
+        "narHash": "sha256-hEAvEN+y/OQ7wA7+u3bFJwXSe8yoSf2QaOMH3hyTJTQ=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "330d0a4167924b43f31cc9406df363f71b768a02",
+        "rev": "b000159bba69b0106a42f65e52dbf27f77aca9d3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                   |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------- |
| [`88bf4f78`](https://github.com/NixOS/nixpkgs/commit/88bf4f78bed3d97bcb63e01129829d8881f7c82d) | `` virtualbox/virtualboxGuestAdditions: update/fix license to gpl3Only `` |
| [`f60a1fe1`](https://github.com/NixOS/nixpkgs/commit/f60a1fe18cbcced3441ccd941397195766fd2455) | `` firefox-bin-unwrapped: 137.0.2 -> 138.0 ``                             |
| [`ce64a7fe`](https://github.com/NixOS/nixpkgs/commit/ce64a7fe26624efd87edeb3d13eb121b2fbc8dcd) | `` firefox-esr-128-unwrapped: 128.9.0esr -> 128.10.0esr ``                |
| [`fa1778ba`](https://github.com/NixOS/nixpkgs/commit/fa1778baa89b970f3dd3e6880ac59400a1ff802b) | `` firefox-unwrapped: 137.0.2 -> 138.0 ``                                 |
| [`9429127d`](https://github.com/NixOS/nixpkgs/commit/9429127d6cc8ccbaf60c9bc2b9ed3e15a7c6bd91) | `` rust-cbindgen: 0.27.0 -> 0.28.0 ``                                     |
| [`01e594d3`](https://github.com/NixOS/nixpkgs/commit/01e594d36465496e77753e40486e95e6fb0ab603) | `` amazon-ssm-agent: 3.3.1802.0 -> 3.3.1957.0 ``                          |