### PR TITLE
chore(flake/nix-gaming): `9898d505` -> `f1ebcf84`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1057,11 +1057,11 @@
         "nixpkgs": "nixpkgs_5"
       },
       "locked": {
-        "lastModified": 1747787704,
-        "narHash": "sha256-/4lsR5fZq5vqTenm4IpkETFl2wRuXGfAlN3Io6foTuc=",
+        "lastModified": 1747832434,
+        "narHash": "sha256-18RNkW1+4LR8lxc/2NX0yfzeBHaps2WmD7v/v42nlsQ=",
         "owner": "fufexan",
         "repo": "nix-gaming",
-        "rev": "9898d505d78552400b3cf44a162344664d1a7806",
+        "rev": "f1ebcf84687d31dd13a7178539ac5ed391ad9c0e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                              | Message                                                  |
| --------------------------------------------------------------------------------------------------- | -------------------------------------------------------- |
| [`f1ebcf84`](https://github.com/fufexan/nix-gaming/commit/f1ebcf84687d31dd13a7178539ac5ed391ad9c0e) | `` workflows/build: add wineprefix-preparer to matrix `` |
| [`25c2b057`](https://github.com/fufexan/nix-gaming/commit/25c2b05744b48febdf41933fffd88184fbaa7bb9) | `` wineprefix-preparer: install dxvk-nvapi DLLs ``       |