### PR TITLE
chore(flake/home-manager): `1e8c62c6` -> `c0962eee`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -496,11 +496,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1746204974,
-        "narHash": "sha256-Evu4H0/kzaQoCNLGQTp+JGTqkywzPx0IAo20Ci2zNck=",
+        "lastModified": 1746243165,
+        "narHash": "sha256-DQycVmlyLQNLjLJ/FzpokVmbxGQ8HjQQ4zN4nyq2vII=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "1e8c62c651242fc685b10efc4a48ab777635fb7f",
+        "rev": "c0962eeeabfb8127713f859ec8a5f0e86dead0f2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                               |
| ----------------------------------------------------------------------------------------------------------- | ----------------------------------------------------- |
| [`c0962eee`](https://github.com/nix-community/home-manager/commit/c0962eeeabfb8127713f859ec8a5f0e86dead0f2) | `` thunderbird: fix accounts being removed (#6959) `` |
| [`123297c5`](https://github.com/nix-community/home-manager/commit/123297c57e77c692fae7e860e701823367afbec4) | `` onagre: add module (#6958) ``                      |