### PR TITLE
chore(flake/akuse-flake): `f53697e0` -> `608ddab4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -48,11 +48,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1747005687,
-        "narHash": "sha256-u/vISe7SpTfiuZtYfo1cln7EAC/yV1QP3sVgC9uAAXs=",
+        "lastModified": 1747024914,
+        "narHash": "sha256-7funPYEGcy19XkMBzPPOosK7glqwciPhtELiLXCPZx8=",
         "owner": "Rishabh5321",
         "repo": "akuse-flake",
-        "rev": "f53697e0916e764e5a97e2876e6b9d1c6ad4d3aa",
+        "rev": "608ddab451d546c6ca75d486cc65f615c71eb7ef",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                   | Message                                            |
| -------------------------------------------------------------------------------------------------------- | -------------------------------------------------- |
| [`608ddab4`](https://github.com/Rishabh5321/akuse-flake/commit/608ddab451d546c6ca75d486cc65f615c71eb7ef) | `` Restrict GitLab sync workflow to main branch `` |