### PR TITLE
chore(flake/zen-browser): `a6c831b1` -> `5302618e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1550,11 +1550,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1746159736,
-        "narHash": "sha256-ZSLHyWzjCMtwQwVxHpki+bnsb46mMzkVtx1T/kRHO2g=",
+        "lastModified": 1746189486,
+        "narHash": "sha256-+fggfEtZc3wG/53OB0GTjLp75dZcKewmO4SfbfmUNS8=",
         "owner": "0xc000022070",
         "repo": "zen-browser-flake",
-        "rev": "a6c831b152c2da4b868db44dfd70a160f8039365",
+        "rev": "5302618e43d74140deaff99567ef2a79ed25a951",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                          | Message                                                               |
| --------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------- |
| [`5302618e`](https://github.com/0xc000022070/zen-browser-flake/commit/5302618e43d74140deaff99567ef2a79ed25a951) | `` chore(update): twilight @ x86_64 && aarch64 to 1.12t#1746188053 `` |