### PR TITLE
chore(flake/home-manager): `901f8fef` -> `d23d20f5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -512,11 +512,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1748182899,
-        "narHash": "sha256-r6MHSalDFydlUmjorVTSsyhLjIt8VWNtGc5+mffXvFQ=",
+        "lastModified": 1748227609,
+        "narHash": "sha256-SaSdslyo6UGDpPUlmrPA4dWOEuxCy2ihRN9K6BnqYsA=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "901f8fef7f349cf8a8e97b3230b22fd592df9160",
+        "rev": "d23d20f55d49d8818ac1f1b2783671e8a6725022",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                     |
| ----------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------- |
| [`d23d20f5`](https://github.com/nix-community/home-manager/commit/d23d20f55d49d8818ac1f1b2783671e8a6725022) | `` sway: add bindswitches option (#7095) ``                 |
| [`a45222c7`](https://github.com/nix-community/home-manager/commit/a45222c731d61b259d267346e8e098b320f4c681) | `` superfile: add exiftool when metadata enabled (#7118) `` |
| [`03affdcb`](https://github.com/nix-community/home-manager/commit/03affdcbf2bf300e5b9dea29daac2f6bf4529cf6) | `` dconf: Fix dconf config not apply correctly (#7130) ``   |