### PR TITLE
chore(flake/zen-browser): `c81169fc` -> `467a4e32`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1550,11 +1550,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1746068231,
-        "narHash": "sha256-wVibcbbNiDgSfOCW2J4xWlIlgBYnSn6/Zg1k2wadTEg=",
+        "lastModified": 1746069381,
+        "narHash": "sha256-tuKmt3dej84Xid/4igmMg93FPCUBE8I0QjdWc1QZi34=",
         "owner": "0xc000022070",
         "repo": "zen-browser-flake",
-        "rev": "c81169fc88c2e54f6b765fa926e24ec465bce42e",
+        "rev": "467a4e3215a6f1981565ab59c04ef64c91c3f4f1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                          | Message                                                               |
| --------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------- |
| [`467a4e32`](https://github.com/0xc000022070/zen-browser-flake/commit/467a4e3215a6f1981565ab59c04ef64c91c3f4f1) | `` chore(update): twilight @ x86_64 && aarch64 to 1.12t#1746069091 `` |