### PR TITLE
chore(flake/zen-browser): `04d98271` -> `fbf37a85`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1668,11 +1668,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1748143192,
-        "narHash": "sha256-KvP468pbSw0c6fXQmd4Q2tp/ywxvxrz5ijRT3odniaw=",
+        "lastModified": 1748204388,
+        "narHash": "sha256-A1RDA/nPYcO7nc2TgRIt5F+dSUwPJiH+iKplTKKndDk=",
         "owner": "0xc000022070",
         "repo": "zen-browser-flake",
-        "rev": "04d982716fb6c1fc64e0de6e55103b15c892ceda",
+        "rev": "fbf37a85baa9a866e0d260aa71ec3c7fa3b508c8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                          | Message                                                               |
| --------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------- |
| [`fbf37a85`](https://github.com/0xc000022070/zen-browser-flake/commit/fbf37a85baa9a866e0d260aa71ec3c7fa3b508c8) | `` chore(update): twilight @ x86_64 && aarch64 to 1.13t#1748201094 `` |