### PR TITLE
chore(flake/home-manager): `dbc90cc3` -> `098e365d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -514,11 +514,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1747334031,
-        "narHash": "sha256-AoicyrJCTsPAio47Vbwy+gJjUeDZtB+WMbzxZRwc7k0=",
+        "lastModified": 1747340209,
+        "narHash": "sha256-tUiXrwlJoG3dzJ+fSwv1S3VPU5ODSPZJHoBmlu4t344=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "dbc90cc3ae9c8f927200a6ceaf4aa247ea6bc443",
+        "rev": "098e365dd83311cc8236f83ea6be42abb49a6c76",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                                            |
| ----------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------- |
| [`098e365d`](https://github.com/nix-community/home-manager/commit/098e365dd83311cc8236f83ea6be42abb49a6c76) | `` borgmatic: add darwin-specific documentation to services.borgmatic.frequency `` |
| [`8ae36f8e`](https://github.com/nix-community/home-manager/commit/8ae36f8ea2e0621b6cdea862e938aaa018e0ef27) | `` nix-gc: fix documentation ``                                                    |