### PR TITLE
chore(flake/hyprland): `cdf5736f` -> `46ac115b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -625,11 +625,11 @@
         "xdph": "xdph"
       },
       "locked": {
-        "lastModified": 1746281222,
-        "narHash": "sha256-Q+t43sBvv0+iq/jatZ7a+GACptpQ/7hZ/9xY6ODN5zw=",
+        "lastModified": 1746291290,
+        "narHash": "sha256-96SpKoIyUsRas+h6RhnPcgbduyH2j2YrujWpsuKdK8Q=",
         "owner": "hyprwm",
         "repo": "Hyprland",
-        "rev": "cdf5736f1a5e6cc1c3bb8fd50501ab17189725ea",
+        "rev": "46ac115bd19ee3aff5c816033de0b1d55a74e33f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                                                         |
| ------------------------------------------------------------------------------------------------ | --------------------------------------------------------------- |
| [`46ac115b`](https://github.com/hyprwm/Hyprland/commit/46ac115bd19ee3aff5c816033de0b1d55a74e33f) | `` protocols: refactor class member vars (types) (#10261) ``    |
| [`3465efcd`](https://github.com/hyprwm/Hyprland/commit/3465efcdc1d15402ca23e7ce609905c5814fb9ee) | `` internal: Use vecnotinrect instead of !vecinrect (#10262) `` |