### PR TITLE
chore(flake/zen-browser): `51f70fd2` -> `97ce051e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1550,11 +1550,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1746217277,
-        "narHash": "sha256-+91Irf6OzLM+6tm84lMUd8fSXVFEP/NjMDVJod0zUxY=",
+        "lastModified": 1746241415,
+        "narHash": "sha256-wJ8rmhNvJVKgasY36hmaSf4QlzcAvZEcc0iCrjtrb4A=",
         "owner": "0xc000022070",
         "repo": "zen-browser-flake",
-        "rev": "51f70fd2cb6642f8de983c783f31d9447b6057c6",
+        "rev": "97ce051e94db0ca08514acf411c6125adb195ea5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                          | Message                                                               |
| --------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------- |
| [`97ce051e`](https://github.com/0xc000022070/zen-browser-flake/commit/97ce051e94db0ca08514acf411c6125adb195ea5) | `` chore(update): twilight @ x86_64 && aarch64 to 1.12t#1746237445 `` |