### PR TITLE
chore(flake/home-manager): `8d832ddf` -> `7c1cefb9`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -496,11 +496,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1747155932,
-        "narHash": "sha256-NnPzzXEqfYjfrimLzK0JOBItfdEJdP/i6SNTuunCGgw=",
+        "lastModified": 1747184352,
+        "narHash": "sha256-GBZulv50wztp5cgc405t1uOkxQYhSkMqeKLI+iSrlpk=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "8d832ddfda9facf538f3dda9b6985fb0234f151c",
+        "rev": "7c1cefb98369cc85440642fdccc1c1394ca6dd2c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                           |
| ----------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------- |
| [`7c1cefb9`](https://github.com/nix-community/home-manager/commit/7c1cefb98369cc85440642fdccc1c1394ca6dd2c) | `` zsh: avoid IFD while sourcing prezto ``                        |
| [`5f36563a`](https://github.com/nix-community/home-manager/commit/5f36563a5cae05bcfbaa5e08a69d2e8d94242f61) | `` zsh: consider zsh.{profile,login,logout,env}Extra in prezto `` |
| [`b44c39cf`](https://github.com/nix-community/home-manager/commit/b44c39cf4618ccf58df2b68827ca95a3fecf0655) | `` foliate: fix theme settings example (#7053) ``                 |