### PR TITLE
chore(flake/zen-browser): `d25f7e7f` -> `04d98271`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1852,11 +1852,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1748090150,
-        "narHash": "sha256-WrcGLv4Q94B2eG+jj5EckQfItR4zTAz/8uX2to4bU4g=",
+        "lastModified": 1748143192,
+        "narHash": "sha256-KvP468pbSw0c6fXQmd4Q2tp/ywxvxrz5ijRT3odniaw=",
         "owner": "0xc000022070",
         "repo": "zen-browser-flake",
-        "rev": "d25f7e7fc5a2ebcb4c41924b4755eec642e6f18d",
+        "rev": "04d982716fb6c1fc64e0de6e55103b15c892ceda",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                          | Message                                                               |
| --------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------- |
| [`04d98271`](https://github.com/0xc000022070/zen-browser-flake/commit/04d982716fb6c1fc64e0de6e55103b15c892ceda) | `` chore(update): twilight @ x86_64 && aarch64 to 1.13t#1748142491 `` |