### PR TITLE
chore(flake/nix-gaming): `0ec005ba` -> `aa4362cf`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1000,11 +1000,11 @@
         "nixpkgs": "nixpkgs_5"
       },
       "locked": {
-        "lastModified": 1748189689,
-        "narHash": "sha256-hB74AiTtPkvnZHKi09AQ/VndCcgllzzpSm4/SGfOPKA=",
+        "lastModified": 1748281511,
+        "narHash": "sha256-feFNkno0UVfXWJln474OdHMBqH0grtXp6WDzXYxcvaQ=",
         "owner": "fufexan",
         "repo": "nix-gaming",
-        "rev": "0ec005ba4fe744d1e8f960e8a3c45ae3aeb262c1",
+        "rev": "aa4362cf3b4ec587bbe43132a7b8384934fb38af",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                              | Message                        |
| --------------------------------------------------------------------------------------------------- | ------------------------------ |
| [`aa4362cf`](https://github.com/fufexan/nix-gaming/commit/aa4362cf3b4ec587bbe43132a7b8384934fb38af) | `` dxvk: fix gplasync build `` |