### PR TITLE
chore(flake/stylix): `101d23df` -> `3c172cbb`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1365,11 +1365,11 @@
         "tinted-zed": "tinted-zed"
       },
       "locked": {
-        "lastModified": 1747441332,
-        "narHash": "sha256-On+cwR/dMW9s+YWsYifIaRs18nNyK5HVFJav6HsRrU8=",
+        "lastModified": 1747516727,
+        "narHash": "sha256-k3H8hzLjAHZjdirCcIwK9r/BDM77T1z+xK71D7Jo2ng=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "101d23dfacbb2704c40639ae9b6ac1d41de7143a",
+        "rev": "3c172cbbc6a657039c6eb0c2eec83c27c69342e2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                        | Message                                            |
| --------------------------------------------------------------------------------------------- | -------------------------------------------------- |
| [`3c172cbb`](https://github.com/danth/stylix/commit/3c172cbbc6a657039c6eb0c2eec83c27c69342e2) | `` gnome-text-editor: update style path (#1296) `` |