### PR TITLE
chore(flake/nixpkgs-stable): `ba8b70ee` -> `9b5ac7ad`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1044,11 +1044,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1747335874,
-        "narHash": "sha256-IKKIXTSYJMmUtE+Kav5Rob8SgLPnfnq4Qu8LyT4gdqQ=",
+        "lastModified": 1747485343,
+        "narHash": "sha256-YbsZyuRE1tobO9sv0PUwg81QryYo3L1F3R3rF9bcG38=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "ba8b70ee098bc5654c459d6a95dfc498b91ff858",
+        "rev": "9b5ac7ad45298d58640540d0323ca217f32a6762",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                  |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------ |
| [`85e4a8c8`](https://github.com/NixOS/nixpkgs/commit/85e4a8c86f09f883370ca17538ac9bad911b1542) | `` brave: 1.78.97 -> 1.78.102 ``                                         |
| [`7deee16c`](https://github.com/NixOS/nixpkgs/commit/7deee16cd5e8c456baa188330a382d1fa3fc62a3) | `` vencord: 1.12.1 -> 1.12.2 ``                                          |
| [`87c77012`](https://github.com/NixOS/nixpkgs/commit/87c77012a9cb212b9e183fc2bca1b5e4cd3bbcb5) | `` kexec-tools: Set meta.mainProgram to kexec ``                         |
| [`e8c60e89`](https://github.com/NixOS/nixpkgs/commit/e8c60e89e37ec978ea458845344b046f2de76ad4) | `` thunderbird: fix calendar again after icu76 switch ``                 |
| [`51d5a958`](https://github.com/NixOS/nixpkgs/commit/51d5a958c56a9dbb40dd3197f4f4a2cedee35132) | `` screen: 5.0.0 -> 5.0.1 ``                                             |
| [`4c5482e1`](https://github.com/NixOS/nixpkgs/commit/4c5482e1fb53bc3f3354e15b114fadb40dd2f70e) | `` screen: remove unused configureFlags ``                               |
| [`f6e7f019`](https://github.com/NixOS/nixpkgs/commit/f6e7f019eb6eafdbf51e2ebbce26c773c184eaf0) | `` screen: fix darwin build ``                                           |
| [`59f85b84`](https://github.com/NixOS/nixpkgs/commit/59f85b8457b95beb7d0f84aecc8a22f6e0bc1e8f) | `` screen: mark as broken on darwin ``                                   |
| [`7959cc9b`](https://github.com/NixOS/nixpkgs/commit/7959cc9b56a7de62c15f1ab54d8065b256d6f478) | `` screen: 4.9.1 -> 5.0.0 ``                                             |
| [`a1b8c658`](https://github.com/NixOS/nixpkgs/commit/a1b8c658c03242e941bb9a471f4d46d590ecacf9) | `` nextcloudPackages: update ``                                          |
| [`007be4ad`](https://github.com/NixOS/nixpkgs/commit/007be4ad359204709cc896bc8be796dc5dc84ceb) | `` nextcloud31: 31.0.4 -> 31.0.5 ``                                      |
| [`e77330cc`](https://github.com/NixOS/nixpkgs/commit/e77330cc2ac292489f5c26063cbff3216b5cefe0) | `` nextcloud30: 30.0.10 -> 30.0.11 ``                                    |
| [`669f84d1`](https://github.com/NixOS/nixpkgs/commit/669f84d19213913189fc0a2e57108b662baaf08a) | `` maintainers: remove zanculmarktum ``                                  |
| [`480ecdd1`](https://github.com/NixOS/nixpkgs/commit/480ecdd1b53477c8038a17581ce2856449d09e57) | `` microsoft-edge: 136.0.3240.64 -> 136.0.3240.76 ``                     |
| [`7e734188`](https://github.com/NixOS/nixpkgs/commit/7e734188fd640fae1543ad228f3685eae7ae769c) | `` microsoft-edge: 135.0.3179.85 -> 136.0.3240.64 ``                     |
| [`f299e1c6`](https://github.com/NixOS/nixpkgs/commit/f299e1c6f738df90ca38f3d322c4004a3e5e192b) | `` google-chrome: 136.0.7103.59 -> 136.0.7103.113 ``                     |
| [`eac64c6d`](https://github.com/NixOS/nixpkgs/commit/eac64c6d01e42effd3b3b9ba3bb4b228d54226f6) | `` syslogng: 4.8.1 -> 4.8.2 ``                                           |
| [`c5a7c999`](https://github.com/NixOS/nixpkgs/commit/c5a7c999afff10a47bc55a797e4a08182ce76679) | `` libplctag: 2.6.3 -> 2.6.4 ``                                          |
| [`268a5d30`](https://github.com/NixOS/nixpkgs/commit/268a5d308b7422410406734d43f8806434e659f0) | `` anki-bin: 25.02.4 -> 25.02.5 ``                                       |
| [`c32e477f`](https://github.com/NixOS/nixpkgs/commit/c32e477fd0395acfb0f5c885dd6b5f34274af74b) | `` anki-bin: 25.02 -> 25.02.4 ``                                         |
| [`48218131`](https://github.com/NixOS/nixpkgs/commit/4821813191717df4acbbed5f06155b03818751e4) | `` anki-bin: add cything as maintainer ``                                |
| [`8f9d162c`](https://github.com/NixOS/nixpkgs/commit/8f9d162c5d40bc20229d0e32608c5b8da1e9f981) | `` maintainers: add cything ``                                           |
| [`c241179b`](https://github.com/NixOS/nixpkgs/commit/c241179ba076b437ab4b7bd1bada1cbbcd6a99cf) | `` anki-bin: 24.11 -> 25.02 ``                                           |
| [`5ffd9d5c`](https://github.com/NixOS/nixpkgs/commit/5ffd9d5c10732e6b62deb16e1a7b98ea4631dc91) | `` anki-bin: add missing dependency on libxshmfence ``                   |
| [`6ac3538d`](https://github.com/NixOS/nixpkgs/commit/6ac3538dd86b54fc1754ae9a2dadd93425a13894) | `` anki-bin: 24.06.3 -> 24.11 ``                                         |
| [`e47840f3`](https://github.com/NixOS/nixpkgs/commit/e47840f37911ada2ebb8f38297c7a58104d6843c) | `` sudo-rs: cleanup ``                                                   |
| [`55a8d862`](https://github.com/NixOS/nixpkgs/commit/55a8d86267622442e69337ab63ad3e1c2d3f9d4e) | `` sudo-rs: use finalAttrs ``                                            |
| [`e56caa54`](https://github.com/NixOS/nixpkgs/commit/e56caa54b0190fbb4d64e13a2e790a97120253cb) | `` sudo-rs: add myself as maintainer ``                                  |
| [`c21d1b49`](https://github.com/NixOS/nixpkgs/commit/c21d1b498ef83ff6e9d1f7c2d3b187ade38a4e7e) | `` sudo-rs: 0.2.5 -> 0.2.6 ``                                            |
| [`f6d93195`](https://github.com/NixOS/nixpkgs/commit/f6d931954d72a91e8a186034e6fe19b269bd402d) | `` sudo-rs: add meta.mainProgram ``                                      |
| [`f6be8539`](https://github.com/NixOS/nixpkgs/commit/f6be85398e3425667f35ded17b84c84b3fc0de86) | `` sudo-rs: 0.2.4 -> 0.2.5 ``                                            |
| [`c9d1f784`](https://github.com/NixOS/nixpkgs/commit/c9d1f78491e24cacdbbeb8da45303a5b5b22a712) | `` sudo-rs: 0.2.3 -> 0.2.4 ``                                            |
| [`270e105f`](https://github.com/NixOS/nixpkgs/commit/270e105f8caa8ebbd5152ba10fb4a208b82b2fe9) | `` sudo-rs: switch to fetchCargoVendor to facilitate the cherry-picks `` |
| [`4ba3724d`](https://github.com/NixOS/nixpkgs/commit/4ba3724dbb4aa21c6bfa9752a06c14ce9e9a85e6) | `` linux_testing: 6.15-rc5 -> 6.15-rc6 ``                                |
| [`4afab2e1`](https://github.com/NixOS/nixpkgs/commit/4afab2e126ae55991a893c03f2fa7ecc89621c19) | `` xen: patch with XSA-469 ``                                            |
| [`4d016123`](https://github.com/NixOS/nixpkgs/commit/4d0161235249ce2ebc16f51a7fb8878d749c2866) | `` xen: patch with XSA-467 ``                                            |
| [`e790c3b0`](https://github.com/NixOS/nixpkgs/commit/e790c3b03faadaa8e6694ad6165d56d32a212953) | `` varnish77: 7.7.0 -> 7.7.1 ``                                          |
| [`b3a468f2`](https://github.com/NixOS/nixpkgs/commit/b3a468f26364321a77470a477082510dc61f1b06) | `` varnish76: 7.6.2 -> 7.6.3 ``                                          |
| [`82bfd0e1`](https://github.com/NixOS/nixpkgs/commit/82bfd0e19290b8e8f715ff198b99c4b6e3a1b3f8) | `` varnish60: 6.0.13 -> 6.0.14 ``                                        |
| [`e93de65b`](https://github.com/NixOS/nixpkgs/commit/e93de65b207242dc84ba68ff7850682f7fa3580c) | `` varnish77: init at 7.7.0 ``                                           |
| [`adb6db2c`](https://github.com/NixOS/nixpkgs/commit/adb6db2c6b9ffb3760ad792f6fcad7dfaf868100) | `` varnish76: 7.6.1 -> 7.6.2 ``                                          |
| [`842d9ba4`](https://github.com/NixOS/nixpkgs/commit/842d9ba4e5dcdb76a6965f95f8400f4ee8f900c8) | `` varnish76: init at 7.6.1 ``                                           |
| [`bd19d122`](https://github.com/NixOS/nixpkgs/commit/bd19d122bac78abc9f9f29263ab7b202c29710e8) | `` rundeck: 5.11.1 -> 5.12.0 ``                                          |
| [`b45f85d8`](https://github.com/NixOS/nixpkgs/commit/b45f85d8a19976b69e97307b5a935b3add6c436e) | `` floorp-unwrapped: 11.26.0 -> 11.26.1 ``                               |
| [`28233114`](https://github.com/NixOS/nixpkgs/commit/282331143fa8d0dc402174ecfb6e264e3523d13c) | `` teams-for-linux: 1.13.0 -> 1.13.1 ``                                  |
| [`5a8954b2`](https://github.com/NixOS/nixpkgs/commit/5a8954b2393d18bc7fe173efa7162c32ad7aaa6d) | `` teams-for-linux: 1.12.8 -> 1.13.0 ``                                  |
| [`62bf6bf2`](https://github.com/NixOS/nixpkgs/commit/62bf6bf228eb84c5625dabf8d1ee22568705af8c) | `` teams-for-linux: 1.12.7 -> 1.12.8 ``                                  |
| [`2ded6f68`](https://github.com/NixOS/nixpkgs/commit/2ded6f688a504d41948e4edf2cc37b8a7d465db1) | `` bitwarden-desktop: 2025.1.1 -> 2025.2.0 (#381008) ``                  |