### PR TITLE
chore(flake/grayjay): `e7623aff` -> `837c58e2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -490,11 +490,11 @@
         "nixpkgs": "nixpkgs_3"
       },
       "locked": {
-        "lastModified": 1747321393,
-        "narHash": "sha256-h0lR9EAfFV3UquHCE/ptn7X6QMjPaw+ZHxHoxZTqj4A=",
+        "lastModified": 1747462650,
+        "narHash": "sha256-fByIwwdIrLVKX2AQ4hQaARM3Kukst6VxbIykK0c36QI=",
         "owner": "rishabh5321",
         "repo": "grayjay-flake",
-        "rev": "e7623aff5cf49fdac55434d7c298f85df429a119",
+        "rev": "837c58e2a1b255619a7bc4761a7d2313b9ae368c",
         "type": "github"
       },
       "original": {
@@ -1076,11 +1076,11 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1747179050,
-        "narHash": "sha256-qhFMmDkeJX9KJwr5H32f1r7Prs7XbQWtO0h3V0a0rFY=",
+        "lastModified": 1747327360,
+        "narHash": "sha256-LSmTbiq/nqZR9B2t4MRnWG7cb0KVNU70dB7RT4+wYK4=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "adaa24fbf46737f3f1b5497bf64bae750f82942e",
+        "rev": "e06158e58f3adee28b139e9c2bcfcc41f8625b46",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                     | Message                                          |
| ---------------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
| [`837c58e2`](https://github.com/Rishabh5321/grayjay-flake/commit/837c58e2a1b255619a7bc4761a7d2313b9ae368c) | `` chore(flake/nixpkgs): adaa24fb -> e06158e5 `` |