### PR TITLE
chore(flake/home-manager): `5da6eafc` -> `708074ae`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -496,11 +496,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1746630201,
-        "narHash": "sha256-2i/xaGRhngpk2h/WEtppodY6mpfozOEBhlW9sZquTbk=",
+        "lastModified": 1746632058,
+        "narHash": "sha256-Mp5Bbvb+YlFEZ76C/0wFS6C1lRfH3D60u465wFNlnS0=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "5da6eafceb2ea15b39de54d853cc224409e4c1a9",
+        "rev": "708074ae6db9e0468e4f48477f856e8c2d059795",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                                             |
| ----------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------- |
| [`708074ae`](https://github.com/nix-community/home-manager/commit/708074ae6db9e0468e4f48477f856e8c2d059795) | `` treewide: Prevent IFD by default ``                                              |
| [`ae442685`](https://github.com/nix-community/home-manager/commit/ae442685297517b5fcdd85787d95c3927e4aabf5) | `` prezto: Remove unnecessary import-from-derivation ``                             |
| [`f3384e68`](https://github.com/nix-community/home-manager/commit/f3384e688da328fcec78c6a437566b40fd6f8a18) | `` tmpfiles: also remove files that need to be removed during activation (#6980) `` |
| [`1d5fb9da`](https://github.com/nix-community/home-manager/commit/1d5fb9da1061e30012ee68675a489ac5780c1877) | `` flake.lock: Update (#6992) ``                                                    |