### PR TITLE
chore(flake/home-manager): `f045bd46` -> `2eabb26d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -496,11 +496,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1746177088,
-        "narHash": "sha256-hmHKl4meWr6ryzqQAwRD3+3Ihfb/Y/0CbK+WnE+oa6Q=",
+        "lastModified": 1746192237,
+        "narHash": "sha256-2FJhmmq+G8ub+vYbrY/b02rIfS+5lbzkU1G2jKkWIaU=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "f045bd46b73c3b0ed4e46cdb6036b3d5823d7dee",
+        "rev": "2eabb26d0859c7710a2aa76c3b0ff4149f41b04a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                                              |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------ |
| [`2eabb26d`](https://github.com/nix-community/home-manager/commit/2eabb26d0859c7710a2aa76c3b0ff4149f41b04a) | `` restic: allow the convenience script to source environmentFile (#6947) ``         |
| [`f15be4fe`](https://github.com/nix-community/home-manager/commit/f15be4feb6e98fc2c52d4f8088400619381fd171) | `` clipcat: add module (#6946) ``                                                    |
| [`c5cad190`](https://github.com/nix-community/home-manager/commit/c5cad190ba252eb94540ee06955a53c7807963f8) | `` zsh: update doc to show how to add `initContent` at multiple location. (#6945) `` |
| [`669e813c`](https://github.com/nix-community/home-manager/commit/669e813c752696c66ad7e1cd34b65ee4315058d9) | `` element-desktop: add module (#6935) ``                                            |