### PR TITLE
chore(flake/akuse-flake): `bab6d26f` -> `023c7801`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -48,11 +48,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1746296994,
-        "narHash": "sha256-Ajo0Zl9nBVTiU3dY770va0HACFlhp8uUaYkfTm9MW6k=",
+        "lastModified": 1746393651,
+        "narHash": "sha256-wSFSvXgMh2H41St5ZPA0PcR+lbYM52RUgkvrTDKqFDw=",
         "owner": "Rishabh5321",
         "repo": "akuse-flake",
-        "rev": "bab6d26f2191a4de9e1a56aee67a2443da8ad11c",
+        "rev": "023c7801c349fb32ff5cd9b6d243a2eedb9c6030",
         "type": "github"
       },
       "original": {
@@ -999,11 +999,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1746232882,
-        "narHash": "sha256-MHmBH2rS8KkRRdoU/feC/dKbdlMkcNkB5mwkuipVHeQ=",
+        "lastModified": 1746328495,
+        "narHash": "sha256-uKCfuDs7ZM3QpCE/jnfubTg459CnKnJG/LwqEVEdEiw=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "7a2622e2c0dbad5c4493cb268aba12896e28b008",
+        "rev": "979daf34c8cacebcd917d540070b52a3c2b9b16e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                   | Message                                          |
| -------------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
| [`023c7801`](https://github.com/Rishabh5321/akuse-flake/commit/023c7801c349fb32ff5cd9b6d243a2eedb9c6030) | `` chore(flake/nixpkgs): 7a2622e2 -> 979daf34 `` |