### PR TITLE
chore(flake/spicetify-nix): `73024766` -> `8c1be0e5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1328,11 +1328,11 @@
         "systems": "systems_5"
       },
       "locked": {
-        "lastModified": 1747546358,
-        "narHash": "sha256-xizOQStno5y3k+LhPoJ9jg3NYvVl2pILGtyMFSE7Qto=",
+        "lastModified": 1747607404,
+        "narHash": "sha256-xj2Ji+rE+oYjf0BsTDT7K/StnYuZQK9MTbX8U1DUcC0=",
         "owner": "Gerg-L",
         "repo": "spicetify-nix",
-        "rev": "73024766e3f70de838db1335d0f400e85eeca48e",
+        "rev": "8c1be0e5e9a7f35ccd6f7b10bcfa08f2734dad91",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message             |
| ----------------------------------------------------------------------------------------------------- | ------------------- |
| [`8c1be0e5`](https://github.com/Gerg-L/spicetify-nix/commit/8c1be0e5e9a7f35ccd6f7b10bcfa08f2734dad91) | `` Revert "test" `` |