### PR TITLE
chore(flake/hyprland): `cc0792c1` -> `23470502`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -641,11 +641,11 @@
         "xdph": "xdph"
       },
       "locked": {
-        "lastModified": 1748174133,
-        "narHash": "sha256-dZLdDts/b6ujjrLj62cqwPD+jWM4yuE/aERFWWK9yjs=",
+        "lastModified": 1748191712,
+        "narHash": "sha256-q4Phr64XO/gq//0jwiYkcMXiWmSJ4VE/0Aqx1aE7DHM=",
         "owner": "hyprwm",
         "repo": "Hyprland",
-        "rev": "cc0792c1dce250311a19e92bad204eefae072592",
+        "rev": "2347050285920925db8bc844e3232bc932eef21e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                                                                    |
| ------------------------------------------------------------------------------------------------ | -------------------------------------------------------------------------- |
| [`23470502`](https://github.com/hyprwm/Hyprland/commit/2347050285920925db8bc844e3232bc932eef21e) | `` pass/surface: make sure popup blurs are marked for require live blur `` |
| [`a58ab20e`](https://github.com/hyprwm/Hyprland/commit/a58ab20e8bc27a50d55e924b13047db6bbf9dc4a) | `` debug/pass: show live/precompile blur in debug ``                       |