### PR TITLE
chore(flake/home-manager): `8a318641` -> `35535345`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -496,11 +496,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1746413188,
-        "narHash": "sha256-i6BoiQP0PasExESQHszC0reQHfO6D4aI2GzOwZMOI20=",
+        "lastModified": 1746585355,
+        "narHash": "sha256-p+3fK8HEYC+0q4gPKSE4OSRxqt5H/tWZkB9wF7aaWOY=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "8a318641ac13d3bc0a53651feaee9560f9b2d89a",
+        "rev": "35535345be0be7dbae2e9b787c6cf790f8c893d5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                          |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
| [`35535345`](https://github.com/nix-community/home-manager/commit/35535345be0be7dbae2e9b787c6cf790f8c893d5) | `` television: add shell integrations (#6983) `` |
| [`60964ff8`](https://github.com/nix-community/home-manager/commit/60964ff845ec5965cde978377f3f73bcef84abe5) | `` mako: fix example config (#6987) ``           |