### PR TITLE
chore(flake/zen-browser): `c2f45958` -> `9ab2d73d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1550,11 +1550,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1747192203,
-        "narHash": "sha256-nwfzLUFupXp4+X3JN8fvobp92s9TeeX6ajSoYaiX9Jc=",
+        "lastModified": 1747214458,
+        "narHash": "sha256-GAhtPWmcZ6zBE9+F1SrmO0NF7b6aZ2+ju/o0L5ccvLY=",
         "owner": "0xc000022070",
         "repo": "zen-browser-flake",
-        "rev": "c2f45958e7d552e4e55d269ef023a9c2fce8f183",
+        "rev": "9ab2d73dabb6c1bef8963f5708bcd88d5d1f2074",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                          | Message                                                  |
| --------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------- |
| [`9ab2d73d`](https://github.com/0xc000022070/zen-browser-flake/commit/9ab2d73dabb6c1bef8963f5708bcd88d5d1f2074) | `` chore(update): beta @ x86_64 && aarch64 to 1.12.4b `` |