### PR TITLE
chore(flake/home-manager): `e95a7c5b` -> `12e67385`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -496,11 +496,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1746798521,
-        "narHash": "sha256-axfz/jBEH9XHpS7YSumstV7b2PrPf7L8bhWUtLBv3nA=",
+        "lastModified": 1746892839,
+        "narHash": "sha256-0b9us0bIOgA1j/s/6zlxVyP3m97yAh0U+YwKayJ6mmU=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "e95a7c5b6fa93304cd2fd78cf676c4f6d23c422c",
+        "rev": "12e67385964d9c9304daa81d0ad5ba3b01fdd35e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                            |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------ |
| [`12e67385`](https://github.com/nix-community/home-manager/commit/12e67385964d9c9304daa81d0ad5ba3b01fdd35e) | `` docs: remove recommendation to wait for maintainers for news `` |
| [`6fd639db`](https://github.com/nix-community/home-manager/commit/6fd639dbe5183850b6c4a7fb47ae04c4808cb891) | `` docs: update news.md to highlight create-news-entry command ``  |
| [`c4bd004d`](https://github.com/nix-community/home-manager/commit/c4bd004d9d8981837d958264b809f7edc93d9957) | `` flake.nix: expose create-news-entry as a package ``             |