### PR TITLE
chore(flake/zen-browser): `9ab2d73d` -> `a15a4d27`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1550,11 +1550,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1747214458,
-        "narHash": "sha256-GAhtPWmcZ6zBE9+F1SrmO0NF7b6aZ2+ju/o0L5ccvLY=",
+        "lastModified": 1747229462,
+        "narHash": "sha256-JC/M6MboP7K0auO+A6MND+D7oPzB4E8J3YPHOVArPQU=",
         "owner": "0xc000022070",
         "repo": "zen-browser-flake",
-        "rev": "9ab2d73dabb6c1bef8963f5708bcd88d5d1f2074",
+        "rev": "a15a4d2772feb280d0ae2edaddf79dbf7894d594",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                          | Message                                                               |
| --------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------- |
| [`a15a4d27`](https://github.com/0xc000022070/zen-browser-flake/commit/a15a4d2772feb280d0ae2edaddf79dbf7894d594) | `` chore(update): twilight @ x86_64 && aarch64 to 1.13t#1747226483 `` |