### PR TITLE
chore(flake/better-control): `0aa59add` -> `b841875e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -135,11 +135,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1748284522,
-        "narHash": "sha256-ncqqEtIge76ef11x66kqewcK9UH1G9XAYJJl3nGSh38=",
+        "lastModified": 1748352924,
+        "narHash": "sha256-wK5qFVpIf4lpUD2hH9bIBr94YWGP1XkEB0e3sy7eatM=",
         "owner": "rishabh5321",
         "repo": "better-control-flake",
-        "rev": "0aa59add7c18c4b9d24f5f62184b392d695c1258",
+        "rev": "b841875ed7dfbc1ab47059232de06d19d3756899",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                            | Message                                                                                            |
| ----------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------- |
| [`dbe802e6`](https://github.com/Rishabh5321/better-control-flake/commit/dbe802e672e5add08889dca168aa4cddfb5d0112) | `` feat: Update better-control to latest 'main' commit 2ec64b577a15751a5abb3cd231cea0d0d7096b20 `` |