### PR TITLE
chore(flake/better-control): `f342d5a2` -> `2e37e7ca`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -135,11 +135,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1748359542,
-        "narHash": "sha256-Y8HtOZEoX5YanK0KYF8KXaF9YyHCs3wMlmP9Rw8vNeA=",
+        "lastModified": 1748410117,
+        "narHash": "sha256-933F3iSL5EJK8dMJm+T2EAxBSzYPNf8sBb/m/UzV8iw=",
         "owner": "rishabh5321",
         "repo": "better-control-flake",
-        "rev": "f342d5a2508a177a70e08500411e3dc8a5a252da",
+        "rev": "2e37e7ca52814ec0f45f5933ccc244def5bcb5a4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                            | Message                                                                                                   |
| ----------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------- |
| [`2e37e7ca`](https://github.com/Rishabh5321/better-control-flake/commit/2e37e7ca52814ec0f45f5933ccc244def5bcb5a4) | `` feat: Update better-control to latest 'main' commit 6dd56b25a7dde4a08d4721de4ad302d9bb5242b9 (#138) `` |
| [`78e29c59`](https://github.com/Rishabh5321/better-control-flake/commit/78e29c5947e7acd4b387d7b1503199b0ca2be68e) | `` Fix missing `fi` statements in release check workflow ``                                               |
| [`897662cd`](https://github.com/Rishabh5321/better-control-flake/commit/897662cdfda2205623d0398b7ac5f1b92ca352e8) | `` Fix GitHub Action workflow syntax and improve documentation ``                                         |
| [`b8b08673`](https://github.com/Rishabh5321/better-control-flake/commit/b8b08673c3aa1128463724c9dd12d23b89e00e3d) | `` Improve GitHub workflow with GH CLI authentication ``                                                  |
| [`92e0ab2d`](https://github.com/Rishabh5321/better-control-flake/commit/92e0ab2d2371a6fd08808d71e7a03f97bc31e695) | `` Update token to REPO_ACCESS_TOKEN for GitHub API operations ``                                         |
| [`a90d12d7`](https://github.com/Rishabh5321/better-control-flake/commit/a90d12d70146b7a5d31e3812e7dff04a83b3533e) | `` Change merge method from 'merge' to 'squash' in release check ``                                       |
| [`657f7c81`](https://github.com/Rishabh5321/better-control-flake/commit/657f7c811de0994ed443c9f41fd94d5d6d409c2d) | `` Downgrade peter-evans/create-pull-request to v6 ``                                                     |