### PR TITLE
chore(flake/stylix): `ce5fcf85` -> `45aa0e84`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1291,11 +1291,11 @@
         "tinted-zed": "tinted-zed"
       },
       "locked": {
-        "lastModified": 1746455300,
-        "narHash": "sha256-SxHatwTIR1qEqAHJrThUHYM86hauXsJud3o/L+oEyYY=",
+        "lastModified": 1746469524,
+        "narHash": "sha256-uwFQebWXtMsRBmzKOYa6jjs7PDnfSuwyrqPK6yzqamU=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "ce5fcf851d6546a24e5b5b17ee7051b4b384be79",
+        "rev": "45aa0e849282dba5979e7bb3d0f6676bbd9dc130",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                        | Message                        |
| --------------------------------------------------------------------------------------------- | ------------------------------ |
| [`45aa0e84`](https://github.com/danth/stylix/commit/45aa0e849282dba5979e7bb3d0f6676bbd9dc130) | `` fzf: add testbed (#1201) `` |