### PR TITLE
chore(flake/home-manager): `954615c5` -> `c09ccd7d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -514,11 +514,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1747279714,
-        "narHash": "sha256-UdxlE8yyrKiGq3bgGyJ78AdFwh+fuRAruKtyFY5Zq5I=",
+        "lastModified": 1747332433,
+        "narHash": "sha256-AUikwUae+YACUNL0GsQJGCW2ChwCuDg3l96m6FFhg7o=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "954615c510c9faa3ee7fb6607ff72e55905e69f2",
+        "rev": "c09ccd7d39eb4c246fcb0e2b3e4be0361a85c19a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                                                 |
| ----------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------- |
| [`c09ccd7d`](https://github.com/nix-community/home-manager/commit/c09ccd7d39eb4c246fcb0e2b3e4be0361a85c19a) | `` services.borgmatic: add initial support for darwin ``                                |
| [`34d44d7f`](https://github.com/nix-community/home-manager/commit/34d44d7f1b7da16509538f72ec6bee121932a3e1) | `` services.borgmatic: wrap systemd configuration within a isLinux condition ``         |
| [`1c2fccef`](https://github.com/nix-community/home-manager/commit/1c2fccef832e5fbf2df4162f742f76a153aa5443) | `` services.nix-gc: extract darwin agent interval code to new library file ``           |
| [`3b930bb6`](https://github.com/nix-community/home-manager/commit/3b930bb653dd9ed7da5fe86c147bbc67492efe2c) | `` services.nix-gc: improve error message when nix.gc.frequency is invalid on darwin `` |
| [`ad1e8bb7`](https://github.com/nix-community/home-manager/commit/ad1e8bb782ed91b4966ab5b642f9b2c5813354ce) | `` dbus: Create with pacakges options (#7064) ``                                        |