### PR TITLE
chore(flake/better-control): `2e37e7ca` -> `5f932949`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -135,11 +135,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1748410117,
-        "narHash": "sha256-933F3iSL5EJK8dMJm+T2EAxBSzYPNf8sBb/m/UzV8iw=",
+        "lastModified": 1748411687,
+        "narHash": "sha256-jvV9VBqoChlHurecRNBftPDPn/vxdEY0Ez38xhXu2vU=",
         "owner": "rishabh5321",
         "repo": "better-control-flake",
-        "rev": "2e37e7ca52814ec0f45f5933ccc244def5bcb5a4",
+        "rev": "5f9329495ead7cb9ddd637a8970126a6f9196e3a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                            | Message                                             |
| ----------------------------------------------------------------------------------------------------------------- | --------------------------------------------------- |
| [`5f932949`](https://github.com/Rishabh5321/better-control-flake/commit/5f9329495ead7cb9ddd637a8970126a6f9196e3a) | `` Add commit-author for automatic flake updates `` |
| [`52baece4`](https://github.com/Rishabh5321/better-control-flake/commit/52baece424eb359706a8e51f686ffbd310750e13) | `` Add permissions for GitHub Actions workflow ``   |