### PR TITLE
chore(flake/zen-browser): `f7df01be` -> `4327bc93`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1550,11 +1550,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1746673883,
-        "narHash": "sha256-AJKmlEa+LWgNWD0gSdiu/m4bcNdkDldH53X9SpHDwSY=",
+        "lastModified": 1746685734,
+        "narHash": "sha256-bA6UKUmA/byQjO5MuyOT62Z4rg36DW4kt7QIqEQTDB0=",
         "owner": "0xc000022070",
         "repo": "zen-browser-flake",
-        "rev": "f7df01be857e2b5cbe4d77a1ff92e9095438b8e1",
+        "rev": "4327bc9352789c7e28bda04696a38a08f10dd716",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                          | Message                                                  |
| --------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------- |
| [`4327bc93`](https://github.com/0xc000022070/zen-browser-flake/commit/4327bc9352789c7e28bda04696a38a08f10dd716) | `` chore(update): beta @ x86_64 && aarch64 to 1.12.2b `` |