### PR TITLE
chore(flake/zed-editor-flake): `72aff6db` -> `d2071024`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1031,11 +1031,11 @@
         "patched-nixpkgs": "patched-nixpkgs"
       },
       "locked": {
-        "lastModified": 1748362074,
+        "lastModified": 1748364611,
         "narHash": "sha256-8Mi1oYpJGTARrpnOItzyWApO4SoCPBlZQs0SYcgItFs=",
         "owner": "rishabh5321",
         "repo": "zed-editor-flake",
-        "rev": "72aff6db15a14ec67368239e7a4380c2473fec19",
+        "rev": "d2071024880f890cebadf5b2ffe0c35123d68c5d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                        | Message                                                               |
| ------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------- |
| [`d2071024`](https://github.com/Rishabh5321/zed-editor-flake/commit/d2071024880f890cebadf5b2ffe0c35123d68c5d) | `` Update committer to use GitHub Actions bot identity ``             |
| [`9595c9fe`](https://github.com/Rishabh5321/zed-editor-flake/commit/9595c9fe2ce3781a62e3b607186492c838a07886) | `` Update committer name to use GPG signing email for Zed packages `` |