### PR TITLE
chore(flake/nix-gaming): `5d7985a2` -> `29ba418c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1057,11 +1057,11 @@
         "nixpkgs": "nixpkgs_5"
       },
       "locked": {
-        "lastModified": 1747620037,
-        "narHash": "sha256-M5yyl1Cp5rolwGBuCEKXG6qJj9lao16lshqPF83z0qs=",
+        "lastModified": 1747770728,
+        "narHash": "sha256-fJfRymPcAoAz8A/z4Vmlu9g/AN9Wyotep7DsR1m5OGA=",
         "owner": "fufexan",
         "repo": "nix-gaming",
-        "rev": "5d7985a2d5c877f6a276a2b024fff6bb2995ff24",
+        "rev": "29ba418c6449f123b0d4319d4226e06bd2038150",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                              | Message                                                                             |
| --------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------- |
| [`29ba418c`](https://github.com/fufexan/nix-gaming/commit/29ba418c6449f123b0d4319d4226e06bd2038150) | `` wineprefix-preparer: handle mcfgthread changes, fix syswow64 path on wine 10+ `` |
| [`70c7d522`](https://github.com/fufexan/nix-gaming/commit/70c7d522d60eb3ff6a8e9a9cd6544f5266c1c59c) | `` vkd3d-proton: build with submodules, fix gcc13+ ``                               |
| [`dffd370d`](https://github.com/fufexan/nix-gaming/commit/dffd370d8293005ebff09d632e76f602ea2c98bd) | `` dxvk: 2.0 -> 2.6.1, fix gcc13+ build, swap to dxvk-gplasync ``                   |