### PR TITLE
chore(flake/home-manager): `ff915842` -> `c74665ab`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -496,11 +496,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1746981801,
-        "narHash": "sha256-+Bfr0KqZV6gZdA7e2kupeoawozaLIHLuiPtC54uxbFc=",
+        "lastModified": 1747009742,
+        "narHash": "sha256-TNhbM7R45fpq2cdWzvFj+H5ZTcE//I5XSe78GFh0cDY=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "ff915842e4a2e63c4c8c5c08c6870b9d5b3c3ee9",
+        "rev": "c74665abd6e4e37d3140e68885bc49a994ffa53c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                        |
| ----------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------- |
| [`c74665ab`](https://github.com/nix-community/home-manager/commit/c74665abd6e4e37d3140e68885bc49a994ffa53c) | `` bacon: add prefs location to settings decription (#7030) `` |
| [`7a3f3e55`](https://github.com/nix-community/home-manager/commit/7a3f3e550737c3ed43f6abf33a560cb58537d21f) | `` misc: fix mozilla native messaging hosts ``                 |
| [`a48fecda`](https://github.com/nix-community/home-manager/commit/a48fecda099e9324134f6dd88fe7e38f58d2d9d2) | `` files: add home.file.<name>.ignorelinks ``                  |
| [`910292fe`](https://github.com/nix-community/home-manager/commit/910292fe342071f83d6906c7ca24864eba28676a) | `` halloy: add module (#7034) ``                               |
| [`ecb21624`](https://github.com/nix-community/home-manager/commit/ecb216242293f8a31c5426b40190700e5b3686fd) | `` numbat: add module ``                                       |
| [`563e1b6c`](https://github.com/nix-community/home-manager/commit/563e1b6cb08256aa883526f5f3deb6970f390e58) | `` maintainers: add Aehmlo ``                                  |
| [`5daf23a3`](https://github.com/nix-community/home-manager/commit/5daf23a38f53119803d1e329bf2eaa101563999c) | `` zellij: add themes option (#7031) ``                        |