### PR TITLE
chore(flake/zen-browser): `1963b927` -> `d25f7e7f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1851,11 +1851,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1748060564,
-        "narHash": "sha256-KTceiwnQm5MFAjtQtSp2/lkodwSd2jub/wCYfVGIFKI=",
+        "lastModified": 1748090150,
+        "narHash": "sha256-WrcGLv4Q94B2eG+jj5EckQfItR4zTAz/8uX2to4bU4g=",
         "owner": "0xc000022070",
         "repo": "zen-browser-flake",
-        "rev": "1963b92737b62652fa85e1dfc57d5f4c6d28aea4",
+        "rev": "d25f7e7fc5a2ebcb4c41924b4755eec642e6f18d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                          | Message                                                               |
| --------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------- |
| [`d25f7e7f`](https://github.com/0xc000022070/zen-browser-flake/commit/d25f7e7fc5a2ebcb4c41924b4755eec642e6f18d) | `` chore(update): twilight @ x86_64 && aarch64 to 1.13t#1748087866 `` |