### PR TITLE
chore(flake/zen-browser): `5c102e1a` -> `6d5c26cd`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1550,11 +1550,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1746350330,
-        "narHash": "sha256-8L7+rAUZWmD3cCW0ggdFM9N1uGxFFTp2L86JgPAZll4=",
+        "lastModified": 1746371925,
+        "narHash": "sha256-LBSLvDVgp/v4bBA0AtFBzEngYkHUuhmj/fDranW1E3A=",
         "owner": "0xc000022070",
         "repo": "zen-browser-flake",
-        "rev": "5c102e1af59678450d031e2688e5e052fd60b732",
+        "rev": "6d5c26cdb95e65113677a015afbc7244b9cf21b0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                          | Message                                                                 |
| --------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------- |
| [`6d5c26cd`](https://github.com/0xc000022070/zen-browser-flake/commit/6d5c26cdb95e65113677a015afbc7244b9cf21b0) | `` chore(update): twilight @ x86_64 && aarch64 to 1.12.1t#1746368857 `` |