### PR TITLE
chore(flake/akuse-flake): `023c7801` -> `96a3ba6a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -48,11 +48,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1746393651,
-        "narHash": "sha256-wSFSvXgMh2H41St5ZPA0PcR+lbYM52RUgkvrTDKqFDw=",
+        "lastModified": 1746552072,
+        "narHash": "sha256-zwxiMdRAfU7Lf7aL1jegcyJl5D3GvuZk02ZGNjZdGmE=",
         "owner": "Rishabh5321",
         "repo": "akuse-flake",
-        "rev": "023c7801c349fb32ff5cd9b6d243a2eedb9c6030",
+        "rev": "96a3ba6a532b6c2bdbb9fadf6fe980dd8fc4f811",
         "type": "github"
       },
       "original": {
@@ -999,11 +999,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1746328495,
-        "narHash": "sha256-uKCfuDs7ZM3QpCE/jnfubTg459CnKnJG/LwqEVEdEiw=",
+        "lastModified": 1746461020,
+        "narHash": "sha256-7+pG1I9jvxNlmln4YgnlW4o+w0TZX24k688mibiFDUE=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "979daf34c8cacebcd917d540070b52a3c2b9b16e",
+        "rev": "3730d8a308f94996a9ba7c7138ede69c1b9ac4ae",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                   | Message                                          |
| -------------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
| [`96a3ba6a`](https://github.com/Rishabh5321/akuse-flake/commit/96a3ba6a532b6c2bdbb9fadf6fe980dd8fc4f811) | `` chore(flake/nixpkgs): 979daf34 -> 3730d8a3 `` |