### PR TITLE
chore(flake/nixpkgs-stable): `ca49c430` -> `cd2812de`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1118,11 +1118,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1747610100,
-        "narHash": "sha256-rpR5ZPMkWzcnCcYYo3lScqfuzEw5Uyfh+R0EKZfroAc=",
+        "lastModified": 1747825515,
+        "narHash": "sha256-BWpMQymVI73QoKZdcVCxUCCK3GNvr/xa2Dc4DM1o2BE=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "ca49c4304acf0973078db0a9d200fd2bae75676d",
+        "rev": "cd2812de55cf87df88a9e09bf3be1ce63d50c1a6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                         |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------- |
| [`cd2812de`](https://github.com/NixOS/nixpkgs/commit/cd2812de55cf87df88a9e09bf3be1ce63d50c1a6) | `` limine: 9.3.0 -> 9.3.2 ``                                                    |
| [`25702053`](https://github.com/NixOS/nixpkgs/commit/257020538af056af7ae6c23594c0495e68d1c94f) | `` limine: add prince213 to maintainers ``                                      |
| [`f64ff96c`](https://github.com/NixOS/nixpkgs/commit/f64ff96c0a7aaf87026fd275647c93b517ec2c34) | `` nixos/doc/rl-2505: Mention minimal postgresql requirement for gitlab 18 ``   |
| [`a1d1c7af`](https://github.com/NixOS/nixpkgs/commit/a1d1c7afd947b856e2168988f1cb662e60dff838) | `` nixos/gitlab: update minimum PostgreSQL version assertion ``                 |
| [`7489e889`](https://github.com/NixOS/nixpkgs/commit/7489e88915b92b9483ea5a81993142d3b4e9336e) | `` gitlab: move to pkgs/by-name ``                                              |
| [`b437573e`](https://github.com/NixOS/nixpkgs/commit/b437573e4a1fb1b4dc795b9138013c3b795865bb) | `` gitlab: 17.11.2 -> 18.0.0 ``                                                 |
| [`d8c429b1`](https://github.com/NixOS/nixpkgs/commit/d8c429b16a4022dff591f9b095df0d75d2d9404f) | `` nixos/limine: carefully remove files instead of nuking them ``               |
| [`ecc74afa`](https://github.com/NixOS/nixpkgs/commit/ecc74afaf44c6016f14c103242f8a9ac283c1ce9) | `` nixos/limine: atomically copy files ``                                       |
| [`e7df0771`](https://github.com/NixOS/nixpkgs/commit/e7df0771b4f5b1fa0d70a1681c9356e2a393e48e) | `` pan: 0.158 -> 0.162 ``                                                       |
| [`3087ace5`](https://github.com/NixOS/nixpkgs/commit/3087ace5ca54bea7c42700c8682939ab39894ebf) | `` better-control: init at 6.11.6 ``                                            |
| [`f3537455`](https://github.com/NixOS/nixpkgs/commit/f35374558e368de0684fe6120124f10a14c64896) | `` maintainers: add Rishabh5321 ``                                              |
| [`e01dd0db`](https://github.com/NixOS/nixpkgs/commit/e01dd0db36afd6164f71823b5ff29500645000ca) | `` udevCheckHook: init ``                                                       |
| [`7c33418b`](https://github.com/NixOS/nixpkgs/commit/7c33418bb0e722a632658b9f847e144dab14a5e0) | `` brscan5: remove deprecated SYSFS udev rule ``                                |
| [`6782628b`](https://github.com/NixOS/nixpkgs/commit/6782628b427fef4282e6261f9afcc5bc6632463b) | `` anytype: Minor fixes to .desktop file ``                                     |
| [`e9461aa3`](https://github.com/NixOS/nixpkgs/commit/e9461aa3e34cf8e6ae3221bc8f12b47dafbb9bfa) | `` nixos/spotifyd: Fix 404 URLs  (#408504) ``                                   |
| [`9edb9881`](https://github.com/NixOS/nixpkgs/commit/9edb988168311e041681dcdc9e06414fa038a6f4) | `` clojure: fix and enable strictDeps ``                                        |
| [`3152f9d3`](https://github.com/NixOS/nixpkgs/commit/3152f9d33a45f17d10e8e773098cd66ee080a2ea) | `` scorched3d: add gcc 14 fix ``                                                |
| [`fa9260a9`](https://github.com/NixOS/nixpkgs/commit/fa9260a9feba5b50879903ddf381302c58729fc4) | `` mumble: Apply point release number to internal version string ``             |
| [`d7e52193`](https://github.com/NixOS/nixpkgs/commit/d7e521930e36013745bab41a21a584e980c73547) | `` tsukimi: 0.20.0 -> 0.21.0 ``                                                 |
| [`8b2ea031`](https://github.com/NixOS/nixpkgs/commit/8b2ea03133c738970b99646cb5609c12df93be9a) | `` iplookup-gtk: 0.4.0 -> 0.4.1 ``                                              |
| [`3eee9a91`](https://github.com/NixOS/nixpkgs/commit/3eee9a91de5f1f93891efffab050da210ba79607) | `` helmfile-wrapped: 1.0.0 -> 1.1.0 ``                                          |
| [`1640a299`](https://github.com/NixOS/nixpkgs/commit/1640a299be2c93f2782a044629788a87af78642d) | `` openvpn3: 24 -> 24.1 ``                                                      |
| [`c9dd6a69`](https://github.com/NixOS/nixpkgs/commit/c9dd6a690566eb1526760fb96d80ebd4bd393752) | `` moonlight-qt: build against sdl2-compat ``                                   |
| [`16e8991c`](https://github.com/NixOS/nixpkgs/commit/16e8991cec116c9796cf1a8897fc20aa3cd8d915) | `` proton-ge-bin: add myself as maintainer ``                                   |
| [`dd5a7954`](https://github.com/NixOS/nixpkgs/commit/dd5a79547dca10399460a5af5626dc074e16e502) | `` proton-ge-bin: GE-Proton10-2 -> GE-Proton10-3 ``                             |
| [`ada2854c`](https://github.com/NixOS/nixpkgs/commit/ada2854c2803b1dd6dabd5686ffbb4a571f5cfe2) | `` proton-ge-bin: GE-Proton10-1 -> GE-Proton10-2 ``                             |
| [`ca0f1439`](https://github.com/NixOS/nixpkgs/commit/ca0f1439c561a01cd5a331c1d8113d9da7ed0f38) | `` nixos-rebuild-ng: use Final in constants.py ``                               |
| [`9634c329`](https://github.com/NixOS/nixpkgs/commit/9634c3293822bf136e9b1cb635874be0ee117f25) | `` nixos-rebuild-ng: mark logger as Final ``                                    |
| [`3bf9894d`](https://github.com/NixOS/nixpkgs/commit/3bf9894d7682c9e206f1b9ecaf58e505a22d2f06) | `` nixos-rebuild-ng: alert user if we can't clean-up remote process ``          |
| [`621a8d5c`](https://github.com/NixOS/nixpkgs/commit/621a8d5ce40eb96fdefde387c240d93a0956ed3b) | `` nixos-rebuild-ng: kill underlying remote process ``                          |
| [`31c69144`](https://github.com/NixOS/nixpkgs/commit/31c69144b207399153ac3491c26e361bc5576330) | `` synapse-admin-etkecc: 0.10.4-etke40 -> 0.10.4-etke41 ``                      |
| [`b31ced56`](https://github.com/NixOS/nixpkgs/commit/b31ced563d41925219475adbdc28e9fd30dc3e7c) | `` gitlab-runner: Make Bash a runtime dependency to fix clear-docker-cache. ``  |
| [`2451b54f`](https://github.com/NixOS/nixpkgs/commit/2451b54fb46a77b152996a6a9ff2c7122c6914bc) | `` linux/hardened/patches/6.6: v6.6.83-hardened1 -> v6.6.90-hardened1 ``        |
| [`fab51ff7`](https://github.com/NixOS/nixpkgs/commit/fab51ff715e1b8856ca289f452b3f0f2c62075ba) | `` linux/hardened/patches/6.14: init at v6.14.6-hardened1 ``                    |
| [`358ad9d0`](https://github.com/NixOS/nixpkgs/commit/358ad9d0303e4cb81171df3197bad8fff0957cb0) | `` linux/hardened/patches/6.13: v6.13.7-hardened1 -> v6.13.12-hardened1 ``      |
| [`103574ce`](https://github.com/NixOS/nixpkgs/commit/103574ce2f60fb9537d91be21565da1f805c522f) | `` linux/hardened/patches/6.12: v6.12.19-hardened1 -> v6.12.28-hardened1 ``     |
| [`b7df92b7`](https://github.com/NixOS/nixpkgs/commit/b7df92b7669efa0b7a3099f2f6d955aa1f2382c2) | `` linux/hardened/patches/6.1: v6.1.131-hardened1 -> v6.1.138-hardened1 ``      |
| [`4d6ba54e`](https://github.com/NixOS/nixpkgs/commit/4d6ba54edf4a6f005efca4e06dc4ed863ef5b9e2) | `` linux/hardened/patches/5.4: v5.4.291-hardened1 -> v5.4.293-hardened1 ``      |
| [`83d754b1`](https://github.com/NixOS/nixpkgs/commit/83d754b14220d64469bfdf295b329c4d2d624762) | `` linux/hardened/patches/5.15: v5.15.179-hardened1 -> v5.15.182-hardened1 ``   |
| [`f699660c`](https://github.com/NixOS/nixpkgs/commit/f699660ce1ea5fb93ee96c1d645c8f7b3897fa55) | `` linux/hardened/patches/5.10: v5.10.235-hardened1 -> v5.10.237-hardened1 ``   |
| [`a6be49f1`](https://github.com/NixOS/nixpkgs/commit/a6be49f1892ab59929a6280f528215aa1097fde5) | `` linux_latest-libre: 19769 -> 19792 ``                                        |
| [`566a4bfc`](https://github.com/NixOS/nixpkgs/commit/566a4bfce3158a7558091fa272466e4726079863) | `` linux-rt_6_6: 6.6.77-rt50 -> 6.6.87-rt54 ``                                  |
| [`ef2c70f1`](https://github.com/NixOS/nixpkgs/commit/ef2c70f12740448283c9f835440d79df914ace08) | `` linux-rt_6_1: 6.1.128-rt49 -> 6.1.134-rt51 ``                                |
| [`8b1a3f88`](https://github.com/NixOS/nixpkgs/commit/8b1a3f88bfd7a1426a625ac3cc9cae9f2b6dc62a) | `` linux-rt_5_15: 5.15.177-rt83 -> 5.15.179-rt84 ``                             |
| [`eb6fbb5b`](https://github.com/NixOS/nixpkgs/commit/eb6fbb5bd37a9e9e1106b98de27c898e1ce50c7c) | `` linux-rt_5_10: 5.10.234-rt127 -> 5.10.237-rt131 ``                           |
| [`3c8d59d1`](https://github.com/NixOS/nixpkgs/commit/3c8d59d1943ba7cc7c1432cb0353359c3be3a29e) | `` linux_testing: 6.15-rc6 -> 6.15-rc7 ``                                       |
| [`03c3cfde`](https://github.com/NixOS/nixpkgs/commit/03c3cfde8f7c7f3b7cdce7f6932c5fb6dba02d8f) | `` irccat: 0.4.8 -> 0.4.12 ``                                                   |
| [`f551d91f`](https://github.com/NixOS/nixpkgs/commit/f551d91f2e243acd6ba3cd78a347a7a19cb825f6) | `` nixos/systemd: unconditional systemd-journald-audit.socket ``                |
| [`0c6b3ff3`](https://github.com/NixOS/nixpkgs/commit/0c6b3ff33745cd88870db99e1bef1f2513b415d0) | `` nixos/tests/systemd-journal: Fix failing tests ``                            |
| [`80138878`](https://github.com/NixOS/nixpkgs/commit/8013887864bb0e19b7b9415ed32cc988766395a1) | `` doctoc: remove dangling symlinks ``                                          |
| [`ef5bc91e`](https://github.com/NixOS/nixpkgs/commit/ef5bc91e93fa4cfac047c05353f9a87f5c7bca66) | `` nixos/i18n: Remove special handling of LANGUAGE ``                           |
| [`53efec63`](https://github.com/NixOS/nixpkgs/commit/53efec63d6f19b6556d13146ee618242ae94d44f) | `` nixosTests.i18n: init ``                                                     |
| [`fdba2152`](https://github.com/NixOS/nixpkgs/commit/fdba21526068665d7ee1ac8a7977522f6564e8cf) | `` i18n: Add charset related settings ``                                        |
| [`e2667d75`](https://github.com/NixOS/nixpkgs/commit/e2667d755cb10da3773e7b21f0337a427f5f3471) | `` share-preview: 0.5.0 -> 1.0.0 ``                                             |
| [`4a79c48d`](https://github.com/NixOS/nixpkgs/commit/4a79c48d1461fb18fc32924c650ebe853044ba04) | `` ladybird: 0-unstable-2025-05-07 -> 0-unstable-2025-05-18 ``                  |
| [`a9e3ea5d`](https://github.com/NixOS/nixpkgs/commit/a9e3ea5d777a932970f79560f6b290537400e859) | `` vulkan-memory-allocator: 3.2.1 -> 3.3.0 ``                                   |
| [`f16f2b30`](https://github.com/NixOS/nixpkgs/commit/f16f2b30269d88ef45e4aadd94b97380416bb8c6) | `` python3Packages.whisperx: disable import check for aarch64-linux ``          |
| [`7c9a9d02`](https://github.com/NixOS/nixpkgs/commit/7c9a9d026f84fe209cb0cd2735f10035ece1570d) | `` ptyxis: 47.10 -> 48.3 ``                                                     |
| [`7e6e2afd`](https://github.com/NixOS/nixpkgs/commit/7e6e2afdb3f69b136cea873979b432b1f7bc04a5) | `` ipmitool: fix IANA registry warnings ``                                      |
| [`d0764b7e`](https://github.com/NixOS/nixpkgs/commit/d0764b7e968c6f96e08f24aae3b087c881be75b3) | `` k3s: better util-linux patch url ``                                          |
| [`3708c987`](https://github.com/NixOS/nixpkgs/commit/3708c98785612f41bc9e989ebddcb5a68fa05ae2) | `` k3s: #405952: fix mount regression ``                                        |
| [`83085bba`](https://github.com/NixOS/nixpkgs/commit/83085bba1d0a3ad9033e82d7f1cd4091cedfac58) | `` k3s: use util-linuxMinimal ``                                                |
| [`c239eca2`](https://github.com/NixOS/nixpkgs/commit/c239eca2d989378e41401333e302a910cd47f266) | `` nixos/k3s: get tests working again ``                                        |
| [`79e272ab`](https://github.com/NixOS/nixpkgs/commit/79e272abd4bb099ea98cc068fdd690a0ce2fcfe3) | `` python313Packages.turrishw: disable tests on darwin ``                       |
| [`0fb6bb75`](https://github.com/NixOS/nixpkgs/commit/0fb6bb757adf009e4702f903bbfbd2d691791565) | `` python313Packages.turrishw: fix changelog entry ``                           |
| [`9c3542c2`](https://github.com/NixOS/nixpkgs/commit/9c3542c273c81dd3d92ad774181e72e20a338094) | `` snac2: 2.75 -> 2.77 ``                                                       |
| [`d86afdce`](https://github.com/NixOS/nixpkgs/commit/d86afdcecae3524130f237bd1ab73a806587ef37) | `` nixos/tests/oncall: Fix LDAP mapping ``                                      |
| [`e4d44b9a`](https://github.com/NixOS/nixpkgs/commit/e4d44b9ac65747872ea8b2e8a91db2ba81f7c240) | `` deliantra-server: remove ``                                                  |
| [`636724d4`](https://github.com/NixOS/nixpkgs/commit/636724d4a81477c8cd8281c2ec277b8135b3652c) | `` geteduroam: init at 0.10 ``                                                  |
| [`8d82c8a0`](https://github.com/NixOS/nixpkgs/commit/8d82c8a0a76d108faff707f2a7118ded78e12d67) | `` home-assistant-custom-components.xiaomi_miot: 1.0.18 -> 1.0.19 ``            |
| [`070dd179`](https://github.com/NixOS/nixpkgs/commit/070dd17943874ff15631478d911cf703c42f2d74) | `` python3Packages.auto-lazy-imports: init at 0.4.2 ``                          |
| [`f6ea3240`](https://github.com/NixOS/nixpkgs/commit/f6ea3240121ea9bc4fa1beaa2b95f96d6328eba9) | `` python3Packages.hatch-autorun: init at 1.1.0 ``                              |
| [`50e53b39`](https://github.com/NixOS/nixpkgs/commit/50e53b391c4cc350e9eb658c5cd76c5bbd9bbd97) | `` sticky-notes: 0.2.6 -> 0.2.7 ``                                              |
| [`925b2a51`](https://github.com/NixOS/nixpkgs/commit/925b2a5177733c5f09140dcb0a44270dae8fcc2f) | `` pgadmin4: fix build for sandbox=relaxed builds on darwin ``                  |
| [`cd443e9e`](https://github.com/NixOS/nixpkgs/commit/cd443e9ecb942ff81a112a9106e91818753d5ba6) | `` apptainer: 1.4.0 -> 1.4.1 ``                                                 |
| [`30c143bd`](https://github.com/NixOS/nixpkgs/commit/30c143bded8f6cc8be5da6078d9c6afd19c06755) | `` element-call: 0.10.0 -> 0.11.1 ``                                            |
| [`11b66f75`](https://github.com/NixOS/nixpkgs/commit/11b66f75834e1aab5101dbfeaf1d44ae96fc395d) | `` librewolf-unwrapped: 138.0.1-2 -> 138.0.4-1 ``                               |
| [`aff790ba`](https://github.com/NixOS/nixpkgs/commit/aff790ba7cf7d51842769f952f5c780ab1c48c5c) | `` microsoft-edge: remove ``                                                    |
| [`6447b338`](https://github.com/NixOS/nixpkgs/commit/6447b338495148e14eca8a8f738e9f1894a6b4f8) | `` godot3-mono: fix compile error with mono 6.14 ``                             |
| [`2db6cadf`](https://github.com/NixOS/nixpkgs/commit/2db6cadfc0845e49442fb1a96441f632f6565cd2) | `` lrcget: use cargo-tauri.hook ``                                              |
| [`6bfb9d34`](https://github.com/NixOS/nixpkgs/commit/6bfb9d34a419adee8d7edf006273a0d33d8bbc21) | `` linuxKernel.kernels.linux_lqx: 6.14.6-lqx1 -> 6.14.7-lqx1 ``                 |
| [`cec51a95`](https://github.com/NixOS/nixpkgs/commit/cec51a9563b57c5ab3a70bc352daed9160bf9452) | `` linuxKernel.kernels.linux_zen: 6.14.6-zen1 -> 6.14.7-zen1 ``                 |
| [`ec1b8d5e`](https://github.com/NixOS/nixpkgs/commit/ec1b8d5ea8e71964aeaec0c3f3c2edec8279e4b5) | `` arduino-cli: remove 'with lib' ``                                            |
| [`935ba05b`](https://github.com/NixOS/nixpkgs/commit/935ba05bff4adcb2b0982b0a8174a63e4feaf1c7) | `` arduino-cli: 1.2.0 -> 1.2.2 ``                                               |
| [`2846ed52`](https://github.com/NixOS/nixpkgs/commit/2846ed52214ec4944a403ef17b0b252a0a82a24a) | `` dependency-track: 4.12.7 -> 4.13.2 ``                                        |
| [`88294331`](https://github.com/NixOS/nixpkgs/commit/88294331fd02374f5255e8350db5b8f45800b369) | `` amazon-image: Increase diskSize 3 -> 4GB ``                                  |
| [`9eaf700b`](https://github.com/NixOS/nixpkgs/commit/9eaf700bf0e7840fbbbbef348048239dafe5e72d) | `` amazon-image: Remove tags from label, use version only ``                    |
| [`c233951d`](https://github.com/NixOS/nixpkgs/commit/c233951d6969920604848120d35865d461dfb1bc) | `` python312Packages.lama-index: update build-system ``                         |
| [`60d3b6ae`](https://github.com/NixOS/nixpkgs/commit/60d3b6ae190878c750a50afaa15399cab2584fb8) | `` python312Packages.curated-transformers: 0.1.1 -> 2.0.1 ``                    |
| [`a60bad2b`](https://github.com/NixOS/nixpkgs/commit/a60bad2b58c6fdeb74f78c294d7e02103b6e3acc) | `` python312Packages.llama-index-core: 0.12.23 -> 0.12.35 ``                    |
| [`4d5bc388`](https://github.com/NixOS/nixpkgs/commit/4d5bc388fef5c23c56edbd4f2751a964cf8518db) | `` python312Packages.llama-index-agent-openai: 0.4.6 -> 0.4.7 ``                |
| [`c1f73838`](https://github.com/NixOS/nixpkgs/commit/c1f73838c8240afbbaa444452cbbbb8b35fbc80b) | `` python312Packages.llama-index-embeddings-huggingface: 0.5.3 -> 0.5.4 ``      |
| [`8188112c`](https://github.com/NixOS/nixpkgs/commit/8188112c7237de3dbc996cd7e7666db3db48ea36) | `` python312Packages.llama-index-graph-stores-neptune: 0.3.2 -> 0.3.3 ``        |
| [`55d63b73`](https://github.com/NixOS/nixpkgs/commit/55d63b73853e112e342b388f151cf648afbb567e) | `` python312Packages.llama-index-llms-openai: 0.3.33 -> 0.3.38 ``               |
| [`6779c602`](https://github.com/NixOS/nixpkgs/commit/6779c602a037c069c5deb22db42528916f533c23) | `` python312Packages.llama-index-vector-stores-postgres: 0.4.2 -> 0.5.3 ``      |
| [`217bc101`](https://github.com/NixOS/nixpkgs/commit/217bc1016ec203a4be78ced8aeb1522f0d2956e4) | `` nixos/tests/kanidm: pin to v1.6 ``                                           |
| [`494cad83`](https://github.com/NixOS/nixpkgs/commit/494cad83b58d93d3d289e24802899530703c7f22) | `` kanidm: fix running on Linux ``                                              |
| [`16f66978`](https://github.com/NixOS/nixpkgs/commit/16f669780b8dc41a43f04d56a4abc642908e9cd2) | `` nixos/tests/installer: fix eval ``                                           |
| [`45c5fa41`](https://github.com/NixOS/nixpkgs/commit/45c5fa41dc295d48ef026b954cf413286cca31a1) | `` python3Packages.pydal: fix Darwin build ``                                   |
| [`c2d6e6ec`](https://github.com/NixOS/nixpkgs/commit/c2d6e6ecd10649861525e6516017dedeb24659bd) | `` release-notes: rework highlights section ``                                  |
| [`0142405c`](https://github.com/NixOS/nixpkgs/commit/0142405cb7d84ffa6bac736c8b145e72a560ad51) | `` nixos/release-notes: deprecate services.pdns-recursor.settings ``            |
| [`77406f7c`](https://github.com/NixOS/nixpkgs/commit/77406f7c09552ba80446c726542e247e22d25fca) | `` nixos/tests/pdns-recursor: test old-settings ``                              |
| [`fb77c246`](https://github.com/NixOS/nixpkgs/commit/fb77c246cb7a17ea5afdfbd0df6b91d0f1c6a2ee) | `` nixos/pdns-recursor: deprecate settings, add yaml-settings ``                |
| [`12206c8a`](https://github.com/NixOS/nixpkgs/commit/12206c8aad5f0a41c3cfdf11c52895595322c0ef) | `` thunderbird-latest-unwrapped: 138.0 -> 138.0.1 ``                            |
| [`ed92aa1b`](https://github.com/NixOS/nixpkgs/commit/ed92aa1b968f7c61446849939d3646a4cef5fc69) | `` thunderbird-esr-unwrapped: 128.10.0 -> 128.10.1 ``                           |
| [`059b47dc`](https://github.com/NixOS/nixpkgs/commit/059b47dcf7545fd09d231e2d43a7eea2013ee3b8) | `` thunderbird-esr-bin-unwrapped: 128.10.0 -> 128.10.1 ``                       |
| [`80547123`](https://github.com/NixOS/nixpkgs/commit/805471238b4f47cf76caf4b1a3aadf83addfd545) | `` linuxPackages.system76-acpi: small improvements ``                           |
| [`00500fe0`](https://github.com/NixOS/nixpkgs/commit/00500fe01f7a1fb99ef4aaeda240703d9d63add7) | `` linuxPackages.system76-acpi: fix build ``                                    |
| [`78703380`](https://github.com/NixOS/nixpkgs/commit/78703380397ba4fa8f1328ce2c3c793d34fa5023) | `` linuxPackages.rtl8821au: fix meta.homepage ``                                |
| [`32b668e0`](https://github.com/NixOS/nixpkgs/commit/32b668e0307a8d4b110babd68bfb5ed2eed72311) | `` linuxPackages.rtl8821au: unstable-2024-03-16 -> unstable-2025-04-08 ``       |
| [`25e8cba5`](https://github.com/NixOS/nixpkgs/commit/25e8cba5ec958eae97f4a05f11018a34c11ecb78) | `` nixos/tests/installer: include x86_64-darwin in platforms for uefi tests ``  |
| [`587a2bd1`](https://github.com/NixOS/nixpkgs/commit/587a2bd106bf2000d2367773de409f9ebed92336) | `` nixos/tests: don't explicitly set `meta.platforms` ``                        |
| [`d6cd75ce`](https://github.com/NixOS/nixpkgs/commit/d6cd75ce6e9a0cdaf38076c604cbfbdcb99acf76) | `` qt6Packages.qgpgme: mark broken on Darwin ``                                 |
| [`f81d7d1b`](https://github.com/NixOS/nixpkgs/commit/f81d7d1b861c896d1e7e62ee8a2a6f15f9758d19) | `` tpm2-tss: disable tcti-libtpms on darwin ``                                  |
| [`8e3671e4`](https://github.com/NixOS/nixpkgs/commit/8e3671e45836dee05b8a0f2deea2a5c83321f40c) | `` teleport: move to by-name ``                                                 |
| [`e302c1fb`](https://github.com/NixOS/nixpkgs/commit/e302c1fb1882f03bac8ea0f4450293470b026f98) | `` teleport: remove with lib ``                                                 |
| [`deac61c2`](https://github.com/NixOS/nixpkgs/commit/deac61c2a844f63ac677e86388d7cf3399f0a34d) | `` teleport: use finalAttrs pattern ``                                          |
| [`eff078eb`](https://github.com/NixOS/nixpkgs/commit/eff078eb029e428ed8cfa50b81483c652eadda9f) | `` niri: 25.02 -> 25.05 ``                                                      |
| [`d9897719`](https://github.com/NixOS/nixpkgs/commit/d98977197469c088ce3b6100a3021582d4535350) | `` flyctl: 0.3.116 -> 0.3.125 ``                                                |
| [`9e3d6f80`](https://github.com/NixOS/nixpkgs/commit/9e3d6f80c300625671f5a39922968c484d0f93bc) | `` wivrn: 0.24.1 -> 0.25 ``                                                     |
| [`ae316829`](https://github.com/NixOS/nixpkgs/commit/ae316829e9f632b6d0a853010b8e23482d9d23a2) | `` nodejs_24: 24.0.1 -> 24.0.2 ``                                               |
| [`41288f7e`](https://github.com/NixOS/nixpkgs/commit/41288f7e0886b40b3caa6c386c5fc95e6791e73e) | `` mono: 6.14.0 -> 6.14.1 ``                                                    |
| [`1586de70`](https://github.com/NixOS/nixpkgs/commit/1586de70b49f2b958fb00ad97ccb6ba01bbe75fa) | `` mono: 6.12.0.182 -> 6.14.0 ``                                                |
| [`b24acc69`](https://github.com/NixOS/nixpkgs/commit/b24acc69581461e079c9966bf5891279e90120bd) | `` python3Packages.wandb: fix x86_64-darwin ``                                  |
| [`f357ba3e`](https://github.com/NixOS/nixpkgs/commit/f357ba3e53974eea7b7ea7960fb8ad2beb71a032) | `` release-notes: removal of signald module and all signald-related packages `` |
| [`5ef1b950`](https://github.com/NixOS/nixpkgs/commit/5ef1b95049926046ed22817538cc16f648b89ecf) | `` signald: drop ``                                                             |
| [`ee21fc2e`](https://github.com/NixOS/nixpkgs/commit/ee21fc2e6919a3310dbcf549a5e13b2d87b09ddc) | `` purple-signald: drop ``                                                      |
| [`8e140286`](https://github.com/NixOS/nixpkgs/commit/8e140286aad4116134c7ae36288af4276bcaf848) | `` signaldctl: drop ``                                                          |
| [`ed59c106`](https://github.com/NixOS/nixpkgs/commit/ed59c106c753000955ea01b85f3c35b631442476) | `` nixos/signald: drop ``                                                       |
| [`b18979b8`](https://github.com/NixOS/nixpkgs/commit/b18979b8229ef57e1707dd8b0a66382fe4869792) | `` pkgsCross.aarch64-darwin.discord-development: 0.0.87 -> 0.0.88 ``            |
| [`25e0adf9`](https://github.com/NixOS/nixpkgs/commit/25e0adf97586edce7d3f11e44e7f99189a8b70e1) | `` pkgsCross.aarch64-darwin.discord-canary: 0.0.774 -> 0.0.784 ``               |
| [`0fbfe433`](https://github.com/NixOS/nixpkgs/commit/0fbfe433ecc0ef78323ccf200cb3c60499a0e72d) | `` pkgsCross.aarch64-darwin.discord-ptb: 0.0.171 -> 0.0.173 ``                  |
| [`2d069cf3`](https://github.com/NixOS/nixpkgs/commit/2d069cf3069935ea3018631b93f0240a9a16ab74) | `` pkgsCross.aarch64-darwin.discord: 0.0.344 -> 0.0.345 ``                      |
| [`932e8c1d`](https://github.com/NixOS/nixpkgs/commit/932e8c1da5ed8d5393bf908eff4ee82163fd5ab7) | `` discord-development: 0.0.74 -> 0.0.75 ``                                     |
| [`5bfbfef6`](https://github.com/NixOS/nixpkgs/commit/5bfbfef6dfe16a3e3ed59fd7ae5fac5e80865d4f) | `` discord-canary: 0.0.668 -> 0.0.678 ``                                        |
| [`05c93e17`](https://github.com/NixOS/nixpkgs/commit/05c93e17fbbbe1dbdfff1ed09886c4e48d6f142b) | `` discord-ptb: 0.0.141 -> 0.0.143 ``                                           |
| [`6648830c`](https://github.com/NixOS/nixpkgs/commit/6648830ce093ac7cafebaa4abcb1c201c3910a22) | `` lasso: fix build with gcc14 ``                                               |
| [`9ac24b33`](https://github.com/NixOS/nixpkgs/commit/9ac24b33ed5d1d84af2679cb46ed97ac40810f75) | `` nixos/tests/common/x11.nix: Fix IceWM theme ``                               |
| [`52121e5d`](https://github.com/NixOS/nixpkgs/commit/52121e5d86c12e0db7e7af32539f3ea1109a3b5c) | `` plexamp: 4.12.2 -> 4.12.3 ``                                                 |
| [`733a7949`](https://github.com/NixOS/nixpkgs/commit/733a794906d7bcd2de76be63c0808f69d80eed4f) | `` est-sfs: drop ``                                                             |
| [`149c1fc5`](https://github.com/NixOS/nixpkgs/commit/149c1fc570c5f7f269c167aaf47f3a6426be4090) | `` xmlroff: mark as broken ``                                                   |
| [`8b7f17f9`](https://github.com/NixOS/nixpkgs/commit/8b7f17f900aa1f3ea5d44e9f03686ce55a2da99a) | `` thunderbird-latest-bin-unwrapped: 138.0 -> 138.0.1 ``                        |
| [`5176aa4a`](https://github.com/NixOS/nixpkgs/commit/5176aa4a9f84ff4ce68db798801c91fffcf25c9c) | `` ggobi: mark as broken ``                                                     |
| [`189c4127`](https://github.com/NixOS/nixpkgs/commit/189c41272841216f948e2290e2ae2382ecf56f3d) | `` webkitgtk_6_0: 2.48.1 → 2.48.2 ``                                            |
| [`79071dda`](https://github.com/NixOS/nixpkgs/commit/79071dda941911d5d69094e0bfbc1688fb2b0b51) | `` notmuch-mailmover: 0.6.0 -> 0.7.0 ``                                         |
| [`6a66795c`](https://github.com/NixOS/nixpkgs/commit/6a66795c9bd3a07531795328dab782c9e1b32402) | `` mautrix-whatsapp: 0.12.0 -> 0.12.1 ``                                        |
| [`e87fc3bf`](https://github.com/NixOS/nixpkgs/commit/e87fc3bfc39bfe5a48ed8e81ab8022c653d5f508) | `` libsignal-ffi: 0.70.0 -> 0.72.1 ``                                           |
| [`2ff29b5d`](https://github.com/NixOS/nixpkgs/commit/2ff29b5d1f574159577b8b05da8f70f317dcdb5d) | `` mautrix-signal: 0.8.2 -> 0.8.3 ``                                            |