### PR TITLE
chore(flake/nixpkgs-stable): `5b35d248` -> `1d3aeb5a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1030,11 +1030,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1746422338,
-        "narHash": "sha256-NTtKOTLQv6dPfRe00OGSywg37A1FYqldS6xiNmqBUYc=",
+        "lastModified": 1746557022,
+        "narHash": "sha256-QkNoyEf6TbaTW5UZYX0OkwIJ/ZMeKSSoOMnSDPQuol0=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "5b35d248e9206c1f3baf8de6a7683fee126364aa",
+        "rev": "1d3aeb5a193b9ff13f63f4d9cc169fb88129f860",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                     |
| ---------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------- |
| [`6ffbc805`](https://github.com/NixOS/nixpkgs/commit/6ffbc805c4d33cce975b3dfcb544f865c67fc671) | `` librewolf: fix syntax error causing patches to not be applied ``         |
| [`95a7aa68`](https://github.com/NixOS/nixpkgs/commit/95a7aa68c4564ba09f946aa59380d3409c7e7a86) | `` amazon-q-cli: add `versionCheckHook` ``                                  |
| [`fbb709c1`](https://github.com/NixOS/nixpkgs/commit/fbb709c183094ed2fcd0a0aac9ac078cb007d0c6) | `` amazon-q-cli: use `finalAttrs` pattern ``                                |
| [`7e6376f7`](https://github.com/NixOS/nixpkgs/commit/7e6376f74c14c878dd4d8975003e42cd54d11f4a) | `` amazon-q-cli: 1.8.0 -> 1.9.1 ``                                          |
| [`d7f3dd31`](https://github.com/NixOS/nixpkgs/commit/d7f3dd319524c0c7ee6a1f60550c5941239c055c) | `` linux_testing: 6.15-rc4 -> 6.15-rc5 ``                                   |
| [`74bb5ca9`](https://github.com/NixOS/nixpkgs/commit/74bb5ca95dba3acd68882568b1cf25f7e97466df) | `` workflows/no-channel: run again when base changed ``                     |
| [`4e1b4ee4`](https://github.com/NixOS/nixpkgs/commit/4e1b4ee420f36e5e204fef11358c33bd50c4577b) | `` workflows/keep-sorted: make it fail ``                                   |
| [`56bae6da`](https://github.com/NixOS/nixpkgs/commit/56bae6da7186dcfece257dba785a85207351b76a) | `` skypeforlinux: remove ``                                                 |
| [`70e47018`](https://github.com/NixOS/nixpkgs/commit/70e4701847c510f0802970c13768b6607db2d777) | `` build(deps): bump actions/create-github-app-token from 2.0.2 to 2.0.6 `` |
| [`e4b08dff`](https://github.com/NixOS/nixpkgs/commit/e4b08dffa873444e66736640f389aa079f1dd8aa) | `` workflows/backport: fix typo ``                                          |
| [`9add1502`](https://github.com/NixOS/nixpkgs/commit/9add1502dc6dd2e838d82630cd88ac977940cc95) | `` whois: 5.5.23 -> 5.6.0 ``                                                |
| [`7bec8fe0`](https://github.com/NixOS/nixpkgs/commit/7bec8fe05b096278edeafb90ace034b96142829a) | `` k3s_1_31: 1.31.7+k3s1 -> 1.31.8+k3s1 ``                                  |
| [`bff64cd3`](https://github.com/NixOS/nixpkgs/commit/bff64cd37d761b8164048da3553e5a5422591dc5) | `` k3s_1_30: 1.30.11+k3s1 -> 1.30.12+k3s1 ``                                |
| [`2e03a190`](https://github.com/NixOS/nixpkgs/commit/2e03a19041d5bd1261925a99f076910fccae0718) | `` k3s_1_29: mark as insecure due to EOL on 2025-02-28 ``                   |
| [`bd2b5c45`](https://github.com/NixOS/nixpkgs/commit/bd2b5c45a27a8c652d9ccacddeb2868aac86be67) | `` librewolf-unwrapped: 137.0.2-1 -> 138.0.1-2 ``                           |
| [`1fa6fef6`](https://github.com/NixOS/nixpkgs/commit/1fa6fef6e75775814edeab91ff24e7ce92eb30dd) | `` velocity: 3.4.0-unstable-2025-04-03 -> 3.4.0-unstable-2025-04-30 ``      |
| [`1744ddf0`](https://github.com/NixOS/nixpkgs/commit/1744ddf0414ef689aeee38beebf063e5a85b3153) | `` budgie-systemmonitor-applet: init at 0.2.1 ``                            |
| [`11641a55`](https://github.com/NixOS/nixpkgs/commit/11641a55e835002fb0a29adb2ed3a8be8f742c87) | `` signal-desktop(darwin): 7.47.0 -> 7.52.0 ``                              |
| [`3ce392cd`](https://github.com/NixOS/nixpkgs/commit/3ce392cd6665cd22a0b2f9b70759d80d72f7b831) | `` signal-desktop: cleanup `copy-noto-emoji.py` ``                          |
| [`1294a4b4`](https://github.com/NixOS/nixpkgs/commit/1294a4b4d93c0f5ef18f0bc438e827461a23b5ab) | `` signal-desktop: replace apple emoji sheets ``                            |
| [`1098ca90`](https://github.com/NixOS/nixpkgs/commit/1098ca90ec6206e3ca339278953bce8a266c35e1) | `` signal-desktop(aarch64-linux): 7.47.0 ->7.52.0 ``                        |
| [`6ff73fd5`](https://github.com/NixOS/nixpkgs/commit/6ff73fd543765b480834db973d74c68d8cf4d1b7) | `` signal-desktop: 7.47.0 -> 7.52.0 ``                                      |