### PR TITLE
chore(flake/better-control): `e3d54fad` -> `cae34222`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -210,11 +210,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1747462495,
-        "narHash": "sha256-1tL0AwbfmjWri0kBGEdc/vtoeFivfZe/Q5O+QCMpu5M=",
+        "lastModified": 1747599136,
+        "narHash": "sha256-28L0hEAM94GENbFpVq5YvNgaEVlTODBYIai2FCFN45A=",
         "owner": "rishabh5321",
         "repo": "better-control-flake",
-        "rev": "e3d54fad4ada7dab63e1862f21fc2419378e1cb0",
+        "rev": "cae342222843f88f8d42c2400bfb6f9fcdd1d6cb",
         "type": "github"
       },
       "original": {
@@ -1060,11 +1060,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1747327360,
-        "narHash": "sha256-LSmTbiq/nqZR9B2t4MRnWG7cb0KVNU70dB7RT4+wYK4=",
+        "lastModified": 1747542820,
+        "narHash": "sha256-GaOZntlJ6gPPbbkTLjbd8BMWaDYafhuuYRNrxCGnPJw=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "e06158e58f3adee28b139e9c2bcfcc41f8625b46",
+        "rev": "292fa7d4f6519c074f0a50394dbbe69859bb6043",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                            | Message                                          |
| ----------------------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
| [`cae34222`](https://github.com/Rishabh5321/better-control-flake/commit/cae342222843f88f8d42c2400bfb6f9fcdd1d6cb) | `` chore(flake/nixpkgs): e06158e5 -> 292fa7d4 `` |