### PR TITLE
chore(flake/stylix): `fa5a34e7` -> `003e6770`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1291,11 +1291,11 @@
         "tinted-zed": "tinted-zed"
       },
       "locked": {
-        "lastModified": 1746374571,
-        "narHash": "sha256-inzqQ93h/d7hNuNBiNCAYXos6KuXr4hGmiW/6ruTiHc=",
+        "lastModified": 1746377672,
+        "narHash": "sha256-iwX+GEcpdJRURUo5lJcHeSe+GssN7W5X8nTpv/EgDO8=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "fa5a34e7b1a8a7245d54790c6830cb3502c7cb76",
+        "rev": "003e6770af4af1e4a49112ecb0ce63c7595f548e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                        | Message                                                                            |
| --------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------- |
| [`003e6770`](https://github.com/danth/stylix/commit/003e6770af4af1e4a49112ecb0ce63c7595f548e) | `` nixvim: move standalone-mode docs from configuration → nixvim readme (#1219) `` |