### PR TITLE
chore(flake/home-manager): `75268f62` -> `621986fe`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -496,11 +496,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1746287478,
-        "narHash": "sha256-z3HiHR2CNAdwyZTWPM2kkzhE1gD1G6ExPxkaiQfNh7s=",
+        "lastModified": 1746317522,
+        "narHash": "sha256-/jZ4Wd4HHUEWPSlNj48k1E4Mh+1fUbwI/vSlPPIMG3U=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "75268f62525920c4936404a056f37b91e299c97e",
+        "rev": "621986fed37c5d0cb8df010ed8369694dc47c09b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------------ |
| [`621986fe`](https://github.com/nix-community/home-manager/commit/621986fed37c5d0cb8df010ed8369694dc47c09b) | `` i3bar-river: add module (#6967) ``                  |
| [`64f7d5e6`](https://github.com/nix-community/home-manager/commit/64f7d5e6b94e2e66e3b344fe8e002c9da97a57b1) | `` wofi: allow path to style.css (#6966) ``            |
| [`d1bbab6b`](https://github.com/nix-community/home-manager/commit/d1bbab6b04d865d759505f33a5c6743bbb544074) | `` mako: refactor (#6948) ``                           |
| [`94f4c666`](https://github.com/nix-community/home-manager/commit/94f4c66660faa994676176d1d3d94618a796c39e) | `` tests/darwinScrublist: add more packages (#6965) `` |