### PR TITLE
chore(flake/hyprland): `bb9aa79b` -> `c19f3836`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -639,11 +639,11 @@
         "xdph": "xdph"
       },
       "locked": {
-        "lastModified": 1747498235,
-        "narHash": "sha256-0k57aComVwNZfyxrKuZnBG/hqufkrJ/NsOoqt75xYCA=",
+        "lastModified": 1747501638,
+        "narHash": "sha256-SLAv+PkP2VblEXSqAU8SVNNQ/MCbaTwuOXth8xJ1cG8=",
         "owner": "hyprwm",
         "repo": "Hyprland",
-        "rev": "bb9aa79b216b952c692c2443c50b0a6d7e5b108d",
+        "rev": "c19f383685000fcf61706c95feb4d80d22c9afe5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                                                                                    |
| ------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------ |
| [`c19f3836`](https://github.com/hyprwm/Hyprland/commit/c19f383685000fcf61706c95feb4d80d22c9afe5) | `` hyprpm: fix crash with enable without an arg ``                                         |
| [`bb5cd5b2`](https://github.com/hyprwm/Hyprland/commit/bb5cd5b2ddcb2dbe58613aa41fa2062208208339) | `` screencopy: store a fb before permission popup if the permission is pending (#10455) `` |