### PR TITLE
chore(flake/zen-browser): `f8a48c4f` -> `58a198db`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1550,11 +1550,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1746562898,
-        "narHash": "sha256-GP+7S02EMw8NGudIIK4QjYuJIkojS7SMm2RIn+jRxTo=",
+        "lastModified": 1746587386,
+        "narHash": "sha256-FRVjZ3yrgWuosOnpc7tfamQ91y5sGgGaGm+DyuQ3kPg=",
         "owner": "0xc000022070",
         "repo": "zen-browser-flake",
-        "rev": "f8a48c4f6f8783cd1f17603081f0bf79bd12a0c8",
+        "rev": "58a198dbd34735ce7ef88f214fa0d7ecacf330ac",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                          | Message                                                                 |
| --------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------- |
| [`58a198db`](https://github.com/0xc000022070/zen-browser-flake/commit/58a198dbd34735ce7ef88f214fa0d7ecacf330ac) | `` chore(update): twilight @ x86_64 && aarch64 to 1.12.2t#1746586724 `` |