### PR TITLE
chore(flake/stylix): `6e55a894` -> `78a96c5c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1291,11 +1291,11 @@
         "tinted-zed": "tinted-zed"
       },
       "locked": {
-        "lastModified": 1746485847,
-        "narHash": "sha256-sO54KpnrzDMHq5W9da+/sI0mJMmL/qNcjIVRXzp9mW4=",
+        "lastModified": 1746488539,
+        "narHash": "sha256-MbtlaMXgki/xeobrRvu61fSUYL3icNu7ewTCr/oPyew=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "6e55a89494c01ad9be6b90212dc79344b402979e",
+        "rev": "78a96c5c5a0289d17c0f8be4fa3eef955c780f5c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                        | Message                                              |
| --------------------------------------------------------------------------------------------- | ---------------------------------------------------- |
| [`78a96c5c`](https://github.com/danth/stylix/commit/78a96c5c5a0289d17c0f8be4fa3eef955c780f5c) | `` doc: fix longestFence usage of lib.max (#1231) `` |