### PR TITLE
chore(flake/akuse-flake): `8c999061` -> `0be0a18b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -48,11 +48,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1746150640,
-        "narHash": "sha256-erwynzv07997c8FP8eLb2EJIkc4s9F0jGNLTJjtEo24=",
+        "lastModified": 1746174633,
+        "narHash": "sha256-IexqqkjUW9ENl9JVHjINyee2DvTv3YVmut162FC7aD8=",
         "owner": "Rishabh5321",
         "repo": "akuse-flake",
-        "rev": "8c9990615f9a2f3dea40b7641a4066fc8f9f5459",
+        "rev": "0be0a18bd88402c6bd9b99741767e3d026f7f632",
         "type": "github"
       },
       "original": {
@@ -999,11 +999,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1746064326,
-        "narHash": "sha256-r7IZkN9NhK/IO9/J6D9ih2P1OXb67nr5HaQ1YAte18w=",
+        "lastModified": 1746141548,
+        "narHash": "sha256-IgBWhX7A2oJmZFIrpRuMnw5RAufVnfvOgHWgIdds+hc=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "91bf6dffa21c7709607c9fdbf9a6acb44e7a0a5d",
+        "rev": "f02fddb8acef29a8b32f10a335d44828d7825b78",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                   | Message                                          |
| -------------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
| [`0be0a18b`](https://github.com/Rishabh5321/akuse-flake/commit/0be0a18bd88402c6bd9b99741767e3d026f7f632) | `` chore(flake/nixpkgs): 91bf6dff -> f02fddb8 `` |