### PR TITLE
chore(flake/grayjay): `930f56de` -> `b3cf9ab3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -528,11 +528,11 @@
         "nixpkgs": "nixpkgs_3"
       },
       "locked": {
-        "lastModified": 1747796880,
-        "narHash": "sha256-7Di7MmV1erYTynwVsFg4A901Oasoq2+1178pIKPCeEo=",
+        "lastModified": 1748153762,
+        "narHash": "sha256-fOkErTezjUaos7+QQXOFK/omuD1vAj4FWZlbUS+ZZJI=",
         "owner": "rishabh5321",
         "repo": "grayjay-flake",
-        "rev": "930f56de7100cdfdb1a29d1a7151d9b13e2bc568",
+        "rev": "b3cf9ab3f90a97e694d71c5723fa73a79aa53c3f",
         "type": "github"
       },
       "original": {
@@ -1201,11 +1201,11 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1747744144,
-        "narHash": "sha256-W7lqHp0qZiENCDwUZ5EX/lNhxjMdNapFnbErcbnP11Q=",
+        "lastModified": 1748026106,
+        "narHash": "sha256-6m1Y3/4pVw1RWTsrkAK2VMYSzG4MMIj7sqUy7o8th1o=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "2795c506fe8fb7b03c36ccb51f75b6df0ab2553f",
+        "rev": "063f43f2dbdef86376cc29ad646c45c46e93234c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                     | Message                                          |
| ---------------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
| [`b3cf9ab3`](https://github.com/Rishabh5321/grayjay-flake/commit/b3cf9ab3f90a97e694d71c5723fa73a79aa53c3f) | `` chore(flake/nixpkgs): 2795c506 -> 063f43f2 `` |