### PR TITLE
chore(flake/hyprland): `f1ac1847` -> `77ecf095`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -625,11 +625,11 @@
         "xdph": "xdph"
       },
       "locked": {
-        "lastModified": 1746198526,
-        "narHash": "sha256-cQh+oXVAUUhX56zz++w3whOfAYvLeq8evtO1sHUlDcw=",
+        "lastModified": 1746199755,
+        "narHash": "sha256-2Gupr6m6FN9daVsk5zFkALknBpiDGV75PAY4Pdj7Mzw=",
         "owner": "hyprwm",
         "repo": "Hyprland",
-        "rev": "f1ac1847ffaccad9d4faf2e47066202d7ab915d1",
+        "rev": "77ecf0950685c7872b3aa8c2e63ef4147b0bb685",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                                           |
| ------------------------------------------------------------------------------------------------ | ------------------------------------------------- |
| [`77ecf095`](https://github.com/hyprwm/Hyprland/commit/77ecf0950685c7872b3aa8c2e63ef4147b0bb685) | `` internal: fix name confusion in SAlphaValue `` |