### PR TITLE
chore(flake/stylix): `bc386295` -> `953e7247`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1291,11 +1291,11 @@
         "tinted-zed": "tinted-zed"
       },
       "locked": {
-        "lastModified": 1746158690,
-        "narHash": "sha256-Pe2emz36QL8GOILXvvmH/agqkspZFrcOrQxv6uufaEc=",
+        "lastModified": 1746223791,
+        "narHash": "sha256-R/DWYbY+Yr/QULujNlozfBUU2s9nZPoRikjIGPTYcR8=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "bc38629511dd9cc78c5ca37a6e546fa66330d50e",
+        "rev": "953e7247ac340e5036f8af47eaccf1a23f1a0257",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                        | Message                                 |
| --------------------------------------------------------------------------------------------- | --------------------------------------- |
| [`953e7247`](https://github.com/danth/stylix/commit/953e7247ac340e5036f8af47eaccf1a23f1a0257) | `` mpv: more sensible values (#1199) `` |