### PR TITLE
chore(flake/home-manager): `8fc1e46a` -> `c1e67103`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -548,11 +548,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1748119343,
-        "narHash": "sha256-/3J/o+qZrn3IJdbi+jde+W0jHA/OAeqa3hH6VA53DWA=",
+        "lastModified": 1748134483,
+        "narHash": "sha256-5PBK1nV8X39K3qUj8B477Aa2RdbLq3m7wRxUKRtggX4=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "8fc1e46ab6d5daac4563c2a3684d68cc0106f458",
+        "rev": "c1e671036224089937e111e32ea899f59181c383",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                    |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------ |
| [`c1e67103`](https://github.com/nix-community/home-manager/commit/c1e671036224089937e111e32ea899f59181c383) | `` sketchybar: add includeSystemPath ``    |
| [`c096c39a`](https://github.com/nix-community/home-manager/commit/c096c39afc2d09341732681890780a5b0b9537b0) | `` sketchybar: config sourceFileOrLines `` |
| [`abe66194`](https://github.com/nix-community/home-manager/commit/abe66194b93701323ea321a618c969c9050046dc) | `` lib/types: add sourceFileOrLines ``     |
| [`e4b0102f`](https://github.com/nix-community/home-manager/commit/e4b0102f697f97af8f4177ba9552995b0bf70b49) | `` sketchybar: use finalpackage wrapper `` |
| [`5dc3bc33`](https://github.com/nix-community/home-manager/commit/5dc3bc336851e979c95eb18d2498698a49d2a178) | `` sketchybar: add module ``               |
| [`c3d48a17`](https://github.com/nix-community/home-manager/commit/c3d48a17aad6778348abb1c4109add90cc42107c) | `` obsidian: add module (#6487) ``         |
| [`cf9ff6d9`](https://github.com/nix-community/home-manager/commit/cf9ff6d9930f74dd949ff2fde953470ecde37749) | `` wayvnc: init (#7123) ``                 |