### PR TITLE
chore(flake/stylix): `4830942f` -> `42b15218`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1461,11 +1461,11 @@
         "tinted-zed": "tinted-zed"
       },
       "locked": {
-        "lastModified": 1747813884,
-        "narHash": "sha256-XKkGD2a3GAFNjs1z58K4wb7as2gNqFzc11uvgvWwYQs=",
+        "lastModified": 1747818590,
+        "narHash": "sha256-O8hKI4Eh7GWWVVxuoZGmDrRmLBX+fE3lI53t6IGx6pg=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "4830942fa2a475c2be5d45ca1267fa77036bf9a6",
+        "rev": "42b1521816580633a27c5367c57695cc99a0f0c1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                                  |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------ |
| [`2b176d49`](https://github.com/nix-community/stylix/commit/2b176d49defb6793eb475809de10097ea6d84b41) | `` discord: use new enable option for testbed ``                         |
| [`a2236aa2`](https://github.com/nix-community/stylix/commit/a2236aa2906a5c9a1029345adb4f14e099f5972a) | `` stylix: use a cheaper module eval for the `enable` option ``          |
| [`dfcab747`](https://github.com/nix-community/stylix/commit/dfcab7476d36cd71d3cd3778ec842a625c5a1e84) | `` stylix: revert improval of how discord testbed is disabled (#1291) `` |
| [`5113479d`](https://github.com/nix-community/stylix/commit/5113479d69e6881ae142bf05084d05adddc27111) | `` stylix: improve how discord testbed is disabled (#1291) ``            |
| [`94010d21`](https://github.com/nix-community/stylix/commit/94010d21184a13efbb8571b3c19878adc0f3f93a) | `` stylix: add testbed enable option ``                                  |
| [`f891cf74`](https://github.com/nix-community/stylix/commit/f891cf742fb262b946705c4ec9ab3b6521ea140d) | `` stylix: refactor textbed.nix autoload ``                              |
| [`1f4de333`](https://github.com/nix-community/stylix/commit/1f4de333d7b2485cdf62e9f6c7d7ef65784fb2cf) | `` stylix: use `concatMap` in testbeds.nix ``                            |
| [`10e04b24`](https://github.com/nix-community/stylix/commit/10e04b24916317e27b22259b2526d862c49bcac6) | `` stylix: use `concatMapStringSep` in testbed.nix ``                    |