### PR TITLE
chore(flake/nix-gaming): `754864d9` -> `1c04e472`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -998,11 +998,11 @@
         "nixpkgs": "nixpkgs_5"
       },
       "locked": {
-        "lastModified": 1747573429,
-        "narHash": "sha256-zFM+gjaF2eEZ/nyh/PWOBr34tsp+PYaKRev98w4269Q=",
+        "lastModified": 1747594704,
+        "narHash": "sha256-IAUIY96BaMM4o+BeMLcviBji/Xais7WfU5TIPjgPEEQ=",
         "owner": "fufexan",
         "repo": "nix-gaming",
-        "rev": "754864d9f20adc084faa32cd47b0979d88134d22",
+        "rev": "1c04e472eafbd37d82af17769d45932e39b37b76",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                              | Message                                            |
| --------------------------------------------------------------------------------------------------- | -------------------------------------------------- |
| [`1c04e472`](https://github.com/fufexan/nix-gaming/commit/1c04e472eafbd37d82af17769d45932e39b37b76) | `` dxvk-nvapi: Use headers included in the repo `` |