### PR TITLE
chore(flake/stylix): `f99fe598` -> `8dd18dd3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1463,11 +1463,11 @@
         "tinted-zed": "tinted-zed"
       },
       "locked": {
-        "lastModified": 1747952198,
-        "narHash": "sha256-GjxRPffuLQQx1G701fzgom+bKxCEJD9fbq44x4gl/n8=",
+        "lastModified": 1748013307,
+        "narHash": "sha256-YNsQCAArUxQNzVmE54AW0Ny7gcpfwCBKkukNdk74eu8=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "f99fe598a68831debbf096e289296c7c7178c21f",
+        "rev": "8dd18dd3955548fe299d7ba337e464bc28dd1448",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                      |
| ----------------------------------------------------------------------------------------------------- | -------------------------------------------- |
| [`8dd18dd3`](https://github.com/nix-community/stylix/commit/8dd18dd3955548fe299d7ba337e464bc28dd1448) | `` hyprlock: fix setting background ``       |
| [`86cfc446`](https://github.com/nix-community/stylix/commit/86cfc446a5f4352c28ae81ae71303a1746cd2d85) | `` hyprlock: add MrSom3body as maintainer `` |