### PR TITLE
chore(flake/nixpkgs-stable): `55d1f923` -> `7c43f080`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1061,11 +1061,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1747953325,
-        "narHash": "sha256-y2ZtlIlNTuVJUZCqzZAhIw5rrKP4DOSklev6c8PyCkQ=",
+        "lastModified": 1748162331,
+        "narHash": "sha256-rqc2RKYTxP3tbjA+PB3VMRQNnjesrT0pEofXQTrMsS8=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "55d1f923c480dadce40f5231feb472e81b0bab48",
+        "rev": "7c43f080a7f28b2774f3b3f43234ca11661bf334",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                                   |
| ---------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------- |
| [`603a6e6c`](https://github.com/NixOS/nixpkgs/commit/603a6e6c9c9aebe9e098540026421275aabf8c93) | `` komikku: 1.76.1 -> 1.77.0 ``                                                                           |
| [`97b2019b`](https://github.com/NixOS/nixpkgs/commit/97b2019b73206633c7ab820ded5a9db61e7e905c) | `` linux/hardened/patches/6.6: v6.6.90-hardened1 -> v6.6.91-hardened1 ``                                  |
| [`ec14dcdf`](https://github.com/NixOS/nixpkgs/commit/ec14dcdf95f3baa4b1bb48de896307497192b9ac) | `` linux/hardened/patches/6.14: v6.14.6-hardened1 -> v6.14.7-hardened1 ``                                 |
| [`ba449c71`](https://github.com/NixOS/nixpkgs/commit/ba449c71be9042c973e2ca91b8416becac6f546d) | `` linux/hardened/patches/6.12: v6.12.28-hardened1 -> v6.12.29-hardened1 ``                               |
| [`cf875a49`](https://github.com/NixOS/nixpkgs/commit/cf875a492c98e9cd9526e9df7831e33bd7281310) | `` linux/hardened/patches/6.1: v6.1.138-hardened1 -> v6.1.139-hardened1 ``                                |
| [`1b427b9a`](https://github.com/NixOS/nixpkgs/commit/1b427b9a6b6d68cd8b28391500ae1c3d2ea165fb) | `` linux/hardened/patches/5.15: v5.15.182-hardened1 -> v5.15.183-hardened1 ``                             |
| [`4360280e`](https://github.com/NixOS/nixpkgs/commit/4360280e9473364c2f1c7693242507a592642409) | `` linux_latest-libre: 19792 -> 19795 ``                                                                  |
| [`be8b04e9`](https://github.com/NixOS/nixpkgs/commit/be8b04e9d3f612a4463db285daa83b4f16a68c3b) | `` linux-rt_5_15: 5.15.179-rt84 -> 5.15.183-rt85 ``                                                       |
| [`58b9124d`](https://github.com/NixOS/nixpkgs/commit/58b9124d4597e1b581dd05d1781cd9e01938e24a) | `` signal-desktop-bin: fix update script for darwin ``                                                    |
| [`83c363e0`](https://github.com/NixOS/nixpkgs/commit/83c363e01aefd51eee716837b8e831d64cf09327) | `` signal-desktop-bin: adjust update-script for aarch64-linux ``                                          |
| [`af1dfbba`](https://github.com/NixOS/nixpkgs/commit/af1dfbba7adfe6a6f6d5196c307f13e92351bb5d) | `` signal-desktop(darwin): 7.52.0 -> 7.55.0 ``                                                            |
| [`19fcab3a`](https://github.com/NixOS/nixpkgs/commit/19fcab3a6054b1d8910d9e31a0824a159abde64d) | `` signal-desktop(aarch64-linux): 7.52.0 -> 7.55.0 ``                                                     |
| [`065eaca2`](https://github.com/NixOS/nixpkgs/commit/065eaca26612984a27b15d5b18c7347d46d2c7a4) | `` signal-desktop-bin: 7.52.0 -> 7.55.0 ``                                                                |
| [`764862b4`](https://github.com/NixOS/nixpkgs/commit/764862b47947403011134660ff59e75bbf084eb0) | `` nixos/direnv: fix silent option... again ``                                                            |
| [`ffffa8bc`](https://github.com/NixOS/nixpkgs/commit/ffffa8bc93b6d7a9ecbadaa6665d67fafb170af0) | `` linuxPackages.prl-tools: 20.3.0-55895 -> 20.3.1-55959 ``                                               |
| [`89086ace`](https://github.com/NixOS/nixpkgs/commit/89086ace05da08bfe043cbcd039120cddf163b69) | `` unzoo: drop ``                                                                                         |
| [`e0e95d32`](https://github.com/NixOS/nixpkgs/commit/e0e95d32a4c5141730dea633a6e4bcc92320916b) | `` quaternion-qt5: remove ``                                                                              |
| [`f99833f9`](https://github.com/NixOS/nixpkgs/commit/f99833f9dcbd3d8bc1c193693c2ef9708e1c838b) | `` zig: 0.14.0 -> 0.14.1 ``                                                                               |
| [`08b81cac`](https://github.com/NixOS/nixpkgs/commit/08b81caca313301095bf0c6367bed533b8b31c4f) | `` mos: 3.4.1 -> 3.5.0 ``                                                                                 |
| [`6e1ed593`](https://github.com/NixOS/nixpkgs/commit/6e1ed593362599e58bf4f2f7b7a22421c9ae2458) | `` kohighlights: remove double wrapping, use pyproject = false ``                                         |
| [`862e9ee9`](https://github.com/NixOS/nixpkgs/commit/862e9ee91c715b7d887636a8eb18ec0906d5c628) | `` nixosTests.turbovnc-headless-server: Remove expected-failing test. ``                                  |
| [`6cce9785`](https://github.com/NixOS/nixpkgs/commit/6cce97853b0de1f3f6f9feea150a28864208b591) | `` grafana: 12.0.0 -> 12.0.0+security-01 ``                                                               |
| [`67bacc88`](https://github.com/NixOS/nixpkgs/commit/67bacc88a0c86f691e155398714307b8c35cef8e) | `` ugrep: 7.4.2 -> 7.4.3 ``                                                                               |
| [`b3620905`](https://github.com/NixOS/nixpkgs/commit/b36209050eb6d7c7a52ab77c6d817aa4ba914225) | `` python3Packages.langgraph-checkpoint-postgres: Disable flaky test ``                                   |
| [`2b837105`](https://github.com/NixOS/nixpkgs/commit/2b837105040d57ce2f8d5a46e7d75b848c301f2e) | `` OWNERS: add myself to `lib/licenses.nix` ``                                                            |
| [`c7f2a1e5`](https://github.com/NixOS/nixpkgs/commit/c7f2a1e5f476c82211a0b6975653153640e1d3c5) | `` parabolic: patch out bypassing wrapped executables ``                                                  |
| [`3302c73c`](https://github.com/NixOS/nixpkgs/commit/3302c73cb738f401c4557467c923550d19a6c759) | `` ci/eval.combine: avoid parsing of plain text file into JSON ``                                         |
| [`c7ccdf09`](https://github.com/NixOS/nixpkgs/commit/c7ccdf09909b7d4f4017f6bb635095e6b59b6247) | `` ci/eval.compare: use lib from pinned nixpkgs ``                                                        |
| [`6c95fb25`](https://github.com/NixOS/nixpkgs/commit/6c95fb2548cae486686465bb1c46a7173217a390) | `` ci/eval: improve api when calling in steps ``                                                          |
| [`55651d12`](https://github.com/NixOS/nixpkgs/commit/55651d126024624f8032e8faa4cb25b041c12b21) | `` workflows/{codeowners,eval}: move env before run ``                                                    |
| [`06fc009d`](https://github.com/NixOS/nixpkgs/commit/06fc009d19195dde0017b6e599d6693f93f8680c) | `` rstudio: fix .desktop file by properly escaping use of cmake variable ``                               |
| [`30b698a5`](https://github.com/NixOS/nixpkgs/commit/30b698a54e435d8d4d18399b14f903286facd5da) | `` workflows/{check-shell,manual-nixos,manual-nixpkgs}: use get-mege-commit action ``                     |
| [`e2a29971`](https://github.com/NixOS/nixpkgs/commit/e2a29971275bc417570400010af4feffa38c114c) | `` workflows/get-merge-commit: move to composite action ``                                                |
| [`3e119410`](https://github.com/NixOS/nixpkgs/commit/3e119410bbc0545e17e557198585640ac252f4ea) | `` workflows: run on merge conflicts as well ``                                                           |
| [`79ea708c`](https://github.com/NixOS/nixpkgs/commit/79ea708cc01146a9c6557df3cdc4ece7481f6b39) | `` workflows/get-merge-commit: inline get-merge-commit.sh script as github-script ``                      |
| [`84cfc9fe`](https://github.com/NixOS/nixpkgs/commit/84cfc9fefdbc14ce912a132472754640018669ed) | `` signal-desktop.ringrtc: use cubeb from nixpkgs ``                                                      |
| [`398a3f96`](https://github.com/NixOS/nixpkgs/commit/398a3f96b291247c2d9ac070b95a327b3929bc0c) | `` cubeb: install pkg-config file ``                                                                      |
| [`fbd83eca`](https://github.com/NixOS/nixpkgs/commit/fbd83eca745a26fc2896ef5df476cc4172588218) | `` cubeb: make derivation customizable ``                                                                 |
| [`cc37e1f3`](https://github.com/NixOS/nixpkgs/commit/cc37e1f3ad48cf8c45760f1872a6b2f18e3632ae) | `` cubeb: add myself to maintainers ``                                                                    |
| [`380f1e2f`](https://github.com/NixOS/nixpkgs/commit/380f1e2fee59dc7a8d11fba3f033e4e406da9590) | `` signal-desktop.webrtc: execute install hooks ``                                                        |
| [`2fc6312c`](https://github.com/NixOS/nixpkgs/commit/2fc6312c93e7a492626973d158ef930848552429) | `` signal-desktop.webrtc: patch in absolute lib paths for dynamic loader ``                               |
| [`d3adf211`](https://github.com/NixOS/nixpkgs/commit/d3adf21163342b83acf6845b66c881098924e49d) | `` plasma5Packages.kinfocenter: fix with `--inherit-argv0` ``                                             |
| [`47fc22d9`](https://github.com/NixOS/nixpkgs/commit/47fc22d9945f764ebe897f789c54db4c21d6b94e) | `` mycelium: 0.6.0 -> 0.6.1 ``                                                                            |
| [`7fc3f94e`](https://github.com/NixOS/nixpkgs/commit/7fc3f94e241a8095197c1c7dd879e00c711dd1ce) | `` nixosTests.mycelium: make less flaky ``                                                                |
| [`2b88f46d`](https://github.com/NixOS/nixpkgs/commit/2b88f46dd8d198aae360942d63d319b03cbca3e5) | `` andcli: init at 2.1.3 ``                                                                               |
| [`c5d60b22`](https://github.com/NixOS/nixpkgs/commit/c5d60b22502a8966652cc8cd735eeedb5e88a187) | `` maintainers: add Cameo007 ``                                                                           |
| [`c75ec413`](https://github.com/NixOS/nixpkgs/commit/c75ec4137fecda300945bd18d06cc4c214e01958) | `` README.md: fix NixOS logo ``                                                                           |
| [`2437cdd8`](https://github.com/NixOS/nixpkgs/commit/2437cdd85af408c9d9c47c61bfb0ce96e4190ffd) | `` workflows/backport: avoid retriggering workflows after adding "has: port to stable" label ``           |
| [`fcb64ac0`](https://github.com/NixOS/nixpkgs/commit/fcb64ac040ff77d0e5825646cd4baf871001d8ea) | `` upnp-router-control: 0.3.4 -> 0.3.5 ``                                                                 |
| [`a85adfbd`](https://github.com/NixOS/nixpkgs/commit/a85adfbd639b47719472bf38ef2c706a88bddd6d) | `` vscode: 1.100.1 -> 1.100.2 ``                                                                          |
| [`1adb5b41`](https://github.com/NixOS/nixpkgs/commit/1adb5b4187bf55cb5c1f1ec076192af647b21c20) | `` kohighlights: dont install docs/screens ``                                                             |
| [`2a42399a`](https://github.com/NixOS/nixpkgs/commit/2a42399a8c6a55bea92bcc9e4c5dbd583fa783c7) | `` kohighlights: remove redundant lib.platforms ``                                                        |
| [`8d895d4e`](https://github.com/NixOS/nixpkgs/commit/8d895d4eebf42aa3279a36b3cf7d893d02d847e1) | `` kohighlights: init at 2.3.1.0 ``                                                                       |
| [`3382d3f3`](https://github.com/NixOS/nixpkgs/commit/3382d3f3f0dbb1266106cb7dadab85aee190f740) | `` doc/rl2511: update allowVariants entry ``                                                              |
| [`874f2f84`](https://github.com/NixOS/nixpkgs/commit/874f2f842953290617058e4fcd196f55917a19da) | `` pkgs/top-level/stage.nix: move most nixpkgs sets to variants ``                                        |
| [`c5a95795`](https://github.com/NixOS/nixpkgs/commit/c5a957957209105c6b2ad41b90474ee50dd128d2) | `` quick-webapps: init at 1.0.2 ``                                                                        |
| [`68fc246b`](https://github.com/NixOS/nixpkgs/commit/68fc246b7abda58978d98788cbe73220765643af) | `` qgis{,-ltr}: require big-parallel system feature ``                                                    |
| [`0f6fc059`](https://github.com/NixOS/nixpkgs/commit/0f6fc059fc9168379365a4931475442a0280ec73) | `` paraview: require big-parallel system feature ``                                                       |
| [`1272743b`](https://github.com/NixOS/nixpkgs/commit/1272743beed8a9806398c65477cfea9ba3e0d8f8) | `` examine: init at 1.0.0 ``                                                                              |
| [`e67c2681`](https://github.com/NixOS/nixpkgs/commit/e67c26810ca08adabebc77b25052e5160a8966d7) | `` doc/rl-2505: fix renovate release notes link ``                                                        |
| [`4d8efb2f`](https://github.com/NixOS/nixpkgs/commit/4d8efb2fafc35d0e636cd52e71d2fbf857280d5d) | `` teleport_16: 16.5.9 -> 16.5.10 ``                                                                      |
| [`aa443aac`](https://github.com/NixOS/nixpkgs/commit/aa443aaccf75f4a99c470e048fb744a9e56aa364) | `` opencomposite: 1.0.1473 -> 1.0.1521 ``                                                                 |
| [`11cb3517`](https://github.com/NixOS/nixpkgs/commit/11cb3517b3af6af300dd6c055aeda73c9bf52c48) | `` Release NixOS 25.05 ``                                                                                 |
| [`f526c3e7`](https://github.com/NixOS/nixpkgs/commit/f526c3e77a4b1211f3b23a6824882cc1a1d6a61b) | `` nixosTests.lomiri-filemanager-app: Fix OCR ``                                                          |
| [`a12287d0`](https://github.com/NixOS/nixpkgs/commit/a12287d041e9d2bb065f35a2d16143dd8d355fc8) | `` lomiri.lomiri-filemanager-app: 1.1.3 -> 1.1.4 ``                                                       |
| [`ea235dc9`](https://github.com/NixOS/nixpkgs/commit/ea235dc9ee0a436d1b41b8cb5b32b78eff052769) | `` Revert "lib.meta.availableOn: Return false if pkg parameter is null" ``                                |
| [`d92038e8`](https://github.com/NixOS/nixpkgs/commit/d92038e86968de30cba29e2796df9255bf460666) | `` eask-cli: 0.11.4 -> 0.11.5 ``                                                                          |
| [`c5ac6556`](https://github.com/NixOS/nixpkgs/commit/c5ac655645834dd38ab2d3e834d30429431382ec) | `` [Backport release-25.05] ente-desktop: fix literal inclusion of '$out' (#410215) ``                    |
| [`479b350a`](https://github.com/NixOS/nixpkgs/commit/479b350a78bbef7a136e7afa81113126b3e2c31b) | `` readest: 0.9.41 -> 0.9.43 ``                                                                           |
| [`4854f02a`](https://github.com/NixOS/nixpkgs/commit/4854f02a885a79c2b711c88bdaed51c609b2c358) | `` webcord: 4.10.5 -> 4.11.0 ``                                                                           |
| [`02a576ec`](https://github.com/NixOS/nixpkgs/commit/02a576ece1a37c3b4902dc40a040ddbe27706662) | `` zizmor: 1.7.0 -> 1.8.0 ``                                                                              |
| [`048ac278`](https://github.com/NixOS/nixpkgs/commit/048ac2787b33964ae4541f25727787c547003d53) | `` maintainers: remove my gpg key ``                                                                      |
| [`99a42b94`](https://github.com/NixOS/nixpkgs/commit/99a42b9435a8b048f8745a93bd9570debc0d6f81) | `` github-runner: 2.323.0 -> 2.324.0 ``                                                                   |
| [`f9e06eb9`](https://github.com/NixOS/nixpkgs/commit/f9e06eb9a5caa7ef3bd4a4c3629d63055c0e59a8) | `` celluloid: 0.28 -> 0.29 ``                                                                             |
| [`dedb89c4`](https://github.com/NixOS/nixpkgs/commit/dedb89c43d03e69271dfe60685e8c4c663fd9dee) | `` sing-box: install shell completions directly ``                                                        |
| [`828eac07`](https://github.com/NixOS/nixpkgs/commit/828eac07e73b4b7e3dcf6ff390a4070a7e163337) | `` sing-box: add prince213 to maintainers ``                                                              |
| [`7c6cc26c`](https://github.com/NixOS/nixpkgs/commit/7c6cc26c27a805fbec6e80a13b21d5261a878424) | `` sing-box: use finalAttrs ``                                                                            |
| [`fca99741`](https://github.com/NixOS/nixpkgs/commit/fca99741a9b5b5b6954121ae88f764d0bef9d03f) | `` sing-box: avoid with lib; ``                                                                           |
| [`775ffcab`](https://github.com/NixOS/nixpkgs/commit/775ffcabc6944a8cd1aeba47d2d944b4d11d6133) | `` qmk: add bootloadhid as a propagatedBuildInput to support flashing more hardware ``                    |
| [`40986e70`](https://github.com/NixOS/nixpkgs/commit/40986e70940bc46f4f875e5954d5e6feb6e4a08a) | `` pencil2d: init at 0.7.0 (#402895) ``                                                                   |
| [`aec78442`](https://github.com/NixOS/nixpkgs/commit/aec78442902aab71decb3141dca966f951fe68d9) | `` nixos/doc/rl-2505: add an entry for nixos/agnos ``                                                     |
| [`5739aebd`](https://github.com/NixOS/nixpkgs/commit/5739aebdf78f808c790430bfd7fb7f1c6c11f914) | `` bootloadhid: init at 0-unstable-2012-12-08 ``                                                          |
| [`b1af5609`](https://github.com/NixOS/nixpkgs/commit/b1af56092e6faef9eb770eab0207f03028176a37) | `` maintainers: add thetaoofsu ``                                                                         |
| [`afb42377`](https://github.com/NixOS/nixpkgs/commit/afb42377cb5b865a6e4fd22560cb02472c2639e1) | `` rquickshare: clean up dependencies, don't use applyPatches ``                                          |
| [`e4e9c720`](https://github.com/NixOS/nixpkgs/commit/e4e9c7200cb86281d918a048a2830a212a8d63b3) | `` directx-shader-compiler: Include libdxil.so and dxv ``                                                 |
| [`1e591dc3`](https://github.com/NixOS/nixpkgs/commit/1e591dc363b8bb1efe972b1c49e12f3e00758134) | `` lazygit: 0.51.0 -> 0.51.1 ``                                                                           |
| [`7e6409f4`](https://github.com/NixOS/nixpkgs/commit/7e6409f466b35f513b1a96d20f01a1050bb3f3ef) | `` ext4magic: add patch to fix segfault ``                                                                |
| [`c7cd3d76`](https://github.com/NixOS/nixpkgs/commit/c7cd3d76b4c95939f7e15f980a0671a397c498f9) | `` neovim-gtk: use `finalAttrs`, remove `with lib` ``                                                     |
| [`ba854887`](https://github.com/NixOS/nixpkgs/commit/ba854887900f27c8b68793f641315e1896796bf5) | `` neovim-qt-unwrapped: use `finalAttrs`, remove `with lib` ``                                            |
| [`6adeba36`](https://github.com/NixOS/nixpkgs/commit/6adeba369be39052491645b5ba39fe98d50f2363) | `` neovide: use `finalAttrs`, remove `with lib` ``                                                        |
| [`c7f133a9`](https://github.com/NixOS/nixpkgs/commit/c7f133a9cac2fa8aa03f1cb2041d957e2cea9b58) | `` tree-sitter: update changelog url ``                                                                   |
| [`49189325`](https://github.com/NixOS/nixpkgs/commit/49189325fd9bc0c756ed4276a9049a45ccbee80f) | `` hyprlandPlugins.hy3: 0.48.0 -> 0.49.0 ``                                                               |
| [`d9234922`](https://github.com/NixOS/nixpkgs/commit/d9234922b0f29d612874916df3430d98ce8d1e81) | `` argbash: update meta.homepage ``                                                                       |
| [`d220a959`](https://github.com/NixOS/nixpkgs/commit/d220a959b60a4820432d71479cf9ae0cd61cb0ae) | `` plant-it-frontend: init at 0.10.0 ``                                                                   |
| [`c8038975`](https://github.com/NixOS/nixpkgs/commit/c8038975d0f8c0edbdb35334a1da96afd1e37c42) | `` plant-it: init at 0.10.0 ``                                                                            |
| [`a8bf682b`](https://github.com/NixOS/nixpkgs/commit/a8bf682bdcc4ee3b07ce02bb6674bf8f1e8a8eb1) | `` maintainers: Add epireyn ``                                                                            |
| [`92e83dd9`](https://github.com/NixOS/nixpkgs/commit/92e83dd9a05e0e55888fd1131ac08c696fecdd00) | `` json-schema-catalog-rs: add versionCheckHook ``                                                        |
| [`b8815f18`](https://github.com/NixOS/nixpkgs/commit/b8815f185664cf102af3b0babf04b82d85c1d19e) | `` json-schema-catalog-rs: init at 0.1.1 ``                                                               |
| [`1bf2e381`](https://github.com/NixOS/nixpkgs/commit/1bf2e381f90c57f01724e8260dac3746f8fa9d09) | `` musicpod: 2.11.4 -> 2.12.0 ``                                                                          |
| [`e03e3dbf`](https://github.com/NixOS/nixpkgs/commit/e03e3dbf67b0a7b1e09caedc403fbe4137e90a76) | `` Apply suggestions from code review ``                                                                  |
| [`1053ed0e`](https://github.com/NixOS/nixpkgs/commit/1053ed0ed1624ea0de584f7c71d3bb5d23df00b5) | `` python313Packages.tracerite: add missing dep ``                                                        |
| [`bee3bb87`](https://github.com/NixOS/nixpkgs/commit/bee3bb87f29210180dafa76f4e4817d32fbee8cf) | `` python3Packages.labelbox: 6.6.0 -> 6.10.0 ``                                                           |
| [`bbdb4945`](https://github.com/NixOS/nixpkgs/commit/bbdb4945bf0f31461cf3f19b4b60953872cf4eb8) | `` python3Packages.labelbox: build missing lbox-clients dependency ``                                     |
| [`7be97c22`](https://github.com/NixOS/nixpkgs/commit/7be97c226ef57d31bf1c074e9952144f02839d8a) | `` nixos/doc/rl-2505: cleanup "new modules" section ``                                                    |
| [`4e3f17c1`](https://github.com/NixOS/nixpkgs/commit/4e3f17c106318c2ed1eefe9c6f3d6c9ed60302f4) | `` doc/rl-2505: fix nexusmods.app entry formatting ``                                                     |
| [`0c0d19b8`](https://github.com/NixOS/nixpkgs/commit/0c0d19b8315bac0f9c247981c3e107e94e607248) | `` doc/rl-2505: move unrelated entries from lib section ``                                                |
| [`8f6b37ec`](https://github.com/NixOS/nixpkgs/commit/8f6b37ece66c7805c799e7bc150e4b1d1c7aaf73) | `` doc/rl-2505: fix links in lib section ``                                                               |
| [`24b41a7f`](https://github.com/NixOS/nixpkgs/commit/24b41a7f8b4db498cbb403cfa846f3dbf7324b49) | `` nixos/i18n: Re-add special handling of LANGUAGE ``                                                     |
| [`ada6f666`](https://github.com/NixOS/nixpkgs/commit/ada6f666ff16f6fb3f99eed9d6833463edbf15ae) | `` pmars: Fix FTBFS due to ncurses change ``                                                              |
| [`298a25ee`](https://github.com/NixOS/nixpkgs/commit/298a25eeec515b733146f2e6c174eb0cdf8d40e1) | `` netbird: fix typo in warning message (#406819) ``                                                      |
| [`95ee32e5`](https://github.com/NixOS/nixpkgs/commit/95ee32e5d8fa0c7f049baa4bfa30f932a74ce835) | `` anytype: fix single instance detection and specify URL in .desktop file ``                             |
| [`690b0772`](https://github.com/NixOS/nixpkgs/commit/690b077209c7ce1f4a1637a99ac8dc6a187dc241) | `` nixos/foot: fix zshrc ``                                                                               |
| [`ad30ac89`](https://github.com/NixOS/nixpkgs/commit/ad30ac89b64edd9deea9ff0544b0d005f0a1920c) | `` catppuccin-plymouth: fix formatting using "nix fmt" as written in the CONTRIBUTING.md documentation `` |
| [`f8356eef`](https://github.com/NixOS/nixpkgs/commit/f8356eef665a22ce29d08edb4a6d281011f19940) | `` catppuccin-plymouth: fix formatting using nixpkgs-fmt and statix ``                                    |
| [`d6cd99f8`](https://github.com/NixOS/nixpkgs/commit/d6cd99f80bc9d2f95cd70fcd48c42b598e98135c) | `` catppuccin-plymouth: fix variant selection ``                                                          |
| [`6588ff10`](https://github.com/NixOS/nixpkgs/commit/6588ff10abf7dfc9b5e528116a3611ad6d67689b) | `` akkoma-admin-fe: Fix build for x86_64-darwin ``                                                        |
| [`9f789881`](https://github.com/NixOS/nixpkgs/commit/9f7898818db142a87457bf7144cb1ac02ee5966a) | `` ulauncher: revert back to webkitgtk_4_0 to fix startup error ``                                        |
| [`69a4741a`](https://github.com/NixOS/nixpkgs/commit/69a4741a6c520c5383172dd8bb02fc95f707f9a3) | `` llvmPackages.lldb-manpages: fix building ``                                                            |
| [`c0d22180`](https://github.com/NixOS/nixpkgs/commit/c0d22180c5ee3318517d5783f8d3c248b66ff665) | `` selinux-sandbox: fix building ``                                                                       |
| [`fade580c`](https://github.com/NixOS/nixpkgs/commit/fade580c6fb2b520824ffeddadab0e84886fc5fd) | `` doc/rl-2505: re-introduce note about __structuredAttrs & python ``                                     |
| [`f0e2cff7`](https://github.com/NixOS/nixpkgs/commit/f0e2cff73314d3715a4112f449e2051bb668fd58) | `` doc/rl-2505: move all package entries from nixos notes ``                                              |
| [`e47625e0`](https://github.com/NixOS/nixpkgs/commit/e47625e0e2be2e6e6919bd166474ece5bd773d86) | `` nixos/doc/rl-2505: use "Release" as header name ``                                                     |
| [`71944a8c`](https://github.com/NixOS/nixpkgs/commit/71944a8ce862c6ea35ec9bd941430c5d864129b1) | `` doc/rl-2505: de-duplicate nixos entires ``                                                             |
| [`1f0fc104`](https://github.com/NixOS/nixpkgs/commit/1f0fc1044ca1bca2acaf30acb85e20d018614129) | `` doc/rl-2505: move some entires from nixos notes ``                                                     |
| [`007e8903`](https://github.com/NixOS/nixpkgs/commit/007e8903a943d89d4544be2e9c58cbe8d41a4bc1) | `` fasthenry: modernize ``                                                                                |
| [`cbe84849`](https://github.com/NixOS/nixpkgs/commit/cbe848490cf9ab0cd9d348a7aa6fbebd9ffc456a) | `` fasthenry: fix build ``                                                                                |
| [`ecd10c7c`](https://github.com/NixOS/nixpkgs/commit/ecd10c7cefb26f55ac0e6089845faab4f34aa6a8) | `` treewide: rm empty inherit ``                                                                          |
| [`6a6cc9ca`](https://github.com/NixOS/nixpkgs/commit/6a6cc9ca37d52c586d77ce59d020a85de6345eec) | `` flatpak: 1.16.0 -> 1.16.1 ``                                                                           |
| [`fa0fa7e5`](https://github.com/NixOS/nixpkgs/commit/fa0fa7e59b43d56324ff59fd03f1b60820852e55) | `` shellcheck-sarif: 0.7.0 -> 0.8.0 ``                                                                    |
| [`2cb6f13e`](https://github.com/NixOS/nixpkgs/commit/2cb6f13eaf24b75345948a715f7c3f4a6452ec7d) | `` sarif-fmt: 0.7.0 -> 0.8.0 ``                                                                           |
| [`bc47c240`](https://github.com/NixOS/nixpkgs/commit/bc47c240c79472d4bd15dd4fc7a1abd3c3326318) | `` hadolint-sarif: 0.7.0 -> 0.8.0 ``                                                                      |
| [`5e404753`](https://github.com/NixOS/nixpkgs/commit/5e40475311c59b3e09488f027339ca262c78cd7c) | `` sydbox: 3.32.7 -> 3.34.0 ``                                                                            |
| [`1ebe1d9a`](https://github.com/NixOS/nixpkgs/commit/1ebe1d9aa9ad58cf4ef95e2c026c04d62a186e7f) | `` nwg-dock-hyprland: 0.4.5 -> 0.4.6 ``                                                                   |
| [`16a5034a`](https://github.com/NixOS/nixpkgs/commit/16a5034a633195b305923f3718bafbe9c58c4df1) | `` scope-tui: 0.3.0-unstable-2024-05-06 -> 0.3.3 ``                                                       |
| [`bb248f8f`](https://github.com/NixOS/nixpkgs/commit/bb248f8ff61a3c51fe6a4b93bd153d6c48733770) | `` vivaldi: 7.3.3635.11 -> 7.3.3635.12 ``                                                                 |
| [`220c75f1`](https://github.com/NixOS/nixpkgs/commit/220c75f1bf246980c920013cf01908495a1531b6) | `` vault-bin: 1.19.3 -> 1.19.4 ``                                                                         |
| [`9920daf3`](https://github.com/NixOS/nixpkgs/commit/9920daf3cd403360896328679d7a4178949b1d3b) | `` vault: 1.19.3 -> 1.19.4 ``                                                                             |
| [`e261f8c8`](https://github.com/NixOS/nixpkgs/commit/e261f8c8295bdb81188e06960d81e72ee70f18cb) | `` librewolf-bin-unwrapped: 138.0.3-1 -> 138.0.4-1 ``                                                     |
| [`46224b87`](https://github.com/NixOS/nixpkgs/commit/46224b87aa722838f081ef1a877cef90a902c13e) | `` librewolf-bin-unwrapped: 138.0.1-2 -> 138.0.3-1 ``                                                     |
| [`042d2e64`](https://github.com/NixOS/nixpkgs/commit/042d2e6417955834abf69920bfe066a07ba26f07) | `` workflows: avoid running jobs when editing title etc. ``                                               |
| [`8b602f0c`](https://github.com/NixOS/nixpkgs/commit/8b602f0cff31f3d39bcaa1f99aff768d6b581c0b) | `` fractal: 11 -> 11.1 ``                                                                                 |
| [`0d55ea6d`](https://github.com/NixOS/nixpkgs/commit/0d55ea6ddbd72177038a5684de6c1a39c8fb5353) | `` lazygit: 0.50.0 -> 0.51.0 ``                                                                           |
| [`05f3285a`](https://github.com/NixOS/nixpkgs/commit/05f3285aae626fc54d708fe153ae458e02c153bb) | `` leo-editor: update meta.homepage ``                                                                    |
| [`c8f63b2a`](https://github.com/NixOS/nixpkgs/commit/c8f63b2a825e77eb4f5d0015921cceaaf6f83e5c) | `` xcircuit: fix build with gcc 14 ``                                                                     |