### PR TITLE
chore(flake/nixpkgs): `979daf34` -> `3730d8a3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1094,11 +1094,11 @@
     },
     "nixpkgs_5": {
       "locked": {
-        "lastModified": 1746328495,
-        "narHash": "sha256-uKCfuDs7ZM3QpCE/jnfubTg459CnKnJG/LwqEVEdEiw=",
+        "lastModified": 1746461020,
+        "narHash": "sha256-7+pG1I9jvxNlmln4YgnlW4o+w0TZX24k688mibiFDUE=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "979daf34c8cacebcd917d540070b52a3c2b9b16e",
+        "rev": "3730d8a308f94996a9ba7c7138ede69c1b9ac4ae",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                |
| ---------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------- |
| [`12a7f012`](https://github.com/NixOS/nixpkgs/commit/12a7f01211501869bad6939789e6266d535d29df) | `` Revert "labels: add backport label for automatic browser updates" ``                |
| [`5232a0a3`](https://github.com/NixOS/nixpkgs/commit/5232a0a33a449fdfd9c797e06613aeb6b2351bdc) | `` cligh: drop ``                                                                      |
| [`3b42616f`](https://github.com/NixOS/nixpkgs/commit/3b42616f4b389f54960825f5bc912c10cd848052) | `` nixos/initrd-ssh: include sshd-auth binary in initrd ``                             |
| [`5388d4f3`](https://github.com/NixOS/nixpkgs/commit/5388d4f37b608407b2d947e7008cdcaba8f2561c) | `` Revert "labels: fix backport labels for CI workflows" ``                            |
| [`54331e11`](https://github.com/NixOS/nixpkgs/commit/54331e1101775c0e8c0cdc642016ec1a79935cbb) | `` labels: fix backport labels for CI workflows ``                                     |
| [`bd798bc0`](https://github.com/NixOS/nixpkgs/commit/bd798bc09b430b6aac619c3f1592a31915dc6299) | `` python312Packages.stestr: 4.1.0 -> 4.2.0 ``                                         |
| [`1776bca4`](https://github.com/NixOS/nixpkgs/commit/1776bca4b9fe5d8097fc31e49b16e214aba7dc76) | `` golangci-lint: 2.1.5 -> 2.1.6 ``                                                    |
| [`128697f0`](https://github.com/NixOS/nixpkgs/commit/128697f058fa84f1630ed80458e86f48bf9c49ff) | `` hmetis: drop ``                                                                     |
| [`0ee9fa8c`](https://github.com/NixOS/nixpkgs/commit/0ee9fa8cfb11b3581b005c495bd2aebf82f78254) | `` crackxls: 0.4 -> 1.0 ``                                                             |
| [`5acdacbf`](https://github.com/NixOS/nixpkgs/commit/5acdacbfcf5697168d647c578f9e4d5770f15d27) | `` nixos/dump1090-fa: init module ``                                                   |
| [`e95a2343`](https://github.com/NixOS/nixpkgs/commit/e95a23432a43394c8e737b4d1520880112f445c8) | `` Refine dependencies from mathcomp-ssreflect to mathcomp-boot ``                     |
| [`0401f9a2`](https://github.com/NixOS/nixpkgs/commit/0401f9a22affbebeacaf9a37321569a7b44da542) | `` coqPackages.mathcomp-boot: init at master (future 2.5.0) ``                         |
| [`952c7177`](https://github.com/NixOS/nixpkgs/commit/952c7177e0ae8a0d5f353f24346ac0a173e55b71) | `` coqPackages.hierarchy-builder: 1.8.1 -> 1.9.1 ``                                    |
| [`87efe407`](https://github.com/NixOS/nixpkgs/commit/87efe407f56d68e5e3b6102cfbdc9b9beef4a1db) | `` wesnoth: add maintainer niklaskorz ``                                               |
| [`b429f9ee`](https://github.com/NixOS/nixpkgs/commit/b429f9eea8cc59ecef5a2867923e8401feddec81) | `` wesnoth: stylistic changes ``                                                       |
| [`d5e20fde`](https://github.com/NixOS/nixpkgs/commit/d5e20fde41381935c8fd70ad63cecf91d67a82a2) | `` wesnoth: add update script ``                                                       |
| [`a0891b0b`](https://github.com/NixOS/nixpkgs/commit/a0891b0b7680f1d3741209848388a07ef70dd073) | `` wesnoth: add darwin app bundle ``                                                   |
| [`effa279e`](https://github.com/NixOS/nixpkgs/commit/effa279e0465a220ba75c118232d57b4f60c5648) | `` wesnoth: fix LLVM 19 compatibility ``                                               |
| [`50f6847c`](https://github.com/NixOS/nixpkgs/commit/50f6847c351f5d9f77a3298a1389c3cbb7c04352) | `` workflows/backport: fix typo ``                                                     |
| [`f0f193f7`](https://github.com/NixOS/nixpkgs/commit/f0f193f794a5340484f13e712287d4551c5ee911) | `` jetty: 12.0.19 -> 12.0.20 ``                                                        |
| [`2462d73f`](https://github.com/NixOS/nixpkgs/commit/2462d73f29f26475de0a9f04e037368da685cdf5) | `` python312Packages.mmengine: fix pytorch 2.6.0 compat ``                             |
| [`77ea92cf`](https://github.com/NixOS/nixpkgs/commit/77ea92cfca273e4adc3fa01d01506676cc1fe009) | `` build(deps): bump actions/create-github-app-token from 2.0.2 to 2.0.6 ``            |
| [`9fa8f80c`](https://github.com/NixOS/nixpkgs/commit/9fa8f80c70fca19560832b4c54e62789dfd9b9c0) | `` hyprpicker: 0.4.4 -> 0.4.5 ``                                                       |
| [`b391284a`](https://github.com/NixOS/nixpkgs/commit/b391284afdb5ea398f287512f3512c22e357ef3e) | `` python312Packages.tensorflow-matadata: fix build by relaxing protobuf dependency `` |
| [`39fbbb7b`](https://github.com/NixOS/nixpkgs/commit/39fbbb7ba06fcbc8d9037f44aa852c7c75c99275) | `` nixos/nextcloud: fix typo in extraApps example (#404314) ``                         |
| [`24d1d631`](https://github.com/NixOS/nixpkgs/commit/24d1d6313daaec3e41d06a448b686f6712d6fbf8) | `` python312Packages.apache-beam: fix build by relaxing protobuf dependency ``         |
| [`6758d645`](https://github.com/NixOS/nixpkgs/commit/6758d64536826ccab0cdff4652d263039e705528) | `` soupault: 4.11.0 → 5.0.0 ``                                                         |
| [`d43488ef`](https://github.com/NixOS/nixpkgs/commit/d43488ef16fa5aa3727a678702c9a6b2c45bf5fe) | `` ocamlPackages.tsort: 2.1.0 → 2.2.0 ``                                               |
| [`72eee9b3`](https://github.com/NixOS/nixpkgs/commit/72eee9b3ddfc3e3dd8954e7fffc7df46032386d1) | `` ocamlPackages.oidc: init at 0.2.0 ``                                                |
| [`aa0b4178`](https://github.com/NixOS/nixpkgs/commit/aa0b4178454b52045d9bf032af4039433527a118) | `` ocamlPackages.jose: init at 0.10.0 ``                                               |
| [`2fff530b`](https://github.com/NixOS/nixpkgs/commit/2fff530be13e93354d9bf6b0c2e6720be359765c) | `` linenoise-ng: drop ``                                                               |
| [`2a8e737a`](https://github.com/NixOS/nixpkgs/commit/2a8e737a8a1b21c076dff2926ec1e722c19923ef) | `` _5etools: drop ``                                                                   |
| [`96ba3cb4`](https://github.com/NixOS/nixpkgs/commit/96ba3cb4b90fd4e8ec00aefac7b2050170bb5fa1) | `` git-stree: drop ``                                                                  |
| [`9bb6a269`](https://github.com/NixOS/nixpkgs/commit/9bb6a2694ecb7f35ec761af28b80ab2684757b26) | `` p0f: fix build for GCC 14 ``                                                        |
| [`3abe6557`](https://github.com/NixOS/nixpkgs/commit/3abe6557dd962ba5c04008da744ad6b148f0e340) | `` pympress: 1.8.5 -> 1.8.6 ``                                                         |
| [`ba2df560`](https://github.com/NixOS/nixpkgs/commit/ba2df560ffc83238e9019b3c6b8592fd33799a72) | `` python312Packages.cltk: 1.3.0 -> 1.5.0 ``                                           |
| [`4d40079f`](https://github.com/NixOS/nixpkgs/commit/4d40079f0ec3485aac1634a1cbca9b4d07e0a30d) | `` Revert "monophony: 2.15.0 -> 3.3.2" ``                                              |
| [`6dd743e4`](https://github.com/NixOS/nixpkgs/commit/6dd743e44f453c52cb6d1320a4dbb3a0f4cf4e3a) | `` oakctl: init at 0.2.12 ``                                                           |
| [`2ea08893`](https://github.com/NixOS/nixpkgs/commit/2ea08893b0c07806c74abd65bd99d24b04d21d15) | `` openssh_gssapi: correct Debian patch URL ``                                         |
| [`2e33d35e`](https://github.com/NixOS/nixpkgs/commit/2e33d35e746f852068a53bdc0de0b8249febf2f3) | `` sdcc: add reminder to remove .PHONY patch with next release ``                      |
| [`a9a6b98f`](https://github.com/NixOS/nixpkgs/commit/a9a6b98f058241aabd23b3d65497eebb5f33310a) | `` sdcc: fix build on Darwin ``                                                        |
| [`353a5726`](https://github.com/NixOS/nixpkgs/commit/353a572642c825c5bd815bb7ee3fec3e88142da3) | `` Revert "tests/openssh: write a test for CVE-2025-32728" ``                          |
| [`19e27e45`](https://github.com/NixOS/nixpkgs/commit/19e27e450c4ed73a5ea1034dc06013662a6eab6a) | `` copilot-language-server: 1.311.0 -> 1.312.0 ``                                      |
| [`839c82f3`](https://github.com/NixOS/nixpkgs/commit/839c82f322d4e4ef52e413ee7f1a826cca5dc583) | `` nwg-panel: 0.10.1 -> 0.10.2 ``                                                      |
| [`62958875`](https://github.com/NixOS/nixpkgs/commit/62958875f6e6aae0a092948c873c56e06aa5342e) | `` Revert "nixos/k3b: remove module as obsolete" ``                                    |
| [`e3895daf`](https://github.com/NixOS/nixpkgs/commit/e3895dafc941b6f419d2f820faabb1e815f437f4) | `` swift: use `aarch64` instead of `arm64` on Linux ``                                 |
| [`a82e2fc7`](https://github.com/NixOS/nixpkgs/commit/a82e2fc718946e3933a7906cf5390c7ac18daf1c) | `` e1s: add carlossless to maintainers ``                                              |
| [`4f083f72`](https://github.com/NixOS/nixpkgs/commit/4f083f72731d109f6edf25977e8c22dc561e3487) | `` python3Packages.pygeocodio: fix darwin build for ZHF ``                             |
| [`c721c2e2`](https://github.com/NixOS/nixpkgs/commit/c721c2e2cf76589731772f11c555cc20bfc10754) | `` phpPackages.phpstan: 2.1.13 -> 2.1.14 ``                                            |
| [`c141f42d`](https://github.com/NixOS/nixpkgs/commit/c141f42d5e33a8b6a78c75bdc1ccd2d4e615ab36) | `` gsl-lite: 0.42.0 -> 0.43.0 ``                                                       |
| [`d51987a0`](https://github.com/NixOS/nixpkgs/commit/d51987a0996b4b5d7afdfb8a616c15bdaaea7ad8) | `` code-cursor: rm sarahec as maintainer ``                                            |
| [`2b336685`](https://github.com/NixOS/nixpkgs/commit/2b3366856abeb139cc6c0a24c6eb431a75d8e191) | `` hmat-oss: modernize ``                                                              |
| [`26f4a510`](https://github.com/NixOS/nixpkgs/commit/26f4a5102f0e774d2ba74083981d61800f63fb37) | `` hmat-oss: fix build on darwin ``                                                    |
| [`2d36d96b`](https://github.com/NixOS/nixpkgs/commit/2d36d96bee69a8159b1aea6b37e00ed41e87a483) | `` gzdoom: 4.14.1 -> 4.14.2 ``                                                         |
| [`ed9d0e88`](https://github.com/NixOS/nixpkgs/commit/ed9d0e888aa410e57b300335131fa1049cc54b01) | `` otto-matic: unstable-2023-11-13 -> 4.0.1-unstable-2025-04-27 ``                     |
| [`2d9a30e4`](https://github.com/NixOS/nixpkgs/commit/2d9a30e4cbc646abd0f574ef6682ae79ff9cf921) | `` python3Packages.lcov-cobertura: fix build ``                                        |
| [`5717091c`](https://github.com/NixOS/nixpkgs/commit/5717091c9a321a70814ee5e5008734250bea5777) | `` openipmi: 2.0.36 -> 2.0.37 ``                                                       |
| [`780cf701`](https://github.com/NixOS/nixpkgs/commit/780cf701c5c17c5deefe7de9ce2fbdb51b41756a) | `` mitra: 3.23.0 -> 4.1.1 ``                                                           |
| [`ab3ba6bb`](https://github.com/NixOS/nixpkgs/commit/ab3ba6bbdf15e31958847b738c0b4dbd4d0c9326) | `` stalwart-mail: 0.11.7 -> 0.11.8 ``                                                  |
| [`4c3ce3fc`](https://github.com/NixOS/nixpkgs/commit/4c3ce3fc9e8cb814cdc7d1b63601c7b591947dea) | `` meowpdf: init at 1.0.0 ``                                                           |
| [`207cd9f2`](https://github.com/NixOS/nixpkgs/commit/207cd9f24fa3e67a63a6a0eb3f6ff5a9e4768788) | `` legcord: 1.1.1 -> 1.1.3 ``                                                          |
| [`4648e2ab`](https://github.com/NixOS/nixpkgs/commit/4648e2ab592b36dc2acd2357dbee4cd48b5da318) | `` python312Packages.fnllm: fix build ``                                               |
| [`c8ef2b70`](https://github.com/NixOS/nixpkgs/commit/c8ef2b704bc89a69d5c5015c8faca6146e0e3570) | `` ioquake3: unstable-2023-08-13 -> 0-unstable-2025-04-25 ``                           |
| [`f8e0b648`](https://github.com/NixOS/nixpkgs/commit/f8e0b648ad6f70766d40388133475b1604b429c8) | `` pik: 0.20.0 -> 0.21.0 ``                                                            |
| [`1b033ec1`](https://github.com/NixOS/nixpkgs/commit/1b033ec17eb6e9842b71948100c62c4003c3d626) | `` immich-go: 0.25.3 -> 0.26.0 ``                                                      |
| [`da71f9f4`](https://github.com/NixOS/nixpkgs/commit/da71f9f483a0ca41d9e06fe13ba5c31bc7b88583) | `` vencord: 1.11.9 -> 1.12.0 ``                                                        |
| [`708091eb`](https://github.com/NixOS/nixpkgs/commit/708091ebe04d934f7e4529b8a4a60184c939fe2f) | `` python3Packages.sabyenc: drop ``                                                    |
| [`a56aa546`](https://github.com/NixOS/nixpkgs/commit/a56aa5465af1aa071df4bfe73a25b6afcb3762a5) | `` python3Packages.parfive: disable failing test ``                                    |
| [`566c0f95`](https://github.com/NixOS/nixpkgs/commit/566c0f9568f22503b4b1988cb5a236e6526121f9) | `` gdl: suppress gcc14 warning ``                                                      |
| [`cbaab9e8`](https://github.com/NixOS/nixpkgs/commit/cbaab9e81887c47affbb3e3f1d2961a326faf0bf) | `` gildas: fix update script ``                                                        |
| [`b6716b47`](https://github.com/NixOS/nixpkgs/commit/b6716b47a7cdc71aaf6740fd25cd48595eb6f655) | `` otfcc: mark as broken ``                                                            |
| [`9d4ca9fd`](https://github.com/NixOS/nixpkgs/commit/9d4ca9fda9a41c1b3c21afe6ec2f144a818f940c) | `` btop: 1.4.1 -> 1.4.2 ``                                                             |
| [`4582f0ab`](https://github.com/NixOS/nixpkgs/commit/4582f0abfb59eb277cebd4f90c7caa3bb110e17e) | `` tabby-agent: remove khaneliman maintainer ``                                        |
| [`92b142d8`](https://github.com/NixOS/nixpkgs/commit/92b142d85c49d143e5d5db87bbb01265f82a8fc7) | `` python312Packages.biothings-client: fix build ``                                    |
| [`c679e0a2`](https://github.com/NixOS/nixpkgs/commit/c679e0a281f817d8eba90897b40f541271f65f8e) | `` python3Packages.pyrfxtrx: 0.31.1 -> 0.32.0 ``                                       |
| [`790abc9b`](https://github.com/NixOS/nixpkgs/commit/790abc9b4e3bbfa251608564043955f1b6fc460f) | `` cargo-embassy: fix build on darwin ``                                               |
| [`a8305531`](https://github.com/NixOS/nixpkgs/commit/a830553100044f4b96e3ddc2dee308a3206cc646) | `` evil-helix: 20250104 -> 20250413 ``                                                 |
| [`6077b78e`](https://github.com/NixOS/nixpkgs/commit/6077b78ec1dcdd652ffd4fdec7556fd0ebdbf37b) | `` evil-helix: add updateScript ``                                                     |
| [`96ed544a`](https://github.com/NixOS/nixpkgs/commit/96ed544a341349ff0f347b3db8d7aa5bf1ea4877) | `` python312Packages.pyfdt: init at 0.3 (#322590) ``                                   |
| [`de670fa4`](https://github.com/NixOS/nixpkgs/commit/de670fa46645033491f265417047ecdeac648bab) | `` workflows/labels: fix wrong yaml file ``                                            |
| [`7a1aa2ca`](https://github.com/NixOS/nixpkgs/commit/7a1aa2caab751400ddb76f04cd91ade326a35e49) | `` elpa: 2025.01.001 -> 2025.01.002 ``                                                 |
| [`70e9cddb`](https://github.com/NixOS/nixpkgs/commit/70e9cddb66597389ad4640ce347c2c4700797b19) | `` luau: `gitUpdater` -> `nix-update-script` ``                                        |
| [`781331ef`](https://github.com/NixOS/nixpkgs/commit/781331efdd66c8c6f4bbb28d97001e53f7034c53) | `` luau: add HeitorAugustoLN as a maintainer ``                                        |
| [`fe6e4a2b`](https://github.com/NixOS/nixpkgs/commit/fe6e4a2b95ccb800dff849c1aed97531e279498d) | `` luau: refactor ``                                                                   |
| [`ff373532`](https://github.com/NixOS/nixpkgs/commit/ff373532a205279df4377f860f7d94e5804d3b9f) | `` luau: 0.671 -> 0.672 ``                                                             |
| [`44af5e7a`](https://github.com/NixOS/nixpkgs/commit/44af5e7a1d52c918f1eb8520fd1ebe29e3e65d50) | `` maintainers: sersorrel -> keysmashes ``                                             |
| [`6cb93f22`](https://github.com/NixOS/nixpkgs/commit/6cb93f221b91b747962cae9d1de26d99f4e1003c) | `` workflows/labeler: fix double quotes ``                                             |
| [`2480e356`](https://github.com/NixOS/nixpkgs/commit/2480e356dc9309a48389aacb80f4bdd8fd2a0897) | `` workflows/backport: avoid broken korthout/backport-action output ``                 |
| [`b6375b21`](https://github.com/NixOS/nixpkgs/commit/b6375b21c0996de13051110c80ff72ec1669261c) | `` workflows/backport: fix conditional ``                                              |
| [`374e14f2`](https://github.com/NixOS/nixpkgs/commit/374e14f2eabdbd31f1d51ce4be255d1e10b1f24f) | `` phpExtensions.ds: 1.5.0 -> 1.6.0 ``                                                 |
| [`e6762359`](https://github.com/NixOS/nixpkgs/commit/e67623596d0f31f912652729993ec20f8bd91059) | `` workflows/labeler: fix repo owner condition ``                                      |
| [`6cc5b627`](https://github.com/NixOS/nixpkgs/commit/6cc5b627a16cea2534c9a376999140d014b65852) | `` protols: 0.11.6 -> 0.12.0 ``                                                        |
| [`6d7712d6`](https://github.com/NixOS/nixpkgs/commit/6d7712d625239b77687e8b9a4fa03c720b132d6b) | `` bird3: downgrade to 3.0.2 (#404140) ``                                              |
| [`b3672211`](https://github.com/NixOS/nixpkgs/commit/b3672211982ba417ab4289f1aab66b96bf73b1e0) | `` unison-ucm: 0.5.37 -> 0.5.39 ``                                                     |
| [`8d92119c`](https://github.com/NixOS/nixpkgs/commit/8d92119c540d78599ba208010c722a60958810f4) | `` electron-source.electron_36: init at 36.1.0 ``                                      |
| [`20401cb2`](https://github.com/NixOS/nixpkgs/commit/20401cb20c563ab65e87fc41c726d5541e912164) | ``  electron-chromedriver_36: init at 36.1.0 ``                                        |
| [`b880fdd3`](https://github.com/NixOS/nixpkgs/commit/b880fdd3f59312a5ac1ec9ab412555415c326b65) | `` electron_36-bin: init at 36.1.0 ``                                                  |
| [`dbcf59c5`](https://github.com/NixOS/nixpkgs/commit/dbcf59c56147a90d727cdf748c3dabc81a32978a) | `` otpauth: 0.5.4 -> 0.6.0 ``                                                          |
| [`23fe35ce`](https://github.com/NixOS/nixpkgs/commit/23fe35ce9d7e72cc820d63b6696b64b6c16da8fa) | `` nuclear: 0.6.46 -> 0.6.47 ``                                                        |
| [`fa154d18`](https://github.com/NixOS/nixpkgs/commit/fa154d184f6aa13691ac3c9de7452c3be60844d3) | `` workflows/backport: add "has: port to stable" label on success ``                   |