### PR TITLE
chore(flake/stylix): `78a96c5c` -> `a2b80b90`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1291,11 +1291,11 @@
         "tinted-zed": "tinted-zed"
       },
       "locked": {
-        "lastModified": 1746488539,
-        "narHash": "sha256-MbtlaMXgki/xeobrRvu61fSUYL3icNu7ewTCr/oPyew=",
+        "lastModified": 1746519367,
+        "narHash": "sha256-bdCCX84HW4CecAgokOi0BgRBR3JSPeGFlusWAGIh3fE=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "78a96c5c5a0289d17c0f8be4fa3eef955c780f5c",
+        "rev": "a2b80b900647f28658a2c9456d9a10ab4aa3b250",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                        | Message                                                                         |
| --------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------- |
| [`a2b80b90`](https://github.com/danth/stylix/commit/a2b80b900647f28658a2c9456d9a10ab4aa3b250) | `` doc: direct to all issues instead of open ones in issue templates (#1232) `` |