### PR TITLE
chore(flake/better-control): `b841875e` -> `4f8c403a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -135,11 +135,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1748352924,
-        "narHash": "sha256-wK5qFVpIf4lpUD2hH9bIBr94YWGP1XkEB0e3sy7eatM=",
+        "lastModified": 1748355787,
+        "narHash": "sha256-iMYj7BH4XMzemcBzvL2cmAi/UPKN94WicBEg4OD0Lh4=",
         "owner": "rishabh5321",
         "repo": "better-control-flake",
-        "rev": "b841875ed7dfbc1ab47059232de06d19d3756899",
+        "rev": "4f8c403aeabdb69fb595d0089640c3fe23802632",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                            | Message                                                                                            |
| ----------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------- |
| [`5f30e4c2`](https://github.com/Rishabh5321/better-control-flake/commit/5f30e4c231adb640911264131a9bbb8569460992) | `` feat: Update better-control to latest 'main' commit dce1cb1caba2bb0eee6aaa4c12d6d2c60f481446 `` |