### PR TITLE
chore(flake/nixpkgs-stable): `b000159b` -> `3e362ce6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1030,11 +1030,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1745921652,
-        "narHash": "sha256-hEAvEN+y/OQ7wA7+u3bFJwXSe8yoSf2QaOMH3hyTJTQ=",
+        "lastModified": 1746055187,
+        "narHash": "sha256-3dqArYSMP9hM7Qpy5YWhnSjiqniSaT2uc5h2Po7tmg0=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "b000159bba69b0106a42f65e52dbf27f77aca9d3",
+        "rev": "3e362ce63e16b9572d8c2297c04f7c19ab6725a5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                               |
| ---------------------------------------------------------------------------------------------- | --------------------------------------------------------------------- |
| [`9dac1e48`](https://github.com/NixOS/nixpkgs/commit/9dac1e48e696a9fdd9ba911eec373ca24a28fe37) | `` electron_33-bin: 33.4.10 -> 33.4.11 ``                             |
| [`8b1707bb`](https://github.com/NixOS/nixpkgs/commit/8b1707bb86348d3a72e18ff58ced34ac355b48f0) | `` electron-chromedriver_33: 33.4.10 -> 33.4.11 ``                    |
| [`62d7956b`](https://github.com/NixOS/nixpkgs/commit/62d7956b592e9844768bb75f04232fee1cc453da) | `` electron-chromedriver_35: 35.2.0 -> 35.2.1 ``                      |
| [`0748b156`](https://github.com/NixOS/nixpkgs/commit/0748b1567dfe5527f517d7c3d557542b46da733c) | `` electron_35-bin: 35.2.0 -> 35.2.1 ``                               |
| [`34391430`](https://github.com/NixOS/nixpkgs/commit/3439143037e64087679ea950238f38bc1eabe3fd) | `` electron-chromedriver_34: 34.5.2 -> 34.5.3 ``                      |
| [`b40818a0`](https://github.com/NixOS/nixpkgs/commit/b40818a0655e7ced0348403ab6e61d16b8607420) | `` electron_34-bin: 34.5.2 -> 34.5.3 ``                               |
| [`98bc82ff`](https://github.com/NixOS/nixpkgs/commit/98bc82ff4446589948fe938f08481f11355feaf9) | `` electron-source.electron_35: 35.2.0 -> 35.2.1 ``                   |
| [`051077c8`](https://github.com/NixOS/nixpkgs/commit/051077c8b771d4ee953fba4a8baed7bec4c339c6) | `` electron-source.electron_34: 34.5.2 -> 34.5.3 ``                   |
| [`34a1afce`](https://github.com/NixOS/nixpkgs/commit/34a1afcea1cb3bdb974f2c543be1be0664e80097) | `` google-chrome: 135.0.7049.114 -> 136.0.7103.59 ``                  |
| [`7f29082c`](https://github.com/NixOS/nixpkgs/commit/7f29082ced1058d7a83547f3a135a2389081a406) | `` necesse-server: 0.32.1-18110069 -> 0.32.1-18204230 ``              |
| [`e95ad982`](https://github.com/NixOS/nixpkgs/commit/e95ad982067f00def169d32704f0959659d32e0a) | `` chromium,chromedriver: 135.0.7049.114 -> 136.0.7103.59 ``          |
| [`444d029b`](https://github.com/NixOS/nixpkgs/commit/444d029bbbeb942491ec946b86a6123cbc26437c) | `` linux_testing: 6.15-rc3 -> 6.15-rc4 ``                             |
| [`28ccf31b`](https://github.com/NixOS/nixpkgs/commit/28ccf31b84d1e536b0f5c782cfaf87b67d5eae37) | `` snipe-it: 8.0.4 -> 8.1.0 ``                                        |
| [`6816200a`](https://github.com/NixOS/nixpkgs/commit/6816200a0747f393c4a09a2e945aca6e98bec17b) | `` floorp: 11.25.0 -> 11.26.0 ``                                      |
| [`05941f03`](https://github.com/NixOS/nixpkgs/commit/05941f03f1a0293aa3e6cdf1ed19a0d42a9c5556) | `` chromium: fix `print()` crashing ``                                |
| [`a5266000`](https://github.com/NixOS/nixpkgs/commit/a526600020f45afad095c48c53ff3407325fe871) | `` libblake3: fix duplicate patch fields ``                           |
| [`58623d3f`](https://github.com/NixOS/nixpkgs/commit/58623d3f991e8e675a182bbf50e892ac7e98849d) | `` libblake3: fix FreeBSD cross-compile builds ``                     |
| [`469c1b9e`](https://github.com/NixOS/nixpkgs/commit/469c1b9e7fc4b0def62f11bea19231971adfcc7f) | `` tbb: fix tests on FreeBSD and Windows ``                           |
| [`3967834c`](https://github.com/NixOS/nixpkgs/commit/3967834c3fcbf5a2b6d2be322bf7e6eea1c5454a) | `` tbb_{2021_11,2022_0}: Fix build on Windows ``                      |
| [`b398eb08`](https://github.com/NixOS/nixpkgs/commit/b398eb08e53e0b824615f2e38a71b7a68fd36f09) | `` tbb_{2021_11,2022_0}: Use Ninja, build in parallel ``              |
| [`a0d91fed`](https://github.com/NixOS/nixpkgs/commit/a0d91feda2ac62d8b54368a4e75cb126bb9d9144) | `` libblake3: Use tbb32 pkgconfig package on 32-bit builds ``         |
| [`a37f6597`](https://github.com/NixOS/nixpkgs/commit/a37f659788ca8024d363f8513e71b7043553a01f) | `` openresty: 1.27.1.1 -> 1.27.1.2 ``                                 |
| [`9ff0b592`](https://github.com/NixOS/nixpkgs/commit/9ff0b5925a5da7577001646a88357096fc068ba4) | `` tail-tray: 0.2.20 -> 0.2.21 ``                                     |
| [`2f7056c0`](https://github.com/NixOS/nixpkgs/commit/2f7056c04e423559bc679a70aeb6619b4ab02835) | `` thunderbird-bin-unwrapped: 128.9.1esr -> 128.9.2esr ``             |
| [`b5ccac50`](https://github.com/NixOS/nixpkgs/commit/b5ccac5054bd7260cf4ee56386911d2fc2f5c602) | `` [BACKPORT 24.11] oxidized: 0.30.1 -> 0.33.0 ``                     |
| [`5f944c4d`](https://github.com/NixOS/nixpkgs/commit/5f944c4d65d7454e19c870b15405b1c52118d709) | `` [BACKPORT 24.11] localized: Migrate ruby admin tools to by-name `` |
| [`e08d897a`](https://github.com/NixOS/nixpkgs/commit/e08d897a3ddd19d407db8077c68bf400d6152059) | `` dotnet-sdk: limit code signing to osx targets ``                   |
| [`7ae29af3`](https://github.com/NixOS/nixpkgs/commit/7ae29af33b2c56f21ce39c675137c0fd85a9662d) | `` starship: add sigmasquadron to meta.maintainers ``                 |
| [`f9cfdf58`](https://github.com/NixOS/nixpkgs/commit/f9cfdf58a7bad56bf29387c1d45fc41c972a098c) | `` starship: migrate to by-name ``                                    |
| [`e937cba9`](https://github.com/NixOS/nixpkgs/commit/e937cba9afe6cd896b785496cdd78412c616f1e8) | `` starship: remove darwin sdks ``                                    |
| [`045bdaaa`](https://github.com/NixOS/nixpkgs/commit/045bdaaab4259af9a5b85a20c8bc1aa459597737) | `` starship: emulate shell completions ``                             |
| [`e554ddfc`](https://github.com/NixOS/nixpkgs/commit/e554ddfc3805980db6554595eb9b503df2c97568) | `` starship: add downloadPage and changelog ``                        |
| [`11a33d4d`](https://github.com/NixOS/nixpkgs/commit/11a33d4dd9ce4ccc6684aeaba445697522ad3b4b) | `` starship: migrate to finalAttrs, remove with lib ``                |
| [`49b20a96`](https://github.com/NixOS/nixpkgs/commit/49b20a96999c79144ed51350248e8c1078bf65eb) | `` starship: remove davidtwco as maintainer ``                        |
| [`2c6f02b1`](https://github.com/NixOS/nixpkgs/commit/2c6f02b197257f7d2eddebac662975f4d9118562) | `` starship: migrate to `fetchCargoVendor` ``                         |
| [`b3724fb9`](https://github.com/NixOS/nixpkgs/commit/b3724fb9878642277d195184e9d6146e75c82e8d) | `` starship: 1.21.1 -> 1.22.1 ``                                      |
| [`9cb544b0`](https://github.com/NixOS/nixpkgs/commit/9cb544b0200a4be8734e6a179ffa59fda1d57bce) | `` firefox-devedition-bin-unwrapped: 138.0b7 -> 138.0b9 ``            |