### PR TITLE
chore(flake/hyprland): `28c9122a` -> `cc0792c1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -641,11 +641,11 @@
         "xdph": "xdph"
       },
       "locked": {
-        "lastModified": 1748112063,
-        "narHash": "sha256-dgPKLaukn6ZH0SDCYjJViKDqE+iHeWJYktfHN+Ecil8=",
+        "lastModified": 1748174133,
+        "narHash": "sha256-dZLdDts/b6ujjrLj62cqwPD+jWM4yuE/aERFWWK9yjs=",
         "owner": "hyprwm",
         "repo": "Hyprland",
-        "rev": "28c9122adbb9cba2ba19ad723eb0f36c19b21f2d",
+        "rev": "cc0792c1dce250311a19e92bad204eefae072592",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                                  |
| ------------------------------------------------------------------------------------------------ | ---------------------------------------- |
| [`cc0792c1`](https://github.com/hyprwm/Hyprland/commit/cc0792c1dce250311a19e92bad204eefae072592) | `` hyprland-uwsm.desktop: Add TryExec `` |