### PR TITLE
chore(flake/hyprland): `7a971735` -> `22b12e30`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -625,11 +625,11 @@
         "xdph": "xdph"
       },
       "locked": {
-        "lastModified": 1746643919,
-        "narHash": "sha256-pgOhwsaiLAX3Ofugdkcwrysd2jqap9o2+7qe4eK0jro=",
+        "lastModified": 1746655655,
+        "narHash": "sha256-hPMsUK1r3Cxx8KoCZVaYJH5ThDT5VRUDMMFmyVei1Eo=",
         "owner": "hyprwm",
         "repo": "Hyprland",
-        "rev": "7a971735af6bfc7f8d74005afa02f6fd01228f89",
+        "rev": "22b12e3013adf66b462b174688f82bd53ba8e721",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                                                  |
| ------------------------------------------------------------------------------------------------ | -------------------------------------------------------- |
| [`22b12e30`](https://github.com/hyprwm/Hyprland/commit/22b12e3013adf66b462b174688f82bd53ba8e721) | `` refactor: cshader class to sshader struct (#10324) `` |