### PR TITLE
chore(flake/nixpkgs): `2795c506` -> `063f43f2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1249,11 +1249,11 @@
     },
     "nixpkgs_6": {
       "locked": {
-        "lastModified": 1747744144,
-        "narHash": "sha256-W7lqHp0qZiENCDwUZ5EX/lNhxjMdNapFnbErcbnP11Q=",
+        "lastModified": 1748026106,
+        "narHash": "sha256-6m1Y3/4pVw1RWTsrkAK2VMYSzG4MMIj7sqUy7o8th1o=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "2795c506fe8fb7b03c36ccb51f75b6df0ab2553f",
+        "rev": "063f43f2dbdef86376cc29ad646c45c46e93234c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                       |
| ---------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------- |
| [`7b75ca24`](https://github.com/NixOS/nixpkgs/commit/7b75ca24f46bcec3cf9a92b0e4dc360a6f896502) | `` vscode-extensions.tabnine.tabnine-vscode: 3.271.0 -> 3.283.0 ``                            |
| [`aacd0f32`](https://github.com/NixOS/nixpkgs/commit/aacd0f322e196d7a58c0ae568aa8d6f44edee8a9) | `` vscode-extensions.pkief.material-icon-theme: 5.22.0 -> 5.23.0 ``                           |
| [`454aecb8`](https://github.com/NixOS/nixpkgs/commit/454aecb8c6f9514066f814e0d9127640490f3256) | `` nixos/bind: add port option ``                                                             |
| [`766a203a`](https://github.com/NixOS/nixpkgs/commit/766a203ac71765eb2604b7c13327b300e0cac601) | `` ente-desktop: fix literal inclusion of '$out' (#410214) ``                                 |
| [`3d01f3bf`](https://github.com/NixOS/nixpkgs/commit/3d01f3bfe8ec447839ed4f5799371d3c05dd281c) | `` nixos/tests: simple zoom-us test to verify the module ``                                   |
| [`1a5059de`](https://github.com/NixOS/nixpkgs/commit/1a5059ded6ac7993240b5e7c6f4cec44791e6269) | `` nixos/programs: add zoom-us module ``                                                      |
| [`b2159038`](https://github.com/NixOS/nixpkgs/commit/b215903865d6896e3af12f6fe26159626feb57dd) | `` zoom-us: allow to select xdg-desktop-portal packages ``                                    |
| [`fcad9fc8`](https://github.com/NixOS/nixpkgs/commit/fcad9fc8ba5d8988ed541b2b531c9b252aebb5dc) | `` eask-cli: 0.11.4 -> 0.11.5 ``                                                              |
| [`de12c906`](https://github.com/NixOS/nixpkgs/commit/de12c9064d6d9d9be20349d9e7f1be7ed0e27ec9) | `` python312Packages.mcp: 1.9.0 -> 1.9.1 ``                                                   |
| [`caa6d7f0`](https://github.com/NixOS/nixpkgs/commit/caa6d7f0a1ba6a49ba096af071a25d8d1dd1adc6) | `` wrangler: 4.16.0 -> 4.16.1 ``                                                              |
| [`98dbc7cc`](https://github.com/NixOS/nixpkgs/commit/98dbc7cc58056dccd71141d7a8f33a001949963d) | `` Revert "lib.meta.availableOn: Return false if pkg parameter is null" ``                    |
| [`39800e5b`](https://github.com/NixOS/nixpkgs/commit/39800e5b828329e709abc4f75578484913942b3c) | `` python3Packages.sectxt: drop pythonRelaxDeps ``                                            |
| [`78fb1e34`](https://github.com/NixOS/nixpkgs/commit/78fb1e343ea78651f01025f6088ddf83ac6e995a) | `` proksi: 0.5.3-unstable-2025-05-12 -> 0.5.3-unstable-2025-05-19 ``                          |
| [`b1a415a4`](https://github.com/NixOS/nixpkgs/commit/b1a415a4225ccd21c3f61c52a2f072456cfe3065) | `` python312Packages.pytorch-metric-learning: cleanup, fix on darwin ``                       |
| [`a4577213`](https://github.com/NixOS/nixpkgs/commit/a45772137a9f93bdc2b3373f9870af5eeaec2a1d) | `` python3Packages.snakemake: 9.4.0 -> 9.5.0 ``                                               |
| [`8d1988d3`](https://github.com/NixOS/nixpkgs/commit/8d1988d31e5795837e3b2af7664b790942a3ee70) | `` sgt-puzzles: 20250510.50985e9 -> 20250523.7fa0305 ``                                       |
| [`931899f5`](https://github.com/NixOS/nixpkgs/commit/931899f5a62b9d3c69de71f7a323722ed9ae2cb9) | `` python313Packages.oslo-log: fix test failure ``                                            |
| [`64e22482`](https://github.com/NixOS/nixpkgs/commit/64e2248201aa849439e3f472154c327a277e56fb) | `` dprint-plugins.dprint-plugin-typescript: 0.95.1 -> 0.95.4 ``                               |
| [`1d987b6a`](https://github.com/NixOS/nixpkgs/commit/1d987b6a4431963cc3c1fb89835356c03ce5c415) | `` cargo-preflight: init at 0.5.1 (#407312) ``                                                |
| [`96d2e75d`](https://github.com/NixOS/nixpkgs/commit/96d2e75db59c0e6fc26ffa383f66fc05cc577b73) | `` python3Packages.oslo-context: 5.7.1 -> 6.0.0 ``                                            |
| [`e2cbbf11`](https://github.com/NixOS/nixpkgs/commit/e2cbbf11fcfc5dc6c7625c5f10f31913dd3003ac) | `` pencil2d: init at 0.7.0 (#402895) ``                                                       |
| [`e5c40404`](https://github.com/NixOS/nixpkgs/commit/e5c404044142a01ad34335d24d084f7fafeb85e7) | `` tree-sitter: update changelog url ``                                                       |
| [`f05abeb3`](https://github.com/NixOS/nixpkgs/commit/f05abeb30e74c7293176a4ac68986bef61a06f34) | `` argbash: update meta.homepage ``                                                           |
| [`a7306030`](https://github.com/NixOS/nixpkgs/commit/a73060300a07860ff64fb6bace6faab590182e82) | `` gnote: 48.0 -> 48.1 ``                                                                     |
| [`b47cac5d`](https://github.com/NixOS/nixpkgs/commit/b47cac5d69e79b0e5696cae1cbd840260aed3b9b) | `` lazygit: 0.51.0 -> 0.51.1 ``                                                               |
| [`2d0d8aab`](https://github.com/NixOS/nixpkgs/commit/2d0d8aaba561eeeb896f377ed7300526db722c5e) | `` teams/apm: remove wolfgangwalther ``                                                       |
| [`ac26f78d`](https://github.com/NixOS/nixpkgs/commit/ac26f78d1b5f1fbdedafd250d2e8c42f9062a712) | `` hyprprop: 0.1-unstable-2025-05-12 -> 0.1-unstable-2025-05-18 ``                            |
| [`57b05ff8`](https://github.com/NixOS/nixpkgs/commit/57b05ff83f9f8d2aa08523f51fdcb67d04213715) | `` ci/OWNERS: add johnrtitor to limine module and tests owners ``                             |
| [`cc77bcf9`](https://github.com/NixOS/nixpkgs/commit/cc77bcf993b8893c01dfecb4b82acc74da9f2b40) | `` limine: add johnrtitor to maintainers ``                                                   |
| [`88d5e40f`](https://github.com/NixOS/nixpkgs/commit/88d5e40fcb215f34703754f54d2cfb7b1359f9ff) | `` limine, nixos/limine, nixosTests.limine: inherit pkgs.limine maintainers ``                |
| [`4fedf57b`](https://github.com/NixOS/nixpkgs/commit/4fedf57b147a717f7e3c9c1a165cd8c2cba16ff8) | `` maintainers: remove runging-grass from maintainers ``                                      |
| [`a91b8544`](https://github.com/NixOS/nixpkgs/commit/a91b85443ca96a1a0be3c76eda7c940e4454feee) | `` zed-editor: 0.186.9 -> 0.187.6 ``                                                          |
| [`575a550b`](https://github.com/NixOS/nixpkgs/commit/575a550b48d3eee37544cdef6ef83d211ea76b33) | `` gh-ost: use finalAttrs ``                                                                  |
| [`a5852b48`](https://github.com/NixOS/nixpkgs/commit/a5852b482eb9fab91dabbe5598ff8cd9bc161966) | `` vimPlugins.avante-nvim: 0.0.23-unstable-2025-05-12 -> 0.0.23-unstable-2025-05-20 ``        |
| [`6abf5db6`](https://github.com/NixOS/nixpkgs/commit/6abf5db6033690c5ca61fc6274617fe079e0447b) | `` python312Packages.tinygrad: 0.10.2 -> 0.10.3 ``                                            |
| [`436e8de8`](https://github.com/NixOS/nixpkgs/commit/436e8de8cbff5cd9314830ef7d880c95177a19fd) | `` python3Packages.pysmartthings: 3.2.2 -> 3.2.3 ``                                           |
| [`81ba6a15`](https://github.com/NixOS/nixpkgs/commit/81ba6a15c20f0a7ab137c6d5a11b6c93a12c46df) | `` mattermost: remove fsagbuya as maintainer ``                                               |
| [`2b1782e2`](https://github.com/NixOS/nixpkgs/commit/2b1782e2a2a12034f3dc15ad0a4e3247688cabeb) | `` lucida-downloader: init at 0.2.0 ``                                                        |
| [`a0022b54`](https://github.com/NixOS/nixpkgs/commit/a0022b5484c22bf4bc76564483c89080dbc303d5) | `` presenterm: fix `sixel` feature support ``                                                 |
| [`6d473150`](https://github.com/NixOS/nixpkgs/commit/6d47315045c4882728c7ef2b0ba2f4072aa998e3) | `` spicetify-cli: 2.40.7 -> 2.40.9 ``                                                         |
| [`524d1867`](https://github.com/NixOS/nixpkgs/commit/524d186748fa7bce49f258774f46610008bf320e) | `` couchdb-dump: init at 0-unstable-2021-07-24 ``                                             |
| [`82dfbe95`](https://github.com/NixOS/nixpkgs/commit/82dfbe95f55235c5b5df6ac5b24f6d3c822b19df) | `` nixos/i18n: Re-add special handling of LANGUAGE ``                                         |
| [`a15c45af`](https://github.com/NixOS/nixpkgs/commit/a15c45aff5c303d97c2ec25a0f698c8a57458d64) | `` namespace-cli: 0.0.413 -> 0.0.415 ``                                                       |
| [`a05da0eb`](https://github.com/NixOS/nixpkgs/commit/a05da0eba7838b4d1b296e16984000dc139020c0) | `` vscode-extensions.emmanuelbeziat.vscode-great-icons: 2.1.118 -> 2.1.119 ``                 |
| [`c84b93ab`](https://github.com/NixOS/nixpkgs/commit/c84b93abbc6598779aa6e18cc3fef1d60fd69462) | `` crossplane-cli: 1.19.1 -> 1.20.0 ``                                                        |
| [`a9d30eba`](https://github.com/NixOS/nixpkgs/commit/a9d30eba6722c8b9386467f833c030b75390850f) | `` tigervnc: 1.14.0 -> 1.15.0 ``                                                              |
| [`ef233976`](https://github.com/NixOS/nixpkgs/commit/ef233976958eae6b5910177714110848d53bc426) | `` tigervnc: use `finalAttrs` pattern instead of `rec` ``                                     |
| [`04f2c64b`](https://github.com/NixOS/nixpkgs/commit/04f2c64b1df9611df6c999e0a150429cd28c3ff0) | `` tigervnc: use `tag` and `hash` in `fetchFromGitHub` ``                                     |
| [`43aa4e69`](https://github.com/NixOS/nixpkgs/commit/43aa4e69825672c87456788d5a5bd8119cf06f37) | `` tigervnc: broken on darwin ``                                                              |
| [`01f7e72a`](https://github.com/NixOS/nixpkgs/commit/01f7e72a9158d179117476a1b8de8c1084939b2b) | `` libretro.flycast: 0-unstable-2025-05-10 -> 0-unstable-2025-05-22 ``                        |
| [`ef1265b3`](https://github.com/NixOS/nixpkgs/commit/ef1265b302bb78117702bebb411294e97734e249) | `` zashboard: 1.83.0 -> 1.90.0 ``                                                             |
| [`b0070bb6`](https://github.com/NixOS/nixpkgs/commit/b0070bb6010edcd777888a177363739f4dcd4635) | `` urbit: 3.3 -> 3.4 ``                                                                       |
| [`f0fe68a3`](https://github.com/NixOS/nixpkgs/commit/f0fe68a3c525815a398483d3407660b64a70cdad) | `` iconic: init at 2025.3.2 ``                                                                |
| [`78304087`](https://github.com/NixOS/nixpkgs/commit/78304087ee9bce960d510035ce2d234b4c7533d2) | `` blackfire: 2.28.23 -> 2.28.24 ``                                                           |
| [`13f585c5`](https://github.com/NixOS/nixpkgs/commit/13f585c5a606b3963b243d9f70e0a6a630616491) | `` ast-grep: remove emulator support ``                                                       |
| [`a3fa8c26`](https://github.com/NixOS/nixpkgs/commit/a3fa8c260689305d6068534671f6e974a3d3a3c3) | `` vimPlugins.blink-cmp: 1.3.0 -> 1.3.1 ``                                                    |
| [`7fb7f0c4`](https://github.com/NixOS/nixpkgs/commit/7fb7f0c4a156c115c761f2f978dc563923236829) | `` nixos/doc/rl-2505: cleanup "new modules" section ``                                        |
| [`b17e45ca`](https://github.com/NixOS/nixpkgs/commit/b17e45ca7c22aef1c3f838baf3e95d33b21a7235) | `` doc/rl-2505: fix nexusmods.app entry formatting ``                                         |
| [`00ae2440`](https://github.com/NixOS/nixpkgs/commit/00ae2440742360e3330c811d813e593db4480a3a) | `` doc/rl-2505: move unrelated entries from lib section ``                                    |
| [`041c3794`](https://github.com/NixOS/nixpkgs/commit/041c3794c439d7de75440d72cf1c0c455a5a9454) | `` doc/rl-2505: fix links in lib section ``                                                   |
| [`017276a4`](https://github.com/NixOS/nixpkgs/commit/017276a4aa686d92e142f14f7dad42d3d2ca8535) | `` netbird: fix typo in warning message (#406819) ``                                          |
| [`12a19f53`](https://github.com/NixOS/nixpkgs/commit/12a19f53143b82bd13b739eef35bf65e8b15dadb) | `` libretro.bsnes: 0-unstable-2025-04-11 -> 0-unstable-2025-05-16 ``                          |
| [`07fbfa43`](https://github.com/NixOS/nixpkgs/commit/07fbfa430bb7a7ff02d83e9c8aa3d856f03a55eb) | `` musicpod: 2.11.4 -> 2.12.0 ``                                                              |
| [`59b2dd24`](https://github.com/NixOS/nixpkgs/commit/59b2dd24961f2e016aa497f837d89961fe907f3f) | `` doc/rl-2505: re-introduce note about __structuredAttrs & python ``                         |
| [`39a20c95`](https://github.com/NixOS/nixpkgs/commit/39a20c95fe7739b3803d5968ae2fa545c315abbe) | `` doc/rl-2505: move all package entries from nixos notes ``                                  |
| [`7edb7646`](https://github.com/NixOS/nixpkgs/commit/7edb76465eac08c5adea504e546945c990828e75) | `` nixos/doc/rl-2505: use "Release" as header name ``                                         |
| [`6f5fa0ee`](https://github.com/NixOS/nixpkgs/commit/6f5fa0eee40002d82016400a5c0fd32592a3de13) | `` doc/rl-2505: de-duplicate nixos entires ``                                                 |
| [`84d63220`](https://github.com/NixOS/nixpkgs/commit/84d6322031d50305c956622a9e80751c41cd6d9b) | `` doc/rl-2505: move some entires from nixos notes ``                                         |
| [`caa185f5`](https://github.com/NixOS/nixpkgs/commit/caa185f524af127e6d0bf76e8373f5fa7c76c74b) | `` maintainers: add tahlonbrahic ``                                                           |
| [`2d536ee8`](https://github.com/NixOS/nixpkgs/commit/2d536ee8e86a89c169ce8c62dc61f63e6b0c0e11) | `` nwg-dock-hyprland: 0.4.5 -> 0.4.6 ``                                                       |
| [`f0b7be38`](https://github.com/NixOS/nixpkgs/commit/f0b7be384af0615a91c6eda7928abeecddda785c) | `` neothesia: 0.2.1 -> 0.3.0 ``                                                               |
| [`50f25772`](https://github.com/NixOS/nixpkgs/commit/50f2577220b42cb6397bffb14c317c9a4be51a89) | `` scope-tui: 0.3.0-unstable-2024-05-06 -> 0.3.3 ``                                           |
| [`9192fa81`](https://github.com/NixOS/nixpkgs/commit/9192fa81aedaf81bc6d0fc7ccf8db8258428ec28) | `` mkbrr: 1.11.0 -> 1.12.0 ``                                                                 |
| [`6e0bcfca`](https://github.com/NixOS/nixpkgs/commit/6e0bcfca24a7f5f17864ffa942d9718cb41ff4ca) | `` squirreldisk: add darwin support, reorder dependencies ``                                  |
| [`4cc6bdd7`](https://github.com/NixOS/nixpkgs/commit/4cc6bdd7375f437ad93a9dd0cb1d43ccc877d0de) | `` squirreldisk: use cargo-tauri.hook, build frontend in main derivation ``                   |
| [`12b46122`](https://github.com/NixOS/nixpkgs/commit/12b46122bccc5de9440a3fc60cc16d67667f50d2) | `` cpython: add `enableDebug` argument to enable `"--with-pydebug"` during build (#409943) `` |
| [`f283f528`](https://github.com/NixOS/nixpkgs/commit/f283f52863b1a6eeb03f037198de0aa63c8700fa) | `` gnome-network-displays: 0.96.0 -> 0.97.0 ``                                                |
| [`64160e33`](https://github.com/NixOS/nixpkgs/commit/64160e33ddd3399a9b648ecc997fd293099baa0c) | `` cherry-studio: 1.3.8 -> 1.3.9 ``                                                           |
| [`1897b6c6`](https://github.com/NixOS/nixpkgs/commit/1897b6c6feffa3881a662ac58bfb18187ab531ab) | `` sheldon: 0.8.1 -> 0.8.2 ``                                                                 |
| [`b34df495`](https://github.com/NixOS/nixpkgs/commit/b34df4959939deeeb4f7d85b06f6dbb26932e21a) | `` argon: 2.0.23 -> 2.0.24 ``                                                                 |
| [`e34d28b3`](https://github.com/NixOS/nixpkgs/commit/e34d28b3f3844a3e5969174c3a4239820976a25a) | `` selinux-sandbox: fix building ``                                                           |
| [`02260cbf`](https://github.com/NixOS/nixpkgs/commit/02260cbf40bcfba6d5d7a96b7010a6b7f9153d0b) | `` llvmPackages.lldb-manpages: fix building ``                                                |
| [`12c057f8`](https://github.com/NixOS/nixpkgs/commit/12c057f8e9e828370aa69dfa02ccb736655c75f9) | `` vimPlugins.sonarlint-nvim: 0-unstable-2025-04-24 -> 0-unstable-2025-05-16 ``               |
| [`ca4a7eb0`](https://github.com/NixOS/nixpkgs/commit/ca4a7eb0cd17b0d353d782359c3691a7a89c8c7e) | `` writeReferencesToFile: remove entirely ``                                                  |
| [`29aa6360`](https://github.com/NixOS/nixpkgs/commit/29aa636061a9d17f4e414ab22b503211a70bf7cf) | `` nextcloud-talk-desktop: 1.1.8 -> 1.1.9 ``                                                  |
| [`50f6934d`](https://github.com/NixOS/nixpkgs/commit/50f6934d89ef2a1d64b90573a5502a5cc4b33edb) | `` tests.nixpkgs-check-by-name: remove throw; no need for this ``                             |
| [`7f2c43de`](https://github.com/NixOS/nixpkgs/commit/7f2c43ded7776fa7e59393eccde2764cf9c907e7) | `` uv: 0.7.6 -> 0.7.7 ``                                                                      |
| [`75e677c3`](https://github.com/NixOS/nixpkgs/commit/75e677c32e01fb41d0128e4ff77c1d5bc1053ef1) | `` maintainers: remove my gpg key ``                                                          |