### PR TITLE
chore(flake/hyprland): `997fefbc` -> `1ce614df`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -625,11 +625,11 @@
         "xdph": "xdph"
       },
       "locked": {
-        "lastModified": 1746481489,
-        "narHash": "sha256-ZXzw0muD2ZDRKJHVKwp9vPKaPoV6QodR+fuekREaXjM=",
+        "lastModified": 1746496467,
+        "narHash": "sha256-PFmX5SvVN54LdFEBzMBIx4JEKOGP5d6nR/PcYHQhMlw=",
         "owner": "hyprwm",
         "repo": "Hyprland",
-        "rev": "997fefbc1113323ed2bf5d782bdafc0d17532647",
+        "rev": "1ce614dfc0eb8b323e603b76975842c1f2e6a553",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                                                                                               |
| ------------------------------------------------------------------------------------------------ | ----------------------------------------------------------------------------------------------------- |
| [`1ce614df`](https://github.com/hyprwm/Hyprland/commit/1ce614dfc0eb8b323e603b76975842c1f2e6a553) | `` animations: Add option for animating workspaces as if the first and last were adjacent (#10277) `` |
| [`930eeac9`](https://github.com/hyprwm/Hyprland/commit/930eeac900c60d147bf26491e15b0727605b3944) | `` window: use stored size for new floating window when persistentsize is set (#10212) ``             |
| [`ec93f8a1`](https://github.com/hyprwm/Hyprland/commit/ec93f8a1cda30f1cf22a24cbc00f680b8bfd0ba8) | `` socket2: add monitorremovedv2 event (#10229) ``                                                    |