### PR TITLE
chore(flake/stylix): `2e58606c` -> `f8833c5e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1461,11 +1461,11 @@
         "tinted-zed": "tinted-zed"
       },
       "locked": {
-        "lastModified": 1747673601,
-        "narHash": "sha256-jVs4byXRcqLpOTsr1MC5XwVyPhasswY2uc+Jkf5Fgmo=",
+        "lastModified": 1747675820,
+        "narHash": "sha256-Z8o3Tu/FN4GOtZl4WNY0Gcp/Uzuz06ILkRy0oPVteM0=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "2e58606c9c14d943783b5c0a8097f6f9712db3ee",
+        "rev": "f8833c5e0c64287cd51a27e6061a88f4225b6b70",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                            |
| ----------------------------------------------------------------------------------------------------- | -------------------------------------------------- |
| [`f8833c5e`](https://github.com/nix-community/stylix/commit/f8833c5e0c64287cd51a27e6061a88f4225b6b70) | `` treewide: update documentation links (#1314) `` |