### PR TITLE
chore(flake/stylix): `716e6669` -> `bc386295`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1291,11 +1291,11 @@
         "tinted-zed": "tinted-zed"
       },
       "locked": {
-        "lastModified": 1746111784,
-        "narHash": "sha256-94MEscICizhXBJvP5o6f9lcY2vWXTSg1XKZZbS19Yso=",
+        "lastModified": 1746158690,
+        "narHash": "sha256-Pe2emz36QL8GOILXvvmH/agqkspZFrcOrQxv6uufaEc=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "716e6669a9840e4ba0d8deb6ab1d016ef01c475a",
+        "rev": "bc38629511dd9cc78c5ca37a6e546fa66330d50e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                        | Message                                 |
| --------------------------------------------------------------------------------------------- | --------------------------------------- |
| [`bc386295`](https://github.com/danth/stylix/commit/bc38629511dd9cc78c5ca37a6e546fa66330d50e) | `` glance: init nixos module (#1187) `` |
| [`87df2a1d`](https://github.com/danth/stylix/commit/87df2a1d9c0171bcba7dfc3ad9179c40befaf07b) | `` eog: add testbed (#1200) ``          |