### PR TITLE
chore(flake/nixpkgs-stable): `a39ed32a` -> `5d736263`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1048,11 +1048,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1746957726,
-        "narHash": "sha256-k9ut1LSfHCr0AW82ttEQzXVCqmyWVA5+SHJkS5ID/Jo=",
+        "lastModified": 1747209494,
+        "narHash": "sha256-fLise+ys+bpyjuUUkbwqo5W/UyIELvRz9lPBPoB0fbM=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "a39ed32a651fdee6842ec930761e31d1f242cb94",
+        "rev": "5d736263df906c5da72ab0f372427814de2f52f8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                        |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------ |
| [`9716504f`](https://github.com/NixOS/nixpkgs/commit/9716504fafbc5ea8de629b998fdbe43e20f35f8b) | `` coqPackages.coq-elpi: expose versions 2.3.0, 2.4.0, and 2.5.0 ``            |
| [`d3df3fd9`](https://github.com/NixOS/nixpkgs/commit/d3df3fd9c687380afc32278efaca4548975f1aa2) | `` firefox-bin-unwrapped: 138.0.1 -> 138.0.3 ``                                |
| [`5f25ea04`](https://github.com/NixOS/nixpkgs/commit/5f25ea04e6303828058394cdea9db1063e681cdd) | `` firefox-unwrapped: 138.0.1 -> 138.0.3 ``                                    |
| [`09b35c91`](https://github.com/NixOS/nixpkgs/commit/09b35c919d51bc292d9de1351296b609b2dd0a6f) | `` activemq: 6.1.3 -> 6.1.6 ``                                                 |
| [`192e75d6`](https://github.com/NixOS/nixpkgs/commit/192e75d6fefe99df9dc14218820d15d98e452a4b) | `` nixos/frigate: create model cache dir ``                                    |
| [`36feba7d`](https://github.com/NixOS/nixpkgs/commit/36feba7d4a5633809628c3da8a654777ea196533) | `` rspamd: disable blas by default ``                                          |
| [`10900729`](https://github.com/NixOS/nixpkgs/commit/109007299027caeda91225fbf2a0430d776c112a) | `` nix-forecast: 0.3.0 -> 0.4.0 ``                                             |
| [`f3c8d923`](https://github.com/NixOS/nixpkgs/commit/f3c8d9231b07edf3a740a579e8ee93724972bd00) | `` buildMozillaMach: update nss version range ``                               |
| [`7c4e6933`](https://github.com/NixOS/nixpkgs/commit/7c4e6933f062da23687758426d376548d304ebc7) | `` buildMozillaMach: reenable system-icu ``                                    |
| [`33896eba`](https://github.com/NixOS/nixpkgs/commit/33896eba263196199780b00285b90ceaf89e7b6f) | `` linux_xanmod_latest: 6.14.5 -> 6.14.6 ``                                    |
| [`d1dc15ca`](https://github.com/NixOS/nixpkgs/commit/d1dc15caeba3f9767f297eec210d2ce9316982ef) | `` linux_xanmod: 6.12.26 -> 6.12.28 ``                                         |
| [`c5af97b5`](https://github.com/NixOS/nixpkgs/commit/c5af97b5a4e534b81a859cd43219c442eddb47c3) | `` linuxKernel.kernels.linux_lqx: 6.14.5-lqx1 -> 6.14.6-lqx1 ``                |
| [`edbbddc6`](https://github.com/NixOS/nixpkgs/commit/edbbddc6439b137bcb14b7e85104f2cb155ac40e) | `` linuxKernel.kernels.linux_zen: 6.14.5-zen1 -> 6.14.6-zen1 ``                |
| [`c7147f06`](https://github.com/NixOS/nixpkgs/commit/c7147f069cf05e6f510526bbf9d5398454c56fbe) | `` python312Packages.alive-progress: move LICENSE to $out/share/doc/ folder `` |
| [`e192c9c6`](https://github.com/NixOS/nixpkgs/commit/e192c9c6d94d3c7c84b6119db3b2a9e6de79c9a6) | `` python312Packages.about-time: move LICENSE to $out/share/doc/ folder ``     |
| [`bcc5ea50`](https://github.com/NixOS/nixpkgs/commit/bcc5ea50719c1958ae89b9eef123fe2370f6afb1) | `` workflows/eval: fix missing dependency of tag job ``                        |
| [`4dad7bd0`](https://github.com/NixOS/nixpkgs/commit/4dad7bd07f4b82b97a7c0543e34e9ddba92ba4ee) | `` workflows/get-merge-commit: fix actionlint warning ``                       |
| [`08cc30a4`](https://github.com/NixOS/nixpkgs/commit/08cc30a4096b01aa8b46302d968b22679a63774c) | `` workflows/check-format: run on all files ``                                 |
| [`06308ec8`](https://github.com/NixOS/nixpkgs/commit/06308ec8d5ad9723dbe26d13e0eba1f94933dbbc) | `` OWNERS: remove ehmry ``                                                     |
| [`4de1e681`](https://github.com/NixOS/nixpkgs/commit/4de1e6816f76f11a3d509542c48f9b97a3ce4ed5) | `` mcpelauncher-{client,ui-qt}: 1.2.0-qt6 -> 1.3.0-qt6 ``                      |
| [`95a344d4`](https://github.com/NixOS/nixpkgs/commit/95a344d410d02567aa631814a3566722ce0b6298) | `` mcpelauncher-client: 1.1.2-qt6 -> 1.2.0-qt6 ``                              |
| [`26873730`](https://github.com/NixOS/nixpkgs/commit/2687373009f869bfe82f553572bde3e8caddef7d) | `` mcpelauncher-client: fix hard-coded paths ``                                |
| [`c0b64b29`](https://github.com/NixOS/nixpkgs/commit/c0b64b298c6b9577d2f8cbec50768bce4f131cb8) | `` mcpelauncher-ui-qt: fix build on Qt 6.9 ``                                  |
| [`3f85194c`](https://github.com/NixOS/nixpkgs/commit/3f85194c2a11c1eb0f8fe325348027cd84b84576) | `` mcpelauncher-ui-qt: 1.1.2-qt6 -> 1.2.0-qt6 ``                               |
| [`2c210526`](https://github.com/NixOS/nixpkgs/commit/2c21052647cc731afc815668bd750dfb0946a870) | `` btrfs-progs.meta.mainProgram: init ``                                       |
| [`3ac0b4a4`](https://github.com/NixOS/nixpkgs/commit/3ac0b4a479a3b46b421582028c43b8c2f5f6f987) | `` workflows/eval: remove attrs step ``                                        |
| [`cce93e81`](https://github.com/NixOS/nixpkgs/commit/cce93e81a46b4941d3e43235a5a5b50c2da2828c) | `` workflows/get-merge-commit: return targetSha ``                             |
| [`406954bf`](https://github.com/NixOS/nixpkgs/commit/406954bfa85e5021156f660aa568d5c128d22b23) | `` workflows/eval: load supportedSystems from JSON file ``                     |
| [`d0b81c69`](https://github.com/NixOS/nixpkgs/commit/d0b81c69c33e238c6695c93ed7f50c8bbc39ca6d) | `` vscode-extensions.amazonwebservices.amazon-q-vscode: init at 1.66.0 ``      |
| [`52e5dedf`](https://github.com/NixOS/nixpkgs/commit/52e5dedf5e19cd5262696854e80034bfaf03c769) | `` php81Extensions.blackfire: 1.92.25 -> 1.92.28 ``                            |
| [`75b2e3a6`](https://github.com/NixOS/nixpkgs/commit/75b2e3a6543da8742b1d9168c8f897c4bfb25630) | `` sta: enable strictDeps ``                                                   |
| [`fcb56b6c`](https://github.com/NixOS/nixpkgs/commit/fcb56b6c7a83eed2e53ed5cd34592cb9ad4d46b0) | `` sta: enable tests ``                                                        |
| [`f2154538`](https://github.com/NixOS/nixpkgs/commit/f21545387a8ff8cd2feb0be29233b778c831680a) | `` sta: unbreak on darwin ``                                                   |
| [`19823315`](https://github.com/NixOS/nixpkgs/commit/198233156ad3f6ebb3b723187ae19edff4e1c58b) | `` workflows/manual-nixpkgs: fix nixdoc path ``                                |
| [`18a61013`](https://github.com/NixOS/nixpkgs/commit/18a610133c9adb339e99070d73d790ae564a3fd5) | `` workflows/check-format: add actionlint ``                                   |
| [`02cfad90`](https://github.com/NixOS/nixpkgs/commit/02cfad902317edf7bad4897c99fd3bef9fbc59df) | `` workflows/check-shell: test aarch64-linux and x86_64-darwin as well ``      |
| [`3811dd9e`](https://github.com/NixOS/nixpkgs/commit/3811dd9ee5872b23c9a682f28989e7d8e7002ad8) | `` workflows/manual-nixos: refactor matrix ``                                  |
| [`0a1d6f56`](https://github.com/NixOS/nixpkgs/commit/0a1d6f56f085784048b7c672cee02842e71f3019) | `` workflows: use ARM runners ``                                               |
| [`019c5d40`](https://github.com/NixOS/nixpkgs/commit/019c5d4029d579fbf5d74829bada9b30cbbab850) | `` workflows/nix-parse: fix failing workflow ``                                |
| [`77251ae0`](https://github.com/NixOS/nixpkgs/commit/77251ae0e8722fef762287d878b932db8f4ce311) | `` workflows/manual-nixos: fix failing workflow ``                             |
| [`5b95125c`](https://github.com/NixOS/nixpkgs/commit/5b95125cee6b1ada641ea5936d8c3c05961fe15f) | `` ci/parse: test for nix 2.3 and lix ``                                       |
| [`b11e4e62`](https://github.com/NixOS/nixpkgs/commit/b11e4e627cea6434efc822a81b4dacaf2b379423) | `` various: fix parse errors for nix 2.3 ``                                    |
| [`1581ad04`](https://github.com/NixOS/nixpkgs/commit/1581ad043a86260336a0c1c445ba0d2295b910e9) | `` ci/parse: init ``                                                           |
| [`9fff4fed`](https://github.com/NixOS/nixpkgs/commit/9fff4fed2acfc8b74744299dcb8844d424dae66b) | `` ci/shell: init ``                                                           |
| [`ef523314`](https://github.com/NixOS/nixpkgs/commit/ef5233143b2d17829c31bb3befdde02678e42994) | `` ci/manual-nixpkgs: init ``                                                  |
| [`2ac64d8a`](https://github.com/NixOS/nixpkgs/commit/2ac64d8aafe97c97b2566a607d91668716467995) | `` ci/manual-nixos: init ``                                                    |
| [`e3e835ca`](https://github.com/NixOS/nixpkgs/commit/e3e835ca674efb813b521d84bcc731e3755d9ba6) | `` ci/lib-tests: init ``                                                       |
| [`23ccd887`](https://github.com/NixOS/nixpkgs/commit/23ccd887e5c3346e09fff6ecc5028713f1c59dc6) | `` workflows/lib-tests: rename from eval-lib-tests ``                          |
| [`ac19af34`](https://github.com/NixOS/nixpkgs/commit/ac19af34504981dbdbc5e918924ebd5d847c3d33) | `` anubis: 1.17.1 -> 1.18.0 ``                                                 |
| [`ac808ebc`](https://github.com/NixOS/nixpkgs/commit/ac808ebc38aab6959f9a32612606bfb51ab7457b) | `` linux_5_15: 5.15.181 -> 5.15.182 ``                                         |
| [`ceb71b88`](https://github.com/NixOS/nixpkgs/commit/ceb71b881e5d588841e4eed111604adb91713559) | `` linux_6_1: 6.1.136 -> 6.1.138 ``                                            |
| [`8527afc5`](https://github.com/NixOS/nixpkgs/commit/8527afc5bbdf13f4ed27cb9717b68b6d3d13d5eb) | `` linux_6_6: 6.6.89 -> 6.6.90 ``                                              |
| [`cb1bc756`](https://github.com/NixOS/nixpkgs/commit/cb1bc75631472c749f3e46fe462a8bd3b454d53d) | `` linux_6_12: 6.12.26 -> 6.12.28 ``                                           |
| [`543cfb3f`](https://github.com/NixOS/nixpkgs/commit/543cfb3fb4201015d97cb702a1d5530e5f865a7e) | `` linux_6_14: 6.14.5 -> 6.14.6 ``                                             |
| [`9f489aca`](https://github.com/NixOS/nixpkgs/commit/9f489aca6f585ec3982a2c8f7845ff05992adb84) | `` thunderbird: 128.9.2esr -> 128.10.0esr ``                                   |
| [`96dae1a8`](https://github.com/NixOS/nixpkgs/commit/96dae1a8a70ed4971e03e11268b402df80f2a416) | `` nixos/gitlab: add activeRecord key files ``                                 |
| [`92b884a4`](https://github.com/NixOS/nixpkgs/commit/92b884a42059d31ded1965bc89967d1263e98c93) | `` tomcat: 11.0.5 -> 11.0.6 ``                                                 |
| [`b560c127`](https://github.com/NixOS/nixpkgs/commit/b560c127f4df919fb26c85125d8c230ac2d5c194) | `` tomcat: 11.0.2 -> 11.0.5 ``                                                 |
| [`5596ed02`](https://github.com/NixOS/nixpkgs/commit/5596ed026c62cdd949bd3f4433642350d4dffaec) | `` tomcat9: 9.0.102 -> 9.0.104 ``                                              |
| [`1ed1eff4`](https://github.com/NixOS/nixpkgs/commit/1ed1eff49d2f6f58db0e1a4d927bd2ad9dcf046f) | `` tomcat10: 10.1.39 -> 10.1.40 ``                                             |
| [`90ebb929`](https://github.com/NixOS/nixpkgs/commit/90ebb92961f9b39f29236897b3d3dff2ff8ee6b9) | `` tomcat10: 10.1.34 -> 10.1.39 ``                                             |
| [`24fe4a37`](https://github.com/NixOS/nixpkgs/commit/24fe4a37d22ab1a8792cd5758e0f5c089cbc6d9c) | `` tomcat9: 9.0.100 -> 9.0.102 ``                                              |
| [`90e401e6`](https://github.com/NixOS/nixpkgs/commit/90e401e6e6aac7748706b7bed4678f320583a94a) | `` tomcat9: 9.0.98 -> 9.0.100 ``                                               |