### PR TITLE
chore(flake/better-control): `0590d39b` -> `20862a96`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -210,11 +210,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1748090092,
-        "narHash": "sha256-iUJ6G0UjiT/y+EueY78z5HTy2X1hHdfuLef84QFDrBY=",
+        "lastModified": 1748110442,
+        "narHash": "sha256-U+hhlFFjyD8e2aDv3DFNjcqW0o7q7MYHT2UaFB82eHQ=",
         "owner": "rishabh5321",
         "repo": "better-control-flake",
-        "rev": "0590d39b35f261c53ba9f819b771a87b05045c37",
+        "rev": "20862a9640407bd0023089be3eaa25c5052dd8cb",
         "type": "github"
       },
       "original": {
@@ -1185,11 +1185,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1747744144,
-        "narHash": "sha256-W7lqHp0qZiENCDwUZ5EX/lNhxjMdNapFnbErcbnP11Q=",
+        "lastModified": 1748026106,
+        "narHash": "sha256-6m1Y3/4pVw1RWTsrkAK2VMYSzG4MMIj7sqUy7o8th1o=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "2795c506fe8fb7b03c36ccb51f75b6df0ab2553f",
+        "rev": "063f43f2dbdef86376cc29ad646c45c46e93234c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                            | Message                                          |
| ----------------------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
| [`20862a96`](https://github.com/Rishabh5321/better-control-flake/commit/20862a9640407bd0023089be3eaa25c5052dd8cb) | `` chore(flake/nixpkgs): 2795c506 -> 063f43f2 `` |