### PR TITLE
chore(flake/stylix): `af4f2b56` -> `3e447578`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1461,11 +1461,11 @@
         "tinted-zed": "tinted-zed"
       },
       "locked": {
-        "lastModified": 1747937519,
-        "narHash": "sha256-My32t5T+XmdUAVM4OBr/aVLAuCThga+ng3cNehqRuag=",
+        "lastModified": 1747940625,
+        "narHash": "sha256-TJDILOHiWEDh8SAi4tHnwU1l28tKR28d4x/7+OYRV98=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "af4f2b56460c57ba0765a4bc2df76b362c2dbb6d",
+        "rev": "3e447578effb29574adf26f74d5a9466f977c5ca",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                                   |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------- |
| [`3e447578`](https://github.com/nix-community/stylix/commit/3e447578effb29574adf26f74d5a9466f977c5ca) | `` doc: give consistant input version and follows instructions (#1271) `` |
| [`e16d94d8`](https://github.com/nix-community/stylix/commit/e16d94d8685f5b1025def349f3dcb06b6cf5a6d5) | `` ci: prefix labels with type (#1256) ``                                 |