### PR TITLE
chore(flake/better-control): `4f4103b9` -> `40d2f963`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -210,11 +210,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1746296053,
-        "narHash": "sha256-DiYtZGxNHgOxfiZ26NS3qrbHbeiZjULCeK1tmSFkFpM=",
+        "lastModified": 1746393010,
+        "narHash": "sha256-hKKgN1aR+KFybG+w9FqZpKntd5dC3VULHA1nYMonxiI=",
         "owner": "rishabh5321",
         "repo": "better-control-flake",
-        "rev": "4f4103b9b46a2ccc3c639c3dc75d68f52417c1ae",
+        "rev": "40d2f963e8e7373839fd044142915a9871b8de61",
         "type": "github"
       },
       "original": {
@@ -1046,11 +1046,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1746232882,
-        "narHash": "sha256-MHmBH2rS8KkRRdoU/feC/dKbdlMkcNkB5mwkuipVHeQ=",
+        "lastModified": 1746328495,
+        "narHash": "sha256-uKCfuDs7ZM3QpCE/jnfubTg459CnKnJG/LwqEVEdEiw=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "7a2622e2c0dbad5c4493cb268aba12896e28b008",
+        "rev": "979daf34c8cacebcd917d540070b52a3c2b9b16e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                            | Message                                          |
| ----------------------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
| [`40d2f963`](https://github.com/Rishabh5321/better-control-flake/commit/40d2f963e8e7373839fd044142915a9871b8de61) | `` chore(flake/nixpkgs): 7a2622e2 -> 979daf34 `` |