### PR TITLE
chore(flake/akuse-flake): `f6101a0b` -> `c09b16d9`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -48,11 +48,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1747278784,
-        "narHash": "sha256-LLIczQjMIVPBlW3HDzw8JM4aUqxmUYUk9wNEd+ISjKA=",
+        "lastModified": 1747459308,
+        "narHash": "sha256-PepKGeRZ+kXUlkGJAvY/yIwzh08Pzhikm8h22VQB86o=",
         "owner": "Rishabh5321",
         "repo": "akuse-flake",
-        "rev": "f6101a0b069507b242be2685ad645f54955958c8",
+        "rev": "c09b16d97b02b7c98b93a79a83ac7534860d8e12",
         "type": "github"
       },
       "original": {
@@ -1013,11 +1013,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1747179050,
-        "narHash": "sha256-qhFMmDkeJX9KJwr5H32f1r7Prs7XbQWtO0h3V0a0rFY=",
+        "lastModified": 1747327360,
+        "narHash": "sha256-LSmTbiq/nqZR9B2t4MRnWG7cb0KVNU70dB7RT4+wYK4=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "adaa24fbf46737f3f1b5497bf64bae750f82942e",
+        "rev": "e06158e58f3adee28b139e9c2bcfcc41f8625b46",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                   | Message                                          |
| -------------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
| [`c09b16d9`](https://github.com/Rishabh5321/akuse-flake/commit/c09b16d97b02b7c98b93a79a83ac7534860d8e12) | `` chore(flake/nixpkgs): adaa24fb -> e06158e5 `` |