### PR TITLE
chore(flake/stylix): `42b15218` -> `d3fadda7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1461,11 +1461,11 @@
         "tinted-zed": "tinted-zed"
       },
       "locked": {
-        "lastModified": 1747818590,
-        "narHash": "sha256-O8hKI4Eh7GWWVVxuoZGmDrRmLBX+fE3lI53t6IGx6pg=",
+        "lastModified": 1747837303,
+        "narHash": "sha256-m4ZaL9rosLM0XHNdUBO2+7ZzLs13x7FdLXlLnPrE7vI=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "42b1521816580633a27c5367c57695cc99a0f0c1",
+        "rev": "d3fadda72abb5d0958b5ce4c0eb551eecc7d538e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                  |
| ----------------------------------------------------------------------------------------------------- | ---------------------------------------- |
| [`7c66eda8`](https://github.com/nix-community/stylix/commit/7c66eda89ec8eabcdd8f21790224e2971c6f9063) | `` treewide: partially apply mkTarget `` |
| [`c4fa6844`](https://github.com/nix-community/stylix/commit/c4fa684471d9230f4ca4d4543f02e8ac4c5f749b) | `` stylix: add mkTarget function ``      |