### PR TITLE
chore(flake/stylix): `77696d77` -> `6b830955`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -517,11 +517,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1746369725,
-        "narHash": "sha256-m3ai7LLFYsymMK0uVywCceWfUhP0k3CALyFOfcJACqE=",
+        "lastModified": 1746912617,
+        "narHash": "sha256-SSw/98B3Htw7iJWCyq08fAEL5w+a/Vj+YbQq0msVFTA=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "1a1793f6d940d22c6e49753548c5b6cb7dc5545d",
+        "rev": "9ef92f1c6b77944198fd368ec805ced842352a1d",
         "type": "github"
       },
       "original": {
@@ -1291,11 +1291,11 @@
         "tinted-zed": "tinted-zed"
       },
       "locked": {
-        "lastModified": 1747005042,
-        "narHash": "sha256-dHkA+mgfSF0CJ8lKEcn4xC9/p2YfKRhQLD3mj8U5VOc=",
+        "lastModified": 1747005453,
+        "narHash": "sha256-78PfIpo3jCuX7pT3k4DkEES+KEy7pnrFGugsQ2w652o=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "77696d77ae58afa41ddd93365a11dad5f906ec02",
+        "rev": "6b8309550e50358b63366d9bf3edb7ef08b9a7cc",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                        | Message                       |
| --------------------------------------------------------------------------------------------- | ----------------------------- |
| [`6b830955`](https://github.com/danth/stylix/commit/6b8309550e50358b63366d9bf3edb7ef08b9a7cc) | `` wayprompt: init (#1250) `` |