### PR TITLE
chore(flake/spicetify-nix): `96d7adda` -> `c09c8cbc`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1254,11 +1254,11 @@
         "systems": "systems_4"
       },
       "locked": {
-        "lastModified": 1745983288,
-        "narHash": "sha256-XUNZDucHnw5SpTG3iJ8xrc6vGdVaP/5jlWErVjOdl/4=",
+        "lastModified": 1746287507,
+        "narHash": "sha256-XzxmpEUbCXcBS7H00QmTAQf9xrMdvaFHrprkwb4i9CU=",
         "owner": "Gerg-L",
         "repo": "spicetify-nix",
-        "rev": "96d7adda80b8bfc06fc0669b68a40feb2339fa95",
+        "rev": "c09c8cbc0d650d451e4b48d00c63831437dae1b2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                              |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------ |
| [`c09c8cbc`](https://github.com/Gerg-L/spicetify-nix/commit/c09c8cbc0d650d451e4b48d00c63831437dae1b2) | `` docs: use titles correctly ``     |
| [`58f93922`](https://github.com/Gerg-L/spicetify-nix/commit/58f93922ab8bea8a56ce44b94b65b97d33df7336) | `` refactor: remove docs subflake `` |
| [`3b75a034`](https://github.com/Gerg-L/spicetify-nix/commit/3b75a0348dea040e209bb9ca065436d8f192b14b) | `` test ``                           |