### PR TITLE
chore(flake/home-manager): `1298a341` -> `f045bd46`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -496,11 +496,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1746169624,
-        "narHash": "sha256-oIAZDng5FYQXnmGJrK4WZX2tsQ1nmxHd9OrcySm/Jf4=",
+        "lastModified": 1746177088,
+        "narHash": "sha256-hmHKl4meWr6ryzqQAwRD3+3Ihfb/Y/0CbK+WnE+oa6Q=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "1298a3418be1a875e9ae6643770b0939814cd441",
+        "rev": "f045bd46b73c3b0ed4e46cdb6036b3d5823d7dee",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                               |
| ----------------------------------------------------------------------------------------------------------- | ----------------------------------------------------- |
| [`f045bd46`](https://github.com/nix-community/home-manager/commit/f045bd46b73c3b0ed4e46cdb6036b3d5823d7dee) | `` fish: keep all fish-completions packages around `` |
| [`361ab448`](https://github.com/nix-community/home-manager/commit/361ab4484e7b91a7b6bdedc6784e2a44d20a3dce) | `` home-environment: add `home.extraDependencies` ``  |