### PR TITLE
chore(flake/stylix): `0e5b1613` -> `49b1eb93`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1384,11 +1384,11 @@
         "tinted-zed": "tinted-zed"
       },
       "locked": {
-        "lastModified": 1747406390,
-        "narHash": "sha256-rDUCzrFPKCOrwJ0Pg9Mo6+8q/7EcSTstl+SotwDL3tA=",
+        "lastModified": 1747415633,
+        "narHash": "sha256-ZRHZrMVrqnallhB2Y+eTZHxF92a+K6tiVAwj++PGk4I=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "0e5b1613bd9285700c99e5ecf0a4e31da8cb5e04",
+        "rev": "49b1eb937152b686626be269ee3fe462d1541d5a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                        | Message                                                       |
| --------------------------------------------------------------------------------------------- | ------------------------------------------------------------- |
| [`49b1eb93`](https://github.com/danth/stylix/commit/49b1eb937152b686626be269ee3fe462d1541d5a) | `` cava: refactor + fix rainbow.enable description (#1276) `` |