### PR TITLE
chore(flake/akuse-flake): `96a3ba6a` -> `16fd6355`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -48,11 +48,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1746552072,
-        "narHash": "sha256-zwxiMdRAfU7Lf7aL1jegcyJl5D3GvuZk02ZGNjZdGmE=",
+        "lastModified": 1746746584,
+        "narHash": "sha256-Ln0K6FW/Fp7DGZZof9z1eRwm30BJubJrIVQVzbHtijo=",
         "owner": "Rishabh5321",
         "repo": "akuse-flake",
-        "rev": "96a3ba6a532b6c2bdbb9fadf6fe980dd8fc4f811",
+        "rev": "16fd6355031401580458f8526089199529a33e1f",
         "type": "github"
       },
       "original": {
@@ -999,11 +999,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1746461020,
-        "narHash": "sha256-7+pG1I9jvxNlmln4YgnlW4o+w0TZX24k688mibiFDUE=",
+        "lastModified": 1746592047,
+        "narHash": "sha256-GYYT5Pc+sZZWomgC7EgDSNSfmXd9Jby9nXQ6bAswUCg=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "3730d8a308f94996a9ba7c7138ede69c1b9ac4ae",
+        "rev": "8fcc71459655f2486b3da197b8d6a62f595a33d2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                   | Message                                          |
| -------------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
| [`16fd6355`](https://github.com/Rishabh5321/akuse-flake/commit/16fd6355031401580458f8526089199529a33e1f) | `` chore(flake/nixpkgs): 3730d8a3 -> 8fcc7145 `` |