### PR TITLE
chore(flake/stylix): `d3fadda7` -> `4ce349da`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1461,11 +1461,11 @@
         "tinted-zed": "tinted-zed"
       },
       "locked": {
-        "lastModified": 1747837303,
-        "narHash": "sha256-m4ZaL9rosLM0XHNdUBO2+7ZzLs13x7FdLXlLnPrE7vI=",
+        "lastModified": 1747847674,
+        "narHash": "sha256-XYVaUKQrda7WOSonewDtpvm8tENIcwWrErobUYMTMoc=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "d3fadda72abb5d0958b5ce4c0eb551eecc7d538e",
+        "rev": "4ce349da56e075f7e3456b48731cbbf5ae8b1eb8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                     |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------- |
| [`4ce349da`](https://github.com/nix-community/stylix/commit/4ce349da56e075f7e3456b48731cbbf5ae8b1eb8) | `` alacritty: fix mkTarget usage (#1332) `` |