### PR TITLE
chore(flake/hyprpanel): `8cf58067` -> `13ad5765`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -838,11 +838,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1748313911,
-        "narHash": "sha256-6Ka/WTCPIlI7VbjwdDa9bGMCYlp9gYfISwKE10Q7atw=",
+        "lastModified": 1748325673,
+        "narHash": "sha256-eW5G6q+c0EolFy4oKW3qgQ4az7k1sNhk8WyhfuAI+8Q=",
         "owner": "Jas-SinghFSU",
         "repo": "HyprPanel",
-        "rev": "8cf58067667f05c8cd8492b01481d7a9da14d055",
+        "rev": "13ad57650f33044c3975fb3a3391ff0f9236498e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                  | Message                                                                      |
| ------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------- |
| [`13ad5765`](https://github.com/Jas-SinghFSU/HyprPanel/commit/13ad57650f33044c3975fb3a3391ff0f9236498e) | `` Fix: playPause command name and json editor theme asset loading (#959) `` |
| [`fff65524`](https://github.com/Jas-SinghFSU/HyprPanel/commit/fff65524c54de5214c2454253671fb449e96e56a) | `` Fix: Added gtksourceview3 to dependencies (#958) ``                       |