### PR TITLE
chore(flake/stylix): `dedf5de5` -> `e38a646e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -830,11 +830,11 @@
         "tinted-zed": "tinted-zed"
       },
       "locked": {
-        "lastModified": 1748369100,
-        "narHash": "sha256-rZO2WC1cVIpmwtBKxkex4lJAM7zqut3+5QKZltBkG5U=",
+        "lastModified": 1748376235,
+        "narHash": "sha256-LIQnskjlVHTJC5dW4xoWlMCtrKeWOPW7/8HYd8IruLA=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "dedf5de5792af6c16560f9cc8864be73ae535251",
+        "rev": "e38a646e5cd3d000c8fffb14632f3bb8a45dd042",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                            |
| ----------------------------------------------------------------------------------------------------- | -------------------------------------------------- |
| [`e38a646e`](https://github.com/nix-community/stylix/commit/e38a646e5cd3d000c8fffb14632f3bb8a45dd042) | `` bemenu: fix undefined variable error (#1390) `` |