### PR TITLE
chore(flake/zen-browser): `5866c62d` -> `f78a228d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1550,11 +1550,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1746462331,
-        "narHash": "sha256-5vYuiOmaK78HBKIH6Bn3No6FQ2MrjkEYa2s0swLXtMo=",
+        "lastModified": 1746483546,
+        "narHash": "sha256-tzNX8HrqLWoLPGxGLGHAW8ja8BU/qDSee1nlc802Imw=",
         "owner": "0xc000022070",
         "repo": "zen-browser-flake",
-        "rev": "5866c62d3aba150251f244fafebd47c7a384fb47",
+        "rev": "f78a228d63dc6d0b82015a8d12a672e59a1522d6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                          | Message                                                                 |
| --------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------- |
| [`f78a228d`](https://github.com/0xc000022070/zen-browser-flake/commit/f78a228d63dc6d0b82015a8d12a672e59a1522d6) | `` chore(update): twilight @ x86_64 && aarch64 to 1.12.2t#1746483343 `` |