### PR TITLE
chore(flake/zen-browser): `04ac1a62` -> `d621ed26`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1749,11 +1749,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1747923575,
-        "narHash": "sha256-/2wm2FazQZ73pJSkT9OqvsdRu3KSUlxFlq6JCH0hP9A=",
+        "lastModified": 1747952334,
+        "narHash": "sha256-3vviUKy/BmqdVtvPHsVXDxmeb7zI3AL41MFx8yqk4+s=",
         "owner": "0xc000022070",
         "repo": "zen-browser-flake",
-        "rev": "04ac1a62f9374f13e851ffe97e7acd803014c05f",
+        "rev": "d621ed2616531c072f7b29ea93ef39cbc46bc79c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                          | Message                                                               |
| --------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------- |
| [`d621ed26`](https://github.com/0xc000022070/zen-browser-flake/commit/d621ed2616531c072f7b29ea93ef39cbc46bc79c) | `` chore(update): twilight @ x86_64 && aarch64 to 1.13t#1747949894 `` |