### PR TITLE
chore(flake/home-manager): `29dda415` -> `2468b2d3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -528,11 +528,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1747763032,
-        "narHash": "sha256-9j3oCbemeH7bTVXJ3pDWxOptbxDx2SdK1jY2AHpjQiw=",
+        "lastModified": 1747793476,
+        "narHash": "sha256-2qAOSixSrbb9l6MI+SI4zGineOzDcc2dgOOFK9Dx+IY=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "29dda415f5b2178278283856c6f9f7b48a2a4353",
+        "rev": "2468b2d35512d093aeb04972a1d8c20a0735793f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                                 |
| ----------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------- |
| [`2468b2d3`](https://github.com/nix-community/home-manager/commit/2468b2d35512d093aeb04972a1d8c20a0735793f) | `` files: show colliding files at bottom in checkLinkTargets (#5495) `` |