### PR TITLE
chore(flake/nixpkgs-stable): `2e1496bf` -> `ca49c430`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1118,11 +1118,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1747428706,
-        "narHash": "sha256-XVds9FkRrY59xRNNq14FNsFGqDiexXX/mlHcX4hPyyk=",
+        "lastModified": 1747610100,
+        "narHash": "sha256-rpR5ZPMkWzcnCcYYo3lScqfuzEw5Uyfh+R0EKZfroAc=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "2e1496bf8652ff4af4e4d4737277f71e4a4f5cb2",
+        "rev": "ca49c4304acf0973078db0a9d200fd2bae75676d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                                                                            |
| ---------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------- |
| [`e61f5200`](https://github.com/NixOS/nixpkgs/commit/e61f5200147a49e6ed1bcf6a36d5fccbbe805ab4) | `` SDL_ttf: fix version string ``                                                                                                                  |
| [`aa373243`](https://github.com/NixOS/nixpkgs/commit/aa3732438e981f31894820157ab2b74862132184) | `` firefox-esr: 128.10.0esr -> 128.10.1esr ``                                                                                                      |
| [`9a444fd4`](https://github.com/NixOS/nixpkgs/commit/9a444fd46a6a33584bfd46484f6bfbc09cc7fa65) | `` dolphin-emu: set correct git revision ``                                                                                                        |
| [`190ce8ef`](https://github.com/NixOS/nixpkgs/commit/190ce8ef0f8307590e4a4d9fd6ef0d6e8745b181) | `` signald: set jdkOnBuild ``                                                                                                                      |
| [`076c54c5`](https://github.com/NixOS/nixpkgs/commit/076c54c593be9fa10f2486ea893aa4491e04bc83) | `` digikam: mark as big-paralllel ``                                                                                                               |
| [`cd28f44d`](https://github.com/NixOS/nixpkgs/commit/cd28f44de0982feb77854dd7d26274307ae1a95d) | `` tomcat: 11.0.6 -> 11.0.7 ``                                                                                                                     |
| [`e24d645c`](https://github.com/NixOS/nixpkgs/commit/e24d645c074f2c5de4d0e7eadb4646c5b94d28e1) | `` tomcat9: 9.0.104 -> 9.0.105 ``                                                                                                                  |
| [`24a5d129`](https://github.com/NixOS/nixpkgs/commit/24a5d1295d38d0a41d1029feb31b57de0fc0cf14) | `` jetty: 12.0.20 -> 12.0.21 ``                                                                                                                    |
| [`a20f81f1`](https://github.com/NixOS/nixpkgs/commit/a20f81f1b6b297726d16895e035b359f03ba3456) | `` tomcat10: 10.1.40 -> 10.1.41 ``                                                                                                                 |
| [`b8841524`](https://github.com/NixOS/nixpkgs/commit/b88415246fea7a9e3e23d504b9778b7d1bb8b749) | `` nodejs_20: 20.19.1 -> 20.19.2 ``                                                                                                                |
| [`88c14c52`](https://github.com/NixOS/nixpkgs/commit/88c14c523ed80ab47bf5c89e3a75cb82717691c3) | `` upscaler: 1.5.1 -> 1.5.2 ``                                                                                                                     |
| [`341df29b`](https://github.com/NixOS/nixpkgs/commit/341df29b3aed2ee8eb6d65a36331da287402c90a) | `` fluffychat: add aleksana to maintainers ``                                                                                                      |
| [`49a18579`](https://github.com/NixOS/nixpkgs/commit/49a185794943e7f6b6ba3baa42222851cbd21f93) | `` fluffychat: 1.26.0 -> 1.26.1 ``                                                                                                                 |
| [`8928fcbd`](https://github.com/NixOS/nixpkgs/commit/8928fcbdf5edc7a38593b027fa50d104b2d1310c) | `` riko4: drop ``                                                                                                                                  |
| [`d6deff04`](https://github.com/NixOS/nixpkgs/commit/d6deff043e5bc386d812769af87c91ac79349bcc) | `` edge-runtime: drop ``                                                                                                                           |
| [`d76d76a3`](https://github.com/NixOS/nixpkgs/commit/d76d76a3df18691534932c659eb22ee5c3c01efb) | `` lngen: fix build with GHC >=9.8.1 ``                                                                                                            |
| [`b12e49a7`](https://github.com/NixOS/nixpkgs/commit/b12e49a7cf7e2e2a86dfa93edc3f927e5a619211) | `` git-annex-utils: drop ``                                                                                                                        |
| [`1f47ea6d`](https://github.com/NixOS/nixpkgs/commit/1f47ea6d8cf53d52475d4322cca7848e46ea2e33) | `` x16: adopt & modernize ``                                                                                                                       |
| [`fa53c7b4`](https://github.com/NixOS/nixpkgs/commit/fa53c7b41f1fc50f4cb1b9f8103bd8f3f2692641) | `` x16: fix build on GCC 14 ``                                                                                                                     |
| [`06f07f8f`](https://github.com/NixOS/nixpkgs/commit/06f07f8f7752025599e8d71f524a931ba218c614) | `` SDL_net: 1.2.8-unstable-2024-04-23 -> 1.2.8-unstable-2025-04-21 ``                                                                              |
| [`b6b5ecb9`](https://github.com/NixOS/nixpkgs/commit/b6b5ecb97a4f023a4a67e755910899817aa7c36c) | `` SDL_image: 1.2.12-unstable-2025-02-13 -> 1.2.12-unstable-2025-04-27 ``                                                                          |
| [`43880c03`](https://github.com/NixOS/nixpkgs/commit/43880c03b79cb7e6ade766ad4f9fabea143b37c6) | `` teleport_16: 16.5.3 -> 16.5.9 ``                                                                                                                |
| [`3b595a9c`](https://github.com/NixOS/nixpkgs/commit/3b595a9c778888c94dbf0e5a92af886e9311cf59) | `` teleport_17: 17.4.5 -> 17.4.8 ``                                                                                                                |
| [`f5d39add`](https://github.com/NixOS/nixpkgs/commit/f5d39add70933e1ff437508893734865dc601b4f) | `` darwin: lib.warn -> lib.warnOnInstantiate ``                                                                                                    |
| [`8cf643e0`](https://github.com/NixOS/nixpkgs/commit/8cf643e05fc18691e2878c1b0ef4142c75c8699a) | `` darwin: reduce `nix search` warning spam ``                                                                                                     |
| [`5e761e6c`](https://github.com/NixOS/nixpkgs/commit/5e761e6c10558a67e16155c08e3f4bcda0afc9c1) | `` edbrowse: drop ``                                                                                                                               |
| [`237d61b1`](https://github.com/NixOS/nixpkgs/commit/237d61b1a250c0f0cf0b32e9ac7e115d10fec054) | `` home-assistant-custom-components.dwd: 2024.11.0 -> 2025.5.0 ``                                                                                  |
| [`10a01804`](https://github.com/NixOS/nixpkgs/commit/10a01804291dfa9563d660963920e8f342b4397d) | `` python3Packages.schema-salad: drop black build-time dependency ``                                                                               |
| [`5397beb7`](https://github.com/NixOS/nixpkgs/commit/5397beb766ca9209982bbf5f83effe8ed58ab937) | `` darling-dmg: fix compilation ``                                                                                                                 |
| [`76aa6504`](https://github.com/NixOS/nixpkgs/commit/76aa65043b35b97819354189968eb647f5ade480) | `` clean: mark as broken ``                                                                                                                        |
| [`3429ab3d`](https://github.com/NixOS/nixpkgs/commit/3429ab3d11d4eb11e88be56af1412d22d3d8f577) | `` firefox-bin-unwrapped: 138.0.3 -> 138.0.4 ``                                                                                                    |
| [`e6c8bfb6`](https://github.com/NixOS/nixpkgs/commit/e6c8bfb62b5598fcb141c41fcd7e364d02400ecf) | `` firefox-unwrapped: 138.0.3 -> 138.0.4 ``                                                                                                        |
| [`a0dbe944`](https://github.com/NixOS/nixpkgs/commit/a0dbe9449e2529072a041d55f1e27b487fcbe692) | `` odyssey: fix build ``                                                                                                                           |
| [`362ee739`](https://github.com/NixOS/nixpkgs/commit/362ee73979a8cccd4c10409a1005b00397feabaa) | `` monado: port vulkan headers bump compat fix ``                                                                                                  |
| [`17817436`](https://github.com/NixOS/nixpkgs/commit/17817436ebcde2d6d86d22654dcd1ffd85adcd2c) | `` luminance: fix GSettings schemas ``                                                                                                             |
| [`94384e2b`](https://github.com/NixOS/nixpkgs/commit/94384e2b7eed1521a78be949674d12753799a160) | `` wivrn: remove usages of with ``                                                                                                                 |
| [`4acf56d4`](https://github.com/NixOS/nixpkgs/commit/4acf56d485d2de7fd478bb9a2250aa60746fe850) | `` wivrn: patch monado to work with vulkan-headers >= 1.4.310 ``                                                                                   |
| [`c678f46a`](https://github.com/NixOS/nixpkgs/commit/c678f46ac1bee61363412d1f807656f927cc8e7c) | `` google-chrome: fix com.google.Chrome.desktop ``                                                                                                 |
| [`ba690447`](https://github.com/NixOS/nixpkgs/commit/ba690447856ac1b21bb473fc18246ab46bcbc2c1) | `` manticore: drop ``                                                                                                                              |
| [`07ed702f`](https://github.com/NixOS/nixpkgs/commit/07ed702f977720ac35fdc195f3518e156baa3a69) | `` linux_5_15: 5.15.182 -> 5.15.183 ``                                                                                                             |
| [`9127b92f`](https://github.com/NixOS/nixpkgs/commit/9127b92f9144467d0369f4d2fc34c1de8fbba918) | `` linux_6_1: 6.1.138 -> 6.1.139 ``                                                                                                                |
| [`b2341e27`](https://github.com/NixOS/nixpkgs/commit/b2341e2739081f8669a891584c644eb27f750860) | `` linux_6_6: 6.6.90 -> 6.6.91 ``                                                                                                                  |
| [`2f10b980`](https://github.com/NixOS/nixpkgs/commit/2f10b980ffd5e3df579e664190255ec167aaa57c) | `` linux_6_12: 6.12.28 -> 6.12.29 ``                                                                                                               |
| [`c0a50f51`](https://github.com/NixOS/nixpkgs/commit/c0a50f51b264965621b25dd3a10d4ed9c45878b0) | `` linux_6_14: 6.14.6 -> 6.14.7 ``                                                                                                                 |
| [`825b7da9`](https://github.com/NixOS/nixpkgs/commit/825b7da918693d19c9992eae2c558a25eae3471c) | `` lutris: migrate to the new meson build system ``                                                                                                |
| [`996d332c`](https://github.com/NixOS/nixpkgs/commit/996d332cb7590d9f52825b3be4c29564b8ca9f4f) | `` Add dependency 'ar' and fix path ``                                                                                                             |
| [`7620586e`](https://github.com/NixOS/nixpkgs/commit/7620586ee921da04ae4c1ed621a831407cf37024) | `` foliate: 3.2.1 -> 3.3.0 ``                                                                                                                      |
| [`75aaf7c0`](https://github.com/NixOS/nixpkgs/commit/75aaf7c003dd457bc94093173e8c93bee31c51ff) | `` fvwm2: fix build with GCC 14 ``                                                                                                                 |
| [`421d7141`](https://github.com/NixOS/nixpkgs/commit/421d7141081627323e78f19b21e92df630bc0ea0) | `` collision: 3.9.0 -> 3.10.0 ``                                                                                                                   |
| [`6e9a0f10`](https://github.com/NixOS/nixpkgs/commit/6e9a0f103ad7afcb4d582a860e4d67808cd789b8) | `` create-react-app: drop ``                                                                                                                       |
| [`53c646a0`](https://github.com/NixOS/nixpkgs/commit/53c646a0aba04796163c93128b1c1d7fcc3f0df0) | `` pantheon.elementary-gtk-theme: 8.2.0 -> 8.2.1 ``                                                                                                |
| [`d7d0a2ec`](https://github.com/NixOS/nixpkgs/commit/d7d0a2ec1473b79b314129cb0a546c6e1e36dda8) | `` epiphany: Fix startup crash on Pantheon ``                                                                                                      |
| [`32e0688d`](https://github.com/NixOS/nixpkgs/commit/32e0688d7d6091b640d63e53a4aef960870ccc82) | `` xfce.thunar: 4.20.2 -> 4.20.3 ``                                                                                                                |
| [`33604d16`](https://github.com/NixOS/nixpkgs/commit/33604d16e3d7f6930e538a0f1bb6289d8a0c4739) | `` invidious: 2.20250504.0 -> 2.20250517.0 ``                                                                                                      |
| [`0da5e3e7`](https://github.com/NixOS/nixpkgs/commit/0da5e3e7edc130c998fb8a0a34ca8ec126f19f0a) | `` gnomeExtensions.applications-menu: fix GMenu import ``                                                                                          |
| [`04bb0fac`](https://github.com/NixOS/nixpkgs/commit/04bb0fac083f329c6adad44370fa5e46c93a14dc) | `` gruvbox-gtk-theme: 0-unstable-2024-11-06 -> 0-unstable-2025-04-24 ``                                                                            |
| [`6b8960c9`](https://github.com/NixOS/nixpkgs/commit/6b8960c9617beba72ae61d3d28f0aa96c11b998a) | `` nightfox-gtk-theme: 0-unstable-2024-11-06 -> 0-unstable-2025-04-24 ``                                                                           |
| [`4974c039`](https://github.com/NixOS/nixpkgs/commit/4974c0395315c0232437298f16a5a41798a7a49b) | `` tokyonight-gtk-theme: 0-unstable-2024-11-06 -> 0-unstable-2025-04-24 ``                                                                         |
| [`b6243a22`](https://github.com/NixOS/nixpkgs/commit/b6243a22e8bcbc816d69696a7202cae2279e6235) | `` matrix-gtk-theme: 0-unstable-2024-11-06 -> 0-unstable-2025-05-06 ``                                                                             |
| [`d1a06ea3`](https://github.com/NixOS/nixpkgs/commit/d1a06ea3d8d6c28d7bb6263156584229d3d93b8b) | `` python312Packages.roadlib: add missing inputs ``                                                                                                |
| [`a9591ff8`](https://github.com/NixOS/nixpkgs/commit/a9591ff829d1d9f4191857406214bc10d075d436) | `` maintainers: updated ohheyrj ``                                                                                                                 |
| [`1c82291c`](https://github.com/NixOS/nixpkgs/commit/1c82291cdde13bdf7029b7c00b86fd706252e249) | `` python3Packages.moderngl: fix context detection under NixOS ``                                                                                  |
| [`43925301`](https://github.com/NixOS/nixpkgs/commit/439253015c10eba3180af715380627a6145e2aff) | `` workflows/eval: fix process job with author id argument ``                                                                                      |
| [`71666466`](https://github.com/NixOS/nixpkgs/commit/71666466ed8059614ffc39d4d7d81d270685fd45) | `` ty: init at 0.0.1-alpha.5 ``                                                                                                                    |
| [`b9176e15`](https://github.com/NixOS/nixpkgs/commit/b9176e15ca0d10f01b36c7dde12b4c79e531878d) | `` ci/nix: 2.24 -> 2.28 ``                                                                                                                         |
| [`4b8b2f34`](https://github.com/NixOS/nixpkgs/commit/4b8b2f3470d19763e036e397f6d3f62b2915dffd) | `` snapcraft: make SSL certs available during tests ``                                                                                             |
| [`f478418a`](https://github.com/NixOS/nixpkgs/commit/f478418afd6076830feedb174d3ee976bb6813b2) | `` ci/eval/compare: manage the "by: package-maintainer" label ``                                                                                   |
| [`4a94acef`](https://github.com/NixOS/nixpkgs/commit/4a94acefbafb0b41530b2fcfc7dca6adb1b2251e) | `` python3Packages.aiocache: disable time-sensitive tests on Darwin ``                                                                             |
| [`9d17e164`](https://github.com/NixOS/nixpkgs/commit/9d17e1645a2212e765d1133ae9b421d9fca0e695) | `` python3Packages.aiocache: cleanup ``                                                                                                            |
| [`7cc7b7c6`](https://github.com/NixOS/nixpkgs/commit/7cc7b7c6395fba069ab2099b7a7da1bc5e641c7d) | `` nixos/tests/vaultwarden: fix UI testing ``                                                                                                      |
| [`7f28e17d`](https://github.com/NixOS/nixpkgs/commit/7f28e17d964550a0165e8d0e4d15685bb4d6a79b) | `` gnomeExtensions.gsconnect: 58 -> 62 ``                                                                                                          |
| [`18867496`](https://github.com/NixOS/nixpkgs/commit/18867496f1411ec8ef717932abec01071af02c99) | `` audiobookshelf: 2.21.0 -> 2.23.0 ``                                                                                                             |
| [`258dca1e`](https://github.com/NixOS/nixpkgs/commit/258dca1e95768c54d697bf92045c72e07ea593f2) | `` nixos/profiles/nix-builder-vm: allow the system derivation to be substituted ``                                                                 |
| [`28d804e6`](https://github.com/NixOS/nixpkgs/commit/28d804e6254a9e3b7bd75f77e3d80c67daa4163b) | `` nixosTests.curl-impersonate: skip failing test ``                                                                                               |
| [`f103e4d6`](https://github.com/NixOS/nixpkgs/commit/f103e4d69553ea04b8410bae449b6d0c1f5cb17f) | `` trilium-server: fix build error ``                                                                                                              |
| [`798cf818`](https://github.com/NixOS/nixpkgs/commit/798cf818e87f101ea06204fce263dda179b09774) | `` mapmap: drop ``                                                                                                                                 |
| [`54fd57b3`](https://github.com/NixOS/nixpkgs/commit/54fd57b38990089ab96b032682208d9dcf64e9a1) | `` tilda: fix build ``                                                                                                                             |
| [`1f0aee98`](https://github.com/NixOS/nixpkgs/commit/1f0aee9898220318fe2d43e68987e20dee622358) | `` salmon: add missing dependency ``                                                                                                               |
| [`13df3e26`](https://github.com/NixOS/nixpkgs/commit/13df3e2636194d7c8d8afc855fc4d76944d717b1) | `` rPackages: fix meta.homepage for packages in BiocAnn and BiocExp ``                                                                             |
| [`442a9a81`](https://github.com/NixOS/nixpkgs/commit/442a9a811e0b5e4d493be5090ea5ed0cb1e9aa86) | `` workflows/periodic-merge: set custom name for haskell-updates merge ``                                                                          |
| [`f309fef2`](https://github.com/NixOS/nixpkgs/commit/f309fef2f30b41c8b220807ea478fef6f09ee8e1) | `` ci/eval: allow configuration of the system to eval attrpaths on ``                                                                              |
| [`1b2b3e1e`](https://github.com/NixOS/nixpkgs/commit/1b2b3e1ea2f67c7e98234ff45b94b567da8fc072) | `` nixos/specialisation: escape and restrict specialisation names ``                                                                               |
| [`27d999ea`](https://github.com/NixOS/nixpkgs/commit/27d999ea28a26fb673a0ba51a22df73f8de4a39e) | `` wayfarer: 1.2.4 -> 1.2.4-unstable-2025-04-12 ``                                                                                                 |
| [`ac2a1462`](https://github.com/NixOS/nixpkgs/commit/ac2a1462ea2d74b3fff482a7b30a50b14fa15623) | `` evcc: 0.203.5 -> 0.203.6 ``                                                                                                                     |
| [`aed40c74`](https://github.com/NixOS/nixpkgs/commit/aed40c740f1689867c63f36a2e6217170a4cf4b3) | `` pngnq: fix with gcc 14 ``                                                                                                                       |
| [`1201bb64`](https://github.com/NixOS/nixpkgs/commit/1201bb64c9d99659077feaede0294d1090f6e1d2) | `` text-engine: remove the `json-glib` dependency ``                                                                                               |
| [`8c7b1e52`](https://github.com/NixOS/nixpkgs/commit/8c7b1e5274836347a6fb0158fe35a12634a268cc) | `` text-engine: 0.1.1 -> 0.1.1-unstable-2024-09-16 ``                                                                                              |
| [`221000de`](https://github.com/NixOS/nixpkgs/commit/221000ded99331add64e7783a1d5f03d214cd2b7) | `` text-engine: refactor ``                                                                                                                        |
| [`cd972b65`](https://github.com/NixOS/nixpkgs/commit/cd972b65cc4b62a931606df89aa4accd27882093) | `` scummvm: fix aarch64-darwin ranlib path ``                                                                                                      |
| [`f4668fe0`](https://github.com/NixOS/nixpkgs/commit/f4668fe0d4032a7526d76f04011d0a6bf007d168) | `` nixos/sourcehut: adapt to new versions ``                                                                                                       |
| [`2670b88b`](https://github.com/NixOS/nixpkgs/commit/2670b88ba9df3b18720c26622576d16dade50fb6) | `` srht-gen-oauth-tok: fix html parsing ``                                                                                                         |
| [`469317e6`](https://github.com/NixOS/nixpkgs/commit/469317e6699fe106541a0cf64adc829533081dd0) | `` sourcehut.*: use latest sqlalchemy ``                                                                                                           |
| [`95b55810`](https://github.com/NixOS/nixpkgs/commit/95b55810674a8b663b624ed8c5c2f6c9ab978578) | `` sourcehut.todosrht: 0.75.10 -> 0.77.5 ``                                                                                                        |
| [`2d62b456`](https://github.com/NixOS/nixpkgs/commit/2d62b4567bd169a540c9a7d9b594c4a87a9b02b3) | `` sourcehut.pastesrht: 0.15.4 -> 0.16.1 ``                                                                                                        |
| [`8e03048e`](https://github.com/NixOS/nixpkgs/commit/8e03048ed3d895dd50064c989db27d55f80d1fcc) | `` sourcehut.pagessrht: 0.15.7 -> 0.16.0 ``                                                                                                        |
| [`b42dae80`](https://github.com/NixOS/nixpkgs/commit/b42dae80f9df137e8c6e53905e0d8084bc5f1952) | `` sourcehut.metasrht: 0.69.8 -> 0.72.11 ``                                                                                                        |
| [`2caf79ff`](https://github.com/NixOS/nixpkgs/commit/2caf79ffc192355431feec65bff52b4cf9b3e9ca) | `` sourcehut.mansrht: 0.16.5 -> 0.18.1 ``                                                                                                          |
| [`8d5cacf2`](https://github.com/NixOS/nixpkgs/commit/8d5cacf26f844951b2f85cf44ae91292247f42cc) | `` sourcehut.listssrht: 0.57.18 -> 0.62.3 ``                                                                                                       |
| [`8a3d510d`](https://github.com/NixOS/nixpkgs/commit/8a3d510d32702a39a39cc83d655d7485fe3fc69a) | `` sourcehut.hubsrht: 0.17.7 -> 0.20.2 ``                                                                                                          |
| [`634f3f20`](https://github.com/NixOS/nixpkgs/commit/634f3f2059e825ead9ac89b70c5d3758d554fc56) | `` sourcehut.hgsrht: 0.33.0 -> 0.36.1 ``                                                                                                           |
| [`9ea57dd7`](https://github.com/NixOS/nixpkgs/commit/9ea57dd77898004d4f35a980c35c099af331bcd7) | `` sourcehut.gitsrht: 0.85.9 -> 0.88.10 ``                                                                                                         |
| [`4854c211`](https://github.com/NixOS/nixpkgs/commit/4854c2116d62241a02b6146f3af78e804e68379c) | `` sourcehut.buildsrht: 0.89.15 -> 0.95.1 ``                                                                                                       |
| [`b92803f3`](https://github.com/NixOS/nixpkgs/commit/b92803f39b1d1df452e0b64026921b75ab4607c9) | `` sourcehut.scmsrht: 0.22.24 -> 0.22.28 ``                                                                                                        |
| [`00b283d2`](https://github.com/NixOS/nixpkgs/commit/00b283d297c62ac7cc254dc593f8377e6bf62c44) | `` sourcehut.srht: 0.71.8 -> 0.76.1 ``                                                                                                             |
| [`cfeb72eb`](https://github.com/NixOS/nixpkgs/commit/cfeb72ebc09f223d4aea6683573f4f5af52742f5) | `` cde: drop ``                                                                                                                                    |
| [`3adc4812`](https://github.com/NixOS/nixpkgs/commit/3adc4812296768becf14f27796b48095aabb9d51) | `` xalanc: fix Clang 19 and GCC 15 compat ``                                                                                                       |
| [`dee17997`](https://github.com/NixOS/nixpkgs/commit/dee17997752062b21afa77f0f8853e6729dc6259) | `` shibboleth-sp: fix build for Clang >=19 ``                                                                                                      |
| [`97ca458d`](https://github.com/NixOS/nixpkgs/commit/97ca458d085d46f39cd77dcc6514a8efffb5666a) | `` quickbms: drop ``                                                                                                                               |
| [`12ade8b9`](https://github.com/NixOS/nixpkgs/commit/12ade8b9db0500769b8bc6b7b00bb203647c7e4c) | `` sgrep: drop ``                                                                                                                                  |
| [`5f4e6b02`](https://github.com/NixOS/nixpkgs/commit/5f4e6b02dca69528da267f8cb39582409c3979e1) | `` axmldec: mark as broken ``                                                                                                                      |
| [`ce527335`](https://github.com/NixOS/nixpkgs/commit/ce5273350802d7589cc4321f193a5fba0d2849cc) | `` evolution-ews: fix patch compiler errors ``                                                                                                     |
| [`073a01ae`](https://github.com/NixOS/nixpkgs/commit/073a01ae10428e364c840370d89d530945d6957d) | `` suidChroot: drop ``                                                                                                                             |
| [`52cc1868`](https://github.com/NixOS/nixpkgs/commit/52cc1868e5fe16881b4cb95e7fa4d40785b3ca2e) | `` afpfs-ng: mark as broken ``                                                                                                                     |
| [`b020a847`](https://github.com/NixOS/nixpkgs/commit/b020a8478b75a66957f48560563aad2725013632) | `` [25.05] libgadu: mark as broken ``                                                                                                              |
| [`edbd478b`](https://github.com/NixOS/nixpkgs/commit/edbd478b0a8f650da8d03224887a6045181765b9) | `` dbench: mark as broken ``                                                                                                                       |
| [`ae7af68d`](https://github.com/NixOS/nixpkgs/commit/ae7af68d65d062beb81244513aafee95a3cabb65) | `` kea: disable on darwin ``                                                                                                                       |
| [`3e314101`](https://github.com/NixOS/nixpkgs/commit/3e314101b8f8a19a53c3ba05da275859756e212a) | `` python313Packages.piper-phonemize: fix aarch64-linux build ``                                                                                   |
| [`0b5b6315`](https://github.com/NixOS/nixpkgs/commit/0b5b6315dda0544333ab69bc3b56a9382b5aca02) | `` python3Packages.slimit: drop ``                                                                                                                 |
| [`d0b619bf`](https://github.com/NixOS/nixpkgs/commit/d0b619bf50741aaff88efd771de4c00786df865a) | `` pretix: drop dependency on slimit ``                                                                                                            |
| [`3462f52c`](https://github.com/NixOS/nixpkgs/commit/3462f52cedf3fb844605ecbda8fef7be63646c49) | `` python313Packages.asyncinotify: mark unsupported on darwin ``                                                                                   |
| [`83febaa0`](https://github.com/NixOS/nixpkgs/commit/83febaa04d87e3aa9dd7eda71ccc3535ccb13ae1) | `` python313Packages.shiboken2: mark broken ``                                                                                                     |
| [`47553f95`](https://github.com/NixOS/nixpkgs/commit/47553f9561ad23da2f7067e0b7fec15afa59a337) | `` kanidm: add darwin support ``                                                                                                                   |
| [`ba4dd403`](https://github.com/NixOS/nixpkgs/commit/ba4dd403c8347f477a978836c24638f538ca58fc) | `` directvnc: drop ``                                                                                                                              |
| [`3a8de38c`](https://github.com/NixOS/nixpkgs/commit/3a8de38c27f0211d0cbf60ecfdf68e3f1b95f2df) | `` moonlight: 1.3.18 -> 1.3.19 ``                                                                                                                  |
| [`136a017b`](https://github.com/NixOS/nixpkgs/commit/136a017b4305d12b82c6b4ae49a36b49d084fd01) | `` brave: 1.78.97 -> 1.78.102 ``                                                                                                                   |
| [`1ba31839`](https://github.com/NixOS/nixpkgs/commit/1ba318392e5c509656dd5fc6cafb7dbaaf5c0d77) | `` dd_rescue: Set mainProgram to `dd_rescue` ``                                                                                                    |
| [`e9b53bec`](https://github.com/NixOS/nixpkgs/commit/e9b53bec00542cce04a0b16f5f739d97f165b61a) | `` dd_rescue: 1.99.8 -> 1.99.21 ``                                                                                                                 |
| [`e87581ac`](https://github.com/NixOS/nixpkgs/commit/e87581acf17089df92ac22e38e18e78b4761f0fd) | `` perl540Packages.SDL: fix build ``                                                                                                               |
| [`a94224f3`](https://github.com/NixOS/nixpkgs/commit/a94224f33b3ee47c35b975cd8ba9cb30c6104f50) | `` python3Packages.pybullet: fix build with GCC 14 ``                                                                                              |
| [`310d0a16`](https://github.com/NixOS/nixpkgs/commit/310d0a163f6cad9c2a39c1a9a967b717e899a886) | `` python3Packages.push-receiver: mark as broken ``                                                                                                |
| [`0863c469`](https://github.com/NixOS/nixpkgs/commit/0863c4697ffeb5f8df94b9712ccea899b0d6ca38) | `` plattenalbum: 2.2.2 -> 2.3.0 ``                                                                                                                 |
| [`4bc4ab8a`](https://github.com/NixOS/nixpkgs/commit/4bc4ab8a6f636dc9a7bf62844bb635cdab944b69) | `` fflogs: 8.17.1 -> 8.17.13 ``                                                                                                                    |
| [`c7a91607`](https://github.com/NixOS/nixpkgs/commit/c7a91607c581796f8d4885d536052d923d76b741) | `` curtail: 1.12.0 -> 1.13.0 ``                                                                                                                    |
| [`71418708`](https://github.com/NixOS/nixpkgs/commit/714187085bd8415b020b0686be4b3fa31dc7e9de) | `` ascii-draw: 1.0.0 -> 1.1.0 ``                                                                                                                   |
| [`ba0e6ff4`](https://github.com/NixOS/nixpkgs/commit/ba0e6ff45de7ad62f76af8c25843871502f2fbb0) | `` varia: 2025.1.24-1 -> 2025.4.22 ``                                                                                                              |
| [`1531a60f`](https://github.com/NixOS/nixpkgs/commit/1531a60f755fe56c0d08096a19cefff922124a23) | `` doc/rl-2505: relnote security.acme changes ``                                                                                                   |
| [`6077ac74`](https://github.com/NixOS/nixpkgs/commit/6077ac74ae94e7764ff79c38889bec2a5e5827ec) | `` nixos/tests/acme: Add CSR test ``                                                                                                               |
| [`dcc7993c`](https://github.com/NixOS/nixpkgs/commit/dcc7993ccc81d6738d37b88005d8d81ecd9b3f8f) | `` acme: Add csr option ``                                                                                                                         |
| [`975f283b`](https://github.com/NixOS/nixpkgs/commit/975f283ba18a6eb759c438bfcaf489607662760a) | `` shh: rev2 switch to upstreamed patches for strace path fixing, clean up check patch, enable manpages and autocomplete with upstream patches, `` |
| [`fdb1dfbf`](https://github.com/NixOS/nixpkgs/commit/fdb1dfbfe63d2f85c9b47f7ccd9f93af88bea82b) | `` cinny-desktop: make more dependencies optional, don't double wrap binary ``                                                                     |
| [`a105a3b7`](https://github.com/NixOS/nixpkgs/commit/a105a3b79e8b9c5b2503cf091051b1162d713a84) | `` doc/tauri: fix example, make openssl linux-only ``                                                                                              |
| [`0e672d7f`](https://github.com/NixOS/nixpkgs/commit/0e672d7f1ec25037c1ceba76e995048b886b9608) | `` whipper: add mainProgram ``                                                                                                                     |