### PR TITLE
chore(flake/thorium): `06ae2b1b` -> `87ec8d62`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1126,11 +1126,11 @@
     },
     "nixpkgs_7": {
       "locked": {
-        "lastModified": 1746328495,
-        "narHash": "sha256-uKCfuDs7ZM3QpCE/jnfubTg459CnKnJG/LwqEVEdEiw=",
+        "lastModified": 1746461020,
+        "narHash": "sha256-7+pG1I9jvxNlmln4YgnlW4o+w0TZX24k688mibiFDUE=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "979daf34c8cacebcd917d540070b52a3c2b9b16e",
+        "rev": "3730d8a308f94996a9ba7c7138ede69c1b9ac4ae",
         "type": "github"
       },
       "original": {
@@ -1384,11 +1384,11 @@
         "nixpkgs": "nixpkgs_7"
       },
       "locked": {
-        "lastModified": 1746393564,
-        "narHash": "sha256-fv4XvmNpsTWK4XMbRnN1GTsNpRWHUs6D0hcfzs43/9c=",
+        "lastModified": 1746551994,
+        "narHash": "sha256-BPmHnIcDlkUz5zapXDa/tAZZq/DYVhPZ+bchWW3uE2Y=",
         "owner": "Rishabh5321",
         "repo": "thorium_flake",
-        "rev": "06ae2b1b121dd56ff56d203305fc9f0c54b022a3",
+        "rev": "87ec8d62d9cc2e8318b1926f42ab3b846bbb024d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                     | Message                                          |
| ---------------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
| [`87ec8d62`](https://github.com/Rishabh5321/thorium_flake/commit/87ec8d62d9cc2e8318b1926f42ab3b846bbb024d) | `` chore(flake/nixpkgs): 979daf34 -> 3730d8a3 `` |