### PR TITLE
chore(flake/better-control): `cae34222` -> `7dfedf61`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -210,11 +210,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1747599136,
-        "narHash": "sha256-28L0hEAM94GENbFpVq5YvNgaEVlTODBYIai2FCFN45A=",
+        "lastModified": 1747627081,
+        "narHash": "sha256-rJRj/Cu5iViVu5ZtIZhqjcwuTT4DLtxVQJFer05LGBI=",
         "owner": "rishabh5321",
         "repo": "better-control-flake",
-        "rev": "cae342222843f88f8d42c2400bfb6f9fcdd1d6cb",
+        "rev": "7dfedf61ecb7ec311c13b29d7a6bade82d131893",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                            | Message                                                 |
| ----------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------- |
| [`7dfedf61`](https://github.com/Rishabh5321/better-control-flake/commit/7dfedf61ecb7ec311c13b29d7a6bade82d131893) | `` chore: add .gitignore to exclude result directory `` |
| [`1370775f`](https://github.com/Rishabh5321/better-control-flake/commit/1370775faa274ff5d51b1a64d34ee2f3432a41a1) | `` feat: Update better-control to v6.11.7 (#102) ``     |