### PR TITLE
chore(flake/akuse-flake): `5db8f83b` -> `f53697e0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -48,11 +48,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1746803632,
-        "narHash": "sha256-lpGkds6IpHhGZtBiaPtQM3OftMF+BFnHYCgBLxwcg08=",
+        "lastModified": 1747005687,
+        "narHash": "sha256-u/vISe7SpTfiuZtYfo1cln7EAC/yV1QP3sVgC9uAAXs=",
         "owner": "Rishabh5321",
         "repo": "akuse-flake",
-        "rev": "5db8f83b221cec154ba4c0a33b9a844b363c483d",
+        "rev": "f53697e0916e764e5a97e2876e6b9d1c6ad4d3aa",
         "type": "github"
       },
       "original": {
@@ -999,11 +999,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1746663147,
-        "narHash": "sha256-Ua0drDHawlzNqJnclTJGf87dBmaO/tn7iZ+TCkTRpRc=",
+        "lastModified": 1746904237,
+        "narHash": "sha256-3e+AVBczosP5dCLQmMoMEogM57gmZ2qrVSrmq9aResQ=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "dda3dcd3fe03e991015e9a74b22d35950f264a54",
+        "rev": "d89fc19e405cb2d55ce7cc114356846a0ee5e956",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                   | Message                                          |
| -------------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
| [`f53697e0`](https://github.com/Rishabh5321/akuse-flake/commit/f53697e0916e764e5a97e2876e6b9d1c6ad4d3aa) | `` chore(flake/nixpkgs): dda3dcd3 -> d89fc19e `` |