### PR TITLE
chore(flake/stylix): `382ec4b3` -> `ad7dcca7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1291,11 +1291,11 @@
         "tinted-zed": "tinted-zed"
       },
       "locked": {
-        "lastModified": 1746920920,
-        "narHash": "sha256-ENbL0XE1+mcZOPfyyzOSGOm8gxr8jYRFmEqjY6bypIs=",
+        "lastModified": 1746979519,
+        "narHash": "sha256-gowWY4N/xm3gbCDCfZIpE4aK8ZS0Nhi3Mo8PzQAoTFs=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "382ec4b31a1c5ce7bac233d31fbe018b17d974b0",
+        "rev": "ad7dcca79d966383807625297bb14390637297cf",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                        | Message                              |
| --------------------------------------------------------------------------------------------- | ------------------------------------ |
| [`ad7dcca7`](https://github.com/danth/stylix/commit/ad7dcca79d966383807625297bb14390637297cf) | `` ci: add labeler action (#1137) `` |