### PR TITLE
chore(flake/spicetify-nix): `8c1be0e5` -> `91519fd8`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1492,11 +1492,11 @@
         "systems": "systems_7"
       },
       "locked": {
-        "lastModified": 1747607404,
-        "narHash": "sha256-xj2Ji+rE+oYjf0BsTDT7K/StnYuZQK9MTbX8U1DUcC0=",
+        "lastModified": 1748143803,
+        "narHash": "sha256-BMcuMTKVYrqV9026hF2WePuP1sehN5E7XnExvI9STDI=",
         "owner": "Gerg-L",
         "repo": "spicetify-nix",
-        "rev": "8c1be0e5e9a7f35ccd6f7b10bcfa08f2734dad91",
+        "rev": "91519fd8534fe7726741490f8b7dad20f1ad4f1f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                     |
| ----------------------------------------------------------------------------------------------------- | --------------------------- |
| [`91519fd8`](https://github.com/Gerg-L/spicetify-nix/commit/91519fd8534fe7726741490f8b7dad20f1ad4f1f) | `` chore: update fetcher `` |