### PR TITLE
chore(flake/better-control): `d999c3f6` -> `69c2865f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -210,11 +210,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1746078028,
-        "narHash": "sha256-ru7KERK7r/BcAdrMZ2FJeqjdjmY+TbuguYtDIvHaW3Y=",
+        "lastModified": 1746152828,
+        "narHash": "sha256-qfM/WQS9HQKRESN3SG9aufsgK/JPpC4+21Ur/k1r8cc=",
         "owner": "rishabh5321",
         "repo": "better-control-flake",
-        "rev": "d999c3f649011d5580259e0217a59319d79a6a34",
+        "rev": "69c2865f4a86070d9947361df5a3350e49d5e149",
         "type": "github"
       },
       "original": {
@@ -1046,11 +1046,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1745930157,
-        "narHash": "sha256-y3h3NLnzRSiUkYpnfvnS669zWZLoqqI6NprtLQ+5dck=",
+        "lastModified": 1746064326,
+        "narHash": "sha256-r7IZkN9NhK/IO9/J6D9ih2P1OXb67nr5HaQ1YAte18w=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "46e634be05ce9dc6d4db8e664515ba10b78151ae",
+        "rev": "91bf6dffa21c7709607c9fdbf9a6acb44e7a0a5d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                            | Message                                          |
| ----------------------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
| [`69c2865f`](https://github.com/Rishabh5321/better-control-flake/commit/69c2865f4a86070d9947361df5a3350e49d5e149) | `` chore(flake/nixpkgs): 46e634be -> 91bf6dff `` |