### PR TITLE
chore(flake/hyprland): `04124988` -> `da3583fd`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -625,11 +625,11 @@
         "xdph": "xdph"
       },
       "locked": {
-        "lastModified": 1746981380,
-        "narHash": "sha256-DtbrvHzKF4diOJWx1FB5wIh8SCSk1Iq5pkA7mh3JAJc=",
+        "lastModified": 1747052147,
+        "narHash": "sha256-c0e3V7Rqu2DZuix1lRBXedInzSskow8ssQSsmqkW38o=",
         "owner": "hyprwm",
         "repo": "Hyprland",
-        "rev": "04124988e8b4a9cdfc5995388ebfaad0005b4b31",
+        "rev": "da3583fd5e86044d02af9fcfac84724e02545336",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                                                          |
| ------------------------------------------------------------------------------------------------ | ---------------------------------------------------------------- |
| [`da3583fd`](https://github.com/hyprwm/Hyprland/commit/da3583fd5e86044d02af9fcfac84724e02545336) | `` opengl: publicize shader creation/usage functions (#10378) `` |