### PR TITLE
chore(flake/home-manager): `5f217e5a` -> `81431b6d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -496,11 +496,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1746040799,
-        "narHash": "sha256-osgPX/SzIpkR50vev/rqoTEAVkEcOWXoQXmbzsaI4KU=",
+        "lastModified": 1746130285,
+        "narHash": "sha256-pWSSUkba57gjbvUTC7xknNOGjpGeVt2lFsViHFYNYdA=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "5f217e5a319f6c186283b530f8c975e66c028433",
+        "rev": "81431b6d6fa756db641109461fc943ba23b550b7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                           |
| ----------------------------------------------------------------------------------------------------------- | --------------------------------- |
| [`81431b6d`](https://github.com/nix-community/home-manager/commit/81431b6d6fa756db641109461fc943ba23b550b7) | `` gpg-agent: fix typo (#6950) `` |