### PR TITLE
chore(flake/better-control): `20862a96` -> `7761204c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -210,11 +210,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1748110442,
-        "narHash": "sha256-U+hhlFFjyD8e2aDv3DFNjcqW0o7q7MYHT2UaFB82eHQ=",
+        "lastModified": 1748215249,
+        "narHash": "sha256-cjvGfYyTVj8iDpl+v3YzMgBRDNVrfse87jfEZRV1GWk=",
         "owner": "rishabh5321",
         "repo": "better-control-flake",
-        "rev": "20862a9640407bd0023089be3eaa25c5052dd8cb",
+        "rev": "7761204c90b9b30f8a2c0bf66bf26196eff697c0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                            | Message                                                                                            |
| ----------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------- |
| [`bc7ed2e7`](https://github.com/Rishabh5321/better-control-flake/commit/bc7ed2e7570ce9fb275ecbc61cec80770c04982f) | `` feat: Update better-control to latest 'main' commit bf55e14cad498470d1f3a9f21815475f7e2cb577 `` |