### PR TITLE
chore(flake/better-control): `800828f0` -> `bcbb7077`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -210,11 +210,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1747794664,
-        "narHash": "sha256-jBt8DeUcoNjSIZD/9ItFIA2lVv/L24YFjA3uaVjBjzU=",
+        "lastModified": 1748080519,
+        "narHash": "sha256-WhH9fxYdSrtOrvUE0hVe9P9vfl7DAHwQwXMxKLVFpog=",
         "owner": "rishabh5321",
         "repo": "better-control-flake",
-        "rev": "800828f04eef441286efba855b83a9c5e9ab5d14",
+        "rev": "bcbb70775a38e8359a123d4ad3ba23c6f8ab1847",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                            | Message                                                       |
| ----------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------- |
| [`bcbb7077`](https://github.com/Rishabh5321/better-control-flake/commit/bcbb70775a38e8359a123d4ad3ba23c6f8ab1847) | `` Update Git user config in release check workflow ``        |
| [`389bda4c`](https://github.com/Rishabh5321/better-control-flake/commit/389bda4c33b3ef7c9e54403df1152a0688b6bae9) | `` Use PAT for git push in release check workflow ``          |
| [`673e37ab`](https://github.com/Rishabh5321/better-control-flake/commit/673e37ab9d15cf0b7d251f51347d40cd6b5f80e8) | `` Fix git push command to specify branch explicitly ``       |
| [`044fd326`](https://github.com/Rishabh5321/better-control-flake/commit/044fd326899b1a180949907be41019c46acd93b9) | `` Fix git push command in release_check workflow ``          |
| [`8e728cc4`](https://github.com/Rishabh5321/better-control-flake/commit/8e728cc42aef6f709e37a121517fe71e00254021) | `` Update Git user configuration in release check workflow `` |
| [`b0c9ba76`](https://github.com/Rishabh5321/better-control-flake/commit/b0c9ba762c8dcecefeaf55cae32de4415ab5b571) | `` Update Git user.name to "web-flow" in release workflow ``  |
| [`c0a03f83`](https://github.com/Rishabh5321/better-control-flake/commit/c0a03f83d4f37e7cc99299c0786d522f55662ad1) | `` Add permissions and simplify branch specification ``       |
| [`83acf158`](https://github.com/Rishabh5321/better-control-flake/commit/83acf158f36cc02fdeeb9c4c2a1519e202d46c0a) | `` Update Git user configuration in release_check workflow `` |
| [`7d62c5ab`](https://github.com/Rishabh5321/better-control-flake/commit/7d62c5ab3adae968797d273f333194daa8b11372) | `` Moving from tag to rev (#108) ``                           |