### PR TITLE
chore(flake/home-manager): `535a541b` -> `df556f2a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -496,11 +496,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1747106332,
-        "narHash": "sha256-mOdRWJzJAMp0hF8aSResyp8BeOO5VoSng1uqtEq+8xI=",
+        "lastModified": 1747147271,
+        "narHash": "sha256-ORthkM8I3GpWDK/pjOSXPuxWjLJV2AwWERKQCsjPPAk=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "535a541b429c1e89f0955c160df1d6d2bfeaf802",
+        "rev": "df556f2a17b7b94148d0275c1a57fed20e62ad18",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                        |
| ----------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------- |
| [`df556f2a`](https://github.com/nix-community/home-manager/commit/df556f2a17b7b94148d0275c1a57fed20e62ad18) | `` tests/mako: add a original deprecation test ``              |
| [`78ad8e3c`](https://github.com/nix-community/home-manager/commit/78ad8e3c31cc5239674dfd7ca6159e5ca14da0e8) | `` tests/mako: add a deprecation test ``                       |
| [`0be2c246`](https://github.com/nix-community/home-manager/commit/0be2c246e37a5b6e851111bfcf07ab37194e4954) | `` mako: deprecate criteria option ``                          |
| [`dc589997`](https://github.com/nix-community/home-manager/commit/dc5899978f8fa5d72424d5242784fb7e84e8573e) | `` services/mako: refactor settings to support INI sections `` |