### PR TITLE
chore(flake/nix-gaming): `03a94869` -> `0ec005ba`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1000,11 +1000,11 @@
         "nixpkgs": "nixpkgs_5"
       },
       "locked": {
-        "lastModified": 1748138358,
-        "narHash": "sha256-gzNxTVgSeCFy5v+VSOHlVvCmix67XyB3CuVOasKTlk8=",
+        "lastModified": 1748189689,
+        "narHash": "sha256-hB74AiTtPkvnZHKi09AQ/VndCcgllzzpSm4/SGfOPKA=",
         "owner": "fufexan",
         "repo": "nix-gaming",
-        "rev": "03a94869cd3c5528b94bf99ffc652b18f284dc20",
+        "rev": "0ec005ba4fe744d1e8f960e8a3c45ae3aeb262c1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                              | Message                                         |
| --------------------------------------------------------------------------------------------------- | ----------------------------------------------- |
| [`0ec005ba`](https://github.com/fufexan/nix-gaming/commit/0ec005ba4fe744d1e8f960e8a3c45ae3aeb262c1) | `` ci: add `wine-tkg-ntsync` to build matrix `` |
| [`625d78ec`](https://github.com/fufexan/nix-gaming/commit/625d78ecddffb3c674cfbadb1ec261f33f5674a0) | `` {modules, wine}: add ntsync support ``       |