### PR TITLE
chore(flake/zen-browser): `e48b7105` -> `1963b927`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1851,11 +1851,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1747998984,
-        "narHash": "sha256-G5UvtOKD3fmVTnVTh1XCZVoD0HsKO8QI18sMWlYxjLs=",
+        "lastModified": 1748060564,
+        "narHash": "sha256-KTceiwnQm5MFAjtQtSp2/lkodwSd2jub/wCYfVGIFKI=",
         "owner": "0xc000022070",
         "repo": "zen-browser-flake",
-        "rev": "e48b7105d570f5e66e1891292525e585eeffa58d",
+        "rev": "1963b92737b62652fa85e1dfc57d5f4c6d28aea4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                          | Message                                                               |
| --------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------- |
| [`1963b927`](https://github.com/0xc000022070/zen-browser-flake/commit/1963b92737b62652fa85e1dfc57d5f4c6d28aea4) | `` chore(update): twilight @ x86_64 && aarch64 to 1.13t#1748056032 `` |