### PR TITLE
chore(flake/hyprland): `1f50cdfa` -> `997fefbc`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -625,11 +625,11 @@
         "xdph": "xdph"
       },
       "locked": {
-        "lastModified": 1746446940,
-        "narHash": "sha256-RG3NQ1qRbseMFoH/Yzh2Ec53urkEREWelo7GIlHIsoA=",
+        "lastModified": 1746481489,
+        "narHash": "sha256-ZXzw0muD2ZDRKJHVKwp9vPKaPoV6QodR+fuekREaXjM=",
         "owner": "hyprwm",
         "repo": "Hyprland",
-        "rev": "1f50cdfa8be87502c555d29bcfa327fb6bea551d",
+        "rev": "997fefbc1113323ed2bf5d782bdafc0d17532647",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                                                                      |
| ------------------------------------------------------------------------------------------------ | ---------------------------------------------------------------------------- |
| [`997fefbc`](https://github.com/hyprwm/Hyprland/commit/997fefbc1113323ed2bf5d782bdafc0d17532647) | `` render: refactor class member vars (#10292) ``                            |
| [`c7eb1410`](https://github.com/hyprwm/Hyprland/commit/c7eb14109865aa6a057b6cd2e36312da80da9caa) | `` renderer: always try to apply a mode if pixel size is invalid (#10291) `` |