### PR TITLE
chore(flake/hyprland): `77ecf095` -> `0c736217`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -625,11 +625,11 @@
         "xdph": "xdph"
       },
       "locked": {
-        "lastModified": 1746199755,
-        "narHash": "sha256-2Gupr6m6FN9daVsk5zFkALknBpiDGV75PAY4Pdj7Mzw=",
+        "lastModified": 1746204835,
+        "narHash": "sha256-tJ34GENiaSYNP4Tll0GFMgXkcaeDpubCZNJWE6UxFhg=",
         "owner": "hyprwm",
         "repo": "Hyprland",
-        "rev": "77ecf0950685c7872b3aa8c2e63ef4147b0bb685",
+        "rev": "0c736217a787928a87224b2bf7e984c446d4fc22",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                                          |
| ------------------------------------------------------------------------------------------------ | ------------------------------------------------ |
| [`0c736217`](https://github.com/hyprwm/Hyprland/commit/0c736217a787928a87224b2bf7e984c446d4fc22) | `` configmgr: fix CConfigValue<> from plugins `` |