### PR TITLE
chore(flake/stylix): `98444a94` -> `71f8b116`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -517,11 +517,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1747081732,
-        "narHash": "sha256-VnR33UmH0KzvTuVg+6oYkDVpnPuHanQisNUXytCRBPQ=",
+        "lastModified": 1747155932,
+        "narHash": "sha256-NnPzzXEqfYjfrimLzK0JOBItfdEJdP/i6SNTuunCGgw=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "f0a7db5ec1d369721e770a45e4d19f8e48186a69",
+        "rev": "8d832ddfda9facf538f3dda9b6985fb0234f151c",
         "type": "github"
       },
       "original": {
@@ -1291,11 +1291,11 @@
         "tinted-zed": "tinted-zed"
       },
       "locked": {
-        "lastModified": 1747248043,
-        "narHash": "sha256-uEEhchsf9l2u7JJk04GZIMRIkuCeJFPSAuTMByqYfIQ=",
+        "lastModified": 1747271033,
+        "narHash": "sha256-FFJoRbdbJQK4LERw1e2LKvYQsO05H4ZQlpjcQmmVqDA=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "98444a942a85072baf12c4a1c4cd5ef9531c8ab0",
+        "rev": "71f8b1166b88751e59648c94ff919cfb94966b3d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                        | Message                                                    |
| --------------------------------------------------------------------------------------------- | ---------------------------------------------------------- |
| [`71f8b116`](https://github.com/danth/stylix/commit/71f8b1166b88751e59648c94ff919cfb94966b3d) | `` nixcord: change theme location on nix-darwin (#1221) `` |
| [`cb42af55`](https://github.com/danth/stylix/commit/cb42af5571ed53c402dc956380a3f0511a9b0d4b) | `` foliate: use upstream option (#1260) ``                 |
| [`2dcb1888`](https://github.com/danth/stylix/commit/2dcb18884f186771285e453a77b8a4778fd18f81) | `` stylix: gitignore .worktree (#1268) ``                  |