### PR TITLE
chore(flake/stylix): `225b2ddb` -> `aa70426f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1375,11 +1375,11 @@
         "tinted-zed": "tinted-zed"
       },
       "locked": {
-        "lastModified": 1748264079,
-        "narHash": "sha256-ROBuBxMUBvj3QWUIBqABzzIWCnZHapCmAdPXramjf8E=",
+        "lastModified": 1748269774,
+        "narHash": "sha256-jIvkWbhsrBSV492OuKJwBLAdearm0jmvXoYSMRNseI0=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "225b2ddbbaa4ae3c2076c1bd1616fefd35e11670",
+        "rev": "aa70426f8f4373da2f454de3e27b565241960599",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                          |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
| [`aa70426f`](https://github.com/nix-community/stylix/commit/aa70426f8f4373da2f454de3e27b565241960599) | `` console: improve color consistency (#1388) `` |