### PR TITLE
chore(flake/home-manager): `f0a7db5e` -> `535a541b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -496,11 +496,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1747081732,
-        "narHash": "sha256-VnR33UmH0KzvTuVg+6oYkDVpnPuHanQisNUXytCRBPQ=",
+        "lastModified": 1747106332,
+        "narHash": "sha256-mOdRWJzJAMp0hF8aSResyp8BeOO5VoSng1uqtEq+8xI=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "f0a7db5ec1d369721e770a45e4d19f8e48186a69",
+        "rev": "535a541b429c1e89f0955c160df1d6d2bfeaf802",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                         |
| ----------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------- |
| [`535a541b`](https://github.com/nix-community/home-manager/commit/535a541b429c1e89f0955c160df1d6d2bfeaf802) | `` halloy: fix themes example (#7046) ``                        |
| [`012cc9e1`](https://github.com/nix-community/home-manager/commit/012cc9e1666b8ce0d6f677b902651f6858dfbe45) | `` halloy: add note about server being required (#7047) ``      |
| [`665c49e0`](https://github.com/nix-community/home-manager/commit/665c49e0c2982d94f30a9826712850a59f70eeb4) | `` gnome-terminal: add package option (#7048) ``                |
| [`628d8cfa`](https://github.com/nix-community/home-manager/commit/628d8cfa5441eabe07fbb24861df1236a8e6dde5) | `` news: migrate news entries to YYYY/MM directory structure `` |
| [`bc13c13e`](https://github.com/nix-community/home-manager/commit/bc13c13ed7f7545a9f34010fa8c3febd1a92c58b) | `` news: reorganize news into YYYY/MM directory structure ``    |