### PR TITLE
chore(flake/better-control): `2b78cb50` -> `e3d54fad`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -210,11 +210,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1747276078,
-        "narHash": "sha256-75Gq4k/k56PFqjbN5gWs1gVtapgezyKCdcsngHYS0qk=",
+        "lastModified": 1747462495,
+        "narHash": "sha256-1tL0AwbfmjWri0kBGEdc/vtoeFivfZe/Q5O+QCMpu5M=",
         "owner": "rishabh5321",
         "repo": "better-control-flake",
-        "rev": "2b78cb50f2b655bfe565938284229a7fcc9f2e51",
+        "rev": "e3d54fad4ada7dab63e1862f21fc2419378e1cb0",
         "type": "github"
       },
       "original": {
@@ -1060,11 +1060,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1747179050,
-        "narHash": "sha256-qhFMmDkeJX9KJwr5H32f1r7Prs7XbQWtO0h3V0a0rFY=",
+        "lastModified": 1747327360,
+        "narHash": "sha256-LSmTbiq/nqZR9B2t4MRnWG7cb0KVNU70dB7RT4+wYK4=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "adaa24fbf46737f3f1b5497bf64bae750f82942e",
+        "rev": "e06158e58f3adee28b139e9c2bcfcc41f8625b46",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                            | Message                                          |
| ----------------------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
| [`e3d54fad`](https://github.com/Rishabh5321/better-control-flake/commit/e3d54fad4ada7dab63e1862f21fc2419378e1cb0) | `` chore(flake/nixpkgs): adaa24fb -> e06158e5 `` |