### PR TITLE
chore(flake/home-manager): `ae755329` -> `97118a31`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -510,11 +510,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1747439237,
-        "narHash": "sha256-5rCGrnkglKKj4cav1U3HC+SIUNJh08pqOK4spQv9RjA=",
+        "lastModified": 1747565775,
+        "narHash": "sha256-B6jmKHUEX1jxxcdoYHl7RVaeohtAVup8o3nuVkzkloA=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "ae755329092c87369b9e9a1510a8cf1ce2b1c708",
+        "rev": "97118a310eb8e13bc1b9b12d67267e55b7bee6c8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                 |
| ----------------------------------------------------------------------------------------------------------- | --------------------------------------- |
| [`97118a31`](https://github.com/nix-community/home-manager/commit/97118a310eb8e13bc1b9b12d67267e55b7bee6c8) | `` flake-module: use toString primop `` |
| [`ee85cfc5`](https://github.com/nix-community/home-manager/commit/ee85cfc5c132e2cf956a7b5ab156ddaedaefcbbc) | `` home-manager: add missing file ``    |
| [`10d13a62`](https://github.com/nix-community/home-manager/commit/10d13a62e3ab95ba904cbc3d2a44ac177d85da65) | `` flake.lock: Update ``                |
| [`9a4a9f1d`](https://github.com/nix-community/home-manager/commit/9a4a9f1d6e43fe4044f6715ae7cc85ccb1d2fe09) | `` home-manager: prepare 25.11 ``       |
| [`e08e6e23`](https://github.com/nix-community/home-manager/commit/e08e6e2389234000b0447e57abf61d8ccd59a68e) | `` home-manager: set 25.05 as stable `` |