### PR TITLE
chore(flake/stylix): `91f71c13` -> `77696d77`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1291,11 +1291,11 @@
         "tinted-zed": "tinted-zed"
       },
       "locked": {
-        "lastModified": 1746983525,
-        "narHash": "sha256-II9J3HTVABUFNxNKXcLg08o8ejNAKbONwO7ZAi4GZ88=",
+        "lastModified": 1747005042,
+        "narHash": "sha256-dHkA+mgfSF0CJ8lKEcn4xC9/p2YfKRhQLD3mj8U5VOc=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "91f71c13b52610c9d27d107500489d0c5c1573e3",
+        "rev": "77696d77ae58afa41ddd93365a11dad5f906ec02",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                        | Message                                                                 |
| --------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------- |
| [`77696d77`](https://github.com/danth/stylix/commit/77696d77ae58afa41ddd93365a11dad5f906ec02) | `` yazi: more color tweaks (#1245) ``                                   |
| [`aaf976a8`](https://github.com/danth/stylix/commit/aaf976a8198be266a5d33b202e1a68363983f4a0) | `` stylix: emphasize compliance with Nixpkgs maintainer list (#1254) `` |