### PR TITLE
chore(flake/zen-browser): `0ea4fe8e` -> `8f523c1a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1639,11 +1639,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1747433905,
-        "narHash": "sha256-5UOAlhEgp896xoSQVrTGO+Z4A7Nkk/Ekj5HOCeotoi4=",
+        "lastModified": 1747451268,
+        "narHash": "sha256-Fj9KW6jRJXQVmLk39baB7KNUANhzcifpNPDLoToi+A4=",
         "owner": "0xc000022070",
         "repo": "zen-browser-flake",
-        "rev": "0ea4fe8e43eec8760e70816c666a3cdd7310a649",
+        "rev": "8f523c1a9d6935d34f76513a1b654e9c42e0343c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                          | Message                                                               |
| --------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------- |
| [`8f523c1a`](https://github.com/0xc000022070/zen-browser-flake/commit/8f523c1a9d6935d34f76513a1b654e9c42e0343c) | `` chore(update): twilight @ x86_64 && aarch64 to 1.13t#1747451156 `` |