### PR TITLE
chore(flake/nix-gaming): `d5de3cea` -> `754864d9`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -998,11 +998,11 @@
         "nixpkgs": "nixpkgs_5"
       },
       "locked": {
-        "lastModified": 1747533402,
-        "narHash": "sha256-qJp0bOnD21uewBaxQM+rVeI0NZQRKcl7wqikp9O8NRk=",
+        "lastModified": 1747573429,
+        "narHash": "sha256-zFM+gjaF2eEZ/nyh/PWOBr34tsp+PYaKRev98w4269Q=",
         "owner": "fufexan",
         "repo": "nix-gaming",
-        "rev": "d5de3ceae21a58c50daf06b7284ffcba885f5e2b",
+        "rev": "754864d9f20adc084faa32cd47b0979d88134d22",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                              | Message                                        |
| --------------------------------------------------------------------------------------------------- | ---------------------------------------------- |
| [`754864d9`](https://github.com/fufexan/nix-gaming/commit/754864d9f20adc084faa32cd47b0979d88134d22) | `` dxvk-nvapi-vkreflex-layer: init at 0.9.0 `` |