### PR TITLE
chore(flake/hyprland): `5ceb0ec1` -> `a5c9b3e4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -643,11 +643,11 @@
         "xdph": "xdph"
       },
       "locked": {
-        "lastModified": 1747300404,
-        "narHash": "sha256-hpgqRXR0UrgaMNuS60QA4IiaZ3lw72qasKLejquiAUs=",
+        "lastModified": 1747301504,
+        "narHash": "sha256-GAI36RNzF9yC0JOauS1+h681ElwdbD9q/qxxuIqcejQ=",
         "owner": "hyprwm",
         "repo": "Hyprland",
-        "rev": "5ceb0ec15df6301cafe95a1b1f73b4f4bf255968",
+        "rev": "a5c9b3e49047b4f03f79c5146d8925363eab3072",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                                                                            |
| ------------------------------------------------------------------------------------------------ | ---------------------------------------------------------------------------------- |
| [`a5c9b3e4`](https://github.com/hyprwm/Hyprland/commit/a5c9b3e49047b4f03f79c5146d8925363eab3072) | `` core: Include cstring whenever strncpy is used (#10404) ``                      |
| [`dfb841c3`](https://github.com/hyprwm/Hyprland/commit/dfb841c303263208c2f8ac7a55fbdf4668594fb7) | `` desktop: prevent layers from dismissing their own seat grabs on map (#10417) `` |