### PR TITLE
chore(flake/better-control): `40d2f963` -> `83bddbb6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -210,11 +210,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1746393010,
-        "narHash": "sha256-hKKgN1aR+KFybG+w9FqZpKntd5dC3VULHA1nYMonxiI=",
+        "lastModified": 1746751935,
+        "narHash": "sha256-WYtMORTJiPorFyFcuB7YOYqZ/yBV91H7VxErSqTp10k=",
         "owner": "rishabh5321",
         "repo": "better-control-flake",
-        "rev": "40d2f963e8e7373839fd044142915a9871b8de61",
+        "rev": "83bddbb64afa59aa1a485a01831650ac56b58400",
         "type": "github"
       },
       "original": {
@@ -1046,11 +1046,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1746328495,
-        "narHash": "sha256-uKCfuDs7ZM3QpCE/jnfubTg459CnKnJG/LwqEVEdEiw=",
+        "lastModified": 1746663147,
+        "narHash": "sha256-Ua0drDHawlzNqJnclTJGf87dBmaO/tn7iZ+TCkTRpRc=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "979daf34c8cacebcd917d540070b52a3c2b9b16e",
+        "rev": "dda3dcd3fe03e991015e9a74b22d35950f264a54",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                            | Message                                          |
| ----------------------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
| [`83bddbb6`](https://github.com/Rishabh5321/better-control-flake/commit/83bddbb64afa59aa1a485a01831650ac56b58400) | `` chore(flake/nixpkgs): 979daf34 -> dda3dcd3 `` |