### PR TITLE
chore(flake/spicetify-nix): `91519fd8` -> `f0595e3b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1492,11 +1492,11 @@
         "systems": "systems_7"
       },
       "locked": {
-        "lastModified": 1748143803,
-        "narHash": "sha256-BMcuMTKVYrqV9026hF2WePuP1sehN5E7XnExvI9STDI=",
+        "lastModified": 1748147548,
+        "narHash": "sha256-9IaAQkgyF4PFtVyui8vF6oJah0iVcO9DaOefjdTMthE=",
         "owner": "Gerg-L",
         "repo": "spicetify-nix",
-        "rev": "91519fd8534fe7726741490f8b7dad20f1ad4f1f",
+        "rev": "f0595e3b59260457042450749eaec00a5a47db35",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                    |
| ----------------------------------------------------------------------------------------------------- | -------------------------- |
| [`f0595e3b`](https://github.com/Gerg-L/spicetify-nix/commit/f0595e3b59260457042450749eaec00a5a47db35) | `` CI update 2025-05-25 `` |