### PR TITLE
chore(flake/thorium): `da56d8e9` -> `8193660d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1126,11 +1126,11 @@
     },
     "nixpkgs_7": {
       "locked": {
-        "lastModified": 1746904237,
-        "narHash": "sha256-3e+AVBczosP5dCLQmMoMEogM57gmZ2qrVSrmq9aResQ=",
+        "lastModified": 1747179050,
+        "narHash": "sha256-qhFMmDkeJX9KJwr5H32f1r7Prs7XbQWtO0h3V0a0rFY=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "d89fc19e405cb2d55ce7cc114356846a0ee5e956",
+        "rev": "adaa24fbf46737f3f1b5497bf64bae750f82942e",
         "type": "github"
       },
       "original": {
@@ -1384,11 +1384,11 @@
         "nixpkgs": "nixpkgs_7"
       },
       "locked": {
-        "lastModified": 1747024611,
-        "narHash": "sha256-N8CeIe06D59l0L6qcVjFjA2ujHYLclr8uE4BJzTV5N0=",
+        "lastModified": 1747278713,
+        "narHash": "sha256-Y00BuVqsvUCO96mtPuaDOGYgwwIVJRIcNiLDyxtfb9o=",
         "owner": "Rishabh5321",
         "repo": "thorium_flake",
-        "rev": "da56d8e9a02c45d125c473f285c216f675867523",
+        "rev": "8193660d2f3a4c6bb984cdd5be91cc4027346227",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                     | Message                                          |
| ---------------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
| [`8193660d`](https://github.com/Rishabh5321/thorium_flake/commit/8193660d2f3a4c6bb984cdd5be91cc4027346227) | `` chore(flake/nixpkgs): d89fc19e -> adaa24fb `` |