### PR TITLE
chore(flake/nix-gaming): `549ba3a2` -> `ab98c9e2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -984,11 +984,11 @@
         "nixpkgs": "nixpkgs_4"
       },
       "locked": {
-        "lastModified": 1746150788,
-        "narHash": "sha256-Qm1EB+wOEjEKak4i1N+A9m/UyKZEjn8QLZcPvYmTV8s=",
+        "lastModified": 1746208853,
+        "narHash": "sha256-VbXKCng1+r4mUQ8z9wVxpqsqn2cYPmt1OwEhakgeF+E=",
         "owner": "fufexan",
         "repo": "nix-gaming",
-        "rev": "549ba3a2d141b8160fa129e3cc4fad5769dc2a8a",
+        "rev": "ab98c9e25a69619dde4b574789b617dd025ff8e3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                              | Message                         |
| --------------------------------------------------------------------------------------------------- | ------------------------------- |
| [`ab98c9e2`](https://github.com/fufexan/nix-gaming/commit/ab98c9e25a69619dde4b574789b617dd025ff8e3) | `` dxvk-nvapi: init at 0.9.0 `` |