### PR TITLE
chore(flake/nix-gaming): `29ba418c` -> `9898d505`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1057,11 +1057,11 @@
         "nixpkgs": "nixpkgs_5"
       },
       "locked": {
-        "lastModified": 1747770728,
-        "narHash": "sha256-fJfRymPcAoAz8A/z4Vmlu9g/AN9Wyotep7DsR1m5OGA=",
+        "lastModified": 1747787704,
+        "narHash": "sha256-/4lsR5fZq5vqTenm4IpkETFl2wRuXGfAlN3Io6foTuc=",
         "owner": "fufexan",
         "repo": "nix-gaming",
-        "rev": "29ba418c6449f123b0d4319d4226e06bd2038150",
+        "rev": "9898d505d78552400b3cf44a162344664d1a7806",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                              | Message                                                        |
| --------------------------------------------------------------------------------------------------- | -------------------------------------------------------------- |
| [`9898d505`](https://github.com/fufexan/nix-gaming/commit/9898d505d78552400b3cf44a162344664d1a7806) | `` vkd3d-proton: use correct version info from pin metadata `` |