### PR TITLE
chore(flake/akuse-flake): `0be0a18b` -> `bab6d26f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -48,11 +48,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1746174633,
-        "narHash": "sha256-IexqqkjUW9ENl9JVHjINyee2DvTv3YVmut162FC7aD8=",
+        "lastModified": 1746296994,
+        "narHash": "sha256-Ajo0Zl9nBVTiU3dY770va0HACFlhp8uUaYkfTm9MW6k=",
         "owner": "Rishabh5321",
         "repo": "akuse-flake",
-        "rev": "0be0a18bd88402c6bd9b99741767e3d026f7f632",
+        "rev": "bab6d26f2191a4de9e1a56aee67a2443da8ad11c",
         "type": "github"
       },
       "original": {
@@ -999,11 +999,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1746141548,
-        "narHash": "sha256-IgBWhX7A2oJmZFIrpRuMnw5RAufVnfvOgHWgIdds+hc=",
+        "lastModified": 1746232882,
+        "narHash": "sha256-MHmBH2rS8KkRRdoU/feC/dKbdlMkcNkB5mwkuipVHeQ=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "f02fddb8acef29a8b32f10a335d44828d7825b78",
+        "rev": "7a2622e2c0dbad5c4493cb268aba12896e28b008",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                   | Message                                          |
| -------------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
| [`bab6d26f`](https://github.com/Rishabh5321/akuse-flake/commit/bab6d26f2191a4de9e1a56aee67a2443da8ad11c) | `` chore(flake/nixpkgs): f02fddb8 -> 7a2622e2 `` |