### PR TITLE
chore(flake/thorium): `87ec8d62` -> `30a5b6ac`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1126,11 +1126,11 @@
     },
     "nixpkgs_7": {
       "locked": {
-        "lastModified": 1746461020,
-        "narHash": "sha256-7+pG1I9jvxNlmln4YgnlW4o+w0TZX24k688mibiFDUE=",
+        "lastModified": 1746592047,
+        "narHash": "sha256-GYYT5Pc+sZZWomgC7EgDSNSfmXd9Jby9nXQ6bAswUCg=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "3730d8a308f94996a9ba7c7138ede69c1b9ac4ae",
+        "rev": "8fcc71459655f2486b3da197b8d6a62f595a33d2",
         "type": "github"
       },
       "original": {
@@ -1384,11 +1384,11 @@
         "nixpkgs": "nixpkgs_7"
       },
       "locked": {
-        "lastModified": 1746551994,
-        "narHash": "sha256-BPmHnIcDlkUz5zapXDa/tAZZq/DYVhPZ+bchWW3uE2Y=",
+        "lastModified": 1746746463,
+        "narHash": "sha256-vpOrEN2+/Mf7tsx+mgux7InfKOtxt75k/kIRCIDyckU=",
         "owner": "Rishabh5321",
         "repo": "thorium_flake",
-        "rev": "87ec8d62d9cc2e8318b1926f42ab3b846bbb024d",
+        "rev": "30a5b6ac81ccd3eef898dfb8dcc4cb18df411ef1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                     | Message                                          |
| ---------------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
| [`30a5b6ac`](https://github.com/Rishabh5321/thorium_flake/commit/30a5b6ac81ccd3eef898dfb8dcc4cb18df411ef1) | `` chore(flake/nixpkgs): 3730d8a3 -> 8fcc7145 `` |