### PR TITLE
chore(flake/home-manager): `cea975d4` -> `3c59c513`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -496,11 +496,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1746710194,
-        "narHash": "sha256-r2zE8+rWZieU05LMKixeU5SsMy9I4truiTPKchTPNaw=",
+        "lastModified": 1746719124,
+        "narHash": "sha256-KOL73WIjO00ds1oIe+5HAcGcpd/TfE6dymmmYbiSlYM=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "cea975d46d08293eae3ad0d9f16207f1ce2dfc81",
+        "rev": "3c59c5132b64e885faca381e713b579dcbddba75",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                              |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------ |
| [`3c59c513`](https://github.com/nix-community/home-manager/commit/3c59c5132b64e885faca381e713b579dcbddba75) | `` wayprompt: init module (#7002) `` |
| [`c84396bd`](https://github.com/nix-community/home-manager/commit/c84396bda0371cb42147c82ad051bebf8a158bd5) | `` rofi: modes optional (#7003) ``   |