### PR TITLE
chore(flake/better-control): `8aa1feb9` -> `0590d39b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -210,11 +210,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1748089527,
-        "narHash": "sha256-wf5IXSVKeId9N9oYvT6xcieZHN6n3bOYnOwCaHQq3HQ=",
+        "lastModified": 1748090092,
+        "narHash": "sha256-iUJ6G0UjiT/y+EueY78z5HTy2X1hHdfuLef84QFDrBY=",
         "owner": "rishabh5321",
         "repo": "better-control-flake",
-        "rev": "8aa1feb9a469bd0fad35d60670e4ad6234360d81",
+        "rev": "0590d39b35f261c53ba9f819b771a87b05045c37",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                            | Message                                                                                            |
| ----------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------- |
| [`0590d39b`](https://github.com/Rishabh5321/better-control-flake/commit/0590d39b35f261c53ba9f819b771a87b05045c37) | `` Trigger CI ``                                                                                   |
| [`d2881566`](https://github.com/Rishabh5321/better-control-flake/commit/d288156688dfc8347c57bd16551c2211af56875e) | `` feat: Update better-control to latest 'main' commit 4c1abfb7b30ee73df49c378b3bbca24e006bea68 `` |
| [`9edec988`](https://github.com/Rishabh5321/better-control-flake/commit/9edec988a20082c7e5f5c4a06d7909ee96d5102b) | `` refactor: Clean up release check workflow by removing unnecessary comments and steps ``         |