### PR TITLE
chore(flake/home-manager): `621986fe` -> `8a318641`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -496,11 +496,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1746317522,
-        "narHash": "sha256-/jZ4Wd4HHUEWPSlNj48k1E4Mh+1fUbwI/vSlPPIMG3U=",
+        "lastModified": 1746413188,
+        "narHash": "sha256-i6BoiQP0PasExESQHszC0reQHfO6D4aI2GzOwZMOI20=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "621986fed37c5d0cb8df010ed8369694dc47c09b",
+        "rev": "8a318641ac13d3bc0a53651feaee9560f9b2d89a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                          |
| ----------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------- |
| [`8a318641`](https://github.com/nix-community/home-manager/commit/8a318641ac13d3bc0a53651feaee9560f9b2d89a) | `` sway-easyfocus: add module (#6976) ``                         |
| [`5f1f4725`](https://github.com/nix-community/home-manager/commit/5f1f472565ee59b5001ae5022bbb1a9a64239f91) | `` mako: use ini atom type (#6977) ``                            |
| [`1a1793f6`](https://github.com/nix-community/home-manager/commit/1a1793f6d940d22c6e49753548c5b6cb7dc5545d) | `` ghostty: fix config syntax file location on darwin (#6970) `` |
| [`8167af65`](https://github.com/nix-community/home-manager/commit/8167af657c0aa58fbe1fabfe7cce0520380c1bb3) | `` mako: fix criterias typo (#6968) ``                           |
| [`3a185176`](https://github.com/nix-community/home-manager/commit/3a185176e48206026b8c1e6dc3f3a37ffff4b9f7) | `` flake.lock: Update (#6969) ``                                 |