### PR TITLE
chore(flake/akuse-flake): `5b3ad4e8` -> `a282093a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -48,11 +48,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1747797319,
-        "narHash": "sha256-HPWqyXMr8O8/1cInunhyqIvRE1fsFISGRxwJ56GkQDs=",
+        "lastModified": 1748111415,
+        "narHash": "sha256-TIat/zlctjRq8NNqrAZmCQdxFRD/oPnAbtGvpA82Jzc=",
         "owner": "rishabh5321",
         "repo": "akuse-flake",
-        "rev": "5b3ad4e84d0d8971034f7abf7a65827f444fe6e4",
+        "rev": "a282093af6a56a6f80fe2370d38a0b5a34ef6582",
         "type": "github"
       },
       "original": {
@@ -1092,11 +1092,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1747744144,
-        "narHash": "sha256-W7lqHp0qZiENCDwUZ5EX/lNhxjMdNapFnbErcbnP11Q=",
+        "lastModified": 1748026106,
+        "narHash": "sha256-6m1Y3/4pVw1RWTsrkAK2VMYSzG4MMIj7sqUy7o8th1o=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "2795c506fe8fb7b03c36ccb51f75b6df0ab2553f",
+        "rev": "063f43f2dbdef86376cc29ad646c45c46e93234c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                   | Message                                          |
| -------------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
| [`a282093a`](https://github.com/Rishabh5321/akuse-flake/commit/a282093af6a56a6f80fe2370d38a0b5a34ef6582) | `` chore(flake/nixpkgs): 2795c506 -> 063f43f2 `` |