### PR TITLE
chore(flake/hyprland): `adbae0f7` -> `78ff20dd`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -625,11 +625,11 @@
         "xdph": "xdph"
       },
       "locked": {
-        "lastModified": 1746310409,
-        "narHash": "sha256-iSyQZMaYjVfr+vb7jO0N9Bh8V9m51ZYUqxWd9BimUpQ=",
+        "lastModified": 1746379361,
+        "narHash": "sha256-HtK/mekTJeye3RDieXUYlMsfwQRUFCwEKfMQYB6A4+s=",
         "owner": "hyprwm",
         "repo": "Hyprland",
-        "rev": "adbae0f74d951e06c575bad3c81a944027dfe413",
+        "rev": "78ff20ddf03166c7fa769419b7c2861db89f412b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                                                                  |
| ------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------ |
| [`78ff20dd`](https://github.com/hyprwm/Hyprland/commit/78ff20ddf03166c7fa769419b7c2861db89f412b) | `` workspaces: Fix empty flag not selecting active workspace (#10237) `` |
| [`2626f89e`](https://github.com/hyprwm/Hyprland/commit/2626f89ea6fe0df585df28052bf1fcca2c50fe8e) | `` protocols: refactor class member vars (n-t) (#10273) ``               |