### PR TITLE
chore(flake/spicetify-nix): `8f1c5c34` -> `a2bc0d49`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1289,11 +1289,11 @@
         "systems": "systems_4"
       },
       "locked": {
-        "lastModified": 1746937129,
-        "narHash": "sha256-Dx/YpnRridWnxF0Xpz9FUP3kl/m2QAOM2BM3KNls3sk=",
+        "lastModified": 1747355848,
+        "narHash": "sha256-WpOTfGuObhpaI38+uHgaOwnMAjHMrdLrfs6D35fKwjk=",
         "owner": "Gerg-L",
         "repo": "spicetify-nix",
-        "rev": "8f1c5c34cf5f99e1d7197d6d9fa7dd44f00966f0",
+        "rev": "a2bc0d49449fc61ca2eb364d6189179059394483",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                          |
| ----------------------------------------------------------------------------------------------------- | -------------------------------- |
| [`a2bc0d49`](https://github.com/Gerg-L/spicetify-nix/commit/a2bc0d49449fc61ca2eb364d6189179059394483) | `` feat: add a few extensions `` |