### PR TITLE
chore(flake/hyprland): `44cb8f76` -> `d9c8a378`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -639,11 +639,11 @@
         "xdph": "xdph"
       },
       "locked": {
-        "lastModified": 1747588206,
-        "narHash": "sha256-RPeB/G4UVK9HX90G8fo8ig/sE10Gk5s09DTVsJzNqgo=",
+        "lastModified": 1747589660,
+        "narHash": "sha256-TbVXhBSsAgd/osdNAzRP6tq+LEFxBRI0+tv66xXuvRQ=",
         "owner": "hyprwm",
         "repo": "Hyprland",
-        "rev": "44cb8f769e45cbe13edc6605e3b51ba041afd92f",
+        "rev": "d9c8a378118d954932eb9906b07150ccd9a3a434",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                                                             |
| ------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------- |
| [`d9c8a378`](https://github.com/hyprwm/Hyprland/commit/d9c8a378118d954932eb9906b07150ccd9a3a434) | `` input: always allow focus to permission popups ``                |
| [`158c0f29`](https://github.com/hyprwm/Hyprland/commit/158c0f2911894f5f97af7361f639f97f6d100c82) | `` permissions: add permission management for keyboards (#10367) `` |