### PR TITLE
chore(flake/zen-browser): `c8fe4a46` -> `50065c8b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1550,11 +1550,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1747067139,
-        "narHash": "sha256-Ua7GVj+bKmlo1oLWoam+dYhI6sQ6KpG4Z4rJvREZTJA=",
+        "lastModified": 1747071553,
+        "narHash": "sha256-EMIzJ+F2DTuOSPD608HaAra9cah87Emz8GjYNGtxpLo=",
         "owner": "0xc000022070",
         "repo": "zen-browser-flake",
-        "rev": "c8fe4a46c3db6fe6e7c88185c75631e776ac60ec",
+        "rev": "50065c8bee3f5c20d29bce19037447b2c2006c48",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                          | Message                                                            |
| --------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------ |
| [`50065c8b`](https://github.com/0xc000022070/zen-browser-flake/commit/50065c8bee3f5c20d29bce19037447b2c2006c48) | `` ci(update): specific format for twilight release title (#60) `` |