### PR TITLE
chore(flake/hyprpanel): `2bb1449f` -> `c203ffe8`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -836,11 +836,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1747029715,
-        "narHash": "sha256-F75IlhzUF+VTPOq+u2Exj+6PjHWPkLcBWDnhO+Vvch4=",
+        "lastModified": 1747531721,
+        "narHash": "sha256-kx7hCuML0sMcjbyjbpplNWsJjLoUfiy23JiS9aG4UWw=",
         "owner": "Jas-SinghFSU",
         "repo": "HyprPanel",
-        "rev": "2bb1449fb6ad60a736ce6fb4de2037d7655545ed",
+        "rev": "c203ffe80f4e7b68e22ba3fde0598622500f5add",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                  | Message                                                                         |
| ------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------- |
| [`c203ffe8`](https://github.com/Jas-SinghFSU/HyprPanel/commit/c203ffe80f4e7b68e22ba3fde0598622500f5add) | `` Fix: Updated hourly weather time to respect military clock setting (#937) `` |