### PR TITLE
chore(flake/zen-browser): `86822e71` -> `e48b7105`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1766,11 +1766,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1747969884,
-        "narHash": "sha256-o3pAUbg4fKR6SYEnUjbyWEub//E4f7qNQqaDlMVWAro=",
+        "lastModified": 1747998984,
+        "narHash": "sha256-G5UvtOKD3fmVTnVTh1XCZVoD0HsKO8QI18sMWlYxjLs=",
         "owner": "0xc000022070",
         "repo": "zen-browser-flake",
-        "rev": "86822e71b77f01b49fdef44565b0b3f523b424b3",
+        "rev": "e48b7105d570f5e66e1891292525e585eeffa58d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                          | Message                                                  |
| --------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------- |
| [`e48b7105`](https://github.com/0xc000022070/zen-browser-flake/commit/e48b7105d570f5e66e1891292525e585eeffa58d) | `` chore(update): beta @ x86_64 && aarch64 to 1.12.8b `` |