### PR TITLE
chore(flake/nixpkgs-stable): `1d3aeb5a` -> `0c0bf9c0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1030,11 +1030,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1746557022,
-        "narHash": "sha256-QkNoyEf6TbaTW5UZYX0OkwIJ/ZMeKSSoOMnSDPQuol0=",
+        "lastModified": 1746810718,
+        "narHash": "sha256-VljtYzyttmvkWUKTVJVW93qAsJsrBbgAzy7DdnJaQfI=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "1d3aeb5a193b9ff13f63f4d9cc169fb88129f860",
+        "rev": "0c0bf9c057382d5f6f63d54fd61f1abd5e1c2f63",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                              |
| ---------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------- |
| [`0aab5ff7`](https://github.com/NixOS/nixpkgs/commit/0aab5ff7a319cec34e96b4ba939b011773c0b78a) | `` linux-firmware: 20250410 -> 20250509 ``                                                           |
| [`86003e6d`](https://github.com/NixOS/nixpkgs/commit/86003e6dea8624a9ae37568843c6572c35ad9388) | `` erlang_25: 25.3.2.20 -> 25.3.2.21 ``                                                              |
| [`4264a2b1`](https://github.com/NixOS/nixpkgs/commit/4264a2b16bea6f5ee47b795385261d48d71ace84) | `` fdroidserver: 2.3.5 -> 2.4.0 ``                                                                   |
| [`796e22ed`](https://github.com/NixOS/nixpkgs/commit/796e22ed96b0b9cc76167d729d470f0bff0d35af) | `` fdroidserver: 2.3.4 -> 2.3.5 ``                                                                   |
| [`e854cc51`](https://github.com/NixOS/nixpkgs/commit/e854cc5103e582472f492068445096759438a971) | `` fdroidserver: 2.3.1 -> 2.3.4 ``                                                                   |
| [`12ae282c`](https://github.com/NixOS/nixpkgs/commit/12ae282c6f2645cb68489fc0d708f0dea74322f7) | `` fdroidserver: 2.3a2 -> 2.3.0 ``                                                                   |
| [`18e3eee2`](https://github.com/NixOS/nixpkgs/commit/18e3eee27dc53d816a0d9d6488ec5157b32d663a) | `` tail-tray: 0.2.21 -> 0.2.22 ``                                                                    |
| [`0f31f218`](https://github.com/NixOS/nixpkgs/commit/0f31f21812e6116218432fe43779a1bfa7de2b51) | `` grafana-image-renderer: 3.12.1 -> 3.12.5 ``                                                       |
| [`a76b7b0c`](https://github.com/NixOS/nixpkgs/commit/a76b7b0cf71e945b3d966540e5ecd79ab4c1e875) | `` php84: 8.4.6 -> 8.4.7 ``                                                                          |
| [`0cefb763`](https://github.com/NixOS/nixpkgs/commit/0cefb7632886bde5d992c8cacb549d754f32b517) | `` discord: 0.0.93 -> 0.0.94 ``                                                                      |
| [`64536037`](https://github.com/NixOS/nixpkgs/commit/645360378adc05737a20ef50f30ee79d81c22db0) | `` php83: 8.3.20 -> 8.3.21 ``                                                                        |
| [`5187041e`](https://github.com/NixOS/nixpkgs/commit/5187041e6b5c81511ae8715d2b094056bd56564b) | `` matrix-synapse: 1.128.0 -> 1.129.0 ``                                                             |
| [`e32e4cbe`](https://github.com/NixOS/nixpkgs/commit/e32e4cbea5d0013538e4dd50b5bd4249e95fb7fa) | `` ladybird: mark vulnerable ``                                                                      |
| [`c0912454`](https://github.com/NixOS/nixpkgs/commit/c0912454bdb017e03d2db9bfb61fd187b21c6bb3) | `` systemd-initrd: migrate test to runTest and add comment for syntax highlighting of test script `` |
| [`49373c27`](https://github.com/NixOS/nixpkgs/commit/49373c27c7cde70c8b4e3d51ddee74b232677483) | `` systemd-initrd: add test to ensure that the permissions on the systemd generators are correct ``  |
| [`04cf881c`](https://github.com/NixOS/nixpkgs/commit/04cf881c5dcdafa79de054a56c7bcb9b46999da7) | `` make-initrd-ng: fix file permissions ``                                                           |
| [`d979eb85`](https://github.com/NixOS/nixpkgs/commit/d979eb85d30524341a949ad9d4bf6e20ea62736c) | `` deepin.deepin-system-monitor: 6.5.0 -> 6.5.4 ``                                                   |
| [`fe49b3cf`](https://github.com/NixOS/nixpkgs/commit/fe49b3cf3b6947c64e1c32b34b96fef7d4eaa31c) | `` ci/eval: use correct maintainer and team positions ``                                             |
| [`18832d7f`](https://github.com/NixOS/nixpkgs/commit/18832d7f4a9a74a9b36a4625751e257f5d4f70d9) | `` ci/eval/compare: support optional byName argument ``                                              |
| [`70e8e20e`](https://github.com/NixOS/nixpkgs/commit/70e8e20efeeb56d3717fe9f9abda2a7e4b0e698c) | `` ci/eval/compare: add meta.teams ``                                                                |
| [`d107bc4e`](https://github.com/NixOS/nixpkgs/commit/d107bc4eb4beeb598810a83487c09c057292cbfe) | `` gitlab: 17.11.1 -> 17.11.2 ``                                                                     |
| [`647aae52`](https://github.com/NixOS/nixpkgs/commit/647aae52436cce8f5c64ffb136ac1e62afd9a3c8) | `` workflows/editorconfig.editorconfig-checker: 2.4.0 -> 3.2.0 ``                                    |
| [`dcb92614`](https://github.com/NixOS/nixpkgs/commit/dcb926149770fd79b02bb54374de6545b644484d) | `` various: remove trailing whitespace ``                                                            |
| [`1d361b44`](https://github.com/NixOS/nixpkgs/commit/1d361b447e47341692478b15aadb77539314f73e) | `` xbindkeys-config: add .editorconfig for generated file ``                                         |
| [`f662d2cf`](https://github.com/NixOS/nixpkgs/commit/f662d2cf80eb5208aaf959a512091c77bc49a522) | `` .editorconfig: move subfolder config into separate .editorconfig files ``                         |
| [`006ebaaf`](https://github.com/NixOS/nixpkgs/commit/006ebaaff9d72b7fcbe5990a6b0f74c0e91f8699) | `` .editorconfig: fix moved folders ``                                                               |
| [`13292207`](https://github.com/NixOS/nixpkgs/commit/13292207856268a95de7b8f96fc29e5864abaa80) | `` ungoogled-chromium: 136.0.7103.59-1 -> 136.0.7103.92-1 ``                                         |
| [`91954fb7`](https://github.com/NixOS/nixpkgs/commit/91954fb73a5427faeec39c4be88652837652df10) | `` python313Packages.django_5: 5.1.8 -> 5.1.9 ``                                                     |
| [`91da743e`](https://github.com/NixOS/nixpkgs/commit/91da743ea41aaf0554307bcdcd58b331a66fe84a) | `` linux_xanmod_latest: 6.14.4 -> 6.14.5 ``                                                          |
| [`e6d5e962`](https://github.com/NixOS/nixpkgs/commit/e6d5e9622a139c0beb9f88d8dac7c66f6fb4d7b5) | `` linux_xanmod: 6.12.25 -> 6.12.26 ``                                                               |
| [`7193fd60`](https://github.com/NixOS/nixpkgs/commit/7193fd6046ac01104f794d25f5f61419c701b495) | `` linux_xanmod_latest: 6.13.12 -> 6.14.4 ``                                                         |
| [`9b8dd53c`](https://github.com/NixOS/nixpkgs/commit/9b8dd53c4fd8dd352c896c9ab84838c666695726) | `` linux_xanmod: 6.12.24 -> 6.12.25 ``                                                               |
| [`1ca9a8fa`](https://github.com/NixOS/nixpkgs/commit/1ca9a8fabcc7b6d382ae42ed5ceb7364539db710) | `` postgresql_17: 17.4 -> 17.5 ``                                                                    |
| [`fddc49ab`](https://github.com/NixOS/nixpkgs/commit/fddc49abd53cb65a986b0552fb7fe467c8381825) | `` postgresql_15: 15.12 -> 15.13 ``                                                                  |
| [`3d314086`](https://github.com/NixOS/nixpkgs/commit/3d31408671c96d4890f379a7efcbd91ad5210d24) | `` postgresql_14: 14.17 -> 14.18 ``                                                                  |
| [`93b8c541`](https://github.com/NixOS/nixpkgs/commit/93b8c541101e426a9e0a3a0e5c557452e170bf26) | `` postgresql_13: 13.20 -> 13.21 ``                                                                  |
| [`7ba46983`](https://github.com/NixOS/nixpkgs/commit/7ba46983b1e680f058989c59311dae5950519d86) | `` workflows/no-channel: fix typo ``                                                                 |
| [`5261fded`](https://github.com/NixOS/nixpkgs/commit/5261fded3b26064d15943e3e92724069f55d9e5e) | `` gotosocial: 0.19.0 -> 0.19.1 ``                                                                   |
| [`ff678dce`](https://github.com/NixOS/nixpkgs/commit/ff678dcec901e8eb9d18dd83bce578b264b74c7d) | `` ci/eval-stats: sort output table by metric name ``                                                |
| [`c87f23db`](https://github.com/NixOS/nixpkgs/commit/c87f23db833365d3630a7fd86b1fcd071e7deac2) | `` fix(ci/eval-stats): resolve prResult symlink ``                                                   |
| [`068e2247`](https://github.com/NixOS/nixpkgs/commit/068e2247d4e51dbb4278966057b622b16d9a94fc) | `` gerrit: 3.10.5 -> 3.10.6 ``                                                                       |
| [`e25c95d5`](https://github.com/NixOS/nixpkgs/commit/e25c95d5bd8ce8b739251ccbdab186d2fb12e54c) | `` skimpdf 1.7.3 -> 1.7.9 ``                                                                         |
| [`479ba557`](https://github.com/NixOS/nixpkgs/commit/479ba557065bc7dfaeaa79706886b439a53cc0b9) | `` labels: prevent labelling PRs to staging-next as backport ``                                      |
| [`2cb7a8a4`](https://github.com/NixOS/nixpkgs/commit/2cb7a8a40254b125e94a2374eda6b548d797dce3) | `` mastodon: 4.3.7 -> 4.3.8 ``                                                                       |
| [`d5d3b3d4`](https://github.com/NixOS/nixpkgs/commit/d5d3b3d41c9611e7601858931e49690b58b438f8) | `` chromium,chromedriver: 136.0.7103.59 -> 136.0.7103.92 ``                                          |
| [`4bab873b`](https://github.com/NixOS/nixpkgs/commit/4bab873b2804c006971a383cb3eb538b9a523be4) | `` bird2: 2.17 -> 2.17.1 ``                                                                          |
| [`c44c037c`](https://github.com/NixOS/nixpkgs/commit/c44c037cc30fdfce3f88e009d43457c2349b81cb) | `` maintainer-list: run keep-sorted ``                                                               |
| [`3d1d2f97`](https://github.com/NixOS/nixpkgs/commit/3d1d2f97f0e88f710a8ad666010f151d614bc4de) | `` workflows/check-maintainers-sorted: drop and replace with keep-sorted ``                          |
| [`d41560f5`](https://github.com/NixOS/nixpkgs/commit/d41560f5afb3297912bb98fc152450dcff742c58) | `` build(deps): bump cachix/install-nix-action from 31.2.0 to 31.3.0 ``                              |
| [`a9777b45`](https://github.com/NixOS/nixpkgs/commit/a9777b458bf2c6fd22e830a41766d89162fc0c43) | `` kanidm: fix provisioning patches for 1.4.x -> 1.5.x ``                                            |
| [`77ad3ac9`](https://github.com/NixOS/nixpkgs/commit/77ad3ac9ccd16704f422bdf6e670d0c907100474) | `` mattermost: 9.11.11 -> 9.11.13 ``                                                                 |
| [`272ce124`](https://github.com/NixOS/nixpkgs/commit/272ce1242fe193baf002f53e18ab7f3ff611ea0d) | `` linuxKernel.kernels.linux_lqx: 6.14.4-lqx1 -> 6.14.5-lqx1 ``                                      |
| [`2a08ac05`](https://github.com/NixOS/nixpkgs/commit/2a08ac058921f4b4df25ad9dcdab0975f76b2017) | `` linuxKernel.kernels.linux_zen: 6.14.4-zen1 -> 6.14.5-zen1 ``                                      |