### PR TITLE
chore(flake/nixpkgs-stable): `3e362ce6` -> `bf3287da`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1030,11 +1030,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1746055187,
-        "narHash": "sha256-3dqArYSMP9hM7Qpy5YWhnSjiqniSaT2uc5h2Po7tmg0=",
+        "lastModified": 1746183838,
+        "narHash": "sha256-kwaaguGkAqTZ1oK0yXeQ3ayYjs8u/W7eEfrFpFfIDFA=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "3e362ce63e16b9572d8c2297c04f7c19ab6725a5",
+        "rev": "bf3287dac860542719fe7554e21e686108716879",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                   |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------- |
| [`06997bcd`](https://github.com/NixOS/nixpkgs/commit/06997bcdc16be53cb6c672242d1a3c7fdadb7781) | `` coqPackages.coq-elpi: enable to override ocamlPackages.elpi version `` |
| [`3a0c9b20`](https://github.com/NixOS/nixpkgs/commit/3a0c9b20e5749402d647cf09316bb1b0fb310945) | `` coqPackages.coq-elpi: fix indentation ``                               |
| [`66390702`](https://github.com/NixOS/nixpkgs/commit/66390702e5bc609435a2fb5b14d842fe4d7b46ee) | `` firefox-bin-unwrapped: 138.0 -> 138.0.1 ``                             |
| [`98add98f`](https://github.com/NixOS/nixpkgs/commit/98add98f48c15079f0bce63004c7390956f4daa8) | `` firefox-unwrapped: 138.0 -> 138.0.1 ``                                 |
| [`a9646f88`](https://github.com/NixOS/nixpkgs/commit/a9646f88c622b4f95c47b1679dea1720adc674d7) | `` yt-dlp: 2025.3.31 -> 2025.4.30 ``                                      |
| [`cd7cff23`](https://github.com/NixOS/nixpkgs/commit/cd7cff2360770e96cedc6b5b02bd7070156c8a40) | `` yt-dlp: 2025.3.27 -> 2025.3.31 ``                                      |
| [`b3954b63`](https://github.com/NixOS/nixpkgs/commit/b3954b631f51719794c9f7352ae4acb6c62711f3) | `` yt-dlp: 2025.03.26 -> 2025.03.27 ``                                    |
| [`ea3ebc19`](https://github.com/NixOS/nixpkgs/commit/ea3ebc19b92ab15ce2f9ea7e76a6cfe8d8aaa0d3) | `` ci/eval: output per chunk stats ``                                     |
| [`a9a0822f`](https://github.com/NixOS/nixpkgs/commit/a9a0822f1db24fb58c30a19eec1eb7c51f9c9680) | `` consul: 1.20.5 -> 1.20.6 ``                                            |
| [`f9899afa`](https://github.com/NixOS/nixpkgs/commit/f9899afa1e9def22b70254647a88ac4f51374b1f) | `` ungoogled-chromium: 135.0.7049.114-1 -> 136.0.7103.59-1 ``             |
| [`ff28bdaa`](https://github.com/NixOS/nixpkgs/commit/ff28bdaa43721eb3abbbd86f81d2e90409c164c0) | `` thunderbird-unwrapped: 137.0.2 -> 138.0 ``                             |
| [`3d327b12`](https://github.com/NixOS/nixpkgs/commit/3d327b12a9ef0497ad8f8a1c613737f29a42dd3b) | `` redmine: 5.1.7 -> 5.1.8 ``                                             |
| [`68a2973a`](https://github.com/NixOS/nixpkgs/commit/68a2973ae0888832673a07ddccb5850d645dd2f7) | `` linuxKernel.kernels.linux_lqx: 6.14.3-lqx1 -> 6.14.4-lqx1 ``           |
| [`63831522`](https://github.com/NixOS/nixpkgs/commit/63831522ed885b8cd22c178042287db6d05241ad) | `` linuxKernel.kernels.linux_zen: 6.14.3-zen1 -> 6.14.4-zen1 ``           |