### PR TITLE
chore(flake/nixpkgs-stable): `537ee982` -> `5b35d248`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1030,11 +1030,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1746301764,
-        "narHash": "sha256-5odz+NZszRya//Zd0P8h+sIwOnV35qJi+73f4I+iv1M=",
+        "lastModified": 1746422338,
+        "narHash": "sha256-NTtKOTLQv6dPfRe00OGSywg37A1FYqldS6xiNmqBUYc=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "537ee98218704e21ea465251de512ab6bbb9012e",
+        "rev": "5b35d248e9206c1f3baf8de6a7683fee126364aa",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                          |
| ---------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------- |
| [`ccf97475`](https://github.com/NixOS/nixpkgs/commit/ccf9747567dbbad2570453e4ca2952a90376d6b7) | `` vencord: 1.11.9 -> 1.12.0 ``                                                  |
| [`f2453191`](https://github.com/NixOS/nixpkgs/commit/f24531911718692766c7fe100a1f4b780a48b5e4) | `` necesse-server: 0.32.1-18204230 -> 0.32.1-18336931 ``                         |
| [`a5208ab0`](https://github.com/NixOS/nixpkgs/commit/a5208ab0d4a5f6707df2872fd71046e74c789504) | `` workflows/labels: fix wrong yaml file ``                                      |
| [`f7371e59`](https://github.com/NixOS/nixpkgs/commit/f7371e5920606886e6f4e5d4551c8eeba2f1f7e3) | `` workflows/backport: avoid broken korthout/backport-action output ``           |
| [`d295faaf`](https://github.com/NixOS/nixpkgs/commit/d295faaf50e2e1565de0bfda21b6e17b8f2f05c2) | `` workflows/backport: fix conditional ``                                        |
| [`30d0db50`](https://github.com/NixOS/nixpkgs/commit/30d0db5013801fa8d38353d18e68d0933825bedb) | `` workflows/backport: add "has: port to stable" label on success ``             |
| [`3d89873b`](https://github.com/NixOS/nixpkgs/commit/3d89873b142b3979fd7be1814b48308b833d4e12) | `` workflows/backport: only trigger on backport labels ``                        |
| [`cd73f139`](https://github.com/NixOS/nixpkgs/commit/cd73f139ed7826c51fc3663955a91fe00b7138da) | `` workflows/labeler: fix double quotes ``                                       |
| [`cc04f682`](https://github.com/NixOS/nixpkgs/commit/cc04f6827d88ebe4ecd0260b13eb2d20895f76fd) | `` bird3: downgrade to 3.0.2 (#404140) ``                                        |
| [`d21dd87c`](https://github.com/NixOS/nixpkgs/commit/d21dd87c031d132a10f000ec9eab0dcf6c6e245b) | `` workflows/labeler: fix repo owner condition ``                                |
| [`e23a6442`](https://github.com/NixOS/nixpkgs/commit/e23a6442d7a52bd31a120fb9f757e96016360103) | `` invidious: 2.20250314.0 -> 2.20250504.0 ``                                    |
| [`79161009`](https://github.com/NixOS/nixpkgs/commit/79161009be92604e682565c97bd4ccb159411a72) | `` pkgsCross.aarch64-darwin.discord-development: 0.0.85 -> 0.0.87 ``             |
| [`293b5eba`](https://github.com/NixOS/nixpkgs/commit/293b5eba6c63b6c305de239618d02896f2a7de73) | `` pkgsCross.aarch64-darwin.discord-canary: 0.0.729 -> 0.0.774 ``                |
| [`243e590e`](https://github.com/NixOS/nixpkgs/commit/243e590e18f4f72d9814518285824bab2fe24ed8) | `` pkgsCross.aarch64-darwin.discord-ptb: 0.0.167 -> 0.0.171 ``                   |
| [`f08d9b9d`](https://github.com/NixOS/nixpkgs/commit/f08d9b9d29d093d3dc6e986da04810458dfbec34) | `` pkgsCross.aarch64-darwin.discord: 0.0.342 -> 0.0.344 ``                       |
| [`5818b20e`](https://github.com/NixOS/nixpkgs/commit/5818b20e697996011f18117c43074f1a6353faa4) | `` discord-development: 0.0.73 -> 0.0.74 ``                                      |
| [`98c56c48`](https://github.com/NixOS/nixpkgs/commit/98c56c48d61a1f6d0ea29e85248aa1e090b495c4) | `` discord-canary: 0.0.649 -> 0.0.668 ``                                         |
| [`f13bcf36`](https://github.com/NixOS/nixpkgs/commit/f13bcf36016cb3d3776d9929cc3e182a9c62c573) | `` discord-ptb: 0.0.136 -> 0.0.141 ``                                            |
| [`eae04ee2`](https://github.com/NixOS/nixpkgs/commit/eae04ee2a965e390b4e91fa13349a4f131505a71) | `` discord: 0.0.91 -> 0.0.93 ``                                                  |
| [`eee2efdb`](https://github.com/NixOS/nixpkgs/commit/eee2efdbbaa5542048d772c0bc22a098c3478450) | `` labels: add workflow related labels ``                                        |
| [`c57f9b5c`](https://github.com/NixOS/nixpkgs/commit/c57f9b5c11369fa90c66ea050b09729c55617e82) | `` workflows/labels: skip for staging-next / haskell-updates / python-updates `` |
| [`84c7cffd`](https://github.com/NixOS/nixpkgs/commit/84c7cffd087608eb9b2270ba58595582a5bf8055) | `` workflows/labels: add a `sync-labels: false` step, migrate some rules ``      |
| [`1f16712f`](https://github.com/NixOS/nixpkgs/commit/1f16712f7e98a804cddc3f62050fa4df002a859b) | `` php82Packages.castor: 0.23.0 -> 0.24.0 ``                                     |
| [`144fd647`](https://github.com/NixOS/nixpkgs/commit/144fd647b77e216bc557a39ac8c6c8ec57ecdffa) | `` signal-cli: 0.13.13 -> 0.13.14 ``                                             |
| [`33790087`](https://github.com/NixOS/nixpkgs/commit/33790087edbf230b15ce4ff4aa1faeb9ae1827ab) | `` signal-cli: add meta.sourceProvenance ``                                      |
| [`429fc54c`](https://github.com/NixOS/nixpkgs/commit/429fc54c18d33b9a46558f14ee2c3b6b3c2bd2f8) | `` signal-cli: 0.13.12 -> 0.13.13 ``                                             |
| [`70b7268e`](https://github.com/NixOS/nixpkgs/commit/70b7268e3a40f3664f95d10dc902a18a2fc7c461) | `` signal-cli: 0.13.11 -> 0.13.12 ``                                             |
| [`6a6ede6f`](https://github.com/NixOS/nixpkgs/commit/6a6ede6f9c796aa239f5af245f186ad6b7f3a9e6) | `` signal-cli: 0.13.10 -> 0.13.11 ``                                             |
| [`8ce69da2`](https://github.com/NixOS/nixpkgs/commit/8ce69da2c36ef9790e9c6674b8d5195d11101c2e) | `` signal-cli: 0.13.9 -> 0.13.10 ``                                              |
| [`5eb72cbf`](https://github.com/NixOS/nixpkgs/commit/5eb72cbfc2fcb8adf404258ff2625878cec23b13) | `` python3Packages.lottie: 0.7.1 -> 0.7.2 ``                                     |
| [`17739ae9`](https://github.com/NixOS/nixpkgs/commit/17739ae94db8c40aedd74baba08b11df2125045f) | `` thunderbird-128-unwrapped: 128.9.1esr -> 128.9.2esr ``                        |
| [`f2abc9de`](https://github.com/NixOS/nixpkgs/commit/f2abc9debb778b7bdba7e1e90f2b8945e4ed3d9a) | `` thunderbird-128-unwrapped: 128.8.1esr -> 128.9.1esr ``                        |
| [`fcd3ffc6`](https://github.com/NixOS/nixpkgs/commit/fcd3ffc6119c14deade90ed155127918199f55fc) | `` thunderbird-bin: make ESR version default for release branch ``               |
| [`7a50a05a`](https://github.com/NixOS/nixpkgs/commit/7a50a05ae0032851d8a8caeea6cb5853fbd90ffa) | `` thunderbird-esr-bin: 128.9.2esr -> 128.10.0esr ``                             |
| [`a7547236`](https://github.com/NixOS/nixpkgs/commit/a7547236c92bc1e7fac0eb12e1b6e0dff89747e6) | `` thunderbird-latest-bin: 137.0.2 -> 138.0 ``                                   |
| [`c098cfd6`](https://github.com/NixOS/nixpkgs/commit/c098cfd673ecf5578a4aed49d9e905fd5bbffbe8) | `` thunderbird-bin: add 137.0.2 as thunderbird-latest-bin ``                     |