### PR TITLE
chore(flake/hyprland): `a5c9b3e4` -> `29460090`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -639,11 +639,11 @@
         "xdph": "xdph"
       },
       "locked": {
-        "lastModified": 1747301504,
-        "narHash": "sha256-GAI36RNzF9yC0JOauS1+h681ElwdbD9q/qxxuIqcejQ=",
+        "lastModified": 1747431568,
+        "narHash": "sha256-pYwBbtvjHgJzvrHkZHsaqgMcCpOmQ4/9kymUgAnAjgk=",
         "owner": "hyprwm",
         "repo": "Hyprland",
-        "rev": "a5c9b3e49047b4f03f79c5146d8925363eab3072",
+        "rev": "2946009006bd8a988ff8a51b83528f6e1d8f0e98",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                                                                       |
| ------------------------------------------------------------------------------------------------ | ----------------------------------------------------------------------------- |
| [`29460090`](https://github.com/hyprwm/Hyprland/commit/2946009006bd8a988ff8a51b83528f6e1d8f0e98) | `` input: do not send mouse events when outside of a surface (#10416) ``      |
| [`b0cc4921`](https://github.com/hyprwm/Hyprland/commit/b0cc49218d37e6e791725b40fe5da97832daa9c8) | `` protocols: simulate mouse movement after activating a toplevel (#10429) `` |