### PR TITLE
chore(flake/hyprland): `2b3cac01` -> `f01e3043`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -625,11 +625,11 @@
         "xdph": "xdph"
       },
       "locked": {
-        "lastModified": 1746725856,
-        "narHash": "sha256-dR/Kf+uOKJglumPl/Ko70nNnMTodijFlJy2F1/Z1nGI=",
+        "lastModified": 1746730909,
+        "narHash": "sha256-1VgtMdr/WY8QffUZl9c6FecUE7E2WjK+gM9B/5Uy/P0=",
         "owner": "hyprwm",
         "repo": "Hyprland",
-        "rev": "2b3cac018ef4cbd7c9b2b5c5249783958ed391fb",
+        "rev": "f01e3043b81d1ad7d886f0502b445bdf3cea0ccc",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                                                                                        |
| ------------------------------------------------------------------------------------------------ | ---------------------------------------------------------------------------------------------- |
| [`f01e3043`](https://github.com/hyprwm/Hyprland/commit/f01e3043b81d1ad7d886f0502b445bdf3cea0ccc) | `` desktop: cleanup code and use std::ranges (#10289) ``                                       |
| [`04c98abd`](https://github.com/hyprwm/Hyprland/commit/04c98abd1fe7f3d63c6060ea175e0a5cd9cd9947) | `` layout: properly assign workspace and monitor when moving a child to the parent (#10338) `` |
| [`53bfb92d`](https://github.com/hyprwm/Hyprland/commit/53bfb92d6539e63e65f63965eca12fa33597764a) | `` layout: allow interacting with pinned windows when fullscreened (#10326) ``                 |