### PR TITLE
chore(flake/stylix): `88e1c23d` -> `101d23df`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1365,11 +1365,11 @@
         "tinted-zed": "tinted-zed"
       },
       "locked": {
-        "lastModified": 1747435030,
-        "narHash": "sha256-C5FhnOfnCAImewkcKbu0L9SuwUF7tleSYCFM+3/Ow24=",
+        "lastModified": 1747441332,
+        "narHash": "sha256-On+cwR/dMW9s+YWsYifIaRs18nNyK5HVFJav6HsRrU8=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "88e1c23df2d8c47e23f744389822e3c45f1bfc19",
+        "rev": "101d23dfacbb2704c40639ae9b6ac1d41de7143a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                        | Message                                                           |
| --------------------------------------------------------------------------------------------- | ----------------------------------------------------------------- |
| [`101d23df`](https://github.com/danth/stylix/commit/101d23dfacbb2704c40639ae9b6ac1d41de7143a) | `` ci: fix dependabot backport label (#1288) ``                   |
| [`4d68f1f7`](https://github.com/danth/stylix/commit/4d68f1f761285a6236e7d45efa227d6f4af09c80) | `` ci: bump DeterminateSystems/update-flake-lock from 24 to 25 `` |
| [`ecfa5c40`](https://github.com/danth/stylix/commit/ecfa5c40b6a063a8d20272c123d05a3b91e14608) | `` flake: include packages in checks (#1285) ``                   |