### PR TITLE
chore(flake/home-manager): `c09ccd7d` -> `dbc90cc3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -514,11 +514,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1747332433,
-        "narHash": "sha256-AUikwUae+YACUNL0GsQJGCW2ChwCuDg3l96m6FFhg7o=",
+        "lastModified": 1747334031,
+        "narHash": "sha256-AoicyrJCTsPAio47Vbwy+gJjUeDZtB+WMbzxZRwc7k0=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "c09ccd7d39eb4c246fcb0e2b3e4be0361a85c19a",
+        "rev": "dbc90cc3ae9c8f927200a6ceaf4aa247ea6bc443",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                               |
| ----------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------- |
| [`dbc90cc3`](https://github.com/nix-community/home-manager/commit/dbc90cc3ae9c8f927200a6ceaf4aa247ea6bc443) | `` rclone: declarative mounts (#7060) ``                              |
| [`b022c9e3`](https://github.com/nix-community/home-manager/commit/b022c9e3b805484e44aaad1973ed7572b0c1b5c4) | `` vscode: allow specifying paths for VSCode JSON settings (#7055) `` |
| [`a99bddfe`](https://github.com/nix-community/home-manager/commit/a99bddfe53cb5ae488bfb0dc0170dae258b2c572) | `` lapce: fix no argument hash for pluginFromRegistry (#7062) ``      |
| [`ec8205c3`](https://github.com/nix-community/home-manager/commit/ec8205c3d7d4b19998d9b762d2c5abd2fc11faa7) | `` dconf: set env var ``                                              |
| [`ff73544e`](https://github.com/nix-community/home-manager/commit/ff73544e4a59dce43a6de7051858a453186ae9bb) | `` dconf: Provide dconf package and dbus service file ``              |
| [`c310818d`](https://github.com/nix-community/home-manager/commit/c310818dca3d92fa6ab769a572c46e04f24b1f87) | `` mako: Fix missing dbus service file (#7065) ``                     |