### PR TITLE
chore(flake/zen-browser): `17dd0241` -> `55f12a3e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1550,11 +1550,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1746734921,
-        "narHash": "sha256-kn9Swevxid1Y8/IaBjr4HnyxQMploh+KkmiOlvTqfFE=",
+        "lastModified": 1746740338,
+        "narHash": "sha256-LtDqXFrusHAVPeb+A5o2tjHfDDhluZ1IRK5LzyuAgpA=",
         "owner": "0xc000022070",
         "repo": "zen-browser-flake",
-        "rev": "17dd0241cacfa1524df0acb997907ad31e058576",
+        "rev": "55f12a3e6128017211370a6a882269ef39346e16",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                          | Message                                                  |
| --------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------- |
| [`55f12a3e`](https://github.com/0xc000022070/zen-browser-flake/commit/55f12a3e6128017211370a6a882269ef39346e16) | `` chore(update): beta @ x86_64 && aarch64 to 1.12.3b `` |