### PR TITLE
chore(flake/nixpkgs-stable): `5d736263` -> `ba8b70ee`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1044,11 +1044,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1747209494,
-        "narHash": "sha256-fLise+ys+bpyjuUUkbwqo5W/UyIELvRz9lPBPoB0fbM=",
+        "lastModified": 1747335874,
+        "narHash": "sha256-IKKIXTSYJMmUtE+Kav5Rob8SgLPnfnq4Qu8LyT4gdqQ=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "5d736263df906c5da72ab0f372427814de2f52f8",
+        "rev": "ba8b70ee098bc5654c459d6a95dfc498b91ff858",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                 |
| ---------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------- |
| [`1308a8df`](https://github.com/NixOS/nixpkgs/commit/1308a8df9460302d947905b198183d837224ce60) | `` zfs_{2_3,unstable}: 2.3.1 -> 2.3.2 ``                                |
| [`9a1d5412`](https://github.com/NixOS/nixpkgs/commit/9a1d5412beb57a7e68e7c4939f5ce1644612a41d) | `` element-desktop: add support for io.element.desktop scheme ``        |
| [`c1d86262`](https://github.com/NixOS/nixpkgs/commit/c1d86262d9fceac424915fb28a65045d8e2ea5c3) | `` pnpm: 10.10.0 -> 10.11.0 ``                                          |
| [`d86d3017`](https://github.com/NixOS/nixpkgs/commit/d86d301749775bf7cae469fa8c4ead835e9fdaa9) | `` brave: 1.77.101 -> 1.78.97 ``                                        |
| [`fd595695`](https://github.com/NixOS/nixpkgs/commit/fd595695151286ff359df3f87861b992d7b54c7b) | `` showtime: 48.0 -> 48.1 ``                                            |
| [`89c5a5bc`](https://github.com/NixOS/nixpkgs/commit/89c5a5bc8a15da8fea5dd1080b103fa44a6d4650) | `` ungoogled-chromium: 136.0.7103.92-1 -> 136.0.7103.113-1 ``           |
| [`00b377bd`](https://github.com/NixOS/nixpkgs/commit/00b377bdb52eb7b69fa8b1a71fc08be1a9158169) | `` chromium,chromedriver: 136.0.7103.92 -> 136.0.7103.113 ``            |
| [`4c11dfe6`](https://github.com/NixOS/nixpkgs/commit/4c11dfe6e68929cb4ed7fc8fdb69d2458b47d74d) | `` vencord: 1.12.0 -> 1.12.1 ``                                         |
| [`a9b34fee`](https://github.com/NixOS/nixpkgs/commit/a9b34fee683e7620c004d845dc529b4b0bddc897) | `` ciscoPacketTracer8: allow overriding src ``                          |
| [`79c5d973`](https://github.com/NixOS/nixpkgs/commit/79c5d973abb66bb50155dca500af4e36c9a32367) | `` ciscoPacketTracer8: revert to fhsEnv ``                              |
| [`3c375ce8`](https://github.com/NixOS/nixpkgs/commit/3c375ce80753efc816772b3e98de9a8e3e1849a9) | `` ciscoPacketTracer8: add version parameter ``                         |
| [`9743f83d`](https://github.com/NixOS/nixpkgs/commit/9743f83ddf929175567308942da8efe5290b13cc) | `` ciscoPacketTracer8: add maintainer gepbird ``                        |
| [`e00650b8`](https://github.com/NixOS/nixpkgs/commit/e00650b813b0a1bb41bb6b3a63dc1c2841d672df) | `` ciscoPacketTracer8: remove `with lib;`, order `meta` attrs ``        |
| [`46dbc895`](https://github.com/NixOS/nixpkgs/commit/46dbc89545901ee757144249f143ea2665e53dca) | `` ciscoPacketTracer{7,8}: re-add `with maintainers` ``                 |
| [`28fbce91`](https://github.com/NixOS/nixpkgs/commit/28fbce91091aeb1f894dac81c46a3916fb8b3b08) | `` ciscoPacketTracer8: disown ``                                        |
| [`4a29adb0`](https://github.com/NixOS/nixpkgs/commit/4a29adb035ac8c98caaa8da5f2b2dfc1281b2020) | `` ciscoPacketTracer7: disown ``                                        |
| [`f3093674`](https://github.com/NixOS/nixpkgs/commit/f3093674218c06d661841e28aa48345c7ed26118) | `` treewide: fix editorconfig ci check ``                               |
| [`8ec30aa9`](https://github.com/NixOS/nixpkgs/commit/8ec30aa9e559255b7a2dfc22c17e3f89956d8f30) | `` squirreldisk: Fix displaying of results ``                           |
| [`006b56c8`](https://github.com/NixOS/nixpkgs/commit/006b56c8c94eeb21378d719cd6fb85a36fb1bb20) | `` Revert "[Backport release-24.11] wlx-overlay-s: 25.3.0 -> 25.4.2" `` |
| [`d6b79a84`](https://github.com/NixOS/nixpkgs/commit/d6b79a84fc91c94b2157276942a076851922986c) | `` snipe-it: 8.1.2 -> 8.1.3 ``                                          |
| [`4b167a90`](https://github.com/NixOS/nixpkgs/commit/4b167a90196e3ee026da01e8730a892d94bb501c) | `` snipe-it: 8.1.0 -> 8.1.2 ``                                          |
| [`b2769389`](https://github.com/NixOS/nixpkgs/commit/b276938991288fe5d1111609cb940403ea76d374) | `` workflows/eval: prevent tag job from failing in forks ``             |
| [`41646271`](https://github.com/NixOS/nixpkgs/commit/41646271eaaafb5d97c21faf65dfd49d7510da13) | `` workflows/eval-aliases: remove unused args ``                        |
| [`f6570a92`](https://github.com/NixOS/nixpkgs/commit/f6570a92b8dba1c14d85e0a2cde042e82d0db683) | `` workflows: improve test-ability in forks ``                          |
| [`fa3c98ed`](https://github.com/NixOS/nixpkgs/commit/fa3c98ed3c77cdf63577f37e59b08e271d7fe148) | `` workflows: self-test on change ``                                    |
| [`9cb73b0a`](https://github.com/NixOS/nixpkgs/commit/9cb73b0a3c605a6562a64d6137629cc6b67c8687) | `` ci: Update pinned Nixpkgs ``                                         |
| [`6a850411`](https://github.com/NixOS/nixpkgs/commit/6a850411d6657e9c9dd4979932a7337026ef4c9c) | `` electron-chromedriver: fix header hashes ``                          |
| [`677fe030`](https://github.com/NixOS/nixpkgs/commit/677fe03045c3b105971bb58ce2f44357faf0642a) | `` electron-bin: fix header hashes ``                                   |
| [`51f7f218`](https://github.com/NixOS/nixpkgs/commit/51f7f218bbd88dc917d184f38028103f77b108c4) | `` electron-chromedriver_36: 36.1.0 -> 36.2.0 ``                        |
| [`f41b8eb5`](https://github.com/NixOS/nixpkgs/commit/f41b8eb5c0b5c7c80f184490f64221291c697ac3) | `` electron_36-bin: 36.1.0 -> 36.2.0 ``                                 |
| [`24a6ccd0`](https://github.com/NixOS/nixpkgs/commit/24a6ccd0ef661d927ec99bf1c58a241b7a31c0f0) | `` electron-chromedriver_35: 35.2.1 -> 35.3.0 ``                        |
| [`3e0e555b`](https://github.com/NixOS/nixpkgs/commit/3e0e555b689b0cf7d602129ecdabf51085edcdd0) | `` electron_35-bin: 35.2.1 -> 35.3.0 ``                                 |
| [`7ab4a822`](https://github.com/NixOS/nixpkgs/commit/7ab4a822c10974b281141248d286f8432518a76a) | `` electron-chromedriver_34: 34.5.3 -> 34.5.5 ``                        |
| [`ab2e8df1`](https://github.com/NixOS/nixpkgs/commit/ab2e8df1dc4417d7b6defc8c0e138723cbccd396) | `` electron_34-bin: 34.5.3 -> 34.5.5 ``                                 |
| [`a71d6e5d`](https://github.com/NixOS/nixpkgs/commit/a71d6e5d6c73634931e9f02f87cff957c119d84c) | `` electron-source.electron_36: 36.1.0 -> 36.2.0 ``                     |
| [`c66cea4c`](https://github.com/NixOS/nixpkgs/commit/c66cea4c3a4448e4ff02f620e977881ea502b3a0) | `` electron-source.electron_35: 35.2.1 -> 35.3.0 ``                     |
| [`ef13a4a1`](https://github.com/NixOS/nixpkgs/commit/ef13a4a1fce5fccaebf770d7c1decdd64211bd00) | `` electron-source.electron_34: 34.5.3 -> 34.5.5 ``                     |
| [`9ac9fe15`](https://github.com/NixOS/nixpkgs/commit/9ac9fe15b3135bca15bb54dbdc8ca97dd331d707) | `` electron-source.electron_36: init at 36.1.0 ``                       |
| [`88694da9`](https://github.com/NixOS/nixpkgs/commit/88694da924703aa002612630f738f831a219fabf) | ``  electron-chromedriver_36: init at 36.1.0 ``                         |
| [`8e26247b`](https://github.com/NixOS/nixpkgs/commit/8e26247bce57a9dab97cc12590d6a9579a71dc74) | `` electron_36-bin: init at 36.1.0 ``                                   |
| [`e923f1bc`](https://github.com/NixOS/nixpkgs/commit/e923f1bc2b69cda2e97535f6d7acaa9afa053de0) | `` electron-source.electron_33: remove as it's EOL ``                   |
| [`40b4b934`](https://github.com/NixOS/nixpkgs/commit/40b4b9344257843bafc1ea66c69a151f84cfb218) | `` electron_33-bin: mark as insecure because it's EOL ``                |
| [`b5b12335`](https://github.com/NixOS/nixpkgs/commit/b5b12335593453976d305344003d2fb6e90bfb7b) | `` deepin.dde-api-proxy: 1.0.16 -> 1.0.20 ``                            |
| [`a7b2f014`](https://github.com/NixOS/nixpkgs/commit/a7b2f014047305f7c5328cd10135b4b68bebe904) | `` virtualboxKvm: use the patch from the 7.1.6 version ``               |
| [`b1526cfd`](https://github.com/NixOS/nixpkgs/commit/b1526cfd7be0bdf9d70eeb03070c077b566bf6fd) | `` virtualbox: 7.1.6a -> 7.1.8 ``                                       |