### PR TITLE
chore(flake/home-manager): `9ef92f1c` -> `de496c9c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -496,11 +496,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1746912617,
-        "narHash": "sha256-SSw/98B3Htw7iJWCyq08fAEL5w+a/Vj+YbQq0msVFTA=",
+        "lastModified": 1746925690,
+        "narHash": "sha256-qbCIdIK3CEMfD+X9bMvp/ZLNxU722RV7zD7kUQS9OBg=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "9ef92f1c6b77944198fd368ec805ced842352a1d",
+        "rev": "de496c9ccb705ed76c1f23c2cad13e8970c37f0b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                            |
| ----------------------------------------------------------------------------------------------------------- | -------------------------------------------------- |
| [`de496c9c`](https://github.com/nix-community/home-manager/commit/de496c9ccb705ed76c1f23c2cad13e8970c37f0b) | `` television: add support for channels (#7026) `` |