### PR TITLE
chore(flake/home-manager): `35535345` -> `5da6eafc`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -496,11 +496,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1746585355,
-        "narHash": "sha256-p+3fK8HEYC+0q4gPKSE4OSRxqt5H/tWZkB9wF7aaWOY=",
+        "lastModified": 1746630201,
+        "narHash": "sha256-2i/xaGRhngpk2h/WEtppodY6mpfozOEBhlW9sZquTbk=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "35535345be0be7dbae2e9b787c6cf790f8c893d5",
+        "rev": "5da6eafceb2ea15b39de54d853cc224409e4c1a9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                                             |
| ----------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------- |
| [`5da6eafc`](https://github.com/nix-community/home-manager/commit/5da6eafceb2ea15b39de54d853cc224409e4c1a9) | `` treewide: remove unused code (#6985) ``                                          |
| [`76274a21`](https://github.com/nix-community/home-manager/commit/76274a2130db36a6754f0bf262daac63f2afbd1e) | `` tests/man: index.bt -> index.db ``                                               |
| [`ba454389`](https://github.com/nix-community/home-manager/commit/ba45438996c3bc6c245af9833904c12836923b8d) | `` tests/darwinScrublist: add newsboat ``                                           |
| [`f78a171f`](https://github.com/nix-community/home-manager/commit/f78a171fe4e6a6e0ae5c33c5be8abe72e8a43eb3) | `` mako: use toKebabCase for option transformation ``                               |
| [`327885ce`](https://github.com/nix-community/home-manager/commit/327885ceae1aecc9b966e9370eb4043d2c169b0c) | `` lib/deprecations: add mkSettingsRenamedOptionModules with transform parameter `` |
| [`94d32062`](https://github.com/nix-community/home-manager/commit/94d32062ca42d8149cd77d2b3e3ec5c8c4103084) | `` lib/strings: add toCaseWithSeparator ``                                          |
| [`9cebc4cb`](https://github.com/nix-community/home-manager/commit/9cebc4cb8af0d4f71acadbb5f53bee1e406cec03) | `` lib/strings: add toKebabCase ``                                                  |
| [`e121442b`](https://github.com/nix-community/home-manager/commit/e121442b6583fdbfd968cca6fb7def58af0b6288) | `` lib/strings: add toSnakeCase ``                                                  |