### PR TITLE
chore(flake/stylix): `e2fe2df9` -> `3993363c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1365,11 +1365,11 @@
         "tinted-zed": "tinted-zed"
       },
       "locked": {
-        "lastModified": 1747573790,
-        "narHash": "sha256-GGCvuftfpt1q+P2V70wySRPGcED2Jc37rWEcyMC7pFI=",
+        "lastModified": 1747577442,
+        "narHash": "sha256-SY1XAq2yaFHCTl3tBfvsQV5LyytmWEyA8z8p/BT05ZA=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "e2fe2df9b00bf5d65bf17f3d4e77c1a27ad20db8",
+        "rev": "3993363c0ca4e2872df00b57db51551267c76c9f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                 |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------- |
| [`3993363c`](https://github.com/nix-community/stylix/commit/3993363c0ca4e2872df00b57db51551267c76c9f) | `` doc: simplify 'Development Setup' section (#1261) `` |