### PR TITLE
chore(flake/stylix): `b8e2e8c7` -> `6c8b77a7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -517,11 +517,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1746317522,
-        "narHash": "sha256-/jZ4Wd4HHUEWPSlNj48k1E4Mh+1fUbwI/vSlPPIMG3U=",
+        "lastModified": 1746369725,
+        "narHash": "sha256-m3ai7LLFYsymMK0uVywCceWfUhP0k3CALyFOfcJACqE=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "621986fed37c5d0cb8df010ed8369694dc47c09b",
+        "rev": "1a1793f6d940d22c6e49753548c5b6cb7dc5545d",
         "type": "github"
       },
       "original": {
@@ -1291,11 +1291,11 @@
         "tinted-zed": "tinted-zed"
       },
       "locked": {
-        "lastModified": 1746389158,
-        "narHash": "sha256-PAJk0I5eiGE40MuvLYhcfjgkjN05cR/AaJxLuuxFYdA=",
+        "lastModified": 1746439475,
+        "narHash": "sha256-9aFYFeE/Atl9i4rj9NqLLLER0y21F1nIF+ZeJ1Ueml4=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "b8e2e8c730abb4b1fc02fea8d9527c15dc69e855",
+        "rev": "6c8b77a7f5c1ff7059c4b6d749ace3b6f083e4bb",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                        | Message                                           |
| --------------------------------------------------------------------------------------------- | ------------------------------------------------- |
| [`6c8b77a7`](https://github.com/danth/stylix/commit/6c8b77a7f5c1ff7059c4b6d749ace3b6f083e4bb) | `` qutebrowser: do not enable darkmode (#1184) `` |
| [`70f331c8`](https://github.com/danth/stylix/commit/70f331c8e7da588e07e70cef15a114f9fcec3cee) | `` stylix: use lib.modules.importApply (#1185) `` |
| [`340a9c54`](https://github.com/danth/stylix/commit/340a9c5455a5690b45dc9812939f824b932bbd7d) | `` mako: remove typo from hm module (#1224) ``    |