### PR TITLE
chore(flake/stylix): `e22f96de` -> `225b2ddb`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1375,11 +1375,11 @@
         "tinted-zed": "tinted-zed"
       },
       "locked": {
-        "lastModified": 1748213724,
-        "narHash": "sha256-ppmdSruEH7sKzhMNdrY+0NVGOe5Q68LDNVcBZuHuU5o=",
+        "lastModified": 1748264079,
+        "narHash": "sha256-ROBuBxMUBvj3QWUIBqABzzIWCnZHapCmAdPXramjf8E=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "e22f96de3f57b1ab1a393607bc08c003925f68fc",
+        "rev": "225b2ddbbaa4ae3c2076c1bd1616fefd35e11670",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                    |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------ |
| [`225b2ddb`](https://github.com/nix-community/stylix/commit/225b2ddbbaa4ae3c2076c1bd1616fefd35e11670) | `` doc: explain testbed options (#1383) `` |