### PR TITLE
chore(flake/nixpkgs-stable): `cd2812de` -> `55d1f923`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1120,11 +1120,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1747825515,
-        "narHash": "sha256-BWpMQymVI73QoKZdcVCxUCCK3GNvr/xa2Dc4DM1o2BE=",
+        "lastModified": 1747953325,
+        "narHash": "sha256-y2ZtlIlNTuVJUZCqzZAhIw5rrKP4DOSklev6c8PyCkQ=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "cd2812de55cf87df88a9e09bf3be1ce63d50c1a6",
+        "rev": "55d1f923c480dadce40f5231feb472e81b0bab48",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                          |
| ---------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------- |
| [`04e3910c`](https://github.com/NixOS/nixpkgs/commit/04e3910cf44a54851a080c95ead445a77f5c17df) | `` nixos/manual/upgrading: update release number 24.11 -> 25.05 ``               |
| [`131205f2`](https://github.com/NixOS/nixpkgs/commit/131205f2f9db4c55173eb77fb3dd2d6e3ff0fd6a) | `` nixos/doc/release-notes-2505: fix table formatting for `system.build` ``      |
| [`f86bd390`](https://github.com/NixOS/nixpkgs/commit/f86bd390bc6758816d14b8b7823ff78a0bbc5a23) | `` doc/rl-2505: Add deprecation warning for removal of GHC versions. ``          |
| [`6f08466f`](https://github.com/NixOS/nixpkgs/commit/6f08466ff8b37329776bb9692e06f820f64cb972) | `` golly: fix build on darwin ``                                                 |
| [`dbb5ea9c`](https://github.com/NixOS/nixpkgs/commit/dbb5ea9c26437ac3381f97d8130f3f43a256887b) | `` ci/eval: remove left-over stats.json ``                                       |
| [`10d58f8a`](https://github.com/NixOS/nixpkgs/commit/10d58f8ab4c15db53733aad129210ec03b4364e9) | `` linux/common-config: disable OF_OVERLAY on x86_64 if version < 5.15 ``        |
| [`6e1ff90a`](https://github.com/NixOS/nixpkgs/commit/6e1ff90aaf6dc15fe715eb561be5c700eec75188) | `` linux/common-config: enable EFI on supported platforms ``                     |
| [`52788bba`](https://github.com/NixOS/nixpkgs/commit/52788bba0bba372c59bd0a4d3b3d9cdf608342b5) | `` linux_5_15: 5.15.183 -> 5.15.184 ``                                           |
| [`637793bd`](https://github.com/NixOS/nixpkgs/commit/637793bdb01d9a2772132265bcf55390c2ae9702) | `` linux_6_1: 6.1.139 -> 6.1.140 ``                                              |
| [`f2d5d9fa`](https://github.com/NixOS/nixpkgs/commit/f2d5d9fa1744f104a6d5c897168473e5311003b2) | `` linux_6_6: 6.6.91 -> 6.6.92 ``                                                |
| [`ec418d1b`](https://github.com/NixOS/nixpkgs/commit/ec418d1b80cb28dc8572644e5479479e02f14792) | `` linux_6_12: 6.12.29 -> 6.12.30 ``                                             |
| [`0f61178d`](https://github.com/NixOS/nixpkgs/commit/0f61178d7ecf2e4aa16aaf3dbcda60f2b75bb54b) | `` linux_6_14: 6.14.7 -> 6.14.8 ``                                               |
| [`d5138ca3`](https://github.com/NixOS/nixpkgs/commit/d5138ca3d6a154a963cfcab8c8202a80cf0b1956) | `` nixos/limine: tidy up the boot menu ``                                        |
| [`27aaacdd`](https://github.com/NixOS/nixpkgs/commit/27aaacdd008d1fbfb7e580924516e136011e2e6a) | `` floorp: 11.26.1 -> 11.26.2 ``                                                 |
| [`26506af3`](https://github.com/NixOS/nixpkgs/commit/26506af385942cb6d96c1c5aaf8498145f81cb8f) | `` nixos/meilisearch: use meilisearch_1_11 for stateVersion below 25.05 ``       |
| [`83a5adfb`](https://github.com/NixOS/nixpkgs/commit/83a5adfbd0d74ec93580bb43a861a9166094e3d8) | `` meilisearch_1_11: init at 1.11.3 ``                                           |
| [`2131c2cb`](https://github.com/NixOS/nixpkgs/commit/2131c2cb01e8935f9b3293bcfb98329c540997a9) | `` wireplumber: 0.5.8 -> 0.5.10 ``                                               |
| [`c8c8dadc`](https://github.com/NixOS/nixpkgs/commit/c8c8dadcde331f0abf76f9a9003369682c198e2a) | `` doc: rl-2505: z3 4.14 -> 4.15 ``                                              |
| [`ce480722`](https://github.com/NixOS/nixpkgs/commit/ce4807228575d25067b4eb361d60ed88eb77850f) | `` z3: refactor ``                                                               |
| [`7ab6069b`](https://github.com/NixOS/nixpkgs/commit/7ab6069ba44d89d9f3d3b7542468709d9154f147) | `` z3_4_15: rename to z3 ``                                                      |
| [`9bfc93a6`](https://github.com/NixOS/nixpkgs/commit/9bfc93a6522784c5278e90d5f39c501dcea5dcdc) | `` z3: add aliases for older versions ``                                         |
| [`bb98fba3`](https://github.com/NixOS/nixpkgs/commit/bb98fba388c729166666b63e121ba8919583eb68) | `` z3: 4.14.1 → 4.15.0, z3_4_14: drop, z3_4_15: init at 4.15.0 ``                |
| [`5eb2b2ee`](https://github.com/NixOS/nixpkgs/commit/5eb2b2eefebbfbdcf90115a6daae5b74d80823bf) | `` ugarit: fix build ``                                                          |
| [`9db7cbf9`](https://github.com/NixOS/nixpkgs/commit/9db7cbf9f65709d8ca320c43cc1126ef50a3d1f1) | `` mattermostLatest: 10.8.0 -> 10.8.1 ``                                         |
| [`60d095da`](https://github.com/NixOS/nixpkgs/commit/60d095da85ea939c4237681799e9c2fc130c0e78) | `` mattermost: 10.5.5 -> 10.5.6 ``                                               |
| [`1f9c0d8a`](https://github.com/NixOS/nixpkgs/commit/1f9c0d8a311c720f40dd46a74d5c8ffe994a72ae) | `` lixPackageSets.{lix_2_92,lix_2_93,git}.lix: fix building on darwin ``         |
| [`3643b0d8`](https://github.com/NixOS/nixpkgs/commit/3643b0d814a21a8d43062a1ca12053719e95b667) | `` velocity: make Nix register dependencies of native libraries ``               |
| [`c20fc9e9`](https://github.com/NixOS/nixpkgs/commit/c20fc9e97d7679fea65855a0465027968378e200) | `` gitlab: 18.0.0 -> 18.0.1 ``                                                   |
| [`07112542`](https://github.com/NixOS/nixpkgs/commit/07112542792045fec342eef7dffbbf2ced2b0997) | `` element-web: 1.11.99 -> 1.11.100 ``                                           |
| [`ed640b08`](https://github.com/NixOS/nixpkgs/commit/ed640b085b70b51d2599cc93c3f0d632a1e2d5cc) | `` element-desktop: 1.11.99 -> 1.11.100 ``                                       |
| [`9ca0be1b`](https://github.com/NixOS/nixpkgs/commit/9ca0be1b3143a56a0ec1e4becc3b7911eff1a813) | `` python313Packages.nomadnet: 0.6.2 -> 0.7.0 ``                                 |
| [`5e47231a`](https://github.com/NixOS/nixpkgs/commit/5e47231a59e6c8bcb94b238bd5e582f39df30a26) | `` python313Packages.rns: 0.9.5 -> 0.9.6 ``                                      |
| [`c264cabb`](https://github.com/NixOS/nixpkgs/commit/c264cabb08ea4ac25ff76f2ed0ee3cac57c71d86) | `` python313Packages.lxmf: 0.6.3 -> 0.7.1 ``                                     |
| [`8247e3ab`](https://github.com/NixOS/nixpkgs/commit/8247e3ab65cb78071bf3ab9c6811f43bdc4987a3) | `` wesnoth: set meta.changelog ``                                                |
| [`5787bd61`](https://github.com/NixOS/nixpkgs/commit/5787bd61ea4ba426a7c676d6e2a10c38a850ace4) | `` wesnoth: 1.18.4 -> 1.18.5 ``                                                  |
| [`615f7034`](https://github.com/NixOS/nixpkgs/commit/615f70340349d16468896db9a9647c057c46a089) | `` yacreader: fix darwin build ``                                                |
| [`fe9e37d7`](https://github.com/NixOS/nixpkgs/commit/fe9e37d756d2523ae7398512d66e435701e06b9e) | `` linuxPackages.v86d: small improvements ``                                     |
| [`d4c6f7ee`](https://github.com/NixOS/nixpkgs/commit/d4c6f7eed4d0be0acb2dcd97934a00a7ce7e9a75) | `` linuxPackages.v86d: fix build ``                                              |
| [`f99963cb`](https://github.com/NixOS/nixpkgs/commit/f99963cbfd5e19477f8a6ede0127aa285290a9d0) | `` ocamlPackages.readline: 0.1 -> 0.2 ``                                         |
| [`b46093bb`](https://github.com/NixOS/nixpkgs/commit/b46093bb1b029ed628dc0c78e55db06887741854) | `` media-downloader: 5.3.2 -> 5.3.3 ``                                           |
| [`a73b775f`](https://github.com/NixOS/nixpkgs/commit/a73b775fd6e95a578e312ca81094a54d6b8e9236) | `` nixVersions.git: 2.29pre20250409_e76bbe41 -> 2.30pre20250521_76a4d4c2 ``      |
| [`c44e43f8`](https://github.com/NixOS/nixpkgs/commit/c44e43f872388b5408aa024c104f059cfbac4f0b) | `` neo4j: fix and enable strictDeps ``                                           |
| [`63b6a715`](https://github.com/NixOS/nixpkgs/commit/63b6a715ed44250c4febbbad30e0a8663086ccc2) | `` nixos/gtklock: init ``                                                        |
| [`5a465d9e`](https://github.com/NixOS/nixpkgs/commit/5a465d9e8f6b513629d69a86d8e48f16f80d6eea) | `` Don't trigger the evaluation of apple-sdk in Linux stdenv ``                  |
| [`547e5d48`](https://github.com/NixOS/nixpkgs/commit/547e5d48163c3a0e3318c106913d3be62fce8047) | `` bind: remove globin from maintainers ``                                       |
| [`58071ef7`](https://github.com/NixOS/nixpkgs/commit/58071ef74072f77355a06abc12a329075e60ff8e) | `` bind: make kubernetes passthru tests conditional on x86_64-linux ``           |
| [`85e096c5`](https://github.com/NixOS/nixpkgs/commit/85e096c5f8367012bb1e720c3a107132552a6373) | `` bind: 9.20.8 -> 9.20.9 ``                                                     |
| [`de90cbad`](https://github.com/NixOS/nixpkgs/commit/de90cbad228e4243a300306d56448be351d7d535) | `` bind: 9.20.7 -> 9.20.8 ``                                                     |
| [`ff7f8619`](https://github.com/NixOS/nixpkgs/commit/ff7f8619500c7027b46c172a30a39c3291267035) | `` percona-server_8_0: 8.0.41-32 -> 8.0.42-33 ``                                 |
| [`ea776c1e`](https://github.com/NixOS/nixpkgs/commit/ea776c1eb0966d561c96f06dcb6d338d4ec86094) | `` nodejs_24: 24.0.2 -> 24.1.0 ``                                                |
| [`cca8ef85`](https://github.com/NixOS/nixpkgs/commit/cca8ef85e6f5d35176e9a5e4fae991b9eb502bcb) | `` python313Packages.supervisor: fix build with python 3.13 ``                   |
| [`5e8bb332`](https://github.com/NixOS/nixpkgs/commit/5e8bb332d6b6773ba3725e61c2bd6e3013ffa9ed) | `` release-notes: document tpm2-pkcs11 abrmd changes for 25.05 ``                |
| [`423873fe`](https://github.com/NixOS/nixpkgs/commit/423873feaa26d9e52aa924a20dc5201fdd2914fd) | `` nixos/tpm2: default pkcs#11 module based on abrmd config ``                   |
| [`93cdd0f6`](https://github.com/NixOS/nixpkgs/commit/93cdd0f649e685126b48359b4e3b115e5998f25e) | `` tpm2-pkcs11: export abrmd passthru ``                                         |
| [`19512738`](https://github.com/NixOS/nixpkgs/commit/195127387b0ff03b3cee29e4b6d33ee34a9b1214) | `` beam26Packages.elixir: 1.18.3 -> 1.18.4 ``                                    |
| [`d052c582`](https://github.com/NixOS/nixpkgs/commit/d052c58287c6aa85f0ca795c4150f64c536d4dcf) | `` erlang_28: 28.0-rc4 -> 28.0 ``                                                |
| [`374570b0`](https://github.com/NixOS/nixpkgs/commit/374570b087d032fd3ff462435889323c402e97b3) | `` SDL2_classic: drop ``                                                         |
| [`79d5a398`](https://github.com/NixOS/nixpkgs/commit/79d5a3983214e9fd440c6d2a86c03048478cb6a8) | `` SDL2_classic_image: drop ``                                                   |
| [`e4f1cf22`](https://github.com/NixOS/nixpkgs/commit/e4f1cf22080e5c1e0877f4eaf4666b484c1521e2) | `` SDL2_classic_mixer: drop ``                                                   |
| [`0b4ab862`](https://github.com/NixOS/nixpkgs/commit/0b4ab8628407d1082ca6b438241dbc304417aa1f) | `` SDL2_classic_ttf: drop ``                                                     |
| [`6d49d90e`](https://github.com/NixOS/nixpkgs/commit/6d49d90eef5fedac99c6cbd00841078902c468af) | `` SDL2_classic: remove passthru tests ``                                        |
| [`6a69bd25`](https://github.com/NixOS/nixpkgs/commit/6a69bd2539dc57cf0ced3414accb3024790e5310) | `` SDL2_classic: use tests that actually use the package ``                      |
| [`83a88e9f`](https://github.com/NixOS/nixpkgs/commit/83a88e9f7d689d4c524f51ee312d9b8910a9eddf) | `` SDL2_classic: 2.32.4 -> 2.32.6 ``                                             |
| [`b5e655b8`](https://github.com/NixOS/nixpkgs/commit/b5e655b8175c135e2d3a153e8ed78674c2a5cecb) | `` SDL2_classic: fix update script ``                                            |
| [`09457cb2`](https://github.com/NixOS/nixpkgs/commit/09457cb230ad481462a02a170ddaae06b32cd254) | `` pygame: migrate to sdl2-compat ``                                             |
| [`8bc000b3`](https://github.com/NixOS/nixpkgs/commit/8bc000b3c9fd11814f65abfa935785edf3bd79fe) | `` pygame-ce: migrate to sdl2-compat ``                                          |
| [`0fdddaca`](https://github.com/NixOS/nixpkgs/commit/0fdddacaf274b2ed09dea9cae92418c9acb919de) | `` python3Packages.gymnasium: explicitly use dummy videodriver in checkPhase ``  |
| [`419efe96`](https://github.com/NixOS/nixpkgs/commit/419efe965b4ad3e79d436214f667f15a6b1a4a91) | `` python3Packages.gym: explicitly use dummy videodriver in checkPhase ``        |
| [`2e8b38f1`](https://github.com/NixOS/nixpkgs/commit/2e8b38f142133b6652f942f1370c02cad0072a46) | `` mullvad-browser: 14.5.1 -> 14.5.2 ``                                          |
| [`d296b6a8`](https://github.com/NixOS/nixpkgs/commit/d296b6a84946aa3aed368f778a57e5b6cfb31f41) | `` tor-browser: 14.5.1 -> 14.5.2 ``                                              |
| [`f5c85555`](https://github.com/NixOS/nixpkgs/commit/f5c8555577cf7e18a382bebcf5ae2a5f267c6fe9) | `` nixos/limine: don't modify boot order on bootloader update ``                 |
| [`016b2284`](https://github.com/NixOS/nixpkgs/commit/016b2284adf8081c962b0c8891916e532b91aacc) | `` qpwgraph: 0.9.0 -> 0.9.2 ``                                                   |
| [`abeca9a5`](https://github.com/NixOS/nixpkgs/commit/abeca9a5e38bacfe6f752140827800a57a9e9344) | `` udevCheckHook: guard platform ``                                              |
| [`cbbc83a3`](https://github.com/NixOS/nixpkgs/commit/cbbc83a308503165a19858ac7a7335ad3a2d2d05) | `` glance: 0.8.1 -> 0.8.3 ``                                                     |
| [`1f5bb8ce`](https://github.com/NixOS/nixpkgs/commit/1f5bb8ce86a4f713dbb8253f3051260a6fec10cd) | `` glance: fix build on x86_64-darwin ``                                         |
| [`5f5b7b36`](https://github.com/NixOS/nixpkgs/commit/5f5b7b360e6404f7d2bea16517150e8bb1de0bdb) | `` pdns-recursor: 5.1.2 -> 5.2.2 ``                                              |
| [`06c38d66`](https://github.com/NixOS/nixpkgs/commit/06c38d6619687ead84cbbb03e9d4b07a675cc58c) | `` attic-server: don't depend on nix ``                                          |
| [`df20fc4c`](https://github.com/NixOS/nixpkgs/commit/df20fc4cbbdf493e3cb0eac123d7baeb9b321b80) | `` nixos-rebuild-ng: assert if get_qualified_name is used by internal modules `` |
| [`231feee6`](https://github.com/NixOS/nixpkgs/commit/231feee62ec58c3411962a46d6461823624a441a) | `` nixos-rebuild-ng: do not use get_qualified_name for non-internal modules ``   |
| [`c04b6a04`](https://github.com/NixOS/nixpkgs/commit/c04b6a04eccfbf309272f9e14cf88592618a476c) | `` nixos-rebuild-ng: avoid get_qualified_name usage for pathlib.Path ``          |
| [`e1b8fcbb`](https://github.com/NixOS/nixpkgs/commit/e1b8fcbb5af503b31cd6b4a1f484bd0206ac29c1) | `` vorbis-tools: remove patch applied upstream ``                                |
| [`2f2a3eb8`](https://github.com/NixOS/nixpkgs/commit/2f2a3eb824b47e09d0a70313bdca36fef048cd62) | `` raycast: 1.98.0 -> 1.99.0 ``                                                  |
| [`7c0dc147`](https://github.com/NixOS/nixpkgs/commit/7c0dc1475d65cf34f8822c67c8a0b0b07b4646e3) | `` esphome: pin paho-mqtt at 1.6.1 ``                                            |
| [`75433c77`](https://github.com/NixOS/nixpkgs/commit/75433c77cb7362531e724d0463fa0457d4d9a034) | `` organicmaps: 2025.03.02-7 -> 2025.05.20-5 ``                                  |
| [`ceda4e89`](https://github.com/NixOS/nixpkgs/commit/ceda4e89d31f3e3eded1af30b9b65858cab7b70b) | `` stalwart-mail: use system jemalloc ``                                         |
| [`ebd1f7a2`](https://github.com/NixOS/nixpkgs/commit/ebd1f7a253c210a5a72886dcf3a486ff45151cc6) | `` synapse-admin-etkecc: 0.10.4-etke41 -> 0.11.0-etke42 ``                       |
| [`c7010410`](https://github.com/NixOS/nixpkgs/commit/c701041032aab47faaae5b26de5ae214ac5b0b52) | `` treefmt: 2.3.0 -> 2.3.1 ``                                                    |
| [`02032eda`](https://github.com/NixOS/nixpkgs/commit/02032edaeb0055dacc7ad8b12aa3eafdafc21929) | `` cups-browsed: Fix cross-compilation RiscV ``                                  |
| [`645dcf4f`](https://github.com/NixOS/nixpkgs/commit/645dcf4f864e256d85868dc332b660653a95b619) | `` authelia: fix cross build ``                                                  |
| [`62f8fb0c`](https://github.com/NixOS/nixpkgs/commit/62f8fb0c1a323ce2707b6272d1259d3a76053f93) | `` tinygo: unmark as broken on Darwin ``                                         |
| [`0651c9a5`](https://github.com/NixOS/nixpkgs/commit/0651c9a51a3a522de1a49bbd6685336673daf220) | `` openocd: unmark as broken on Darwin ``                                        |
| [`cfcba542`](https://github.com/NixOS/nixpkgs/commit/cfcba5424dd55eb4a21c9502b575dcc708c1e1df) | `` jimtcl: unmark as broken on Darwin ``                                         |
| [`0d09a057`](https://github.com/NixOS/nixpkgs/commit/0d09a057851a46a8278711708a10ad22fb75822e) | `` luaPackages.luv: fix `installCheckPhase` on Darwin ``                         |
| [`b3af4ac5`](https://github.com/NixOS/nixpkgs/commit/b3af4ac5867a94f1a9e606e41ccf883f949eead6) | `` gitrs: add libz on darwin ``                                                  |
| [`e8bf3e2f`](https://github.com/NixOS/nixpkgs/commit/e8bf3e2fb5cb75f5eb3cb07c1dac1aaacd0e907e) | `` midori: drop ``                                                               |
| [`b7ec9a04`](https://github.com/NixOS/nixpkgs/commit/b7ec9a04b89c97f55bf24361eb758d61a75cc1cb) | `` authelia: 4.39.1 -> 4.39.3 ``                                                 |
| [`302622d3`](https://github.com/NixOS/nixpkgs/commit/302622d3736af67e7adfa39849a9eacd4f2afae2) | `` qc71_laptop: rectify meta.platforms ``                                        |
| [`df6ad0fc`](https://github.com/NixOS/nixpkgs/commit/df6ad0fcb0fb1f56a1af83cdb10e9b2cae7e4b74) | `` arp-scan-rs: mark as broken on darwin ``                                      |
| [`98446992`](https://github.com/NixOS/nixpkgs/commit/98446992b4f87e50f64b7bf4261f4f8541f5797f) | `` ares-rs: mark as broken on darwin ``                                          |
| [`d4d2192a`](https://github.com/NixOS/nixpkgs/commit/d4d2192aafa7d72ea683bb20b5749148e2019456) | `` deepsecrets: mark as broekn on darwin ``                                      |
| [`f9147b2b`](https://github.com/NixOS/nixpkgs/commit/f9147b2b041130cb47ef110a44952a6442f25f2b) | `` deepsecrets: refactor ``                                                      |
| [`13c6f222`](https://github.com/NixOS/nixpkgs/commit/13c6f2227a67be580610fb00049307628230820a) | `` poutine: mark as broken on darwin ``                                          |
| [`68fdc027`](https://github.com/NixOS/nixpkgs/commit/68fdc0273ab782ecc701a186188105beddcab4d5) | `` unicorn-angr: mark as broken on darwin ``                                     |
| [`973ba913`](https://github.com/NixOS/nixpkgs/commit/973ba91345d3ada065e6b7ec3a9185f3213268a7) | `` azurehound: disable on darwin ``                                              |
| [`06d02daf`](https://github.com/NixOS/nixpkgs/commit/06d02daff6ecb5928f0319c9aa5e5b0ca6d5f979) | `` mx-takeover: disable on darwin ``                                             |
| [`50a80252`](https://github.com/NixOS/nixpkgs/commit/50a802522d904eac8ffc02631b4065b0a2f05526) | `` mx-takeover: refactor ``                                                      |
| [`4f4b9450`](https://github.com/NixOS/nixpkgs/commit/4f4b9450c0f45fc987913bff9d5fbb01ccd4fb80) | `` maigret: mark as broken on darwin ``                                          |
| [`1c1564de`](https://github.com/NixOS/nixpkgs/commit/1c1564de0f9e0ff05dd95b074fcec82f52bd4c69) | `` maigret: refactor ``                                                          |
| [`9f20548c`](https://github.com/NixOS/nixpkgs/commit/9f20548cc69a448dc3c83e3aa50fd5fab8f9c728) | `` librespeed-cli: mark as broken on darwin ``                                   |
| [`4082f008`](https://github.com/NixOS/nixpkgs/commit/4082f008ba95ee73741f2137604b678327ea8104) | `` librespeed-cli: refactor ``                                                   |
| [`c5d3a384`](https://github.com/NixOS/nixpkgs/commit/c5d3a384d4a4a52857a38d537ca40b1e16dc0b54) | `` bitwarden-cli: add zsh completion ``                                          |
| [`c9a844d1`](https://github.com/NixOS/nixpkgs/commit/c9a844d15612e386c06c04a7c34d85666a97a9c0) | `` bottles: fix typo in `warn-unsupported.patch` ``                              |
| [`80bdc3ec`](https://github.com/NixOS/nixpkgs/commit/80bdc3ecff22fee2f1de9dfcdb5f0e914d896ed5) | `` bottles-unwrapped: add `gamemode` to `propagatedBuildInputs` ``               |
| [`87671549`](https://github.com/NixOS/nixpkgs/commit/87671549bffcc69d7e580c0cafab192de385d8a7) | `` bottles: add info to disable unsupported popup ``                             |
| [`c6b57432`](https://github.com/NixOS/nixpkgs/commit/c6b57432a737e3b64e0ebbcec39c5828510aa024) | `` bottles: update `remove-unsupported-warning.patch` ``                         |
| [`31ad7d4e`](https://github.com/NixOS/nixpkgs/commit/31ad7d4e39d5fd8d19e0829dadd1c7ffc0656d33) | `` bottles-unwrapped: 51.17 -> 51.21 ``                                          |
| [`9e8ea59a`](https://github.com/NixOS/nixpkgs/commit/9e8ea59a077ec3de00f72b342dc9933d10364fa7) | `` bottles-unwrapped: add XBagon to maintainers ``                               |
| [`8529bbe7`](https://github.com/NixOS/nixpkgs/commit/8529bbe7d640bfc5d20f62b0942975f5375e6a3d) | `` gupnp_1_6: Use finalAttrs ``                                                  |
| [`0d62eb72`](https://github.com/NixOS/nixpkgs/commit/0d62eb72ea4610bccd46181e2dcdc5aa40a9039c) | `` gupnp_1_6: Unbreak on Darwin ``                                               |
| [`761ad5fc`](https://github.com/NixOS/nixpkgs/commit/761ad5fcad7825ba398950285b71f0e3f4b23a13) | `` gssdp_1_6: Use finalAttrs ``                                                  |
| [`0d1ada76`](https://github.com/NixOS/nixpkgs/commit/0d1ada761ea8aa426d0ea3a0d91dff68a5debec6) | `` gssdp_1_6: Unbreak on Darwin ``                                               |
| [`a55b8b1c`](https://github.com/NixOS/nixpkgs/commit/a55b8b1cf793e26755acaf9069dcc897b7e3724a) | `` cloudflare-warp: wrap warp-cli to fix browser opening ``                      |
| [`de09ce1a`](https://github.com/NixOS/nixpkgs/commit/de09ce1ab6361062817f2fb6211193a48dc24539) | `` nixos/doc/rl-2505: Fix wording of `users.users` subuid allocation note ``     |
| [`bcbcf293`](https://github.com/NixOS/nixpkgs/commit/bcbcf2931ed51637288c27a5dae3b1b61df42790) | `` python313Packages.vat-moss: disable ``                                        |
| [`b280fd97`](https://github.com/NixOS/nixpkgs/commit/b280fd97dcc7cc95c266547c02d7b76d0dbe64a8) | `` matrix-continuwuity: init at 0.5.0-rc.5; nixos/matrix-continuwuity: init ``   |