### PR TITLE
chore(flake/zen-browser): `8358d144` -> `ea7eae1b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1585,11 +1585,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1747278581,
-        "narHash": "sha256-2TzDRpuU3Ae5yEvt8HiNbgK/c6JogUqQGvTQq7Hj+iA=",
+        "lastModified": 1747365155,
+        "narHash": "sha256-4yjNzN+p3H3+6emM9rv5ggcY/Usu0UZ188F+98z0huE=",
         "owner": "0xc000022070",
         "repo": "zen-browser-flake",
-        "rev": "8358d144bccc142fffff1743d1b2dd15e24f7f3a",
+        "rev": "ea7eae1b022b9af4b2f7c8681f570e2862249298",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                          | Message                                                               |
| --------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------- |
| [`ea7eae1b`](https://github.com/0xc000022070/zen-browser-flake/commit/ea7eae1b022b9af4b2f7c8681f570e2862249298) | `` chore(update): twilight @ x86_64 && aarch64 to 1.13t#1747364635 `` |