### PR TITLE
chore(flake/stylix): `a2b80b90` -> `965865bc`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1291,11 +1291,11 @@
         "tinted-zed": "tinted-zed"
       },
       "locked": {
-        "lastModified": 1746519367,
-        "narHash": "sha256-bdCCX84HW4CecAgokOi0BgRBR3JSPeGFlusWAGIh3fE=",
+        "lastModified": 1746542234,
+        "narHash": "sha256-kBlPMNZXPzDG4HUmdqYpvjvVYkoDdDrVvO14cKgHaiU=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "a2b80b900647f28658a2c9456d9a10ab4aa3b250",
+        "rev": "965865bc36033ead241e107f486418e6f600d58b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                        | Message                         |
| --------------------------------------------------------------------------------------------- | ------------------------------- |
| [`965865bc`](https://github.com/danth/stylix/commit/965865bc36033ead241e107f486418e6f600d58b) | `` sxiv: add testbed (#1190) `` |