### PR TITLE
chore(flake/zen-browser): `6d5c26cd` -> `b60de43b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1550,11 +1550,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1746371925,
-        "narHash": "sha256-LBSLvDVgp/v4bBA0AtFBzEngYkHUuhmj/fDranW1E3A=",
+        "lastModified": 1746383085,
+        "narHash": "sha256-nM5FN+zFPsBq6hOu2cdx4dV33JWNPTca7OIXdWJV9V4=",
         "owner": "0xc000022070",
         "repo": "zen-browser-flake",
-        "rev": "6d5c26cdb95e65113677a015afbc7244b9cf21b0",
+        "rev": "b60de43b72d74928c7c7f7f278398932d2fed077",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                          | Message                                                  |
| --------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------- |
| [`b60de43b`](https://github.com/0xc000022070/zen-browser-flake/commit/b60de43b72d74928c7c7f7f278398932d2fed077) | `` chore(update): beta @ x86_64 && aarch64 to 1.12.1b `` |