### PR TITLE
chore(flake/home-manager): `c74665ab` -> `fb061f55`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -496,11 +496,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1747009742,
-        "narHash": "sha256-TNhbM7R45fpq2cdWzvFj+H5ZTcE//I5XSe78GFh0cDY=",
+        "lastModified": 1747021744,
+        "narHash": "sha256-IDsM/9/tHQBlhG3tXI2fTM84AUN1uRa7JDPT1LMlGes=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "c74665abd6e4e37d3140e68885bc49a994ffa53c",
+        "rev": "fb061f555f821fe4fb49f8f6f2a0cc3d5728bd52",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                        |
| ----------------------------------------------------------------------------------------------------------- | ---------------------------------------------- |
| [`fb061f55`](https://github.com/nix-community/home-manager/commit/fb061f555f821fe4fb49f8f6f2a0cc3d5728bd52) | `` misc: add news entries for March modules `` |
| [`0083d901`](https://github.com/nix-community/home-manager/commit/0083d901a33696bf8d29966775bc420e302fb7ea) | `` misc: add news entries for April modules `` |
| [`4a7311c2`](https://github.com/nix-community/home-manager/commit/4a7311c2353a1ae1292500e25b0e18866dd115aa) | `` misc: add news entries for May modules ``   |