### PR TITLE
chore(flake/hyprpanel): `0c82ce97` -> `2bb1449f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -822,11 +822,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1745885816,
-        "narHash": "sha256-yuIb6/gGcII+2YgtTLcYdga0pcL63B18xQ/oitOhg7k=",
+        "lastModified": 1747029715,
+        "narHash": "sha256-F75IlhzUF+VTPOq+u2Exj+6PjHWPkLcBWDnhO+Vvch4=",
         "owner": "Jas-SinghFSU",
         "repo": "HyprPanel",
-        "rev": "0c82ce9704c8063be8d8f60443071c91943eb68c",
+        "rev": "2bb1449fb6ad60a736ce6fb4de2037d7655545ed",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                  | Message                                                                  |
| ------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------ |
| [`2bb1449f`](https://github.com/Jas-SinghFSU/HyprPanel/commit/2bb1449fb6ad60a736ce6fb4de2037d7655545ed) | `` Fix: An issue that would cause Matugen colors to not apply. (#929) `` |