### PR TITLE
chore(flake/stylix): `3993363c` -> `2eaa338e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1365,11 +1365,11 @@
         "tinted-zed": "tinted-zed"
       },
       "locked": {
-        "lastModified": 1747577442,
-        "narHash": "sha256-SY1XAq2yaFHCTl3tBfvsQV5LyytmWEyA8z8p/BT05ZA=",
+        "lastModified": 1747578370,
+        "narHash": "sha256-7pk8quDMQcGIVmm7KXMQLI5CbfamwPv/vO20cTcT/wI=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "3993363c0ca4e2872df00b57db51551267c76c9f",
+        "rev": "2eaa338eb879b8432f7e252d6ab8725ada98f52d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                            |
| ----------------------------------------------------------------------------------------------------- | -------------------------------------------------- |
| [`2eaa338e`](https://github.com/nix-community/stylix/commit/2eaa338eb879b8432f7e252d6ab8725ada98f52d) | `` gnome: install User Themes extension (#1306) `` |
| [`8778cde5`](https://github.com/nix-community/stylix/commit/8778cde5fe6fc5a891558b2b0c7379f7741df9b9) | `` doc: set site-url (#1307) ``                    |