### PR TITLE
chore(flake/stylix): `614c12c5` -> `230705d5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1461,11 +1461,11 @@
         "tinted-zed": "tinted-zed"
       },
       "locked": {
-        "lastModified": 1747865103,
-        "narHash": "sha256-2RLLb9x++l1KGDPo6U2E7aGWZx51eBYq4NJ9fv/kyNI=",
+        "lastModified": 1747904607,
+        "narHash": "sha256-2JWxCVAb8qnssrn/4FeIgs+Gk0VZuAfDsF+rUBE7cZU=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "614c12c5db0da406fd232cb9b0e82aec304a854e",
+        "rev": "230705d5fb6c308402579b17e0261e9f15de6f46",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                            |
| ----------------------------------------------------------------------------------------------------- | -------------------------------------------------- |
| [`230705d5`](https://github.com/nix-community/stylix/commit/230705d5fb6c308402579b17e0261e9f15de6f46) | `` gnome: don't apply hm on darwin (#1316) ``      |
| [`043a43a0`](https://github.com/nix-community/stylix/commit/043a43a0f97edd200e5fd8023b588812574747d1) | `` ci: used maintained conflicts action (#1348) `` |