### PR TITLE
chore(flake/spicetify-nix): `752ce227` -> `133e882f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1254,11 +1254,11 @@
         "systems": "systems_4"
       },
       "locked": {
-        "lastModified": 1746524020,
-        "narHash": "sha256-WZwLDxEbh6or5fUvwQ6LaBstTgp0zTmTp49idUg1PHU=",
+        "lastModified": 1746551108,
+        "narHash": "sha256-sTghs3HNf/hwPXJb5Ii8G53PhQNE1ayWgY9IOYSHAOY=",
         "owner": "Gerg-L",
         "repo": "spicetify-nix",
-        "rev": "752ce227a7ba0fd466178040f83876e45935126e",
+        "rev": "133e882f1266f1bb580bea64b9082d423fa005ba",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------ |
| [`133e882f`](https://github.com/Gerg-L/spicetify-nix/commit/133e882f1266f1bb580bea64b9082d423fa005ba) | `` fix(deps): update rust crate octocrab to v0.44.1 `` |