### PR TITLE
chore(flake/zen-browser): `53b304dc` -> `0ea4fe8e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1639,11 +1639,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1747408728,
-        "narHash": "sha256-B38sO5NNWMohtmrQMnAXQIWETcMuaMe/KUJCwhxQCcQ=",
+        "lastModified": 1747433905,
+        "narHash": "sha256-5UOAlhEgp896xoSQVrTGO+Z4A7Nkk/Ekj5HOCeotoi4=",
         "owner": "0xc000022070",
         "repo": "zen-browser-flake",
-        "rev": "53b304dc5f0ab19810bc1cf4bbbb80546afd696a",
+        "rev": "0ea4fe8e43eec8760e70816c666a3cdd7310a649",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                          | Message                                                               |
| --------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------- |
| [`0ea4fe8e`](https://github.com/0xc000022070/zen-browser-flake/commit/0ea4fe8e43eec8760e70816c666a3cdd7310a649) | `` chore(update): twilight @ x86_64 && aarch64 to 1.13t#1747433402 `` |