### PR TITLE
chore(flake/akuse-flake): `16fd6355` -> `e3d7b956`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -48,11 +48,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1746746584,
-        "narHash": "sha256-Ln0K6FW/Fp7DGZZof9z1eRwm30BJubJrIVQVzbHtijo=",
+        "lastModified": 1746755504,
+        "narHash": "sha256-19rsaXxwhn9fkJXXj0tRBwlNzc7FoD5BsP9HqbbGpEg=",
         "owner": "Rishabh5321",
         "repo": "akuse-flake",
-        "rev": "16fd6355031401580458f8526089199529a33e1f",
+        "rev": "e3d7b9568c8b8f0607d998cbfca745964dd1d941",
         "type": "github"
       },
       "original": {
@@ -999,11 +999,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1746592047,
-        "narHash": "sha256-GYYT5Pc+sZZWomgC7EgDSNSfmXd9Jby9nXQ6bAswUCg=",
+        "lastModified": 1746663147,
+        "narHash": "sha256-Ua0drDHawlzNqJnclTJGf87dBmaO/tn7iZ+TCkTRpRc=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "8fcc71459655f2486b3da197b8d6a62f595a33d2",
+        "rev": "dda3dcd3fe03e991015e9a74b22d35950f264a54",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                   | Message                                          |
| -------------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
| [`e3d7b956`](https://github.com/Rishabh5321/akuse-flake/commit/e3d7b9568c8b8f0607d998cbfca745964dd1d941) | `` chore(flake/nixpkgs): 8fcc7145 -> dda3dcd3 `` |