### PR TITLE
chore(flake/hyprland): `2ee5118d` -> `8d661810`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -625,11 +625,11 @@
         "xdph": "xdph"
       },
       "locked": {
-        "lastModified": 1746030925,
-        "narHash": "sha256-D0qU3BhDg9XrU1S/DdozBPnWViGPtyRYhsgOrDAP/Gs=",
+        "lastModified": 1746050800,
+        "narHash": "sha256-HJDWf9ONdaZ0UIbadwE0l++AOrnCOaRrikBcuzDnNvs=",
         "owner": "hyprwm",
         "repo": "Hyprland",
-        "rev": "2ee5118d7a4a59d3ccfaed305bfc05c79cea7637",
+        "rev": "8d6618104e28f6444d917b398244c56ac32ae993",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                                            |
| ------------------------------------------------------------------------------------------------ | -------------------------------------------------- |
| [`8d661810`](https://github.com/hyprwm/Hyprland/commit/8d6618104e28f6444d917b398244c56ac32ae993) | `` cmake: ignore Wclobbered ``                     |
| [`50e1bec8`](https://github.com/hyprwm/Hyprland/commit/50e1bec85f8febdd78f50d94f140d07f9b34148d) | `` helpers: refactor class member vars (#10218) `` |
| [`b8a204c2`](https://github.com/hyprwm/Hyprland/commit/b8a204c21d6b36a5b3ccf4c125553c61a9fd6b90) | `` ci: minor fixes to glaze ``                     |