### PR TITLE
chore(flake/hyprpanel): `c203ffe8` -> `12d6960e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -838,11 +838,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1747531721,
-        "narHash": "sha256-kx7hCuML0sMcjbyjbpplNWsJjLoUfiy23JiS9aG4UWw=",
+        "lastModified": 1748203813,
+        "narHash": "sha256-VCwlSYJjXFhQSdwjk7FdeyALIzknOM1TavCDt3KLgB8=",
         "owner": "Jas-SinghFSU",
         "repo": "HyprPanel",
-        "rev": "c203ffe80f4e7b68e22ba3fde0598622500f5add",
+        "rev": "12d6960e198cf5107aed84a4b21e95c826d43dad",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                  | Message                                                                        |
| ------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------ |
| [`12d6960e`](https://github.com/Jas-SinghFSU/HyprPanel/commit/12d6960e198cf5107aed84a4b21e95c826d43dad) | `` feat(nixos): enabled systemd service, removed deprecation notice (#943) ``  |
| [`f5f00945`](https://github.com/Jas-SinghFSU/HyprPanel/commit/f5f00945bf94efa6eaa1ba3a6e4b1777a72b7c0c) | `` Fix: Don't show margins around disabled elements in the Dashboard (#946) `` |
| [`4303c1cb`](https://github.com/Jas-SinghFSU/HyprPanel/commit/4303c1cb7145b8f6b4135240ac14456d22933837) | `` Fix: Remove full path /bin/bash in exec command (#953) ``                   |