### PR TITLE
chore(flake/home-manager): `65d2282f` -> `559f6d36`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -528,11 +528,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1747747328,
-        "narHash": "sha256-3Gc5CqAJqpvI4gIU1Oxbl5w440b+rY9HvDzs5C0ChBA=",
+        "lastModified": 1747753534,
+        "narHash": "sha256-hbDBa5a6jnxoD0OqijmCKF45Hiv4uubb340OMr5DJhc=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "65d2282ff6cf560f54997013bd1e575fbd0a7ebf",
+        "rev": "559f6d36b32dd2180ebac40c522dd36290430fc5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                       |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------- |
| [`559f6d36`](https://github.com/nix-community/home-manager/commit/559f6d36b32dd2180ebac40c522dd36290430fc5) | `` news: add some more missing news items (#7097) ``          |
| [`d3f5d870`](https://github.com/nix-community/home-manager/commit/d3f5d870e3f33f69fa6c0f9bcc44f8803a30e38e) | `` home-manager: add force option for gtk-2 config (#7073) `` |