### PR TITLE
chore(flake/zen-browser): `1965b827` -> `17dd0241`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1550,11 +1550,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1746725877,
-        "narHash": "sha256-0YQx51XJyV43yjdv2+RHoO+C8wgI5V9L1DGVGr1+8hY=",
+        "lastModified": 1746734921,
+        "narHash": "sha256-kn9Swevxid1Y8/IaBjr4HnyxQMploh+KkmiOlvTqfFE=",
         "owner": "0xc000022070",
         "repo": "zen-browser-flake",
-        "rev": "1965b827dc7f89e48744ec52e41dce920485ea85",
+        "rev": "17dd0241cacfa1524df0acb997907ad31e058576",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                          | Message                                                                 |
| --------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------- |
| [`17dd0241`](https://github.com/0xc000022070/zen-browser-flake/commit/17dd0241cacfa1524df0acb997907ad31e058576) | `` chore(update): twilight @ x86_64 && aarch64 to 1.12.3t#1746730032 `` |
| [`be0384aa`](https://github.com/0xc000022070/zen-browser-flake/commit/be0384aad3020cace82901139df71850f8feaaee) | `` revert: "ci(update): better twilight release name (#57)" (#58) ``    |