### PR TITLE
chore(flake/hyprland): `bd4733a0` -> `81cd526f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -659,11 +659,11 @@
         "xdph": "xdph"
       },
       "locked": {
-        "lastModified": 1747926140,
-        "narHash": "sha256-QhbtDAlufsLYsoC+8j6XWiyANWCGuZBHwuC2Nn+VnQU=",
+        "lastModified": 1748036495,
+        "narHash": "sha256-kYyrhoxu8pZ/YHd2Yy2VNaRGeqydOh1OTayvknhweGg=",
         "owner": "hyprwm",
         "repo": "Hyprland",
-        "rev": "bd4733a0ff2b89fd3f22dc6ec9ff00e070753662",
+        "rev": "81cd526f923f4a9074bbfef59b4c7e9f3350c349",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                                                                              |
| ------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------ |
| [`81cd526f`](https://github.com/hyprwm/Hyprland/commit/81cd526f923f4a9074bbfef59b4c7e9f3350c349) | `` cursor: fix screencopy cursor pos and duplicate shape with sw cursors (#10519) `` |