### PR TITLE
chore(flake/zen-browser): `9e7b6774` -> `8ea62f0a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1550,11 +1550,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1746927799,
-        "narHash": "sha256-Sc0U99sp23lUgN0r2QBgh/g0j+YNeLr26905WqCw+Fw=",
+        "lastModified": 1746933269,
+        "narHash": "sha256-KcNetsT3QnJJhJTfOdBQK/+/pjD3xAP+cvl1hciLoVs=",
         "owner": "0xc000022070",
         "repo": "zen-browser-flake",
-        "rev": "9e7b67744af2ffb9f90e00a87ea4611a86d1e449",
+        "rev": "8ea62f0a38c615af424eb9b4ef53f8824637cefe",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                          | Message                                                                 |
| --------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------- |
| [`8ea62f0a`](https://github.com/0xc000022070/zen-browser-flake/commit/8ea62f0a38c615af424eb9b4ef53f8824637cefe) | `` chore(update): twilight @ x86_64 && aarch64 to 1.12.3t#1746932516 `` |