### PR TITLE
chore(flake/akuse-flake): `1371496a` -> `e9dd7fa0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -48,11 +48,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1748262813,
-        "narHash": "sha256-S/q3SrubTXJhQ5KQCECZJEPwTqkssm1m/clMMks2fiA=",
+        "lastModified": 1748284695,
+        "narHash": "sha256-hQzbzXlVk858ZKAHVyFpfTbs07Y1XgycN3tciUYxSMw=",
         "owner": "rishabh5321",
         "repo": "akuse-flake",
-        "rev": "1371496a0c99bc4cbaa63fcfe63edbe00d4c739c",
+        "rev": "e9dd7fa0f9a7398192d74991c8d1b74ac9cd933c",
         "type": "github"
       },
       "original": {
@@ -1015,11 +1015,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1748026106,
-        "narHash": "sha256-6m1Y3/4pVw1RWTsrkAK2VMYSzG4MMIj7sqUy7o8th1o=",
+        "lastModified": 1748190013,
+        "narHash": "sha256-R5HJFflOfsP5FBtk+zE8FpL8uqE7n62jqOsADvVshhE=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "063f43f2dbdef86376cc29ad646c45c46e93234c",
+        "rev": "62b852f6c6742134ade1abdd2a21685fd617a291",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                   | Message                                          |
| -------------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
| [`e9dd7fa0`](https://github.com/Rishabh5321/akuse-flake/commit/e9dd7fa0f9a7398192d74991c8d1b74ac9cd933c) | `` chore(flake/nixpkgs): 063f43f2 -> 62b852f6 `` |