### PR TITLE
chore(flake/akuse-flake): `c09b16d9` -> `1f2d7ee8`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -48,11 +48,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1747459308,
-        "narHash": "sha256-PepKGeRZ+kXUlkGJAvY/yIwzh08Pzhikm8h22VQB86o=",
+        "lastModified": 1747599886,
+        "narHash": "sha256-UWTteHnIp6USXs2RQoZ8wPpS4O+XggfVst3tSiHVId8=",
         "owner": "Rishabh5321",
         "repo": "akuse-flake",
-        "rev": "c09b16d97b02b7c98b93a79a83ac7534860d8e12",
+        "rev": "1f2d7ee8d935cf161d62560c873f42fa054c957f",
         "type": "github"
       },
       "original": {
@@ -1013,11 +1013,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1747327360,
-        "narHash": "sha256-LSmTbiq/nqZR9B2t4MRnWG7cb0KVNU70dB7RT4+wYK4=",
+        "lastModified": 1747542820,
+        "narHash": "sha256-GaOZntlJ6gPPbbkTLjbd8BMWaDYafhuuYRNrxCGnPJw=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "e06158e58f3adee28b139e9c2bcfcc41f8625b46",
+        "rev": "292fa7d4f6519c074f0a50394dbbe69859bb6043",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                   | Message                                          |
| -------------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
| [`1f2d7ee8`](https://github.com/Rishabh5321/akuse-flake/commit/1f2d7ee8d935cf161d62560c873f42fa054c957f) | `` chore(flake/nixpkgs): e06158e5 -> 292fa7d4 `` |