### PR TITLE
chore(flake/akuse-flake): `608ddab4` -> `f6101a0b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -48,11 +48,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1747024914,
-        "narHash": "sha256-7funPYEGcy19XkMBzPPOosK7glqwciPhtELiLXCPZx8=",
+        "lastModified": 1747278784,
+        "narHash": "sha256-LLIczQjMIVPBlW3HDzw8JM4aUqxmUYUk9wNEd+ISjKA=",
         "owner": "Rishabh5321",
         "repo": "akuse-flake",
-        "rev": "608ddab451d546c6ca75d486cc65f615c71eb7ef",
+        "rev": "f6101a0b069507b242be2685ad645f54955958c8",
         "type": "github"
       },
       "original": {
@@ -999,11 +999,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1746904237,
-        "narHash": "sha256-3e+AVBczosP5dCLQmMoMEogM57gmZ2qrVSrmq9aResQ=",
+        "lastModified": 1747179050,
+        "narHash": "sha256-qhFMmDkeJX9KJwr5H32f1r7Prs7XbQWtO0h3V0a0rFY=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "d89fc19e405cb2d55ce7cc114356846a0ee5e956",
+        "rev": "adaa24fbf46737f3f1b5497bf64bae750f82942e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                   | Message                                          |
| -------------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
| [`f6101a0b`](https://github.com/Rishabh5321/akuse-flake/commit/f6101a0b069507b242be2685ad645f54955958c8) | `` chore(flake/nixpkgs): d89fc19e -> adaa24fb `` |