### PR TITLE
chore(flake/hyprpanel): `436dcbfc` -> `8cf58067`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -838,11 +838,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1748284447,
-        "narHash": "sha256-99/GrZHZ+e8MLgUvEqLM0tXlVbgKBEYuGMHTigjYgvQ=",
+        "lastModified": 1748313911,
+        "narHash": "sha256-6Ka/WTCPIlI7VbjwdDa9bGMCYlp9gYfISwKE10Q7atw=",
         "owner": "Jas-SinghFSU",
         "repo": "HyprPanel",
-        "rev": "436dcbfcf2458784203d83c4b96e7b0c3fb66762",
+        "rev": "8cf58067667f05c8cd8492b01481d7a9da14d055",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                  | Message                                                                                      |
| ------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------- |
| [`8cf58067`](https://github.com/Jas-SinghFSU/HyprPanel/commit/8cf58067667f05c8cd8492b01481d7a9da14d055) | `` Minor: Refactor the code-base for better organization and compartmentalization. (#934) `` |