### PR TITLE
chore(flake/zen-browser): `87941091` -> `d4005e94`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1750,11 +1750,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1747628828,
-        "narHash": "sha256-6oUq+it6ONFrj7GWVDAewfYFUXjgl9ukCjArUwsfJnA=",
+        "lastModified": 1747658502,
+        "narHash": "sha256-7SunK8XumGZz+ITBmOMVEHqrCFtP0hAyydftLkXqnw0=",
         "owner": "0xc000022070",
         "repo": "zen-browser-flake",
-        "rev": "879410914ccbc5aeb3cd15428bfdf0ad15ae5d33",
+        "rev": "d4005e943d4276023fb81d598811c9ab04d141d0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                          | Message                                                               |
| --------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------- |
| [`d4005e94`](https://github.com/0xc000022070/zen-browser-flake/commit/d4005e943d4276023fb81d598811c9ab04d141d0) | `` chore(update): twilight @ x86_64 && aarch64 to 1.13t#1747654847 `` |