### PR TITLE
chore(flake/nixpkgs-stable): `0c0bf9c0` -> `a39ed32a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1030,11 +1030,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1746810718,
-        "narHash": "sha256-VljtYzyttmvkWUKTVJVW93qAsJsrBbgAzy7DdnJaQfI=",
+        "lastModified": 1746957726,
+        "narHash": "sha256-k9ut1LSfHCr0AW82ttEQzXVCqmyWVA5+SHJkS5ID/Jo=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "0c0bf9c057382d5f6f63d54fd61f1abd5e1c2f63",
+        "rev": "a39ed32a651fdee6842ec930761e31d1f242cb94",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                    |
| ---------------------------------------------------------------------------------------------- | ---------------------------------------------------------- |
| [`aa256aec`](https://github.com/NixOS/nixpkgs/commit/aa256aec7149a29dbe2b2ec04d1086b0f16f0298) | `` workflows/eval-aliases: split from eval ``              |
| [`72778c43`](https://github.com/NixOS/nixpkgs/commit/72778c43a5b08da724628d4daf558b4b61b3a046) | `` workflows/check-nixf-tidy: drop ``                      |
| [`b793f5ff`](https://github.com/NixOS/nixpkgs/commit/b793f5ffc003e6624df23fd99c03b0c3474108cd) | `` fetchurl: don't prefer hashed mirrors by default ``     |
| [`6591df26`](https://github.com/NixOS/nixpkgs/commit/6591df26df5d1a1c1ef17a2c7938cfef07e0c850) | `` workflows/keep-sorted: drop and move to treefmt ``      |
| [`a89ab840`](https://github.com/NixOS/nixpkgs/commit/a89ab840508514ebe7285328ccd57c793406eeb8) | `` workflows/editorconfig: drop and move to treefmt ``     |
| [`1e445555`](https://github.com/NixOS/nixpkgs/commit/1e4455556bbbe3532e230d7769be576237a77e26) | `` widevine-cdm: 4.10.2830.0 -> 4.10.2891.0 ``             |
| [`a3c29582`](https://github.com/NixOS/nixpkgs/commit/a3c295824a4412eef7ee2fe22ef3d78384ea0969) | `` widevine-cdm: fix eval outside unsupported platforms `` |
| [`74c3bb1f`](https://github.com/NixOS/nixpkgs/commit/74c3bb1f9b3e74b6c56e61f338ac8d452a9c4cdd) | `` widevine-cdm: add aarch64-linux ``                      |
| [`2cbf8688`](https://github.com/NixOS/nixpkgs/commit/2cbf86884a8a57034d50b5c43867795c7e5ce4c0) | `` widevine-cdm: move to by-name ``                        |
| [`6f216d0e`](https://github.com/NixOS/nixpkgs/commit/6f216d0e5479b1d77094fa16cb5ef6082859da04) | `` ci/compare: nix stats comparison ``                     |