### PR TITLE
chore(flake/hyprland): `b90910c0` -> `185c9684`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -657,11 +657,11 @@
         "xdph": "xdph"
       },
       "locked": {
-        "lastModified": 1747842100,
-        "narHash": "sha256-NpzBIVMqW9ClK3Ltsr2+XfnwI172ikGGHhFs8KVEnns=",
+        "lastModified": 1747863861,
+        "narHash": "sha256-CR4/UmMfg5airc53B4QtHEZlX76NFJQbkUDXx8bLPTo=",
         "owner": "hyprwm",
         "repo": "Hyprland",
-        "rev": "b90910c0dcc6db9d7529d02190b0a19f69cb46e3",
+        "rev": "185c96849ef59da3e101116662d942dea16b468a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                                                                 |
| ------------------------------------------------------------------------------------------------ | ----------------------------------------------------------------------- |
| [`185c9684`](https://github.com/hyprwm/Hyprland/commit/185c96849ef59da3e101116662d942dea16b468a) | `` input: unhide cursor on tablet events after touch events (#10484) `` |