### PR TITLE
chore(flake/home-manager): `d2b3e6c8` -> `5f217e5a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -496,11 +496,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1745987135,
-        "narHash": "sha256-8Up4QPuMZEJBU0eefAY+nUe7DYKQQzvaHnMpNdwRgKA=",
+        "lastModified": 1746040799,
+        "narHash": "sha256-osgPX/SzIpkR50vev/rqoTEAVkEcOWXoQXmbzsaI4KU=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "d2b3e6c83d457aa0e7f9344c61c3fed32bad0f7e",
+        "rev": "5f217e5a319f6c186283b530f8c975e66c028433",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                      |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------ |
| [`5f217e5a`](https://github.com/nix-community/home-manager/commit/5f217e5a319f6c186283b530f8c975e66c028433) | `` restic: change service type from `simple` to `oneshot` `` |
| [`7f301a4d`](https://github.com/nix-community/home-manager/commit/7f301a4d968f3b846efde5a43455d959b69a348f) | `` restic: fix certain integration tests ``                  |
| [`272eb00d`](https://github.com/nix-community/home-manager/commit/272eb00d1396bd86e77ebefd1abc47dfcab837b3) | `` fcitx5: ensure config doesn't get overwritten (#6940) ``  |
| [`c9c2c1a1`](https://github.com/nix-community/home-manager/commit/c9c2c1a14e8d6292857272a0a56a4213664ec8fa) | `` kime: fix systemd service (#6911) ``                      |