### PR TITLE
chore(flake/thorium): `479a2e12` -> `06ae2b1b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1126,11 +1126,11 @@
     },
     "nixpkgs_7": {
       "locked": {
-        "lastModified": 1746232882,
-        "narHash": "sha256-MHmBH2rS8KkRRdoU/feC/dKbdlMkcNkB5mwkuipVHeQ=",
+        "lastModified": 1746328495,
+        "narHash": "sha256-uKCfuDs7ZM3QpCE/jnfubTg459CnKnJG/LwqEVEdEiw=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "7a2622e2c0dbad5c4493cb268aba12896e28b008",
+        "rev": "979daf34c8cacebcd917d540070b52a3c2b9b16e",
         "type": "github"
       },
       "original": {
@@ -1384,11 +1384,11 @@
         "nixpkgs": "nixpkgs_7"
       },
       "locked": {
-        "lastModified": 1746296844,
-        "narHash": "sha256-hkeVuo5oiRbYjh1txUlO5N3gi4kLar9s5tEDeFetKyE=",
+        "lastModified": 1746393564,
+        "narHash": "sha256-fv4XvmNpsTWK4XMbRnN1GTsNpRWHUs6D0hcfzs43/9c=",
         "owner": "Rishabh5321",
         "repo": "thorium_flake",
-        "rev": "479a2e126c1e880eba668689d815b4fe879f2193",
+        "rev": "06ae2b1b121dd56ff56d203305fc9f0c54b022a3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                     | Message                                          |
| ---------------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
| [`06ae2b1b`](https://github.com/Rishabh5321/thorium_flake/commit/06ae2b1b121dd56ff56d203305fc9f0c54b022a3) | `` chore(flake/nixpkgs): 7a2622e2 -> 979daf34 `` |