### PR TITLE
chore(flake/hyprland): `b2ad21a6` -> `5d005f11`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -625,11 +625,11 @@
         "xdph": "xdph"
       },
       "locked": {
-        "lastModified": 1745994418,
-        "narHash": "sha256-6XBBacpZfBGpNLiE48AALuRdMfpf1KzzdG3zHiY2jdg=",
+        "lastModified": 1746018443,
+        "narHash": "sha256-8eC5ZKHil0fgK8cmYZcDZyhRU0XlgcYy2ggIGmLBUIU=",
         "owner": "hyprwm",
         "repo": "Hyprland",
-        "rev": "b2ad21a65c9801012cdb4cb49a94257c0e44adf6",
+        "rev": "5d005f11fa218d26ed2cf6ce75cd9aac9c2c00e5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                                                 |
| ------------------------------------------------------------------------------------------------ | ------------------------------------------------------- |
| [`5d005f11`](https://github.com/hyprwm/Hyprland/commit/5d005f11fa218d26ed2cf6ce75cd9aac9c2c00e5) | `` xdg-bell: fix wrong resource cast ``                 |
| [`54c89104`](https://github.com/hyprwm/Hyprland/commit/54c89104de0fca8d2e1df411bfb53d5c09a5fc5e) | `` DonationNag: ask after each major update (#10213) `` |