### PR TITLE
chore(flake/home-manager): `45c29856` -> `65d2282f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -528,11 +528,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1747688838,
-        "narHash": "sha256-FZq4/3OtGV/cti9Vccsy2tGSUrxTO4hkDF9oeGRTen4=",
+        "lastModified": 1747747328,
+        "narHash": "sha256-3Gc5CqAJqpvI4gIU1Oxbl5w440b+rY9HvDzs5C0ChBA=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "45c2985644b60ab64de2a2d93a4d132ecb87cf66",
+        "rev": "65d2282ff6cf560f54997013bd1e575fbd0a7ebf",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                                                       |
| ----------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------- |
| [`65d2282f`](https://github.com/nix-community/home-manager/commit/65d2282ff6cf560f54997013bd1e575fbd0a7ebf) | `` fontconfig: Fix missing default fontconfig files (#7045) ``                                |
| [`20974416`](https://github.com/nix-community/home-manager/commit/20974416338898f0725a87832e4cd9bd82cbdaad) | `` services.home-manager.autoExpire: add support for darwin ``                                |
| [`04ebd2c4`](https://github.com/nix-community/home-manager/commit/04ebd2c4224ad6a78385bbc30f06dd89f0aa843b) | `` services.home-manager.autoExpire: extract cleanup script to new variable ``                |
| [`382b34f6`](https://github.com/nix-community/home-manager/commit/382b34f6569262e92b0e947ca5c49354c61b7f8c) | `` services.home-manager.autoExpire: wrap systemd configuration within a isLinux condition `` |