### PR TITLE
chore(flake/stylix): `c32026ea` -> `614c12c5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1461,11 +1461,11 @@
         "tinted-zed": "tinted-zed"
       },
       "locked": {
-        "lastModified": 1747853856,
-        "narHash": "sha256-5Vn08CLJfXnJKOspVU8G5uT+o0tSvDck/LRBRfK7tNM=",
+        "lastModified": 1747865103,
+        "narHash": "sha256-2RLLb9x++l1KGDPo6U2E7aGWZx51eBYq4NJ9fv/kyNI=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "c32026eab2b314c4599fe4a4f6070229d2d7a5f5",
+        "rev": "614c12c5db0da406fd232cb9b0e82aec304a854e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                 |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------- |
| [`614c12c5`](https://github.com/nix-community/stylix/commit/614c12c5db0da406fd232cb9b0e82aec304a854e) | `` ci: fix tag for label merge conflicts (#1344) ``     |
| [`46caa412`](https://github.com/nix-community/stylix/commit/46caa4122c4eacafba8e38f4b9344dd149064a10) | `` ci: add workflow to label merge conflicts (#1269) `` |