### PR TITLE
chore(flake/zen-browser): `fb75635e` -> `a25c9a70`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1550,11 +1550,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1746246154,
-        "narHash": "sha256-zEwSEAfrb4Y7QFa8Ae1rqkYwVUd6GxHIFoS34CvDEeM=",
+        "lastModified": 1746263898,
+        "narHash": "sha256-CVD0qXCo3Ia5u+w2YnBATVxyDpKAO3Xd2lOFrCmC20E=",
         "owner": "0xc000022070",
         "repo": "zen-browser-flake",
-        "rev": "fb75635e5679cf57dee4622ea13a1e8e55eff10b",
+        "rev": "a25c9a70ff59a22aec0ef938df190fcd1bf70bcf",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                          | Message                                                |
| --------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------ |
| [`a25c9a70`](https://github.com/0xc000022070/zen-browser-flake/commit/a25c9a70ff59a22aec0ef938df190fcd1bf70bcf) | `` chore(update): beta @ x86_64 && aarch64 to 1.12b `` |