### PR TITLE
chore(flake/hyprland): `fa1e343b` -> `2b3cac01`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -625,11 +625,11 @@
         "xdph": "xdph"
       },
       "locked": {
-        "lastModified": 1746721787,
-        "narHash": "sha256-ZqQQDry1rRuuqilVONEtifqQbxwymsIRWY2byO/BBdQ=",
+        "lastModified": 1746725856,
+        "narHash": "sha256-dR/Kf+uOKJglumPl/Ko70nNnMTodijFlJy2F1/Z1nGI=",
         "owner": "hyprwm",
         "repo": "Hyprland",
-        "rev": "fa1e343b0448d20b9b64dfa19fa28b6883d8af47",
+        "rev": "2b3cac018ef4cbd7c9b2b5c5249783958ed391fb",
         "type": "github"
       },
       "original": {
@@ -773,11 +773,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1746637914,
-        "narHash": "sha256-YRYeG+Zp7dQKYBtyOv15vXzLfguinmUm6LNzq5cCEkc=",
+        "lastModified": 1746655412,
+        "narHash": "sha256-kVQ0bHVtX6baYxRWWIh4u3LNJZb9Zcm2xBeDPOGz5BY=",
         "owner": "hyprwm",
         "repo": "hyprlang",
-        "rev": "e863ebcee936dd57f360cca4fec0220da19c5b2d",
+        "rev": "557241780c179cf7ef224df392f8e67dab6cef83",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                          |
| ------------------------------------------------------------------------------------------------ | -------------------------------- |
| [`2b3cac01`](https://github.com/hyprwm/Hyprland/commit/2b3cac018ef4cbd7c9b2b5c5249783958ed391fb) | `` flake.lock: update ``         |
| [`f909b0f1`](https://github.com/hyprwm/Hyprland/commit/f909b0f114e9024d6edbdad0e714df4c6cf961f5) | `` opengl: fix legacyrenderer `` |