### PR TITLE
chore(flake/nixpkgs-stable): `bf3287da` -> `537ee982`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1030,11 +1030,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1746183838,
-        "narHash": "sha256-kwaaguGkAqTZ1oK0yXeQ3ayYjs8u/W7eEfrFpFfIDFA=",
+        "lastModified": 1746301764,
+        "narHash": "sha256-5odz+NZszRya//Zd0P8h+sIwOnV35qJi+73f4I+iv1M=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "bf3287dac860542719fe7554e21e686108716879",
+        "rev": "537ee98218704e21ea465251de512ab6bbb9012e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                             |
| ---------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------- |
| [`537ee982`](https://github.com/NixOS/nixpkgs/commit/537ee98218704e21ea465251de512ab6bbb9012e) | `` spacecookie: enable networking on darwin ``                                      |
| [`6001ef3e`](https://github.com/NixOS/nixpkgs/commit/6001ef3e9154501b18e643d62475f2b8914b3b53) | `` spacecookie: 1.0.0.2 -> 1.0.0.3 ``                                               |
| [`847a7073`](https://github.com/NixOS/nixpkgs/commit/847a70736dd10d4c87f5e2c5c8dadb1a1c397a3f) | `` forgejo-lts: 7.0.14 -> 7.0.15 ``                                                 |
| [`814c5a93`](https://github.com/NixOS/nixpkgs/commit/814c5a93857d6ea84317898678275cad8772ea86) | `` forgejo: 11.0.0 -> 11.0.1 ``                                                     |
| [`5573ca7f`](https://github.com/NixOS/nixpkgs/commit/5573ca7f3607da51aecee3847b64051d78f06055) | `` phpunit: 12.1.3 -> 12.1.4 ``                                                     |
| [`4a62a706`](https://github.com/NixOS/nixpkgs/commit/4a62a70653d4b9abff07e102445179f5df680f81) | `` poptracker: fix sdl2-compat compat, unbreak ``                                   |
| [`093f9f69`](https://github.com/NixOS/nixpkgs/commit/093f9f69a0eee15163ecc7a900593469a55bfcfb) | `` mullvad-browser: 14.5 -> 14.5.1 ``                                               |
| [`8862da5d`](https://github.com/NixOS/nixpkgs/commit/8862da5dd811aeee2d3808e180771d6a4af63282) | `` tor-browser: 14.5 -> 14.5.1 ``                                                   |
| [`67a61e1b`](https://github.com/NixOS/nixpkgs/commit/67a61e1b334d53119106c3fcaeb51557d1046b7b) | `` coqPackages.coq-elpi: run nixfmt ``                                              |
| [`1b0a3302`](https://github.com/NixOS/nixpkgs/commit/1b0a33025bd2a39b1bf37c5a9da0ff5dc815cbe0) | `` anubis: 1.16.0 -> 1.17.1 ``                                                      |
| [`85d12b5a`](https://github.com/NixOS/nixpkgs/commit/85d12b5a16171e81611ca6114f9c8446c2914886) | `` anubis: add ryand56 as maintainer ``                                             |
| [`84f33554`](https://github.com/NixOS/nixpkgs/commit/84f33554e5df3527c94b15674f9c876abb1a3808) | `` build(deps): bump cachix/install-nix-action from 31.1.0 to 31.2.0 ``             |
| [`107833d2`](https://github.com/NixOS/nixpkgs/commit/107833d29560a93a218b726ce8f2981fafd501c9) | `` freetube: 0.23.4 -> 0.23.5 ``                                                    |
| [`78b3a332`](https://github.com/NixOS/nixpkgs/commit/78b3a332b4d0232328b127e293c5ec241a34c9e5) | `` nss_latest: 3.110 -> 3.111 ``                                                    |
| [`eeeea59c`](https://github.com/NixOS/nixpkgs/commit/eeeea59c1b00383fa7fd4141e2ab0860de61e07a) | `` linux_5_4: 5.4.292 -> 5.4.293 ``                                                 |
| [`9df2276e`](https://github.com/NixOS/nixpkgs/commit/9df2276ec9996fa30dc5afbd31a832281cdebf8d) | `` linux_5_10: 5.10.236 -> 5.10.237 ``                                              |
| [`671ba840`](https://github.com/NixOS/nixpkgs/commit/671ba84065e129219e096e1ca57aad2467ebcb8a) | `` linux_5_15: 5.15.180 -> 5.15.181 ``                                              |
| [`234571ef`](https://github.com/NixOS/nixpkgs/commit/234571efa338541a8818057de2d60f5f34f20729) | `` linux_6_1: 6.1.135 -> 6.1.136 ``                                                 |
| [`5fc148fe`](https://github.com/NixOS/nixpkgs/commit/5fc148fe196f65ba78c1d6715c7d1d1d148c8a8f) | `` linux_6_6: 6.6.88 -> 6.6.89 ``                                                   |
| [`2ec126e3`](https://github.com/NixOS/nixpkgs/commit/2ec126e3cdf67070b5cf738105a0537e64bff758) | `` linux_6_12: 6.12.25 -> 6.12.26 ``                                                |
| [`0d88e1b7`](https://github.com/NixOS/nixpkgs/commit/0d88e1b704b80e30b5735846f68cced55127f4d3) | `` linux_6_14: 6.14.4 -> 6.14.5 ``                                                  |
| [`14c53468`](https://github.com/NixOS/nixpkgs/commit/14c53468a5df408a0bb15ef186eac6bf525f0131) | `` morphosis: 48.1 -> 48.2 ``                                                       |
| [`05d0b89b`](https://github.com/NixOS/nixpkgs/commit/05d0b89b1e12e43b0cefc8945948bc066dbb655b) | `` mozillavpn: 2.26.0 → 2.27.0, patch for Qt 6.9 compatibility ``                   |
| [`b2eb53b4`](https://github.com/NixOS/nixpkgs/commit/b2eb53b42eba28126371e51bef1ac66e62ce5ae3) | `` edopro: 40.1.4 -> 41.0.2 ``                                                      |
| [`2d34eb40`](https://github.com/NixOS/nixpkgs/commit/2d34eb4068bd35767f8cd920a1f1a570dc5bac62) | `` edopro: Use writeShellApplication for launcher script, keep assets in subdirs `` |
| [`2d25f3c8`](https://github.com/NixOS/nixpkgs/commit/2d25f3c84e65f21d767af344b2dfe3524ebfc7a0) | `` edopro: Build & set up ocgcore from src as default core ``                       |
| [`fe51da8a`](https://github.com/NixOS/nixpkgs/commit/fe51da8a81bd1a54e6739a08dae97f98fb73ff0e) | `` edopro: Fix passthru.updateScript ``                                             |
| [`4241b8f7`](https://github.com/NixOS/nixpkgs/commit/4241b8f70bd8b4efb8c4588fbfe80cd9bfaa78a3) | `` knot-resolver: nit fixes ``                                                      |
| [`cc944a9c`](https://github.com/NixOS/nixpkgs/commit/cc944a9c3b16a4986db3a118ad35ed9c3c8987e9) | `` knot-resolver: 5.7.4 -> 5.7.5 ``                                                 |
| [`a5897004`](https://github.com/NixOS/nixpkgs/commit/a589700467065f86f8b82a2a70404ab458367bf8) | `` nixos/snipe-it: clear and rebuild caches on startup ``                           |