### PR TITLE
chore(flake/nix-gaming): `c6e45fa3` -> `9fdd4ba9`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1057,11 +1057,11 @@
         "nixpkgs": "nixpkgs_5"
       },
       "locked": {
-        "lastModified": 1747839874,
-        "narHash": "sha256-/TViJB/6zIaDx4DqSdXjVQCmAT9J3/y960eRYihazIA=",
+        "lastModified": 1747907015,
+        "narHash": "sha256-mPOFgZ/irdYMBoHtlcb4eIFK7BvkK7U4AeT2TWmO6Jc=",
         "owner": "fufexan",
         "repo": "nix-gaming",
-        "rev": "c6e45fa3c9ba0163e2dc60286c74db1bda3c6f6e",
+        "rev": "9fdd4ba978e69162032c93068f154f5057528a97",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                              | Message                                           |
| --------------------------------------------------------------------------------------------------- | ------------------------------------------------- |
| [`9fdd4ba9`](https://github.com/fufexan/nix-gaming/commit/9fdd4ba978e69162032c93068f154f5057528a97) | `` faf-client: disable bwrap for update script `` |