### PR TITLE
chore(flake/zen-browser): `16e095bf` -> `87941091`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1639,11 +1639,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1747592715,
-        "narHash": "sha256-2rq/h8xHOuGi+Vhi4cfioN1HA06qFssiIN2ZgMTITnM=",
+        "lastModified": 1747628828,
+        "narHash": "sha256-6oUq+it6ONFrj7GWVDAewfYFUXjgl9ukCjArUwsfJnA=",
         "owner": "0xc000022070",
         "repo": "zen-browser-flake",
-        "rev": "16e095bf03d26fd26d22f589b96e7b8853a05b70",
+        "rev": "879410914ccbc5aeb3cd15428bfdf0ad15ae5d33",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                          | Message                                                               |
| --------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------- |
| [`87941091`](https://github.com/0xc000022070/zen-browser-flake/commit/879410914ccbc5aeb3cd15428bfdf0ad15ae5d33) | `` chore(update): twilight @ x86_64 && aarch64 to 1.13t#1747625934 `` |