### PR TITLE
chore(flake/home-manager): `d2263ce5` -> `74d31e11`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -510,11 +510,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1747374689,
-        "narHash": "sha256-JT/aBZqmK1LbExzwT9cPkvxKc0IC4i6tZKOPjsSWFbI=",
+        "lastModified": 1747427366,
+        "narHash": "sha256-c3UfEsnT94bt6ta1VELYQhAWkQWFGlB+7DmBmthlGGg=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "d2263ce5f4c251c0f7608330e8fdb7d1f01f0667",
+        "rev": "74d31e1165341bf510ee2017841a599f5cfc1608",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                           |
| ----------------------------------------------------------------------------------------------------------- | --------------------------------- |
| [`74d31e11`](https://github.com/nix-community/home-manager/commit/74d31e1165341bf510ee2017841a599f5cfc1608) | `` ptyxis: init module (#7075) `` |