### PR TITLE
chore(nix): update nixpkgs channel and enable lutris

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1002,16 +1002,16 @@
     },
     "nixpkgs_8": {
       "locked": {
-        "lastModified": 1772173633,
-        "narHash": "sha256-MOH58F4AIbCkh6qlQcwMycyk5SWvsqnS/TCfnqDlpj4=",
+        "lastModified": 1772198003,
+        "narHash": "sha256-I45esRSssFtJ8p/gLHUZ1OUaaTaVLluNkABkk6arQwE=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "c0f3d81a7ddbc2b1332be0d8481a672b4f6004d6",
+        "rev": "dd9b079222d43e1943b6ebd802f04fd959dc8e61",
         "type": "github"
       },
       "original": {
         "owner": "nixos",
-        "ref": "nixpkgs-unstable",
+        "ref": "nixos-unstable",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -6,7 +6,7 @@
     # Core Infrastructure
     ######################
 
-    nixpkgs.url = "github:nixos/nixpkgs/nixpkgs-unstable";
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
     nixpkgs-stable.url = "github:nixos/nixpkgs/nixos-25.11";
 
     nixos-hardware.url = "github:NixOS/nixos-hardware/master";

--- a/modules/user/gaming/default.nix
+++ b/modules/user/gaming/default.nix
@@ -3,7 +3,7 @@
 { ... }:
 {
   imports = [
-    # ./lutris.nix
+    ./lutris.nix
     #./mangohud.nix
   ];
 }


### PR DESCRIPTION
Update nixpkgs unstable channel reference to `nixos-unstable`. Also enable the lutris gaming module.