### PR TITLE
chore(flake/home-manager): `708074ae` -> `ec71b516`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -496,11 +496,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1746632058,
-        "narHash": "sha256-Mp5Bbvb+YlFEZ76C/0wFS6C1lRfH3D60u465wFNlnS0=",
+        "lastModified": 1746661235,
+        "narHash": "sha256-TAm/SnOT8AD3YKYOdjtg5Nmf/hCKEwc0USHBIoXV8qo=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "708074ae6db9e0468e4f48477f856e8c2d059795",
+        "rev": "ec71b5162848e6369bdf2be8d2f1dd41cded88e8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                             |
| ----------------------------------------------------------------------------------------------------------- | --------------------------------------------------- |
| [`ec71b516`](https://github.com/nix-community/home-manager/commit/ec71b5162848e6369bdf2be8d2f1dd41cded88e8) | `` sbt: Scoping credentials to ThisBuild (#6026) `` |
| [`a8e2d08f`](https://github.com/nix-community/home-manager/commit/a8e2d08ffdc68123316b57cf2ad51244c7eca335) | `` alot: allow commas in maildir path (#6989) ``    |