### PR TITLE
chore(flake/stylix): `6690180c` -> `1c71f3bd`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1291,11 +1291,11 @@
         "tinted-zed": "tinted-zed"
       },
       "locked": {
-        "lastModified": 1746806701,
-        "narHash": "sha256-3XzWny4EsC1SuBuNP0yWI1lwuFbo1P8jioayreHODqg=",
+        "lastModified": 1746875263,
+        "narHash": "sha256-WhcWBF8c7l9LoLQ18n9NjuvCBF5WJ6c2DemDTZgGKsI=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "6690180c17153026c854584e8b7cb9df599127fe",
+        "rev": "1c71f3bde228f7b17c1aad75f2b97276daf8db42",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                        | Message                                |
| --------------------------------------------------------------------------------------------- | -------------------------------------- |
| [`1c71f3bd`](https://github.com/danth/stylix/commit/1c71f3bde228f7b17c1aad75f2b97276daf8db42) | `` treewide: use lib.getExe (#1241) `` |