### PR TITLE
chore(flake/stylix): `1fdbf01e` -> `dedf5de5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -830,11 +830,11 @@
         "tinted-zed": "tinted-zed"
       },
       "locked": {
-        "lastModified": 1748276618,
-        "narHash": "sha256-reC7nvUfJMaIYJb5pVOuTFbOfj/L9eo21drj+9EbrkE=",
+        "lastModified": 1748369100,
+        "narHash": "sha256-rZO2WC1cVIpmwtBKxkex4lJAM7zqut3+5QKZltBkG5U=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "1fdbf01ebe4b7838aa3d95334325ce8445625332",
+        "rev": "dedf5de5792af6c16560f9cc8864be73ae535251",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                            |
| ----------------------------------------------------------------------------------------------------- | -------------------------------------------------- |
| [`dedf5de5`](https://github.com/nix-community/stylix/commit/dedf5de5792af6c16560f9cc8864be73ae535251) | `` doc: enable `hash-files` ``                     |
| [`19e48021`](https://github.com/nix-community/stylix/commit/19e48021e36d86004e1b3b04cf9e305ab67e8017) | `` doc: add redirect for 'Standalone Nixvim' ``    |
| [`9f94e353`](https://github.com/nix-community/stylix/commit/9f94e353734a3ceb2a7573a84eb92d37c325e9e3) | `` doc: add JavaScript redirects ``                |
| [`97468930`](https://github.com/nix-community/stylix/commit/9746893051f7dbf3b51aeb955fa132b9e84ace1a) | `` flake: add 'biome' to treefmt for javascript `` |