### PR TITLE
chore(flake/home-manager): `f2b5bf55` -> `e95a7c5b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -496,11 +496,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1746796988,
-        "narHash": "sha256-p6O0JDG/MxVwIzcFzj5NAQI5Uq39GSK5DZLP4KzK9NI=",
+        "lastModified": 1746798521,
+        "narHash": "sha256-axfz/jBEH9XHpS7YSumstV7b2PrPf7L8bhWUtLBv3nA=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "f2b5bf55aa439a6c517adfcb9715a5a952020c5f",
+        "rev": "e95a7c5b6fa93304cd2fd78cf676c4f6d23c422c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                                          |
| ----------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------- |
| [`e95a7c5b`](https://github.com/nix-community/home-manager/commit/e95a7c5b6fa93304cd2fd78cf676c4f6d23c422c) | `` Revert "direnv: update nushell env conversion logic (#6999)" (#7014) ``       |
| [`b706037a`](https://github.com/nix-community/home-manager/commit/b706037a60acc727f1b5c037e84dc61a35ef1db1) | `` distrobox: make systemd unit optional (#7007) ``                              |
| [`e9bd9568`](https://github.com/nix-community/home-manager/commit/e9bd9568db6b627155664090ea39a1b6ece0af47) | `` jujutsu: store configuration in $XDG_CONFIG_HOME for all platforms (#6994) `` |