### PR TITLE
chore(flake/stylix): `6b830955` -> `0c0df649`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1291,11 +1291,11 @@
         "tinted-zed": "tinted-zed"
       },
       "locked": {
-        "lastModified": 1747005453,
-        "narHash": "sha256-78PfIpo3jCuX7pT3k4DkEES+KEy7pnrFGugsQ2w652o=",
+        "lastModified": 1747070959,
+        "narHash": "sha256-QJ8kMmkfUmDiJv/aq9obRPG5Z/fB6nXrejJA003+Hd0=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "6b8309550e50358b63366d9bf3edb7ef08b9a7cc",
+        "rev": "0c0df649f7dcbc597fa1d47e8f9a5c2cedab6145",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                        | Message                                         |
| --------------------------------------------------------------------------------------------- | ----------------------------------------------- |
| [`0c0df649`](https://github.com/danth/stylix/commit/0c0df649f7dcbc597fa1d47e8f9a5c2cedab6145) | `` wayprompt: add myself as maintainer ``       |
| [`787a156f`](https://github.com/danth/stylix/commit/787a156f461b09388150dd2b82f977914968c05a) | `` wayprompt: capitalize name ``                |
| [`e020f1e8`](https://github.com/danth/stylix/commit/e020f1e8159cc8999eb3c0b81c8f0711394d2dc2) | `` wayprompt: support opacity ``                |
| [`89ebfe95`](https://github.com/danth/stylix/commit/89ebfe959b94f3a9828f97cca8def137a6243aae) | `` wayprompt: drop generation of 0x prefixes `` |