### PR TITLE
chore(flake/zen-browser): `697676ff` -> `efa32c93`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1550,11 +1550,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1746825459,
-        "narHash": "sha256-d5Pbf8fn+fvkl3XQRmojybbCTCAUpq7WWfkaBg8mXKc=",
+        "lastModified": 1746846243,
+        "narHash": "sha256-AV7zvbi1SVbGxODW7SKw3MhMkS1SQNNwp+XEky14rR4=",
         "owner": "0xc000022070",
         "repo": "zen-browser-flake",
-        "rev": "697676ff0c4f6377659db7972e8db845d65181f9",
+        "rev": "efa32c933ca9f6341bbf57ede9a674d45ebe72e2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                          | Message                                                                 |
| --------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------- |
| [`efa32c93`](https://github.com/0xc000022070/zen-browser-flake/commit/efa32c933ca9f6341bbf57ede9a674d45ebe72e2) | `` chore(update): twilight @ x86_64 && aarch64 to 1.12.3t#1746846115 `` |