### PR TITLE
chore(flake/stylix): `953e7247` -> `fe3feecf`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1291,11 +1291,11 @@
         "tinted-zed": "tinted-zed"
       },
       "locked": {
-        "lastModified": 1746223791,
-        "narHash": "sha256-R/DWYbY+Yr/QULujNlozfBUU2s9nZPoRikjIGPTYcR8=",
+        "lastModified": 1746296397,
+        "narHash": "sha256-FRMt4Gl18KLqz8lj8oRUSrzytrg9TDYm9D8KXP4tcKY=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "953e7247ac340e5036f8af47eaccf1a23f1a0257",
+        "rev": "fe3feecf23f8c71067c47a2cfaca5e86c8723450",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                        | Message                                                         |
| --------------------------------------------------------------------------------------------- | --------------------------------------------------------------- |
| [`fe3feecf`](https://github.com/danth/stylix/commit/fe3feecf23f8c71067c47a2cfaca5e86c8723450) | `` testbed: wrap autostart command in a shell script (#1204) `` |