### PR TITLE
chore(flake/stylix): `3c172cbb` -> `91b23c7b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1365,11 +1365,11 @@
         "tinted-zed": "tinted-zed"
       },
       "locked": {
-        "lastModified": 1747516727,
-        "narHash": "sha256-k3H8hzLjAHZjdirCcIwK9r/BDM77T1z+xK71D7Jo2ng=",
+        "lastModified": 1747524044,
+        "narHash": "sha256-kqgZvjMPpmzxHhHJX5Ml54xRupy/bs8pO+3HYKSVglY=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "3c172cbbc6a657039c6eb0c2eec83c27c69342e2",
+        "rev": "91b23c7bc60b29e0140242db7cf9e46e2bb685be",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                        | Message                                                          |
| --------------------------------------------------------------------------------------------- | ---------------------------------------------------------------- |
| [`91b23c7b`](https://github.com/danth/stylix/commit/91b23c7bc60b29e0140242db7cf9e46e2bb685be) | `` doc: explain how to build & check the docs locally (#1273) `` |