### PR TITLE
chore(flake/stylix): `230705d5` -> `c1ef1efd`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1461,11 +1461,11 @@
         "tinted-zed": "tinted-zed"
       },
       "locked": {
-        "lastModified": 1747904607,
-        "narHash": "sha256-2JWxCVAb8qnssrn/4FeIgs+Gk0VZuAfDsF+rUBE7cZU=",
+        "lastModified": 1747925461,
+        "narHash": "sha256-Ot6xKkQvH48zi74ozBs5GmLcfly60tcniGsmzsxc8c8=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "230705d5fb6c308402579b17e0261e9f15de6f46",
+        "rev": "c1ef1efd8fe5d263f3e9ebf34b64c377f27ebe06",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                               |
| ----------------------------------------------------------------------------------------------------- | ----------------------------------------------------- |
| [`c1ef1efd`](https://github.com/nix-community/stylix/commit/c1ef1efd8fe5d263f3e9ebf34b64c377f27ebe06) | `` qutebrowser: simplify dark mode setting (#1352) `` |