### PR TITLE
chore(flake/sddm-sugar-candy-nix): `c9bd3e9b` -> `a6aa623b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1299,11 +1299,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1748172224,
-        "narHash": "sha256-tzugUKV+r4RJyzHx10HnnwBN/Qa3ZjtwpThAD3rfvjs=",
+        "lastModified": 1748261441,
+        "narHash": "sha256-xZym8Aze8Ejd9e3IJVPrzpTOHor66alggxZCHxiPbJE=",
         "owner": "Zhaith-Izaliel",
         "repo": "sddm-sugar-candy-nix",
-        "rev": "c9bd3e9b90e4fa5e417c36154599d5121431df45",
+        "rev": "a6aa623ba0f9a583d0fae8911beab99247d4e059",
         "type": "gitlab"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                               | Message                                              |
| -------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------- |
| [`cc93c242`](https://github.com/Zhaith-Izaliel/sddm-sugar-candy-nix/commit/cc93c242fd84f188163c6f95ace744777aa0e9e7) | `` fix: update version in props ``                   |
| [`85307d13`](https://github.com/Zhaith-Izaliel/sddm-sugar-candy-nix/commit/85307d1331a802be511bad320aad231805770023) | `` fix(dependencies): use libsforqt5 sddm instead `` |