### PR TITLE
chore(flake/zen-browser): `05d25edd` -> `c81169fc`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1550,11 +1550,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1746055080,
-        "narHash": "sha256-eptxPbYHOgzNYmgsjRdpdak/PxzR0CDYAV0x0+Me6ys=",
+        "lastModified": 1746068231,
+        "narHash": "sha256-wVibcbbNiDgSfOCW2J4xWlIlgBYnSn6/Zg1k2wadTEg=",
         "owner": "0xc000022070",
         "repo": "zen-browser-flake",
-        "rev": "05d25edde8197beba3026e5922a519fbf6359c64",
+        "rev": "c81169fc88c2e54f6b765fa926e24ec465bce42e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                          | Message                                                               |
| --------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------- |
| [`c81169fc`](https://github.com/0xc000022070/zen-browser-flake/commit/c81169fc88c2e54f6b765fa926e24ec465bce42e) | `` chore: add issue template for bug reports (#56) ``                 |
| [`115e6a25`](https://github.com/0xc000022070/zen-browser-flake/commit/115e6a25fd1883598ee8d7eef0a0032a3abf4176) | `` chore(update): twilight @ x86_64 && aarch64 to 1.12t#1746055470 `` |