### PR TITLE
chore(flake/home-manager): `c0962eee` -> `75268f62`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -496,11 +496,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1746243165,
-        "narHash": "sha256-DQycVmlyLQNLjLJ/FzpokVmbxGQ8HjQQ4zN4nyq2vII=",
+        "lastModified": 1746287478,
+        "narHash": "sha256-z3HiHR2CNAdwyZTWPM2kkzhE1gD1G6ExPxkaiQfNh7s=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "c0962eeeabfb8127713f859ec8a5f0e86dead0f2",
+        "rev": "75268f62525920c4936404a056f37b91e299c97e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                                    |
| ----------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------- |
| [`75268f62`](https://github.com/nix-community/home-manager/commit/75268f62525920c4936404a056f37b91e299c97e) | `` tests: enable all firefox tests on darwin (plus derivations) (#6960) `` |
| [`929f8ee8`](https://github.com/nix-community/home-manager/commit/929f8ee8362aec0a2bcbcbbd485e86e701496a73) | `` thunderbird: deprecate darwinSetupWarning option (#6531) ``             |