### PR TITLE
chore(flake/home-manager): `12e67385` -> `9ef92f1c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -496,11 +496,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1746892839,
-        "narHash": "sha256-0b9us0bIOgA1j/s/6zlxVyP3m97yAh0U+YwKayJ6mmU=",
+        "lastModified": 1746912617,
+        "narHash": "sha256-SSw/98B3Htw7iJWCyq08fAEL5w+a/Vj+YbQq0msVFTA=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "12e67385964d9c9304daa81d0ad5ba3b01fdd35e",
+        "rev": "9ef92f1c6b77944198fd368ec805ced842352a1d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                    |
| ----------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------- |
| [`9ef92f1c`](https://github.com/nix-community/home-manager/commit/9ef92f1c6b77944198fd368ec805ced842352a1d) | `` waveterm: fix markdown in description ``                |
| [`13289f06`](https://github.com/nix-community/home-manager/commit/13289f06429700f3ecf8f5109ed8831839f09145) | `` services.autorandr: improve systemd unit description `` |
| [`1875b5a1`](https://github.com/nix-community/home-manager/commit/1875b5a1606a897d9285d80600c7ab566911c7bc) | `` services.autorandr: improve configurability ``          |
| [`555f88ad`](https://github.com/nix-community/home-manager/commit/555f88ad3452f1d2ce1560e7209b0b6af0c6033b) | `` services.autorandr: add package option ``               |
| [`4f442217`](https://github.com/nix-community/home-manager/commit/4f44221724ce074404fb0e569acdd6c456ed22d2) | `` services.autorandr: add lowlevl to maintainers ``       |
| [`b96c332d`](https://github.com/nix-community/home-manager/commit/b96c332dce9a1974ee046a4dcd5860a5f41009f5) | `` maintainers: add lowlevl ``                             |