### PR TITLE
chore(flake/hyprland): `a51e639d` -> `75f2cb5f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -625,11 +625,11 @@
         "xdph": "xdph"
       },
       "locked": {
-        "lastModified": 1747241297,
-        "narHash": "sha256-BcIFOXyY1SS8vTP753cUu+A0rm/0Guj18Z7NChswpjE=",
+        "lastModified": 1747247479,
+        "narHash": "sha256-y+S9IsF+VbGPvSh/Xr/Qbz1/xGtpsU4DbEE+PnvKg8I=",
         "owner": "hyprwm",
         "repo": "Hyprland",
-        "rev": "a51e639d81b445ad00c5403198e0c1f6c18ed303",
+        "rev": "75f2cb5f6559ca6ca7c6300b270e5ddc3fdabe31",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                                                                 |
| ------------------------------------------------------------------------------------------------ | ----------------------------------------------------------------------- |
| [`75f2cb5f`](https://github.com/hyprwm/Hyprland/commit/75f2cb5f6559ca6ca7c6300b270e5ddc3fdabe31) | `` xwayland: do not include xcb.h when xwayland is disabled (#10407) `` |