### PR TITLE
chore(flake/home-manager): `355a6b93` -> `d6b0c054`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -496,11 +496,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1746193516,
-        "narHash": "sha256-7KqthzbP7LbJpo6DtxlTg2Fqcs7HL1iV1vd1mM8q/u0=",
+        "lastModified": 1746202459,
+        "narHash": "sha256-t0Pcnn+BAABOmGhpBmvSFE1qz7HQwYsZrhN7t3NLCtE=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "355a6b937d07a95cb0b753ef513bcaad09128dea",
+        "rev": "d6b0c054571a444acd2755b038bb7df5eb7954a7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                            |
| ----------------------------------------------------------------------------------------------------------- | ---------------------------------- |
| [`d6b0c054`](https://github.com/nix-community/home-manager/commit/d6b0c054571a444acd2755b038bb7df5eb7954a7) | `` visidata: add module (#6956) `` |