### PR TITLE
chore(flake/hyprland): `22b12e30` -> `fa1e343b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -625,11 +625,11 @@
         "xdph": "xdph"
       },
       "locked": {
-        "lastModified": 1746655655,
-        "narHash": "sha256-hPMsUK1r3Cxx8KoCZVaYJH5ThDT5VRUDMMFmyVei1Eo=",
+        "lastModified": 1746721787,
+        "narHash": "sha256-ZqQQDry1rRuuqilVONEtifqQbxwymsIRWY2byO/BBdQ=",
         "owner": "hyprwm",
         "repo": "Hyprland",
-        "rev": "22b12e3013adf66b462b174688f82bd53ba8e721",
+        "rev": "fa1e343b0448d20b9b64dfa19fa28b6883d8af47",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                                                           |
| ------------------------------------------------------------------------------------------------ | ----------------------------------------------------------------- |
| [`fa1e343b`](https://github.com/hyprwm/Hyprland/commit/fa1e343b0448d20b9b64dfa19fa28b6883d8af47) | `` compositor: set fullscreenstate on movetoworkspace (#10303) `` |