### PR TITLE
refactor(theming): make stylix optional and simplify configs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,8 +10,8 @@ env:
     experimental-features = nix-command flakes
     max-jobs = auto
     download-buffer-size = 500000000
-    substituters = https://rishabh5321.cachix.org https://cache.nixos.org https://hyprland.cachix.org https://nixpkgs-wayland.cachix.org https://nix-gaming.cachix.org
-    trusted-public-keys = rishabh5321.cachix.org-1:mxfBIH2XElE6ieFXXYBA9Ame4mVTbAf1TGR843siggk= cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= hyprland.cachix.org-1:a7pgxzMz7+chwVL3/pzj6jIBMioiJM7ypFP8PwtkuGc= nixpkgs-wayland.cachix.org-1:3lwxaILxMRkVhehr5StQprHdEo4IrE8sRho9R9HOLYA= nix-gaming.cachix.org-1:nbjlureqMbRAxR1gJ/f3hxemL9svXaZF/Ees8vCUUs4=
+    substituters = https://rishabh5321.cachix.org https://cache.nixos.org https://nixpkgs-wayland.cachix.org https://nix-config.cachix.org https://nix-community.cachix.org https://hyprland.cachix.org https://nixpkgs-wayland.cachix.org https://nix-gaming.cachix.org
+    trusted-public-keys = rishabh5321.cachix.org-1:mxfBIH2XElE6ieFXXYBA9Ame4mVTbAf1TGR843siggk= cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= nixpkgs-wayland.cachix.org-1:3lwxaILxMRkVhehr5StQprHdEo4IrE8sRho9R9HOLYA= nix-config.cachix.org-1:Vd6raEuldeIZpttVQfrUbLvXJHzzzkS0pezXCVVjDG4= nix-community.cachix.org-1:mB9FSh9qf2dCimDSUo8Zy7bkq5CX+/rkCWyvRCYg3Fs= hyprland.cachix.org-1:a7pgxzMz7+chwVL3/pzj6jIBMioiJM7ypFP8PwtkuGc= nixpkgs-wayland.cachix.org-1:3lwxaILxMRkVhehr5StQprHdEo4IrE8sRho9R9HOLYA= nix-gaming.cachix.org-1:nbjlureqMbRAxR1gJ/f3hxemL9svXaZF/Ees8vCUUs4=
 on:
   push:
     branches: [main]

--- a/flake.lock
+++ b/flake.lock
@@ -139,11 +139,11 @@
         "nixpkgs": "nixpkgs_3"
       },
       "locked": {
-        "lastModified": 1780520447,
-        "narHash": "sha256-uIxIjj6pYlCkPzoTS9oEw0LAfpQ9iWMKKXxWatl6u3M=",
+        "lastModified": 1780546779,
+        "narHash": "sha256-Cexp7eTWuDe/zhXi7QHM/rI2kGNDmhF9vqqJ1ukpQfU=",
         "owner": "Rishabh5321",
         "repo": "custom-packages-flake",
-        "rev": "93bfabdb7ff45ec6031c28a09145eca585814753",
+        "rev": "44df188c7f6b392f9eb80ee13c4ebebadee04316",
         "type": "github"
       },
       "original": {
@@ -160,11 +160,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1780498191,
-        "narHash": "sha256-BuvJ6IfRxx552EoK/MHa1HMipObiBXNSrqHfPNXb4rQ=",
+        "lastModified": 1780531574,
+        "narHash": "sha256-DngmgE5GUbqFzZnnCrM2Z6lGNDGkSfXvNVUhPZSLjgY=",
         "owner": "AvengeMedia",
         "repo": "DankMaterialShell",
-        "rev": "e5fff91ae66fa44379ffe31f25ed8cf5c6807d67",
+        "rev": "59431869dc14ab1cb2d05bbbf81839d95e4724cd",
         "type": "github"
       },
       "original": {
@@ -506,11 +506,11 @@
         "nixpkgs-lib": "nixpkgs-lib_4"
       },
       "locked": {
-        "lastModified": 1777678872,
-        "narHash": "sha256-EPIFsulyon7Z1vLQq5Fk64GR8L7cQsT+IPhcsukVbgk=",
+        "lastModified": 1778716662,
+        "narHash": "sha256-m1Yf0wZ8j1OHjTc2UwHwyQRSnNeSgLJOd7q5Y45hzi4=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "5250617bffd85403b14dbf43c3870e7f255d2c16",
+        "rev": "f7c1a2d347e4c52d5fb8d10cb4d94b5884e546fb",
         "type": "github"
       },
       "original": {
@@ -778,11 +778,11 @@
         "scenefx": "scenefx"
       },
       "locked": {
-        "lastModified": 1780447643,
-        "narHash": "sha256-5IkMWQAgov75uIrGjmrZQJ+Q7H78wMkjaNkL46DuX2U=",
+        "lastModified": 1780541279,
+        "narHash": "sha256-UdwXcUeOgfct2GBadVCsonMIay3Gndylr0pMmxz7z/k=",
         "owner": "mangowm",
         "repo": "mango",
-        "rev": "bea689ca0c1c859ab49a6a21e63034dc07c4ab80",
+        "rev": "8a92184667ae945955c2139847e5e1994a5f9671",
         "type": "github"
       },
       "original": {
@@ -893,11 +893,11 @@
         "nixpkgs": "nixpkgs_6"
       },
       "locked": {
-        "lastModified": 1780462023,
-        "narHash": "sha256-SaAKJJ0RQzc8mVJ45VwzPtTCyclNZpvmhb+csMpSgGQ=",
+        "lastModified": 1780548072,
+        "narHash": "sha256-kgr+QJ5Mgu3NnMdP8kedbbeOKJUy4Iw8O/1Mw4qc7kI=",
         "owner": "fufexan",
         "repo": "nix-gaming",
-        "rev": "b6b4b649b365269202da0d67b44b0e85f0c8fb5a",
+        "rev": "193620288f9b064eb0f8ce80ad36991a895f6a01",
         "type": "github"
       },
       "original": {
@@ -914,11 +914,11 @@
         "nixpkgs-nixcord": "nixpkgs-nixcord"
       },
       "locked": {
-        "lastModified": 1780509217,
-        "narHash": "sha256-CAes5A7+1S8v0Hb/MyZOs1JXF5RZbgUQ/rpXDEBoc2c=",
+        "lastModified": 1780536336,
+        "narHash": "sha256-s1k5Es8gahsPAzokDDp0c5ttoWSiNu49wlkyUGUXycw=",
         "owner": "FlameFlag",
         "repo": "nixcord",
-        "rev": "585248a6299df3f0dd6b84fcd8ea1e5f74b32062",
+        "rev": "e0f07ebefc985e1cc8aa4c9b7bbceb81431f7012",
         "type": "github"
       },
       "original": {
@@ -1107,11 +1107,11 @@
     },
     "nixpkgs-stable_2": {
       "locked": {
-        "lastModified": 1780203844,
-        "narHash": "sha256-K5sT4jTpGs15ADhviMKNBH38REpPf5Q6mM1+N6cArVE=",
+        "lastModified": 1780453794,
+        "narHash": "sha256-bXMRa9VTsHSPXL4Cw8R6JJLQeY3Y/IP4+YJCYVmQ7FY=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "b51242d7d43689db2f3be91bd05d5b24fbb469c4",
+        "rev": "6b316287bae2ee04c9b93c8c858d930fd07d7338",
         "type": "github"
       },
       "original": {
@@ -1123,11 +1123,11 @@
     },
     "nixpkgs_10": {
       "locked": {
-        "lastModified": 1779560665,
-        "narHash": "sha256-tpyBcxPpcQb8ukyNF7DoCwfSY3VPsxHoYwj00Cayv5o=",
+        "lastModified": 1780243769,
+        "narHash": "sha256-x5UQuRsH3MqI0U9afaXSNqzTPSeZlRLvFAav2Ux1pNw=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "64c08a7ca051951c8eae34e3e3cb1e202fe36786",
+        "rev": "331800de5053fcebacf6813adb5db9c9dca22a0c",
         "type": "github"
       },
       "original": {
@@ -1139,11 +1139,11 @@
     },
     "nixpkgs_11": {
       "locked": {
-        "lastModified": 1779560665,
-        "narHash": "sha256-tpyBcxPpcQb8ukyNF7DoCwfSY3VPsxHoYwj00Cayv5o=",
+        "lastModified": 1780243769,
+        "narHash": "sha256-x5UQuRsH3MqI0U9afaXSNqzTPSeZlRLvFAav2Ux1pNw=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "64c08a7ca051951c8eae34e3e3cb1e202fe36786",
+        "rev": "331800de5053fcebacf6813adb5db9c9dca22a0c",
         "type": "github"
       },
       "original": {
@@ -1170,11 +1170,11 @@
     },
     "nixpkgs_13": {
       "locked": {
-        "lastModified": 1779560665,
-        "narHash": "sha256-tpyBcxPpcQb8ukyNF7DoCwfSY3VPsxHoYwj00Cayv5o=",
+        "lastModified": 1780243769,
+        "narHash": "sha256-x5UQuRsH3MqI0U9afaXSNqzTPSeZlRLvFAav2Ux1pNw=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "64c08a7ca051951c8eae34e3e3cb1e202fe36786",
+        "rev": "331800de5053fcebacf6813adb5db9c9dca22a0c",
         "type": "github"
       },
       "original": {
@@ -1202,11 +1202,11 @@
     },
     "nixpkgs_15": {
       "locked": {
-        "lastModified": 1777578337,
-        "narHash": "sha256-Ad49moKWeXtKBJNy2ebiTQUEgdLyvGmTeykAQ9xM+Z4=",
+        "lastModified": 1780243769,
+        "narHash": "sha256-x5UQuRsH3MqI0U9afaXSNqzTPSeZlRLvFAav2Ux1pNw=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "15f4ee454b1dce334612fa6843b3e05cf546efab",
+        "rev": "331800de5053fcebacf6813adb5db9c9dca22a0c",
         "type": "github"
       },
       "original": {
@@ -1391,11 +1391,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1780520503,
-        "narHash": "sha256-3AdmCfPytkPWbu5lVAPbiwbFOwJnlat+zfPlBwz5K7s=",
+        "lastModified": 1780557973,
+        "narHash": "sha256-61zCGu0HK+vNAFbdZv2WMp7dTuMaVfAb744Puvxz438=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "b90f8d16bbf13140ef946494e3abc1e588fa2215",
+        "rev": "845567f6de2afe3c5adff19184c3774047a5d92b",
         "type": "github"
       },
       "original": {
@@ -1525,11 +1525,11 @@
         "nixpkgs": "nixpkgs_12"
       },
       "locked": {
-        "lastModified": 1779430452,
-        "narHash": "sha256-zTslhsxLqUlRTML506iougTGzyR38Fzhzn7t4KDEuuE=",
+        "lastModified": 1780303737,
+        "narHash": "sha256-7HgdJBG4BgAPDyHKKxWtxj7nziqsQo6zQCXtwy+L9fs=",
         "owner": "quickshell-mirror",
         "repo": "quickshell",
-        "rev": "4b4fca3224ab977dc515ac0bb78d00b3dfa71e00",
+        "rev": "b66495fcc5022681b56b61f928c7acbe910e722c",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -155,11 +155,11 @@
           allowUnfreePredicate = _: true;
         };
         overlays = [
-          (_: prev: {
-            openldap = prev.openldap.overrideAttrs {
-              doCheck = !prev.stdenv.hostPlatform.isi686;
-            };
-          })
+          # (_: prev: {
+          #   openldap = prev.openldap.overrideAttrs {
+          #     doCheck = !prev.stdenv.hostPlatform.isi686;
+          #   };
+          # })
           nur.overlays.default
           # inputs.hyprpanel.overlay
           # sddm-sugar-candy-nix.overlays.default

--- a/flake.nix
+++ b/flake.nix
@@ -130,6 +130,7 @@
     , wallpapers-repo
     , lsfg-vk-flake
     , system-manager
+    , niri
     , #, nix-colorizer
       #, plasma-manager
       ...

--- a/hosts/caelestiabook/configuration.nix
+++ b/hosts/caelestiabook/configuration.nix
@@ -16,6 +16,8 @@
   networking.hostName = "caelestiabook"; # Define your hostname.
   # networking.wireless.enable = true;  # Enables wireless support via wpa_supplicant.
 
+  stylix.enable = false;
+
   # Configure network proxy if necessary
   # networking.proxy.default = "http://user:password@proxy:port/";
   # networking.proxy.noProxy = "127.0.0.1,localhost,internal.domain";

--- a/hosts/dankmaterialbook/configuration.nix
+++ b/hosts/dankmaterialbook/configuration.nix
@@ -16,6 +16,8 @@
   networking.hostName = "dankmaterialbook"; # Define your hostname.
   # networking.wireless.enable = true;  # Enables wireless support via wpa_supplicant.
 
+  stylix.enable = false;
+
   # Configure network proxy if necessary
   # networking.proxy.default = "http://user:password@proxy:port/";
   # networking.proxy.noProxy = "127.0.0.1,localhost,internal.domain";

--- a/hosts/dell/configuration.nix
+++ b/hosts/dell/configuration.nix
@@ -34,7 +34,7 @@
     flake = "github:Rishabh5321/dotfiles";
     host = "dell";
     # useNom = false;
-    minimumBatteryToProceedWithoutAC = 40;
+    # minimumBatteryToProceedWithoutAC = 40;
   };
 
   services.nfs.server.enable = true;
@@ -49,6 +49,8 @@
 
   networking.hostName = "dell"; # Define your hostname.
   # networking.wireless.enable = true;  # Enables wireless support via wpa_supplicant.
+
+  stylix.enable = false;
 
   # Configure network proxy if necessary
   # networking.proxy.default = "http://user:password@proxy:port/";

--- a/hosts/dell/hardware-configuration.nix
+++ b/hosts/dell/hardware-configuration.nix
@@ -55,10 +55,6 @@
     fsType = "ntfs";
   };
 
-  #fileSystems."/mnt/Win_Disk" = {
-  #  device = "/dev/disk/by-uuid/78CCFCB0CCFC69B0";
-  #  fsType = "ntfs";
-  #};
   # Enables DHCP on each ethernet and wireless interface. In case of scripted networking
   # (the default) this is the recommended approach. When using systemd-networkd it's
   # still possible to use this option, but it's recommended to use it in conjunction

--- a/hosts/dell/home.nix
+++ b/hosts/dell/home.nix
@@ -8,13 +8,6 @@
   imports = [
     ../../modules/user
     ../../modules/desktop/Sway-DMS/home
-    #../../modules/desktop/Gnome/home
-    #./gnome.nix
-    # Or modules exported from other flakes (such as nix-colors):
-    # inputs.nix-colors.homeManagerModules.default
-
-    # You can also split up your configuration and import pieces of it here:
-    # ./nvim.nix
   ];
 
   nixpkgs = {
@@ -24,16 +17,6 @@
       outputs.overlays.additions
       outputs.overlays.modifications
       outputs.overlays.unstable-packages
-
-      # You can also add overlays exported from other flakes:
-      # neovim-nightly-overlay.overlays.default
-
-      # Or define it inline, for example:
-      # (final: prev: {
-      #   hi = final.hello.overrideAttrs (oldAttrs: {
-      #     patches = [ ./change-hello-to-hi.patch ];
-      #   });
-      # })
     ];
     # Configure your nixpkgs instance
     config = {

--- a/hosts/iso/configuration.nix
+++ b/hosts/iso/configuration.nix
@@ -16,6 +16,8 @@
   isoImage.makeUsbBootable = true;
   isoImage.volumeID = "NIXOS_ISO";
 
+  stylix.enable = lib.mkForce false;
+
   # Network configuration
   networking.hostName = "nixos-iso";
   networking.networkmanager.enable = true;

--- a/hosts/kdebook/configuration.nix
+++ b/hosts/kdebook/configuration.nix
@@ -18,6 +18,8 @@
   networking.hostName = "kdebook"; # Define your hostname.
   # networking.wireless.enable = true;  # Enables wireless support via wpa_supplicant.
 
+  stylix.enable = false;
+
   # Configure network proxy if necessary
   # networking.proxy.default = "http://user:password@proxy:port/";
   # networking.proxy.noProxy = "127.0.0.1,localhost,internal.domain";

--- a/hosts/mangowc/configuration.nix
+++ b/hosts/mangowc/configuration.nix
@@ -18,6 +18,8 @@
   networking.hostName = "swaydms"; # Define your hostname.
   # networking.wireless.enable = true;  # Enables wireless support via wpa_supplicant.
 
+  stylix.enable = false;
+
   # Configure network proxy if necessary
   # networking.proxy.default = "http://user:password@proxy:port/";
   # networking.proxy.noProxy = "127.0.0.1,localhost,internal.domain";

--- a/hosts/niridms/configuration.nix
+++ b/hosts/niridms/configuration.nix
@@ -16,6 +16,8 @@
   networking.hostName = "niridms"; # Define your hostname.
   # networking.wireless.enable = true;  # Enables wireless support via wpa_supplicant.
 
+  stylix.enable = false;
+
   # Configure network proxy if necessary
   # networking.proxy.default = "http://user:password@proxy:port/";
   # networking.proxy.noProxy = "127.0.0.1,localhost,internal.domain";

--- a/hosts/noctaliabook/configuration.nix
+++ b/hosts/noctaliabook/configuration.nix
@@ -16,6 +16,8 @@
   networking.hostName = "noctaliabook"; # Define your hostname.
   # networking.wireless.enable = true;  # Enables wireless support via wpa_supplicant.
 
+  stylix.enable = false;
+
   # Configure network proxy if necessary
   # networking.proxy.default = "http://user:password@proxy:port/";
   # networking.proxy.noProxy = "127.0.0.1,localhost,internal.domain";

--- a/hosts/redmi/configuration.nix
+++ b/hosts/redmi/configuration.nix
@@ -16,6 +16,8 @@
   networking.hostName = "redmi"; # Define your hostname.
   # networking.wireless.enable = true;  # Enables wireless support via wpa_supplicant.
 
+  stylix.enable = false;
+
   # Configure network proxy if necessary
   # networking.proxy.default = "http://user:password@proxy:port/";
   # networking.proxy.noProxy = "127.0.0.1,localhost,internal.domain";

--- a/hosts/swaydms/configuration.nix
+++ b/hosts/swaydms/configuration.nix
@@ -18,6 +18,8 @@
   networking.hostName = "swaydms"; # Define your hostname.
   # networking.wireless.enable = true;  # Enables wireless support via wpa_supplicant.
 
+  stylix.enable = false;
+
   # Configure network proxy if necessary
   # networking.proxy.default = "http://user:password@proxy:port/";
   # networking.proxy.noProxy = "127.0.0.1,localhost,internal.domain";

--- a/hosts/swaynoctalia/configuration.nix
+++ b/hosts/swaynoctalia/configuration.nix
@@ -18,6 +18,8 @@
   networking.hostName = "swaynoctalia"; # Define your hostname.
   # networking.wireless.enable = true;  # Enables wireless support via wpa_supplicant.
 
+  stylix.enable = false;
+
   # Configure network proxy if necessary
   # networking.proxy.default = "http://user:password@proxy:port/";
   # networking.proxy.noProxy = "127.0.0.1,localhost,internal.domain";

--- a/modules/desktop/Hypr-Caelestia/home/core/hyprland.nix
+++ b/modules/desktop/Hypr-Caelestia/home/core/hyprland.nix
@@ -7,6 +7,13 @@
 let
   inherit (import ../misc/variables.nix) browser terminal extraMonitorSettings;
   modifier = "SUPER";
+  stylixEnabled = config ? stylix && config.stylix.enable;
+  palette = if stylixEnabled then config.stylix.base16Scheme else {
+    base00 = "000000"; base01 = "1e1e2e"; base02 = "313244"; base03 = "45475a";
+    base04 = "585b70"; base05 = "cdd6f4"; base06 = "f5e0dc"; base07 = "b4befe";
+    base08 = "f38ba8"; base09 = "fab387"; base0A = "f9e2af"; base0B = "a6e3a1";
+    base0C = "94e2d5"; base0D = "89b4fa"; base0E = "cba6f7"; base0F = "f2cdcd";
+  };
 in
 with lib;
 {
@@ -88,8 +95,8 @@ with lib;
         extend_border_grab_area = 15;
         hover_icon_on_border = true;
         allow_tearing = false;
-        "col.active_border" = "rgb(${config.stylix.base16Scheme.base0D}) rgb(${config.stylix.base16Scheme.base0B}) 45deg";
-        "col.inactive_border" = "rgb(${config.stylix.base16Scheme.base00})";
+        "col.active_border" = lib.mkIf stylixEnabled "rgb(${palette.base0D}) rgb(${palette.base0B}) 45deg";
+        "col.inactive_border" = lib.mkIf stylixEnabled "rgb(${palette.base00})";
       };
 
       # ── Input Settings ─────────────────────────────────────────────────────

--- a/modules/desktop/Hypr-Caelestia/home/core/hyprlock.nix
+++ b/modules/desktop/Hypr-Caelestia/home/core/hyprlock.nix
@@ -1,14 +1,20 @@
 { config
 , lib
-, wallpaper
-, wallpapers
 , pkgs
 , ...
 }:
+
 let
-  color0 = "rgb(${config.stylix.base16Scheme.base00})";
-  color5 = "rgb(${config.stylix.base16Scheme.base05})";
-  color14 = "rgb(${config.stylix.base16Scheme.base0E})";
+  stylixEnabled = config ? stylix && config.stylix.enable;
+  palette = if stylixEnabled then config.stylix.base16Scheme else {
+    base00 = "000000"; base01 = "1e1e2e"; base02 = "313244"; base03 = "45475a";
+    base04 = "585b70"; base05 = "cdd6f4"; base06 = "f5e0dc"; base07 = "b4befe";
+    base08 = "f38ba8"; base09 = "fab387"; base0A = "f9e2af"; base0B = "a6e3a1";
+    base0C = "94e2d5"; base0D = "89b4fa"; base0E = "cba6f7"; base0F = "f2cdcd";
+  };
+  color0 = "rgb(${palette.base00})";
+  color5 = "rgb(${palette.base05})";
+  color14 = "rgb(${palette.base0E})";
 in
 {
   programs.hyprlock = {
@@ -16,92 +22,81 @@ in
     package = pkgs.hyprlock;
     settings = {
       general = {
-        grace = 1;
+        disable_loading = true;
+        hide_cursor = false;
+        grace = 0;
+        no_fade_in = false;
       };
-      background = {
-        path = lib.mkForce "${wallpapers}/${wallpaper}";
-        blur_size = 5;
-        blur_passes = 1;
-        noise = 0.0117;
-        contrast = 1.3;
-        brightness = 0.8;
-        vibrancy = 0.21;
-        vibrancy_darkness = 0.0;
-      };
-      "input-field" = {
-        size = "250, 50";
-        outline_thickness = 3;
-        dots_size = 0.33;
-        dots_spacing = 0.15;
-        dots_center = true;
-        outer_color = lib.mkForce color5;
-        inner_color = lib.mkForce color0;
-        font_color = lib.mkForce color14;
-        fade_on_empty = true;
-        placeholder_text = "<i>Password...</i>";
-        hide_input = false;
-        position = "0, 40";
-        halign = "center";
-        valign = "bottom";
-      };
-      "label" = lib.mkForce [
+
+      background = lib.mkForce [
         {
-          text = "cmd[update:18000000] echo \"<b> $(date +'%A, %-d %B %Y') </b>\"";
-          color = color14;
-          font_size = 34;
+          path = "screenshot";
+          blur_passes = 3;
+          blur_size = 8;
+        }
+      ];
+
+      input-field = lib.mkForce [
+        {
+          size = "200, 50";
+          position = "0, -80";
+          monitor = "";
+          dots_center = true;
+          fade_on_empty = false;
+          font_color = if stylixEnabled then lib.mkForce color14 else color5;
+          inner_color = if stylixEnabled then lib.mkForce color0 else color0;
+          outer_color = if stylixEnabled then lib.mkForce color5 else color5;
+          outline_thickness = 5;
+          placeholder_text = "Password...";
+          shadow_passes = 2;
+        }
+      ];
+
+      label = lib.mkForce [
+        {
+          monitor = "";
+          text = "$TIME";
+          color = if stylixEnabled then lib.mkForce color14 else color14;
+          font_size = 120;
           font_family = "JetBrains Mono Nerd Font Mono ExtraBold";
-          position = "0, -100";
+          position = "0, 80";
           halign = "center";
-          valign = "top";
+          valign = "center";
         }
         {
-          text = "cmd[update:1000] echo -e \"$(date +'%I')\""; #AM/PM
-          color = "rgba(255, 185, 0, .6)";
-          font_size = 200;
-          font_family = "JetBrains Mono Nerd Font Mono ExtraBold";
-          position = "0, -200";
+          monitor = "";
+          text = "Hi there, $USER";
+          color = if stylixEnabled then lib.mkForce color14 else color14;
+          font_size = 25;
+          font_family = "JetBrains Mono Nerd Font Mono";
+          position = "0, -40";
           halign = "center";
-          valign = "top";
+          valign = "center";
         }
         {
-          text = "cmd[update:1000] echo -e \"$(date +'%M')\"";
-          color = "rgba(255, 255, 255, .6)";
-          font_size = 200;
+          monitor = "";
+          text = "cmd[update:1000] echo \"$(date +'%A, %d %B')\"";
+          color = if stylixEnabled then lib.mkForce color14 else color14;
+          font_size = 24;
           font_family = "JetBrains Mono Nerd Font Mono ExtraBold";
-          position = "0, -500";
+          position = "0, 10";
           halign = "center";
-          valign = "top";
+          valign = "center";
         }
         {
-          text = "cmd[update:1000] echo -e \"$(date +'%S %p')\""; #AM/PM
-          color = color14;
-          font_size = 40;
-          font_family = "JetBrains Mono Nerd Font Mono ExtraBold";
-          position = "0, -500";
-          halign = "center";
-          valign = "top";
-        }
-        {
-          text = "   $USER";
-          color = color14;
+          monitor = "";
+          text = " $USER";
+          color = if stylixEnabled then lib.mkForce color14 else color14;
           font_size = 18;
-          font_family = "Inter Display Medium";
+          font_family = "JetBrains Mono Nerd Font Mono";
           position = "0, 100";
           halign = "center";
           valign = "bottom";
         }
         {
-          text = "cmd[update:60000] echo \"<b> $(uptime -p || $Scripts/UptimeNixOS.sh) </b>\"";
-          color = color14;
-          font_size = 24;
-          font_family = "JetBrains Mono Nerd Font Mono ExtraBold";
-          position = "0, 0";
-          halign = "right";
-          valign = "bottom";
-        }
-        {
-          text = "cmd[update:3600000] [ -f ~/.cache/.weather_cache ] && cat  ~/.cache/.weather_cache";
-          color = color14;
+          monitor = "";
+          text = "󰌾 Lock Screen";
+          color = if stylixEnabled then lib.mkForce color14 else color14;
           font_size = 24;
           font_family = "JetBrains Mono Nerd Font Mono ExtraBold";
           position = "50, 0";

--- a/modules/desktop/Hypr-Caelestia/main/sddm.nix
+++ b/modules/desktop/Hypr-Caelestia/main/sddm.nix
@@ -1,85 +1,45 @@
-{ pkgs, config, ... }:
+{ pkgs, config, lib, ... }:
 
-
+let
+  stylixEnabled = config ? stylix && config.stylix.enable;
+in
 {
-
   services.displayManager.sddm = {
     enable = true;
     wayland.enable = true;
     theme = "sddm-astronaut-theme";
     package = pkgs.kdePackages.sddm;
     extraPackages = with pkgs; [
+      # kdePackages.qt6-declarative
+      kdePackages.qtsvg
       kdePackages.qtsvg
       kdePackages.qtmultimedia
       kdePackages.qtvirtualkeyboard
     ];
-    settings.Theme = {
+    settings.Theme = lib.mkIf stylixEnabled {
       CursorTheme = config.stylix.cursor.name;
       CursorSize = config.stylix.cursor.size;
     };
   };
 
   environment.systemPackages = [
-    (
+    (if stylixEnabled then
+      let
+        colors = config.lib.stylix.colors.withHashtag;
+      in
       pkgs.sddm-astronaut.override {
-        themeConfig = with config.lib.stylix.colors.withHashtag; {
-          Font = "JetBrainsMono";
-          FontSize = "12";
+        themeConfig = {
           Background = "${config.stylix.image}";
-          CropBackground = "false";
-          BackgroundHorizontalAlignment = "center";
-          BackgroundVerticalAlignment = "center";
-          DimBackground = "0.0";
-          HeaderTextColor = "${base07}";
-          DateTextColor = "${base07}";
-          TimeTextColor = "${base07}";
-
-          FormBackgroundColor = "${base00}";
-          BackgroundColor = "${base00}";
-          DimBackgroundColor = "${base00}";
-
-          LoginFieldBackgroundColor = "#${base00}";
-          PasswordFieldBackgroundColor = "${base00}";
-          LoginFieldTextColo = "${base0D}";
-          PasswordFieldTestColor = "${base0D}";
-          UserIconColor = "${base0D}";
-          PasswordIconColor = "${base0D}";
-
-          PlaceholderTextColor = "${base02}";
-          WarningColor = "${base0A}";
-
-          LoginButtonTextColor = "${base0D}";
-          LoginButtonBackgroundColor = "${base00}";
-          SystemButtonsIconsColor = "${base0D}";
-          SessionButtonTextColor = "${base0D}";
-          VirtualKeyboardButtonTextColor = "${base0D}";
-
-          DropdownTextColor = "${base0D}";
-          DropdownSelectedBackgroundColor = "${base00}";
-          DropdownBackgroundColor = "${base00}";
-
-          HighlightTextColor = "${base0D}";
-          HighlightBackgroundColor = "${base0D}";
-          HighlightBorderColor = "${base0D}";
-
-          HoverUserIconColor = "${base0A}";
-          HoverPasswordIconColor = "${base0A}";
-          HoverSystemButtonsIconsColor = "${base0A}";
-          HoverSessionButtonTextColor = "${base0A}";
-          HoverVirtualKeyboardButtonTextColor = "${base0A}";
-
+          CursorColor = colors.base05;
+          FullBlur = "true";
           PartialBlur = "true";
-          BlurMax = "35";
-          Blur = "2.0";
-
-          HourFormat = "h:mm AP";
-
+          HeaderTextColor = colors.base05;
           HaveFormBackground = "false";
           FormPosition = "left";
-
         };
       }
-    )
+    else
+      pkgs.sddm-astronaut)
   ];
 
   security.pam.services.sddm.enableGnomeKeyring = true;

--- a/modules/desktop/Hypr-Noctalia/home/core/hyprland.nix
+++ b/modules/desktop/Hypr-Noctalia/home/core/hyprland.nix
@@ -7,6 +7,13 @@
 let
   inherit (import ../misc/variables.nix) browser terminal extraMonitorSettings;
   modifier = "SUPER";
+  stylixEnabled = config ? stylix && config.stylix.enable;
+  palette = if stylixEnabled then config.stylix.base16Scheme else {
+    base00 = "000000"; base01 = "1e1e2e"; base02 = "313244"; base03 = "45475a";
+    base04 = "585b70"; base05 = "cdd6f4"; base06 = "f5e0dc"; base07 = "b4befe";
+    base08 = "f38ba8"; base09 = "fab387"; base0A = "f9e2af"; base0B = "a6e3a1";
+    base0C = "94e2d5"; base0D = "89b4fa"; base0E = "cba6f7"; base0F = "f2cdcd";
+  };
 in
 with lib;
 {
@@ -23,6 +30,7 @@ with lib;
       variables = [ "--all" ];
     };
     settings = {
+      # xwayland.enable = true;
       env = [
         "NIXOS_OZONE_WL, 1"
         "NIXPKGS_ALLOW_UNFREE, 1"
@@ -87,8 +95,8 @@ with lib;
         extend_border_grab_area = 15;
         hover_icon_on_border = true;
         allow_tearing = false;
-        "col.active_border" = "rgb(${config.stylix.base16Scheme.base0D}) rgb(${config.stylix.base16Scheme.base0B}) 45deg";
-        "col.inactive_border" = "rgb(${config.stylix.base16Scheme.base00})";
+        "col.active_border" = lib.mkIf stylixEnabled "rgb(${palette.base0D}) rgb(${palette.base0B}) 45deg";
+        "col.inactive_border" = lib.mkIf stylixEnabled "rgb(${palette.base00})";
       };
 
       # ── Input Settings ─────────────────────────────────────────────────────

--- a/modules/desktop/Hypr-Noctalia/home/core/hyprlock.nix
+++ b/modules/desktop/Hypr-Noctalia/home/core/hyprlock.nix
@@ -1,14 +1,20 @@
 { config
 , lib
-, wallpaper
-, wallpapers
 , pkgs
 , ...
 }:
+
 let
-  color0 = "rgb(${config.stylix.base16Scheme.base00})";
-  color5 = "rgb(${config.stylix.base16Scheme.base05})";
-  color14 = "rgb(${config.stylix.base16Scheme.base0E})";
+  stylixEnabled = config ? stylix && config.stylix.enable;
+  palette = if stylixEnabled then config.stylix.base16Scheme else {
+    base00 = "000000"; base01 = "1e1e2e"; base02 = "313244"; base03 = "45475a";
+    base04 = "585b70"; base05 = "cdd6f4"; base06 = "f5e0dc"; base07 = "b4befe";
+    base08 = "f38ba8"; base09 = "fab387"; base0A = "f9e2af"; base0B = "a6e3a1";
+    base0C = "94e2d5"; base0D = "89b4fa"; base0E = "cba6f7"; base0F = "f2cdcd";
+  };
+  color0 = "rgb(${palette.base00})";
+  color5 = "rgb(${palette.base05})";
+  color14 = "rgb(${palette.base0E})";
 in
 {
   programs.hyprlock = {
@@ -16,92 +22,81 @@ in
     package = pkgs.hyprlock;
     settings = {
       general = {
-        grace = 1;
+        disable_loading = true;
+        hide_cursor = false;
+        grace = 0;
+        no_fade_in = false;
       };
-      background = {
-        path = lib.mkForce "${wallpapers}/${wallpaper}";
-        blur_size = 5;
-        blur_passes = 1;
-        noise = 0.0117;
-        contrast = 1.3;
-        brightness = 0.8;
-        vibrancy = 0.21;
-        vibrancy_darkness = 0.0;
-      };
-      "input-field" = {
-        size = "250, 50";
-        outline_thickness = 3;
-        dots_size = 0.33;
-        dots_spacing = 0.15;
-        dots_center = true;
-        outer_color = lib.mkForce color5;
-        inner_color = lib.mkForce color0;
-        font_color = lib.mkForce color14;
-        fade_on_empty = true;
-        placeholder_text = "<i>Password...</i>";
-        hide_input = false;
-        position = "0, 40";
-        halign = "center";
-        valign = "bottom";
-      };
-      "label" = lib.mkForce [
+
+      background = lib.mkForce [
         {
-          text = "cmd[update:18000000] echo \"<b> $(date +'%A, %-d %B %Y') </b>\"";
-          color = color14;
-          font_size = 34;
+          path = "screenshot";
+          blur_passes = 3;
+          blur_size = 8;
+        }
+      ];
+
+      input-field = lib.mkForce [
+        {
+          size = "200, 50";
+          position = "0, -80";
+          monitor = "";
+          dots_center = true;
+          fade_on_empty = false;
+          font_color = if stylixEnabled then lib.mkForce color14 else color5;
+          inner_color = if stylixEnabled then lib.mkForce color0 else color0;
+          outer_color = if stylixEnabled then lib.mkForce color5 else color5;
+          outline_thickness = 5;
+          placeholder_text = "Password...";
+          shadow_passes = 2;
+        }
+      ];
+
+      label = lib.mkForce [
+        {
+          monitor = "";
+          text = "$TIME";
+          color = if stylixEnabled then lib.mkForce color14 else color14;
+          font_size = 120;
           font_family = "JetBrains Mono Nerd Font Mono ExtraBold";
-          position = "0, -100";
+          position = "0, 80";
           halign = "center";
-          valign = "top";
+          valign = "center";
         }
         {
-          text = "cmd[update:1000] echo -e \"$(date +'%I')\""; #AM/PM
-          color = "rgba(255, 185, 0, .6)";
-          font_size = 200;
-          font_family = "JetBrains Mono Nerd Font Mono ExtraBold";
-          position = "0, -200";
+          monitor = "";
+          text = "Hi there, $USER";
+          color = if stylixEnabled then lib.mkForce color14 else color14;
+          font_size = 25;
+          font_family = "JetBrains Mono Nerd Font Mono";
+          position = "0, -40";
           halign = "center";
-          valign = "top";
+          valign = "center";
         }
         {
-          text = "cmd[update:1000] echo -e \"$(date +'%M')\"";
-          color = "rgba(255, 255, 255, .6)";
-          font_size = 200;
+          monitor = "";
+          text = "cmd[update:1000] echo \"$(date +'%A, %d %B')\"";
+          color = if stylixEnabled then lib.mkForce color14 else color14;
+          font_size = 24;
           font_family = "JetBrains Mono Nerd Font Mono ExtraBold";
-          position = "0, -500";
+          position = "0, 10";
           halign = "center";
-          valign = "top";
+          valign = "center";
         }
         {
-          text = "cmd[update:1000] echo -e \"$(date +'%S %p')\""; #AM/PM
-          color = color14;
-          font_size = 40;
-          font_family = "JetBrains Mono Nerd Font Mono ExtraBold";
-          position = "0, -500";
-          halign = "center";
-          valign = "top";
-        }
-        {
-          text = "   $USER";
-          color = color14;
+          monitor = "";
+          text = " $USER";
+          color = if stylixEnabled then lib.mkForce color14 else color14;
           font_size = 18;
-          font_family = "Inter Display Medium";
+          font_family = "JetBrains Mono Nerd Font Mono";
           position = "0, 100";
           halign = "center";
           valign = "bottom";
         }
         {
-          text = "cmd[update:60000] echo \"<b> $(uptime -p || $Scripts/UptimeNixOS.sh) </b>\"";
-          color = color14;
-          font_size = 24;
-          font_family = "JetBrains Mono Nerd Font Mono ExtraBold";
-          position = "0, 0";
-          halign = "right";
-          valign = "bottom";
-        }
-        {
-          text = "cmd[update:3600000] [ -f ~/.cache/.weather_cache ] && cat  ~/.cache/.weather_cache";
-          color = color14;
+          monitor = "";
+          text = "󰌾 Lock Screen";
+          color = if stylixEnabled then lib.mkForce color14 else color14;
           font_size = 24;
           font_family = "JetBrains Mono Nerd Font Mono ExtraBold";
           position = "50, 0";

--- a/modules/desktop/Hypr-Noctalia/main/sddm.nix
+++ b/modules/desktop/Hypr-Noctalia/main/sddm.nix
@@ -1,85 +1,45 @@
-{ pkgs, config, ... }:
+{ pkgs, config, lib, ... }:
 
-
+let
+  stylixEnabled = config ? stylix && config.stylix.enable;
+in
 {
-
   services.displayManager.sddm = {
     enable = true;
     wayland.enable = true;
     theme = "sddm-astronaut-theme";
     package = pkgs.kdePackages.sddm;
     extraPackages = with pkgs; [
+      # kdePackages.qt6-declarative
+      kdePackages.qtsvg
       kdePackages.qtsvg
       kdePackages.qtmultimedia
       kdePackages.qtvirtualkeyboard
     ];
-    settings.Theme = {
+    settings.Theme = lib.mkIf stylixEnabled {
       CursorTheme = config.stylix.cursor.name;
       CursorSize = config.stylix.cursor.size;
     };
   };
 
   environment.systemPackages = [
-    (
+    (if stylixEnabled then
+      let
+        colors = config.lib.stylix.colors.withHashtag;
+      in
       pkgs.sddm-astronaut.override {
-        themeConfig = with config.lib.stylix.colors.withHashtag; {
-          Font = "JetBrainsMono";
-          FontSize = "12";
+        themeConfig = {
           Background = "${config.stylix.image}";
-          CropBackground = "false";
-          BackgroundHorizontalAlignment = "center";
-          BackgroundVerticalAlignment = "center";
-          DimBackground = "0.0";
-          HeaderTextColor = "${base07}";
-          DateTextColor = "${base07}";
-          TimeTextColor = "${base07}";
-
-          FormBackgroundColor = "${base00}";
-          BackgroundColor = "${base00}";
-          DimBackgroundColor = "${base00}";
-
-          LoginFieldBackgroundColor = "#${base00}";
-          PasswordFieldBackgroundColor = "${base00}";
-          LoginFieldTextColo = "${base0D}";
-          PasswordFieldTestColor = "${base0D}";
-          UserIconColor = "${base0D}";
-          PasswordIconColor = "${base0D}";
-
-          PlaceholderTextColor = "${base02}";
-          WarningColor = "${base0A}";
-
-          LoginButtonTextColor = "${base0D}";
-          LoginButtonBackgroundColor = "${base00}";
-          SystemButtonsIconsColor = "${base0D}";
-          SessionButtonTextColor = "${base0D}";
-          VirtualKeyboardButtonTextColor = "${base0D}";
-
-          DropdownTextColor = "${base0D}";
-          DropdownSelectedBackgroundColor = "${base00}";
-          DropdownBackgroundColor = "${base00}";
-
-          HighlightTextColor = "${base0D}";
-          HighlightBackgroundColor = "${base0D}";
-          HighlightBorderColor = "${base0D}";
-
-          HoverUserIconColor = "${base0A}";
-          HoverPasswordIconColor = "${base0A}";
-          HoverSystemButtonsIconsColor = "${base0A}";
-          HoverSessionButtonTextColor = "${base0A}";
-          HoverVirtualKeyboardButtonTextColor = "${base0A}";
-
+          CursorColor = colors.base05;
+          FullBlur = "true";
           PartialBlur = "true";
-          BlurMax = "35";
-          Blur = "2.0";
-
-          HourFormat = "h:mm AP";
-
+          HeaderTextColor = colors.base05;
           HaveFormBackground = "false";
-          FormPosition = "right";
-
+          FormPosition = "left";
         };
       }
-    )
+    else
+      pkgs.sddm-astronaut)
   ];
 
   security.pam.services.sddm.enableGnomeKeyring = true;

--- a/modules/desktop/Hypr-dankMaterialShell/home/core/hyprland.nix
+++ b/modules/desktop/Hypr-dankMaterialShell/home/core/hyprland.nix
@@ -7,6 +7,13 @@
 let
   inherit (import ../misc/variables.nix) browser terminal extraMonitorSettings;
   modifier = "SUPER";
+  stylixEnabled = config ? stylix && config.stylix.enable;
+  palette = if stylixEnabled then config.stylix.base16Scheme else {
+    base00 = "000000"; base01 = "1e1e2e"; base02 = "313244"; base03 = "45475a";
+    base04 = "585b70"; base05 = "cdd6f4"; base06 = "f5e0dc"; base07 = "b4befe";
+    base08 = "f38ba8"; base09 = "fab387"; base0A = "f9e2af"; base0B = "a6e3a1";
+    base0C = "94e2d5"; base0D = "89b4fa"; base0E = "cba6f7"; base0F = "f2cdcd";
+  };
 in
 with lib;
 {
@@ -80,8 +87,8 @@ with lib;
         extend_border_grab_area = 15;
         hover_icon_on_border = true;
         allow_tearing = false;
-        "col.active_border" = "rgb(${config.stylix.base16Scheme.base0D}) rgb(${config.stylix.base16Scheme.base0B}) 45deg";
-        "col.inactive_border" = "rgb(${config.stylix.base16Scheme.base00})";
+        "col.active_border" = lib.mkIf stylixEnabled "rgb(${palette.base0D}) rgb(${palette.base0B}) 45deg";
+        "col.inactive_border" = lib.mkIf stylixEnabled "rgb(${palette.base00})";
       };
 
       render = {

--- a/modules/desktop/Hypr-dankMaterialShell/home/core/hyprlock.nix
+++ b/modules/desktop/Hypr-dankMaterialShell/home/core/hyprlock.nix
@@ -1,14 +1,20 @@
 { config
 , lib
-, wallpaper
-, wallpapers
 , pkgs
 , ...
 }:
+
 let
-  color0 = "rgb(${config.stylix.base16Scheme.base00})";
-  color5 = "rgb(${config.stylix.base16Scheme.base05})";
-  color14 = "rgb(${config.stylix.base16Scheme.base0E})";
+  stylixEnabled = config ? stylix && config.stylix.enable;
+  palette = if stylixEnabled then config.stylix.base16Scheme else {
+    base00 = "000000"; base01 = "1e1e2e"; base02 = "313244"; base03 = "45475a";
+    base04 = "585b70"; base05 = "cdd6f4"; base06 = "f5e0dc"; base07 = "b4befe";
+    base08 = "f38ba8"; base09 = "fab387"; base0A = "f9e2af"; base0B = "a6e3a1";
+    base0C = "94e2d5"; base0D = "89b4fa"; base0E = "cba6f7"; base0F = "f2cdcd";
+  };
+  color0 = "rgb(${palette.base00})";
+  color5 = "rgb(${palette.base05})";
+  color14 = "rgb(${palette.base0E})";
 in
 {
   programs.hyprlock = {
@@ -16,92 +22,81 @@ in
     package = pkgs.hyprlock;
     settings = {
       general = {
-        grace = 1;
+        disable_loading = true;
+        hide_cursor = false;
+        grace = 0;
+        no_fade_in = false;
       };
-      background = {
-        path = lib.mkForce "${wallpapers}/${wallpaper}";
-        blur_size = 5;
-        blur_passes = 1;
-        noise = 0.0117;
-        contrast = 1.3;
-        brightness = 0.8;
-        vibrancy = 0.21;
-        vibrancy_darkness = 0.0;
-      };
-      "input-field" = {
-        size = "250, 50";
-        outline_thickness = 3;
-        dots_size = 0.33;
-        dots_spacing = 0.15;
-        dots_center = true;
-        outer_color = lib.mkForce color5;
-        inner_color = lib.mkForce color0;
-        font_color = lib.mkForce color14;
-        fade_on_empty = true;
-        placeholder_text = "<i>Password...</i>";
-        hide_input = false;
-        position = "0, 40";
-        halign = "center";
-        valign = "bottom";
-      };
-      "label" = lib.mkForce [
+
+      background = lib.mkForce [
         {
-          text = "cmd[update:18000000] echo \"<b> $(date +'%A, %-d %B %Y') </b>\"";
-          color = color14;
-          font_size = 34;
+          path = "screenshot";
+          blur_passes = 3;
+          blur_size = 8;
+        }
+      ];
+
+      input-field = lib.mkForce [
+        {
+          size = "200, 50";
+          position = "0, -80";
+          monitor = "";
+          dots_center = true;
+          fade_on_empty = false;
+          font_color = if stylixEnabled then lib.mkForce color14 else color5;
+          inner_color = if stylixEnabled then lib.mkForce color0 else color0;
+          outer_color = if stylixEnabled then lib.mkForce color5 else color5;
+          outline_thickness = 5;
+          placeholder_text = "Password...";
+          shadow_passes = 2;
+        }
+      ];
+
+      label = lib.mkForce [
+        {
+          monitor = "";
+          text = "$TIME";
+          color = if stylixEnabled then lib.mkForce color14 else color14;
+          font_size = 120;
           font_family = "JetBrains Mono Nerd Font Mono ExtraBold";
-          position = "0, -100";
+          position = "0, 80";
           halign = "center";
-          valign = "top";
+          valign = "center";
         }
         {
-          text = "cmd[update:1000] echo -e \"$(date +'%I')\""; #AM/PM
-          color = "rgba(255, 185, 0, .6)";
-          font_size = 200;
-          font_family = "JetBrains Mono Nerd Font Mono ExtraBold";
-          position = "0, -200";
+          monitor = "";
+          text = "Hi there, $USER";
+          color = if stylixEnabled then lib.mkForce color14 else color14;
+          font_size = 25;
+          font_family = "JetBrains Mono Nerd Font Mono";
+          position = "0, -40";
           halign = "center";
-          valign = "top";
+          valign = "center";
         }
         {
-          text = "cmd[update:1000] echo -e \"$(date +'%M')\"";
-          color = "rgba(255, 255, 255, .6)";
-          font_size = 200;
+          monitor = "";
+          text = "cmd[update:1000] echo \"$(date +'%A, %d %B')\"";
+          color = if stylixEnabled then lib.mkForce color14 else color14;
+          font_size = 24;
           font_family = "JetBrains Mono Nerd Font Mono ExtraBold";
-          position = "0, -500";
+          position = "0, 10";
           halign = "center";
-          valign = "top";
+          valign = "center";
         }
         {
-          text = "cmd[update:1000] echo -e \"$(date +'%S %p')\""; #AM/PM
-          color = color14;
-          font_size = 40;
-          font_family = "JetBrains Mono Nerd Font Mono ExtraBold";
-          position = "0, -500";
-          halign = "center";
-          valign = "top";
-        }
-        {
-          text = "   $USER";
-          color = color14;
+          monitor = "";
+          text = " $USER";
+          color = if stylixEnabled then lib.mkForce color14 else color14;
           font_size = 18;
-          font_family = "Inter Display Medium";
+          font_family = "JetBrains Mono Nerd Font Mono";
           position = "0, 100";
           halign = "center";
           valign = "bottom";
         }
         {
-          text = "cmd[update:60000] echo \"<b> $(uptime -p || $Scripts/UptimeNixOS.sh) </b>\"";
-          color = color14;
-          font_size = 24;
-          font_family = "JetBrains Mono Nerd Font Mono ExtraBold";
-          position = "0, 0";
-          halign = "right";
-          valign = "bottom";
-        }
-        {
-          text = "cmd[update:3600000] [ -f ~/.cache/.weather_cache ] && cat  ~/.cache/.weather_cache";
-          color = color14;
+          monitor = "";
+          text = "󰌾 Lock Screen";
+          color = if stylixEnabled then lib.mkForce color14 else color14;
           font_size = 24;
           font_family = "JetBrains Mono Nerd Font Mono ExtraBold";
           position = "50, 0";

--- a/modules/desktop/Hyprland/home/core/hyprland.nix
+++ b/modules/desktop/Hyprland/home/core/hyprland.nix
@@ -2,344 +2,336 @@
 
 let
   inherit (import ../misc/variables.nix) browser terminal extraMonitorSettings;
+  stylixEnabled = config ? stylix && config.stylix.enable;
+  palette = if stylixEnabled then config.stylix.base16Scheme else {
+    base00 = "000000"; base01 = "1e1e2e"; base02 = "313244"; base03 = "45475a";
+    base04 = "585b70"; base05 = "cdd6f4"; base06 = "f5e0dc"; base07 = "b4befe";
+    base08 = "f38ba8"; base09 = "fab387"; base0A = "f9e2af"; base0B = "a6e3a1";
+    base0C = "94e2d5"; base0D = "89b4fa"; base0E = "cba6f7"; base0F = "f2cdcd";
+  };
 in
 with lib; {
   systemd.user.targets.hyprland-session.Unit.Wants = [ "xdg-desktop-autostart.target" ];
 
   wayland.windowManager.hyprland = {
     enable = true;
-    configType = "hyprlang";
     package = pkgs.hyprland;
+    configType = "hyprlang";
     portalPackage = pkgs.xdg-desktop-portal-hyprland;
     systemd = {
       enable = true;
       enableXdgAutostart = true;
       variables = [ "--all" ];
     };
-    # settings = {
-    #   xwayland.enable = true;
-    # };
-
-    extraConfig =
-      let
-        modifier = "SUPER";
-      in
-      concatStrings [
-        ''
-
-      # ── Environment Variables ─────────────────────────────────────────────
-      env = NIXOS_OZONE_WL, 1
-      env = NIXPKGS_ALLOW_UNFREE, 1
-      env = XDG_CURRENT_DESKTOP, Hyprland
-      env = XDG_SESSION_TYPE, wayland
-      env = XDG_SESSION_DESKTOP, Hyprland
-      env = GDK_BACKEND, wayland,x11
-      env = CLUTTER_BACKEND, wayland
-      env = QT_QPA_PLATFORM,wayland;xcb
-      env = QT_WAYLAND_DISABLE_WINDOWDECORATION, 1
-      env = QT_AUTO_SCREEN_SCALE_FACTOR, 1
-      env = SDL_VIDEODRIVER, wayland
-      env = MOZ_ENABLE_WAYLAND, 1
-      env = WLR_RENDERER,vulkan
-
+    settings = {
+      # xwayland.enable = true;
+      env = [
+        "NIXOS_OZONE_WL, 1"
+        "NIXPKGS_ALLOW_UNFREE, 1"
+        "XDG_CURRENT_DESKTOP, Hyprland"
+        "XDG_SESSION_TYPE, wayland"
+        "XDG_SESSION_DESKTOP, Hyprland"
+        "GDK_BACKEND, wayland, x11"
+        "CLUTTER_BACKEND, wayland"
+        "QT_QPA_PLATFORM=wayland;xcb"
+        "QT_WAYLAND_DISABLE_WINDOWDECORATION, 1"
+        "QT_AUTO_SCREEN_SCALE_FACTOR, 1"
+        "SDL_VIDEODRIVER, x11"
+        "MOZ_ENABLE_WAYLAND, 1"
+        # This is to make electron apps start in wayland
+        "ELECTRON_OZONE_PLATFORM_HINT,wayland"
+        # Disabling this by default as it can result in inop cfg
+        # Added card2 in case this gets enabled. For better coverage
+        # This is mostly needed by Hybrid laptops.
+        # but if you have multiple discrete GPUs this will set order
+        #"AQ_DRM_DEVICES,/dev/dri/card0:/dev/dri/card1:/dev/card2"
+        "GDK_SCALE,1"
+        "QT_SCALE_FACTOR,1"
+        "EDITOR,nvim"
+        # Set terminal and xdg_terminal_emulator to kitty
+        # To provent yazi from starting xterm when run from rofi menu
+        # You can set to your preferred terminal if you you like
+        # ToDo: Pull default terminal from config
+        "TERMINAL,kitty"
+        "XDG_TERMINAL_EMULATOR,kitty"
+      ];
       # ── Startup Programs ──────────────────────────────────────────────────
-      exec-once = dbus-update-activation-environment --all --systemd WAYLAND_DISPLAY XDG_CURRENT_DESKTOP
-      exec-once = systemctl --user import-environment QT_QPA_PLATFORMTHEME WAYLAND_DISPLAY XDG_CURRENT_DESKTOP
-      exec-once = swaync # Start notification daemon
-      exec-once = nm-applet --indicator
-      exec-once = systemctl --user start hyprpolkitagent
-      exec-once = kdeconnect-indicator # Start kdeconnect indicator earlier
-      exec-once = wl-paste --type text --watch cliphist store
-      exec-once = wl-paste --type image --watch cliphist store
-      exec-once = killall -q waybar;sleep .5 && waybar
+      "exec-once" = [
+        "dbus-update-activation-environment --all --systemd WAYLAND_DISPLAY XDG_CURRENT_DESKTOP"
+        "systemctl --user import-environment QT_QPA_PLATFORMTHEME WAYLAND_DISPLAY XDG_CURRENT_DESKTOP"
+        "swaync # Start notification daemon"
+        "systemctl --user start hyprpolkitagent"
+        "kdeconnect-indicator # Start kdeconnect indicator earlier"
+        "wl-paste --type text --watch cliphist store"
+        "wl-paste --type image --watch cliphist store"
+        # "sleep 5 &&"
+        "zen"
+        "obsidian"
+        "brave"
+        "discord"
+        "telegram-desktop"
+      ];
 
       # ── Monitor Setup ─────────────────────────────────────────────────────
-      monitor = eDP-1,1920x1080@60,0x0,1
-      ${extraMonitorSettings}
+      monitor =
+        [ "eDP-1,1920x1080@60,0x0,1" ]
+        ++ (lib.filter (s: s != "") (lib.splitString "\n" extraMonitorSettings));
 
       # ── General Settings ──────────────────────────────────────────────────
-      general {
-        gaps_in           = 4
-        gaps_out          = 4
-        border_size       = 2
-        layout            = dwindle
-        resize_on_border  = true
-        extend_border_grab_area = 15
-        hover_icon_on_border = true
-        allow_tearing     = false
-        col.active_border   = rgb(${config.stylix.base16Scheme.base0D}) rgb(${config.stylix.base16Scheme.base0B}) 45deg
-        col.inactive_border = rgb(${config.stylix.base16Scheme.base00})
-      }
+      general = {
+        gaps_in = 2;
+        gaps_out = 4;
+        border_size = 2;
+        layout = "dwindle";
+        resize_on_border = true;
+        extend_border_grab_area = 15;
+        hover_icon_on_border = true;
+        allow_tearing = false;
+        "col.active_border" = lib.mkIf stylixEnabled "rgb(${palette.base0D}) rgb(${palette.base0B}) 45deg";
+        "col.inactive_border" = lib.mkIf stylixEnabled "rgb(${palette.base00})";
+      };
 
       # ── Input Settings ─────────────────────────────────────────────────────
-      input {
-        kb_layout  = us
-        kb_options = grp:alt_shift_toggle,caps:super
-        follow_mouse = 1
-        mouse_refocus = false
-        sensitivity = 0
-        accel_profile = flat
-        force_no_accel = true
+      input = {
+        kb_layout = "us";
+        kb_options = "grp:alt_shift_toggle,caps:super";
+        follow_mouse = 1;
+        mouse_refocus = false;
+        sensitivity = 0;
+        accel_profile = "flat";
+        force_no_accel = true;
 
-        touchpad {
-          natural_scroll = true
-          disable_while_typing = true
-          tap-to-click = true
-          tap-and-drag = true
-          drag_lock = false
-          scroll_factor = 1.0
-        }
-      }
+        touchpad = {
+          natural_scroll = true;
+          disable_while_typing = true;
+          "tap-to-click" = true;
+          "tap-and-drag" = true;
+          drag_lock = false;
+          scroll_factor = 1.0;
+        };
+      };
 
-      gestures {
-        # workspace_swipe = true
-        # workspace_swipe_fingers = 3
-        workspace_swipe_distance = 300
-        workspace_swipe_cancel_ratio = 0.5
-        workspace_swipe_min_speed_to_force = 30
-        workspace_swipe_create_new = true
-      }
+      gestures = {
+        workspace_swipe_distance = 300;
+        workspace_swipe_cancel_ratio = 0.5;
+        workspace_swipe_min_speed_to_force = 30;
+        workspace_swipe_create_new = true;
+      };
 
       "gesture" = "3, horizontal, workspace";
 
-      misc {
-        initial_workspace_tracking = 0
-        mouse_move_enables_dpms    = true
-        key_press_enables_dpms     = true
-        always_follow_on_dnd       = true
-        layers_hog_keyboard_focus  = true
-        animate_manual_resizes     = false
-        animate_mouse_windowdragging = false
-        disable_hyprland_logo      = false
-        disable_splash_rendering   = false
-        force_default_wallpaper    = 0
-        vfr = false
-        vrr = 0
+      misc = {
+        initial_workspace_tracking = 0;
+        mouse_move_enables_dpms = true;
+        key_press_enables_dpms = true;
+        always_follow_on_dnd = true;
+        layers_hog_keyboard_focus = true;
+        animate_manual_resizes = false;
+        animate_mouse_windowdragging = false;
+        disable_hyprland_logo = false;
+        disable_splash_rendering = false;
+        force_default_wallpaper = 0;
+        vfr = false;
+        vrr = 0;
         # render_ahead_of_time = false
         # render_ahead_safezone = 1
-        enable_swallow = true
-        swallow_regex = ^(kitty|alacritty|foot|ghostty)$
-        swallow_exception_regex = ^(wev)$
-      }
+        enable_swallow = true;
+        swallow_regex = "^(kitty|alacritty|foot|ghostty)$";
+        swallow_exception_regex = "^(wev)$";
+      };
 
       # ── Snappier Animations ───────────────────────────────────────────────
-      animations {
-        enabled = yes
+      animations = {
+        enabled = "yes";
 
-        bezier = snap, 0.1, 0, 0.2, 1
-        bezier = linear, 0, 0, 1, 1
-        bezier = md3_standard, 0.2, 0, 0, 1
-        bezier = md3_decel, 0.05, 0.7, 0.1, 1
-        bezier = md3_accel, 0.3, 0, 0.8, 0.15
-        bezier = overshot, 0.05, 0.9, 0.1, 1.1
-        bezier = crazyshot, 0.1, 1.5, 0.76, 0.92
-        bezier = hyprnostretch, 0.05, 0.9, 0.1, 1.0
-        bezier = fluent_decel, 0.1, 1, 0, 1
-        bezier = easeInOutCirc, 0.85, 0, 0.15, 1
-        bezier = easeOutCirc, 0, 0.55, 0.45, 1
-        bezier = easeOutExpo, 0.16, 1, 0.3, 1
+        bezier = [
+          "snap, 0.1, 0, 0.2, 1"
+          "linear, 0, 0, 1, 1"
+          "md3_standard, 0.2, 0, 0, 1"
+          "md3_decel, 0.05, 0.7, 0.1, 1"
+          "md3_accel, 0.3, 0, 0.8, 0.15"
+          "overshot, 0.05, 0.9, 0.1, 1.1"
+          "crazyshot, 0.1, 1.5, 0.76, 0.92"
+          "hyprnostretch, 0.05, 0.9, 0.1, 1.0"
+          "fluent_decel, 0.1, 1, 0, 1"
+          "easeInOutCirc, 0.85, 0, 0.15, 1"
+          "easeOutCirc, 0, 0.55, 0.45, 1"
+          "easeOutExpo, 0.16, 1, 0.3, 1"
+        ];
 
-        # Snappy window animations
-        animation = windows, 1, 3, md3_decel, slide
-        animation = windowsIn, 1, 3, md3_decel, slide
-        animation = windowsOut, 1, 3, md3_accel, slide
-        animation = windowsMove, 1, 2, linear, slide
-
-        animation = fade, 1, 2, md3_decel
-        animation = fadeIn, 1, 2, md3_decel
-        animation = fadeOut, 1, 2, md3_accel
-        animation = fadeSwitch, 0, 1, linear
-        animation = fadeShadow, 1, 2, md3_decel
-        animation = fadeDim, 1, 2, fluent_decel
-
-        animation = border, 1, 2.7, md3_decel
-        animation = borderangle, 1, 2.7, fluent_decel, once
-
-        animation = workspaces, 1, 2, md3_decel, slide
-        animation = specialWorkspace, 1, 2, md3_decel, slidevert
-
-        animation = layers, 1, 2, md3_decel, slide
-        animation = layersIn, 1, 2, md3_decel, slide
-        animation = layersOut, 1, 2, md3_accel, slide
-      }
+        animation = [
+          "windowsIn, 1, 3, default"
+          "windowsOut, 1, 3, default"
+          "workspaces, 1, 5, default"
+          "windowsMove, 1, 4, default"
+          "fade, 1, 3, default"
+          "border, 1, 3, default"
+        ];
+      };
 
       # ── Decoration ─────────────────────────────────────────────────────────
-      decoration {
-        rounding = 6
+      decoration = {
+        rounding = 4;
 
-        # active_opacity = 1.0
-        # inactive_opacity = 0.95
-        # fullscreen_opacity = 1.0
-
-        dim_inactive = false
-        dim_strength = 0.1
-        dim_special = 0.8
-
-        # blur {
-        #   enabled = true
-        #   size = 6
-        #   passes = 3
-        #   ignore_opacity = true
-        #   new_optimizations = true
-        #   xray = false
-        #   noise = 0.0117
-        #   contrast = 1.5000
-        #   brightness = 1.0
-        #   vibrancy = 0.2
-        #   vibrancy_darkness = 0.5
-        #   special = false
-        # }
-      }
+        dim_inactive = false;
+        dim_strength = 0.1;
+        dim_special = 0.8;
+      };
 
       # ── Layout Settings ────────────────────────────────────────────────────
-      dwindle {
-        pseudotile = true
-        preserve_split = true
-        smart_split = false
-        smart_resizing = true
-        permanent_direction_override = false
-        special_scale_factor = 1.0
-        split_width_multiplier = 1.0
+      dwindle = {
+        pseudotile = true;
+        preserve_split = true;
+        smart_split = false;
+        smart_resizing = true;
+        permanent_direction_override = false;
+        special_scale_factor = 1.0;
+        split_width_multiplier = 1.0;
         # no_gaps_when_only = 0
-        use_active_for_splits = true
-        default_split_ratio = 1.0
-      }
+        use_active_for_splits = true;
+        default_split_ratio = 1.0;
+      };
 
-      master {
-        allow_small_split = false
-        special_scale_factor = 1.0
-        mfact = 0.55
-        # new_is_master = true
-        # new_on_top = false
-        # no_gaps_when_only = 0
-        orientation = left
-        # inherit_fullscreen = true
-        # always_center_master = false
-        smart_resizing = true
-        drop_at_cursor = true
-      }
+      master = {
+        allow_small_split = false;
+        special_scale_factor = 1.0;
+        mfact = 0.55;
+        orientation = "left";
+        smart_resizing = true;
+        drop_at_cursor = true;
+      };
 
       # ── Keybindings ────────────────────────────────────────────────────────
-      # Application launchers
-      bind = ${modifier},Return,exec,${terminal}
-      bind = ALT,SPACE,exec,rofi -show drun
-      bind = ${modifier},R,exec,rofi -show run
-      bind = ${modifier},V,exec,cliphist list | rofi -dmenu | cliphist decode | wl-copy
-      bind = ${modifier}CTRL,W,exec,waypaper
-      bind = ${modifier},W,exec,${browser}
-      bind = ${modifier}SHIFT,L,exec,wlogout
-      bind = ${modifier},E,exec,emopicker9000
-      bind = ${modifier},S,exec,screenshootin
-      bind = ${modifier}SHIFT,S,exec,grim -g "$(slurp)" - | swappy -f -
-      bind = ${modifier},D,exec,discord
-      bind = ${modifier},C,exec,hyprpicker -a
-      bind = ${modifier},T,exec,thunar
-      bind = ${modifier},M,exec,spotify
-      bind = ${modifier},N,exec,swaync-client -t -sw
+      bind = [
+        # Application launchers
+        "SUPER,Return,exec,${terminal}"
+        "ALT,SPACE,global,caelestia:launcher"
+        # "SUPER,R,exec,rofi -show run"
+        "SUPER,V,exec,caelestia clipboard"
+        "SUPERALT,W,exec,wallSelector"
+        "SUPER,W,exec,${browser}"
+        "CTRL,L,global,caelestia:lock"
+        # "SUPER,A,global,caelestia:session"
+        "SUPER,E,exec,caelestia emoji -p"
+        "SUPER,S,global,caelestia:screenshot"
+        "SUPERSHIFT,S,exec,grim -g \"$(slurp)\" - | swappy -f -"
+        "SUPER,D,exec,discord"
+        "SUPER,C,exec,hyprpicker -a"
+        "SUPER,T,exec,thunar"
+        "SUPER,M,exec,spotify"
+        "SUPER,N,exec,swaync-client -t -sw"
 
-      # Window management
-      bind = ${modifier},Q,killactive,
-      bind = ${modifier},P,pseudo,
-      bind = ${modifier}SHIFT,I,togglesplit,
-      bind = ${modifier},F,fullscreen,
-      bind = ${modifier}SHIFT,F,togglefloating,
-      bind = ${modifier}SHIFT,C,exit,
-      bind = ${modifier}SHIFT,P,pin,
-      # bind = ${modifier}SHIFT,O,toggleopaque,
+        # Window management
+        "SUPER,Q,killactive,"
+        "SUPER,P,pseudo,"
+        "SUPERSHIFT,I,togglesplit,"
+        "SUPER,F,fullscreen,"
+        "SUPERSHIFT,F,togglefloating,"
+        "SUPERSHIFT,C,exit,"
+        "SUPERSHIFT,P,pin,"
+        # "SUPERSHIFT,O,toggleopaque,"
 
-      # wall control integration
-      bind = ${modifier}SHIFT,W,exec,skwd wall toggle
+        # Better control integration
+        "SUPERSHIFT,W,exec,better-control -w"
 
-      # ── Enhanced Window Movement ───────────────────────────────────────────
-      bind = ${modifier}SHIFT,left, movewindow,l
-      bind = ${modifier}SHIFT,right,movewindow,r
-      bind = ${modifier}SHIFT,up,   movewindow,u
-      bind = ${modifier}SHIFT,down, movewindow,d
-      bind = ${modifier}SHIFT,h,    movewindow,l
-      bind = ${modifier}SHIFT,l,    movewindow,r
-      bind = ${modifier}SHIFT,k,    movewindow,u
-      bind = ${modifier}SHIFT,j,    movewindow,d
+        # ── Enhanced Window Movement ───────────────────────────────────────────
+        "SUPERSHIFT,left, movewindow,l"
+        "SUPERSHIFT,right,movewindow,r"
+        "SUPERSHIFT,up,   movewindow,u"
+        "SUPERSHIFT,down, movewindow,d"
+        "SUPERSHIFT,h,    movewindow,l"
+        "SUPERSHIFT,l,    movewindow,r"
+        "SUPERSHIFT,k,    movewindow,u"
+        "SUPERSHIFT,j,    movewindow,d"
 
-      # Resize windows
-      bind = ${modifier}CONTROL,left, resizeactive,-50 0
-      bind = ${modifier}CONTROL,right,resizeactive,50 0
-      bind = ${modifier}CONTROL,up,   resizeactive,0 -50
-      bind = ${modifier}CONTROL,down, resizeactive,0 50
-      bind = ${modifier}CONTROL,h,    resizeactive,-50 0
-      bind = ${modifier}CONTROL,l,    resizeactive,50 0
-      bind = ${modifier}CONTROL,k,    resizeactive,0 -50
-      bind = ${modifier}CONTROL,j,    resizeactive,0 50
+        # Resize windows
+        "SUPERCONTROL,left, resizeactive,-50 0"
+        "SUPERCONTROL,right,resizeactive,50 0"
+        "SUPERCONTROL,up,   resizeactive,0 -50"
+        "SUPERCONTROL,down, resizeactive,0 50"
+        "SUPERCONTROL,h,    resizeactive,-50 0"
+        "SUPERCONTROL,l,    resizeactive,50 0"
+        "SUPERCONTROL,k,    resizeactive,0 -50"
+        "SUPERCONTROL,j,    resizeactive,0 50"
 
-      # ── Focus Movement ─────────────────────────────────────────────────────
-      bind = ${modifier},left, movefocus,l
-      bind = ${modifier},right,movefocus,r
-      bind = ${modifier},up,   movefocus,u
-      bind = ${modifier},down, movefocus,d
-      bind = ${modifier},h,    movefocus,l
-      bind = ${modifier},k,    movefocus,u
-      bind = ${modifier},j,    movefocus,d
-      bind = ${modifier},l,    movefocus,r
+        # ── Focus Movement ─────────────────────────────────────────────────────
+        "SUPER,left, movefocus,l"
+        "SUPER,right,movefocus,r"
+        "SUPER,up,   movefocus,u"
+        "SUPER,down, movefocus,d"
+        "SUPER,h,    movefocus,l"
+        "SUPER,k,    movefocus,u"
+        "SUPER,j,    movefocus,d"
+        "SUPER,l,    movefocus,r"
 
-      # ── Workspaces ─────────────────────────────────────────────────────────
-      bind = ${modifier},1,workspace,1
-      bind = ${modifier},2,workspace,2
-      bind = ${modifier},3,workspace,3
-      bind = ${modifier},4,workspace,4
-      bind = ${modifier},5,workspace,5
-      bind = ${modifier},6,workspace,6
-      bind = ${modifier},7,workspace,7
-      bind = ${modifier},8,workspace,8
-      bind = ${modifier},9,workspace,9
-      bind = ${modifier},0,workspace,10
+        # ── Workspaces ─────────────────────────────────────────────────────────
+        "SUPER,1,workspace,1"
+        "SUPER,2,workspace,2"
+        "SUPER,3,workspace,3"
+        "SUPER,4,workspace,4"
+        "SUPER,5,workspace,5"
+        "SUPER,6,workspace,6"
+        "SUPER,7,workspace,7"
+        "SUPER,8,workspace,8"
+        "SUPER,9,workspace,9"
+        "SUPER,0,workspace,10"
 
-      bind = ${modifier}SHIFT,1,movetoworkspace,1
-      bind = ${modifier}SHIFT,2,movetoworkspace,2
-      bind = ${modifier}SHIFT,3,movetoworkspace,3
-      bind = ${modifier}SHIFT,4,movetoworkspace,4
-      bind = ${modifier}SHIFT,5,movetoworkspace,5
-      bind = ${modifier}SHIFT,6,movetoworkspace,6
-      bind = ${modifier}SHIFT,7,movetoworkspace,7
-      bind = ${modifier}SHIFT,8,movetoworkspace,8
-      bind = ${modifier}SHIFT,9,movetoworkspace,9
-      bind = ${modifier}SHIFT,0,movetoworkspace,10
+        "SUPERSHIFT,1,movetoworkspace,1"
+        "SUPERSHIFT,2,movetoworkspace,2"
+        "SUPERSHIFT,3,movetoworkspace,3"
+        "SUPERSHIFT,4,movetoworkspace,4"
+        "SUPERSHIFT,5,movetoworkspace,5"
+        "SUPERSHIFT,6,movetoworkspace,6"
+        "SUPERSHIFT,7,movetoworkspace,7"
+        "SUPERSHIFT,8,movetoworkspace,8"
+        "SUPERSHIFT,9,movetoworkspace,9"
+        "SUPERSHIFT,0,movetoworkspace,10"
 
-      # Special workspace (scratchpad)
-      bind = ${modifier}SHIFT,SPACE,movetoworkspace,special
-      bind = ${modifier},SPACE,togglespecialworkspace
+        # Special workspace (scratchpad)
+        "SUPERSHIFT,SPACE,movetoworkspace,special"
+        "SUPER,SPACE,togglespecialworkspace"
 
-      # Workspace navigation
-      bind = ${modifier}CONTROL,right,workspace,e+1
-      bind = ${modifier}CONTROL,left, workspace,e-1
-      bind = ${modifier},mouse_down,workspace,e+1
-      bind = ${modifier},mouse_up,  workspace,e-1
+        # Workspace navigation
+        "SUPERCONTROL,right,workspace,e+1"
+        "SUPERCONTROL,left, workspace,e-1"
+        "SUPER,mouse_down,workspace,e+1"
+        "SUPER,mouse_up,  workspace,e-1"
 
-      # ── Mouse Bindings ─────────────────────────────────────────────────────
-      bindm = ${modifier},mouse:272,movewindow
-      bindm = ${modifier},mouse:273,resizewindow
-      bind = ${modifier},mouse:274,togglefloating
+        # ── Mouse Bindings ─────────────────────────────────────────────────────
+        "SUPER,mouse:274,togglefloating"
 
-      # ── Grouping ───────────────────────────────────────────────────────────
-      bind = ${modifier},G,togglegroup
-      bind = ALT,Tab,changegroupactive
-      bind = ${modifier}ALT,Tab,cyclenext,prev
+        # ── Grouping ───────────────────────────────────────────────────────────
+        "SUPER,G,togglegroup"
+        "ALT,Tab,changegroupactive"
+        "SUPERALT,Tab,cyclenext,prev"
+
+        # ── Quick Actions ──────────────────────────────────────────────────────
+        "SUPERALT,L,exec,swaylock"
+        "SUPERALT,R,exec,hyprctl reload"
+        "SUPERALT,K,exec,hyprctl kill"
+        "CTRLALT,Delete,exec,wlogout"
+      ];
+
+      bindm = [
+        "SUPER,mouse:272,movewindow"
+        "SUPER,mouse:273,resizewindow"
+      ];
 
       # ── Media Keys ─────────────────────────────────────────────────────────
-      bindel = ,XF86AudioRaiseVolume,exec,wpctl set-volume @DEFAULT_AUDIO_SINK@ 5%+
-      bindel = ,XF86AudioLowerVolume,exec,wpctl set-volume @DEFAULT_AUDIO_SINK@ 5%-
-      bindl  = ,XF86AudioMute,        exec,wpctl set-mute @DEFAULT_AUDIO_SINK@ toggle
-      bindl  = ,XF86AudioPlay,        exec,playerctl play-pause
-      bindl  = ,XF86AudioPause,       exec,playerctl play-pause
-      bindl  = ,XF86AudioNext,        exec,playerctl next
-      bindl  = ,XF86AudioPrev,        exec,playerctl previous
-      bindel = ,XF86MonBrightnessDown,exec,brightnessctl set 5%-
-      bindel = ,XF86MonBrightnessUp,  exec,brightnessctl set +5%
-
-      # ── Quick Actions ──────────────────────────────────────────────────────
-      bind = ${modifier}ALT,L,exec,swaylock
-      bind = ${modifier}ALT,R,exec,hyprctl reload
-      bind = ${modifier}ALT,K,exec,hyprctl kill
-      bind = CTRLALT,Delete,exec,wlogout
-      ''
+      bindel = [
+        ",XF86AudioRaiseVolume,exec,wpctl set-volume @DEFAULT_AUDIO_SINK@ 5%+"
+        ",XF86AudioLowerVolume,exec,wpctl set-volume @DEFAULT_AUDIO_SINK@ 5%-"
+        ",XF86MonBrightnessDown,exec,brightnessctl set 5%-"
+        ",XF86MonBrightnessUp,  exec,brightnessctl set +5%"
       ];
+      bindl = [
+        ",XF86AudioMute,        exec,wpctl set-mute @DEFAULT_AUDIO_SINK@ toggle"
+        ",XF86AudioPlay,        exec,playerctl play-pause"
+        ",XF86AudioPause,       exec,playerctl play-pause"
+        ",XF86AudioNext,        exec,playerctl next"
+        ",XF86AudioPrev,        exec,playerctl previous"
+        ",XF86AudioStop,        exec,playerctl stop"
+      ];
+    };
   };
 }

--- a/modules/desktop/Hyprland/home/core/hyprlock.nix
+++ b/modules/desktop/Hyprland/home/core/hyprlock.nix
@@ -1,105 +1,102 @@
 { config
 , lib
-, wallpaper
-, wallpapers
+, pkgs
 , ...
 }:
+
 let
-  color0 = "rgb(${config.stylix.base16Scheme.base00})";
-  color5 = "rgb(${config.stylix.base16Scheme.base05})";
-  color14 = "rgb(${config.stylix.base16Scheme.base0E})";
+  stylixEnabled = if config ? stylix then config.stylix.enable else false;
+  palette = if stylixEnabled then config.stylix.base16Scheme else {
+    base00 = "000000"; base01 = "1e1e2e"; base02 = "313244"; base03 = "45475a";
+    base04 = "585b70"; base05 = "cdd6f4"; base06 = "f5e0dc"; base07 = "b4befe";
+    base08 = "f38ba8"; base09 = "fab387"; base0A = "f9e2af"; base0B = "a6e3a1";
+    base0C = "94e2d5"; base0D = "89b4fa"; base0E = "cba6f7"; base0F = "f2cdcd";
+  };
+  color0 = "rgb(${palette.base00})";
+  color5 = "rgb(${palette.base05})";
+  color14 = "rgb(${palette.base0E})";
 in
 {
   programs.hyprlock = {
     enable = true;
+    package = pkgs.hyprlock;
     settings = {
       general = {
-        grace = 1;
+        disable_loading = true;
+        hide_cursor = false;
+        grace = 0;
+        no_fade_in = false;
       };
-      background = {
-        path = lib.mkForce "${wallpapers}/${wallpaper}";
-        blur_size = 5;
-        blur_passes = 1;
-        noise = 0.0117;
-        contrast = 1.3;
-        brightness = 0.8;
-        vibrancy = 0.21;
-        vibrancy_darkness = 0.0;
-      };
-      "input-field" = {
-        size = "250, 50";
-        outline_thickness = 3;
-        dots_size = 0.33;
-        dots_spacing = 0.15;
-        dots_center = true;
-        outer_color = lib.mkForce color5;
-        inner_color = lib.mkForce color0;
-        font_color = lib.mkForce color14;
-        fade_on_empty = true;
-        placeholder_text = "<i>Password...</i>";
-        hide_input = false;
-        position = "0, 40";
-        halign = "center";
-        valign = "bottom";
-      };
-      "label" = lib.mkForce [
+
+      background = lib.mkForce [
         {
-          text = "cmd[update:18000000] echo \"<b> $(date +'%A, %-d %B %Y') </b>\"";
-          color = color14;
-          font_size = 34;
+          path = "screenshot";
+          blur_passes = 3;
+          blur_size = 8;
+        }
+      ];
+
+      input-field = lib.mkForce [
+        {
+          size = "200, 50";
+          position = "0, -80";
+          monitor = "";
+          dots_center = true;
+          fade_on_empty = false;
+          font_color = if stylixEnabled then lib.mkForce color14 else color5;
+          inner_color = if stylixEnabled then lib.mkForce color0 else color0;
+          outer_color = if stylixEnabled then lib.mkForce color5 else color5;
+          outline_thickness = 5;
+          placeholder_text = "Password...";
+          shadow_passes = 2;
+        }
+      ];
+
+      label = lib.mkForce [
+        {
+          monitor = "";
+          text = "$TIME";
+          color = if stylixEnabled then lib.mkForce color14 else color14;
+          font_size = 120;
           font_family = "JetBrains Mono Nerd Font Mono ExtraBold";
-          position = "0, -100";
+          position = "0, 80";
           halign = "center";
-          valign = "top";
+          valign = "center";
         }
         {
-          text = "cmd[update:1000] echo -e \"$(date +'%I')\""; #AM/PM
-          color = "rgba(255, 185, 0, .6)";
-          font_size = 200;
-          font_family = "JetBrains Mono Nerd Font Mono ExtraBold";
-          position = "0, -200";
+          monitor = "";
+          text = "Hi there, $USER";
+          color = if stylixEnabled then lib.mkForce color14 else color14;
+          font_size = 25;
+          font_family = "JetBrains Mono Nerd Font Mono";
+          position = "0, -40";
           halign = "center";
-          valign = "top";
+          valign = "center";
         }
         {
-          text = "cmd[update:1000] echo -e \"$(date +'%M')\"";
-          color = "rgba(255, 255, 255, .6)";
-          font_size = 200;
+          monitor = "";
+          text = "cmd[update:1000] echo \"$(date +'%A, %d %B')\"";
+          color = if stylixEnabled then lib.mkForce color14 else color14;
+          font_size = 24;
           font_family = "JetBrains Mono Nerd Font Mono ExtraBold";
-          position = "0, -500";
+          position = "0, 10";
           halign = "center";
-          valign = "top";
+          valign = "center";
         }
         {
-          text = "cmd[update:1000] echo -e \"$(date +'%S %p')\""; #AM/PM
-          color = color14;
-          font_size = 40;
-          font_family = "JetBrains Mono Nerd Font Mono ExtraBold";
-          position = "0, -500";
-          halign = "center";
-          valign = "top";
-        }
-        {
-          text = "   $USER";
-          color = color14;
+          monitor = "";
+          text = " $USER";
+          color = if stylixEnabled then lib.mkForce color14 else color14;
           font_size = 18;
-          font_family = "Inter Display Medium";
+          font_family = "JetBrains Mono Nerd Font Mono";
           position = "0, 100";
           halign = "center";
           valign = "bottom";
         }
         {
-          text = "cmd[update:60000] echo \"<b> $(uptime -p || $Scripts/UptimeNixOS.sh) </b>\"";
-          color = color14;
-          font_size = 24;
-          font_family = "JetBrains Mono Nerd Font Mono ExtraBold";
-          position = "0, 0";
-          halign = "right";
-          valign = "bottom";
-        }
-        {
-          text = "cmd[update:3600000] [ -f ~/.cache/.weather_cache ] && cat  ~/.cache/.weather_cache";
-          color = color14;
+          monitor = "";
+          text = "󰌾 Lock Screen";
+          color = if stylixEnabled then lib.mkForce color14 else color14;
           font_size = 24;
           font_family = "JetBrains Mono Nerd Font Mono ExtraBold";
           position = "50, 0";

--- a/modules/desktop/Hyprland/home/services/swaync.nix
+++ b/modules/desktop/Hyprland/home/services/swaync.nix
@@ -1,4 +1,14 @@
-{ config, ... }: {
+{ config, lib, ... }:
+let
+  stylixEnabled = config ? stylix && config.stylix.enable;
+  palette = if stylixEnabled then config.stylix.base16Scheme else {
+    base00 = "000000"; base01 = "000000"; base02 = "000000"; base03 = "000000";
+    base04 = "000000"; base05 = "000000"; base06 = "000000"; base07 = "000000";
+    base08 = "000000"; base09 = "000000"; base0A = "000000"; base0B = "000000";
+    base0C = "000000"; base0D = "000000"; base0E = "000000"; base0F = "000000";
+  };
+in
+{
   home.file.".config/swaync/config.json".text = ''
     {
       "$schema": "/etc/xdg/swaync/configSchema.json",
@@ -54,11 +64,11 @@
         },
         "backlight": {
           "label": "󰃟"
-        },
+        }
       }
     }
   '';
-  home.file.".config/swaync/style.css".text = ''
+  home.file.".config/swaync/style.css".text = if stylixEnabled then ''
     * {
       font-family: JetBrainsMono Nerd Font Mono;
       font-weight: bold;
@@ -66,7 +76,7 @@
     .control-center .notification-row:focus,
     .control-center .notification-row:hover {
       opacity: 0.9;
-      background: #${config.stylix.base16Scheme.base00}
+      background: #${palette.base00}
     }
     .notification-row {
       outline: none;
@@ -79,10 +89,10 @@
       margin: 0px;
     }
     .notification-content {
-      background: #${config.stylix.base16Scheme.base00};
+      background: #${palette.base00};
       padding: 15px;
       border-radius: 16px;
-      border: 2px solid #${config.stylix.base16Scheme.base0B};
+      border: 2px solid #${palette.base0B};
       margin: 0;
     }
     .notification-default-action {
@@ -91,8 +101,8 @@
       border-radius: 16px;
     }
     .close-button {
-      background: #${config.stylix.base16Scheme.base08};
-      color: #${config.stylix.base16Scheme.base00};
+      background: #${palette.base08};
+      color: #${palette.base00};
       text-shadow: none;
       padding: 0;
       border-radius: 16px;
@@ -101,19 +111,19 @@
     }
     .close-button:hover {
       box-shadow: none;
-      background: #${config.stylix.base16Scheme.base0D};
+      background: #${palette.base0D};
       transition: all .15s ease-in-out;
       border: none
     }
     .notification-action {
-      border: 2px solid #${config.stylix.base16Scheme.base0B};
+      border: 2px solid #${palette.base0B};
       border-top: none;
       border-radius: 16px;
     }
     .notification-default-action:hover,
     .notification-action:hover {
-      color: #${config.stylix.base16Scheme.base0B};
-      background: #${config.stylix.base16Scheme.base0B}
+      color: #${palette.base0B};
+      background: #${palette.base0B}
     }
     .notification-default-action {
       border-radius: 16px;
@@ -125,40 +135,40 @@
     }
     .notification-action:first-child {
       border-bottom-left-radius: 16px;
-      background: #${config.stylix.base16Scheme.base00}
+      background: #${palette.base00}
     }
     .notification-action:last-child {
       border-bottom-right-radius: 16px;
-      background: #${config.stylix.base16Scheme.base00}
+      background: #${palette.base00}
     }
     .inline-reply {
       margin-top: 8px
     }
     .inline-reply-entry {
-      background: #${config.stylix.base16Scheme.base00};
-      color: #${config.stylix.base16Scheme.base05};
-      caret-color: #${config.stylix.base16Scheme.base05};
-      border: 1px solid #${config.stylix.base16Scheme.base09};
+      background: #${palette.base00};
+      color: #${palette.base05};
+      caret-color: #${palette.base05};
+      border: 1px solid #${palette.base09};
       border-radius: 16px
     }
     .inline-reply-button {
       margin-left: 4px;
-      background: #${config.stylix.base16Scheme.base00};
-      border: 1px solid #${config.stylix.base16Scheme.base09};
+      background: #${palette.base00};
+      border: 1px solid #${palette.base09};
       border-radius: 16px;
-      color: #${config.stylix.base16Scheme.base05}
+      color: #${palette.base05}
     }
     .inline-reply-button:disabled {
       background: initial;
-      color: #${config.stylix.base16Scheme.base03};
+      color: #${palette.base03};
       border: 1px solid transparent
     }
     .inline-reply-button:hover {
-      background: #${config.stylix.base16Scheme.base00}
+      background: #${palette.base00}
     }
     .body-image {
       margin-top: 6px;
-      background-color: #${config.stylix.base16Scheme.base05};
+      background-color: #${palette.base05};
       border-radius: 16px
     }
     .summary {
@@ -172,7 +182,7 @@
       font-size: 16px;
       font-weight: 700;
       background: transparent;
-      color: #${config.stylix.base16Scheme.base05};
+      color: #${palette.base05};
       text-shadow: none;
       margin-right: 18px
     }
@@ -180,12 +190,12 @@
       font-size: 15px;
       font-weight: 400;
       background: transparent;
-      color: #${config.stylix.base16Scheme.base05};
+      color: #${palette.base05};
       text-shadow: none
     }
     .control-center {
-      background: #${config.stylix.base16Scheme.base00};
-      border: 2px solid #${config.stylix.base16Scheme.base0C};
+      background: #${palette.base00};
+      border: 2px solid #${palette.base0C};
       border-radius: 16px;
     }
     .control-center-list {
@@ -201,8 +211,8 @@
       background: alpha(black, 0)
     }
     .widget-title {
-      color: #${config.stylix.base16Scheme.base0B};
-      background: #${config.stylix.base16Scheme.base00};
+      color: #${palette.base0B};
+      background: #${palette.base00};
       padding: 10px;
       margin: 10px;
       font-size: 1.5rem;
@@ -210,38 +220,38 @@
     }
     .widget-title>button {
       font-size: 1rem;
-      color: #${config.stylix.base16Scheme.base05};
+      color: #${palette.base05};
       text-shadow: none;
-      background: #${config.stylix.base16Scheme.base00};
+      background: #${palette.base00};
       box-shadow: none;
       border-radius: 16px;
     }
     .widget-title>button:hover {
-      background: #${config.stylix.base16Scheme.base08};
-      color: #${config.stylix.base16Scheme.base00};
+      background: #${palette.base08};
+      color: #${palette.base00};
     }
     .widget-dnd {
-      background: #${config.stylix.base16Scheme.base00};
+      background: #${palette.base00};
       padding: 10px;
       margin: 10px;
       border-radius: 16px;
       font-size: large;
-      color: #${config.stylix.base16Scheme.base0B};
+      color: #${palette.base0B};
     }
     .widget-dnd>switch {
       border-radius: 16px;
-      background: #${config.stylix.base16Scheme.base0B};
+      background: #${palette.base0B};
     }
     .widget-dnd>switch:checked {
-      background: #${config.stylix.base16Scheme.base08};
-      border: 1px solid #${config.stylix.base16Scheme.base08};
+      background: #${palette.base08};
+      border: 1px solid #${palette.base08};
     }
     .widget-dnd>switch slider {
-      background: #${config.stylix.base16Scheme.base00};
+      background: #${palette.base00};
       border-radius: 16px
     }
     .widget-dnd>switch:checked slider {
-      background: #${config.stylix.base16Scheme.base00};
+      background: #${palette.base00};
       border-radius: 16px
     }
     .widget-label {
@@ -249,10 +259,10 @@
     }
     .widget-label>label {
       font-size: 1rem;
-      color: #${config.stylix.base16Scheme.base05};
+      color: #${palette.base05};
     }
     .widget-mpris {
-      color: #${config.stylix.base16Scheme.base05};
+      color: #${palette.base05};
       padding: 10px;
       margin: 10px;
       border-radius: 16px;
@@ -280,30 +290,30 @@
       background: transparent
     }
     .widget-volume {
-      background: #${config.stylix.base16Scheme.base01};
+      background: #${palette.base01};
       padding: 10px;
       margin: 10px;
       border-radius: 16px;
       font-size: x-large;
-      color: #${config.stylix.base16Scheme.base05};
+      color: #${palette.base05};
     }
     .widget-volume>box>button {
-      background: #${config.stylix.base16Scheme.base0B};
+      background: #${palette.base0B};
       border: none
     }
     .per-app-volume {
-      background-color: #${config.stylix.base16Scheme.base00};
+      background-color: #${palette.base00};
       padding: 4px 8px 8px;
       margin: 0 8px 8px;
       border-radius: 16px;
     }
     .widget-backlight {
-      background: #${config.stylix.base16Scheme.base01};
+      background: #${palette.base01};
       padding: 10px;
       margin: 10px;
       border-radius: 16px;
       font-size: x-large;
-      color: #${config.stylix.base16Scheme.base05}
+      color: #${palette.base05}
     }
-  '';
+  '' else "";
 }

--- a/modules/desktop/Hyprland/home/ui/rofi/rofi.nix
+++ b/modules/desktop/Hyprland/home/ui/rofi/rofi.nix
@@ -1,7 +1,18 @@
 { pkgs
 , config
+, lib
 , ...
-}: {
+}:
+let
+  stylixEnabled = if config ? stylix then config.stylix.enable else false;
+  palette = if stylixEnabled then config.lib.stylix.colors else {
+    base00 = "000000"; base01 = "1e1e2e"; base02 = "313244"; base03 = "45475a";
+    base04 = "585b70"; base05 = "cdd6f4"; base06 = "f5e0dc"; base07 = "b4befe";
+    base08 = "f38ba8"; base09 = "fab387"; base0A = "f9e2af"; base0B = "a6e3a1";
+    base0C = "94e2d5"; base0D = "89b4fa"; base0E = "cba6f7"; base0F = "f2cdcd";
+  };
+in
+{
   programs = {
     rofi = {
       enable = true;
@@ -20,15 +31,15 @@
         let
           inherit (config.lib.formats.rasi) mkLiteral;
         in
-        {
+        lib.mkIf stylixEnabled {
           "*" = {
-            bg = mkLiteral "#${config.stylix.base16Scheme.base00}";
-            bg-alt = mkLiteral "#${config.stylix.base16Scheme.base01}";
-            foreground = mkLiteral "#${config.stylix.base16Scheme.base07}"; # Kept as base07 for bright white
-            text-selected = mkLiteral "#${config.stylix.base16Scheme.base00}";
-            selected = mkLiteral "#${config.stylix.base16Scheme.base0D}";
-            active = mkLiteral "#${config.stylix.base16Scheme.base0B}";
-            urgent = mkLiteral "#${config.stylix.base16Scheme.base08}";
+            bg = mkLiteral "#${palette.base00}";
+            bg-alt = mkLiteral "#${palette.base01}";
+            foreground = mkLiteral "#${palette.base07}"; # Kept as base07 for bright white
+            text-selected = mkLiteral "#${palette.base00}";
+            selected = mkLiteral "#${palette.base0D}";
+            active = mkLiteral "#${palette.base0B}";
+            urgent = mkLiteral "#${palette.base08}";
           };
           "window" = {
             width = mkLiteral "1000px";
@@ -122,10 +133,9 @@
             cursor = mkLiteral "pointer";
           };
 
-          # --- KEY CHANGES ARE HERE ---
           "element normal.normal" = {
             background-color = mkLiteral "inherit";
-            text-color = mkLiteral "@foreground"; # Explicitly set to white, instead of 'inherit'
+            text-color = mkLiteral "@foreground";
           };
           "element normal.urgent" = {
             background-color = mkLiteral "@urgent";
@@ -137,7 +147,7 @@
           };
           "element alternate.normal" = {
             background-color = mkLiteral "inherit";
-            text-color = mkLiteral "@foreground"; # Explicitly set to white, instead of 'inherit'
+            text-color = mkLiteral "@foreground";
           };
           "element alternate.urgent" = {
             background-color = mkLiteral "@urgent";
@@ -147,7 +157,6 @@
             background-color = mkLiteral "@active";
             text-color = mkLiteral "@text-selected";
           };
-          # --- END OF KEY CHANGES ---
 
           "element selected.normal" = {
             background-color = mkLiteral "@selected";

--- a/modules/desktop/Hyprland/home/ui/waybar/default.nix
+++ b/modules/desktop/Hyprland/home/ui/waybar/default.nix
@@ -4,6 +4,24 @@
 , ...
 }:
 let
+  palette = if (config ? stylix && config.stylix.enable) then config.lib.stylix.colors else {
+    base00 = "000000";
+    base01 = "1e1e2e";
+    base02 = "313244";
+    base03 = "45475a";
+    base04 = "585b70";
+    base05 = "cdd6f4";
+    base06 = "f5e0dc";
+    base07 = "b4befe";
+    base08 = "f38ba8";
+    base09 = "fab387";
+    base0A = "f9e2af";
+    base0B = "a6e3a1";
+    base0C = "94e2d5";
+    base0D = "89b4fa";
+    base0E = "cba6f7";
+    base0F = "f2cdcd";
+  };
   betterTransition = "all 0.3s cubic-bezier(.55,-0.68,.48,1.682)";
   inherit (import ../../misc/variables.nix) clock24h;
 in
@@ -192,8 +210,8 @@ with lib; {
           background: rgba(0,0,0,0);
         }
         #workspaces {
-          color: #${config.lib.stylix.colors.base00};
-          background: #${config.lib.stylix.colors.base01};
+          color: #${palette.base00};
+          background: #${palette.base01};
           margin: 4px 4px;
           padding: 5px 5px;
           border-radius: 16px;
@@ -203,8 +221,8 @@ with lib; {
           padding: 0px 5px;
           margin: 0px 3px;
           border-radius: 16px;
-          color: #${config.lib.stylix.colors.base00};
-          background: linear-gradient(45deg, #${config.lib.stylix.colors.base08}, #${config.lib.stylix.colors.base0D});
+          color: #${palette.base00};
+          background: linear-gradient(45deg, #${palette.base08}, #${palette.base0D});
           opacity: 0.5;
           transition: ${betterTransition};
         }
@@ -213,8 +231,8 @@ with lib; {
           padding: 0px 5px;
           margin: 0px 3px;
           border-radius: 16px;
-          color: #${config.lib.stylix.colors.base00};
-          background: linear-gradient(45deg, #${config.lib.stylix.colors.base08}, #${config.lib.stylix.colors.base0D});
+          color: #${palette.base00};
+          background: linear-gradient(45deg, #${palette.base08}, #${palette.base0D});
           transition: ${betterTransition};
           opacity: 1.0;
           min-width: 40px;
@@ -222,31 +240,31 @@ with lib; {
         #workspaces button:hover {
           font-weight: bold;
           border-radius: 16px;
-          color: #${config.lib.stylix.colors.base00};
-          background: linear-gradient(45deg, #${config.lib.stylix.colors.base08}, #${config.lib.stylix.colors.base0D});
+          color: #${palette.base00};
+          background: linear-gradient(45deg, #${palette.base08}, #${palette.base0D});
           opacity: 0.8;
           transition: ${betterTransition};
         }
         tooltip {
-          background: #${config.lib.stylix.colors.base00};
-          border: 1px solid #${config.lib.stylix.colors.base08};
+          background: #${palette.base00};
+          border: 1px solid #${palette.base08};
           border-radius: 12px;
         }
         tooltip label {
-          color: #${config.lib.stylix.colors.base08};
+          color: #${palette.base08};
         }
         #window, #pulseaudio, #cpu, #memory, #idle_inhibitor {
           font-weight: bold;
           margin: 4px 0px;
           margin-left: 7px;
           padding: 0px 18px;
-          background: #${config.lib.stylix.colors.base04};
-          color: #${config.lib.stylix.colors.base00};
+          background: #${palette.base04};
+          color: #${palette.base00};
           border-radius: 24px 10px 24px 10px;
         }
         #custom-startmenu {
-          color: #${config.lib.stylix.colors.base0B};
-          background: #${config.lib.stylix.colors.base02};
+          color: #${palette.base0B};
+          background: #${palette.base02};
           font-size: 28px;
           margin: 0px;
           padding: 0px 30px 0px 15px;
@@ -255,8 +273,8 @@ with lib; {
         #custom-hyprbindings, #network, #battery,
         #custom-notification, #tray, #custom-exit {
           font-weight: bold;
-          background: #${config.lib.stylix.colors.base0F};
-          color: #${config.lib.stylix.colors.base00};
+          background: #${palette.base0F};
+          color: #${palette.base00};
           margin: 4px 0px;
           margin-right: 7px;
           border-radius: 10px 24px 10px 24px;
@@ -265,7 +283,7 @@ with lib; {
         #clock {
           font-weight: bold;
           color: #0D0E15;
-          background: linear-gradient(90deg, #${config.lib.stylix.colors.base0E}, #${config.lib.stylix.colors.base0C});
+          background: linear-gradient(90deg, #${palette.base0E}, #${palette.base0C});
           margin: 0px;
           padding: 0px 15px 0px 30px;
           border-radius: 0px 0px 0px 40px;

--- a/modules/desktop/Hyprland/home/ui/waybar/test-waybar.nix
+++ b/modules/desktop/Hyprland/home/ui/waybar/test-waybar.nix
@@ -1,7 +1,16 @@
 { config
 , lib
 , ...
-}: with lib; {
+}:
+let
+  palette = if (config ? stylix && config.stylix.enable) then config.lib.stylix.colors else {
+    base00 = "000000"; base01 = "1e1e2e"; base02 = "313244"; base03 = "45475a";
+    base04 = "585b70"; base05 = "cdd6f4"; base06 = "f5e0dc"; base07 = "b4befe";
+    base08 = "f38ba8"; base09 = "fab387"; base0A = "f9e2af"; base0B = "a6e3a1";
+    base0C = "94e2d5"; base0D = "89b4fa"; base0E = "cba6f7"; base0F = "f2cdcd";
+  };
+in
+with lib; {
   programs.waybar = {
     enable = true;
     systemd = {
@@ -120,7 +129,7 @@
       };
     };
 
-    style = with config.lib.stylix.colors; ''
+    style = with palette; ''
       * {
         font-family: JetBrainsMono Nerd Font Mono;
         font-size: 12px;

--- a/modules/desktop/Hyprland/home/ui/waybar/waybar-curved.nix
+++ b/modules/desktop/Hyprland/home/ui/waybar/waybar-curved.nix
@@ -4,7 +4,13 @@
 , ...
 }:
 let
-  palette = config.stylix.base16Scheme;
+  stylixEnabled = config ? stylix && config.stylix.enable;
+  palette = if stylixEnabled then config.stylix.base16Scheme else {
+    base00 = "000000"; base01 = "000000"; base02 = "000000"; base03 = "000000";
+    base04 = "000000"; base05 = "000000"; base06 = "000000"; base07 = "000000";
+    base08 = "000000"; base09 = "000000"; base0A = "000000"; base0B = "000000";
+    base0C = "000000"; base0D = "000000"; base0E = "000000"; base0F = "000000";
+  };
   betterTransition = "all 0.3s cubic-bezier(.55,-0.68,.48,1.682)";
   inherit (import ../../misc/variables.nix) clock24h;
 in
@@ -143,7 +149,7 @@ with lib; {
         };
       }
     ];
-    style = concatStrings [
+    style = lib.mkIf stylixEnabled (concatStrings [
       ''
         * {
           font-family: JetBrainsMono Nerd Font, FontAwesome;
@@ -208,6 +214,6 @@ with lib; {
           border-radius: 16px;
         }
       ''
-    ];
+    ]);
   };
 }

--- a/modules/desktop/Hyprland/home/ui/waybar/waybar-ddubs.nix
+++ b/modules/desktop/Hyprland/home/ui/waybar/waybar-ddubs.nix
@@ -4,7 +4,13 @@
 , ...
 }:
 let
-  palette = config.stylix.base16Scheme;
+  stylixEnabled = config ? stylix && config.stylix.enable;
+  palette = if stylixEnabled then config.stylix.base16Scheme else {
+    base00 = "000000"; base01 = "000000"; base02 = "000000"; base03 = "000000";
+    base04 = "000000"; base05 = "000000"; base06 = "000000"; base07 = "000000";
+    base08 = "000000"; base09 = "000000"; base0A = "000000"; base0B = "000000";
+    base0C = "000000"; base0D = "000000"; base0E = "000000"; base0F = "000000";
+  };
   betterTransition = "all 0.3s cubic-bezier(.55,-0.68,.48,1.682)";
   inherit (import ../../misc/variables.nix) clock24h;
 in
@@ -145,7 +151,7 @@ with lib; {
         };
       }
     ];
-    style = concatStrings [
+    style = lib.mkIf stylixEnabled (concatStrings [
       ''
         * {
           font-family: JetBrainsMono Nerd Font, FontAwesome;
@@ -211,6 +217,6 @@ with lib; {
           border-radius: 8px;
         }
       ''
-    ];
+    ]);
   };
 }

--- a/modules/desktop/Hyprland/home/ui/waybar/waybar-nyx.nix
+++ b/modules/desktop/Hyprland/home/ui/waybar/waybar-nyx.nix
@@ -1,10 +1,17 @@
 { pkgs
 , config
+, lib
 , ...
 }:
 let
   swaync-client = "${pkgs.swaynotificationcenter}/bin/swaync-client";
   transition = "transition: all 0.3s cubic-bezier(.55,-0.68,.48,1.682);";
+  palette = if (config ? stylix && config.stylix.enable) then config.lib.stylix.colors else {
+    base00 = "000000"; base01 = "1e1e2e"; base02 = "313244"; base03 = "45475a";
+    base04 = "585b70"; base05 = "cdd6f4"; base06 = "f5e0dc"; base07 = "b4befe";
+    base08 = "f38ba8"; base09 = "fab387"; base0A = "f9e2af"; base0B = "a6e3a1";
+    base0C = "94e2d5"; base0D = "89b4fa"; base0E = "cba6f7"; base0F = "f2cdcd";
+  };
   animateBlink = ''
     margin: 4px 0;
     animation-name: blink;
@@ -19,9 +26,9 @@ let
     }
   '';
 in
-{
-  config = with config.lib.stylix.colors; {
-    stylix.targets.waybar.enable = false;
+with palette; {
+  config = {
+    stylix.targets.waybar.enable = lib.mkIf (config ? stylix) false;
     programs.waybar = {
       enable = true;
       systemd = {

--- a/modules/desktop/Hyprland/home/ui/waybar/waybar-simple.nix
+++ b/modules/desktop/Hyprland/home/ui/waybar/waybar-simple.nix
@@ -4,7 +4,13 @@
 , ...
 }:
 let
-  palette = config.stylix.base16Scheme;
+  stylixEnabled = config ? stylix && config.stylix.enable;
+  palette = if stylixEnabled then config.stylix.base16Scheme else {
+    base00 = "000000"; base01 = "000000"; base02 = "000000"; base03 = "000000";
+    base04 = "000000"; base05 = "000000"; base06 = "000000"; base07 = "000000";
+    base08 = "000000"; base09 = "000000"; base0A = "000000"; base0B = "000000";
+    base0C = "000000"; base0D = "000000"; base0E = "000000"; base0F = "000000";
+  };
   inherit (import ../../misc/variables.nix) clock24h;
 in
 with lib; {
@@ -143,7 +149,7 @@ with lib; {
         };
       }
     ];
-    style = concatStrings [
+    style = lib.mkIf stylixEnabled (concatStrings [
       ''
         * {
           font-family: JetBrainsMono Nerd Font, FontAwesome;
@@ -179,6 +185,6 @@ with lib; {
           padding: 0px 10px;
         }
       ''
-    ];
+    ]);
   };
 }

--- a/modules/desktop/Hyprland/home/ui/wlogout.nix
+++ b/modules/desktop/Hyprland/home/ui/wlogout.nix
@@ -1,4 +1,14 @@
-{ config, ... }: {
+{ config, lib, ... }:
+let
+  stylixEnabled = config ? stylix && config.stylix.enable;
+  palette = if stylixEnabled then config.stylix.base16Scheme else {
+    base00 = "000000"; base01 = "000000"; base02 = "000000"; base03 = "000000";
+    base04 = "000000"; base05 = "000000"; base06 = "000000"; base07 = "000000";
+    base08 = "000000"; base09 = "000000"; base0A = "000000"; base0B = "000000";
+    base0C = "000000"; base0D = "000000"; base0E = "000000"; base0F = "000000";
+  };
+in
+{
   programs.wlogout = {
     enable = true;
     layout = [
@@ -39,7 +49,7 @@
         "keybind" = "h";
       }
     ];
-    style = ''
+    style = lib.mkIf stylixEnabled ''
       * {
         font-family: "JetBrainsMono NF", FontAwesome, sans-serif;
       	background-image: none;
@@ -49,14 +59,14 @@
       	background-color: rgba(12, 12, 12, 0.1);
       }
       button {
-      	color: #${config.stylix.base16Scheme.base05};
+      	color: #${palette.base05};
         font-size:20px;
         background-repeat: no-repeat;
       	background-position: center;
       	background-size: 25%;
       	border-style: solid;
       	background-color: rgba(12, 12, 12, 0.3);
-      	border: 3px solid #${config.stylix.base16Scheme.base05};
+      	border: 3px solid #${palette.base05};
         box-shadow: 0 4px 8px 0 rgba(0, 0, 0, 0.2), 0 6px 20px 0 rgba(0, 0, 0, 0.19);
         border-radius: 90px;
         margin: 20px;
@@ -64,9 +74,9 @@
       button:focus,
       button:active,
       button:hover {
-        color: #${config.stylix.base16Scheme.base00};
-        background-color: #${config.stylix.base16Scheme.base0B};
-        border: 3px solid #${config.stylix.base16Scheme.base0B};
+        color: #${palette.base00};
+        background-color: #${palette.base0B};
+        border: 3px solid #${palette.base0B};
       }
       #logout {
       	margin: 10px;

--- a/modules/desktop/Hyprland/main/sddm.nix
+++ b/modules/desktop/Hyprland/main/sddm.nix
@@ -1,85 +1,45 @@
-{ pkgs, config, ... }:
+{ pkgs, config, lib, ... }:
 
-
+let
+  stylixEnabled = config ? stylix && config.stylix.enable;
+in
 {
-
   services.displayManager.sddm = {
     enable = true;
     wayland.enable = true;
     theme = "sddm-astronaut-theme";
     package = pkgs.kdePackages.sddm;
     extraPackages = with pkgs; [
+      # kdePackages.qt6-declarative
+      kdePackages.qtsvg
       kdePackages.qtsvg
       kdePackages.qtmultimedia
       kdePackages.qtvirtualkeyboard
     ];
-    settings.Theme = {
+    settings.Theme = lib.mkIf stylixEnabled {
       CursorTheme = config.stylix.cursor.name;
       CursorSize = config.stylix.cursor.size;
     };
   };
 
   environment.systemPackages = [
-    (
+    (if stylixEnabled then
+      let
+        colors = config.lib.stylix.colors.withHashtag;
+      in
       pkgs.sddm-astronaut.override {
-        themeConfig = with config.lib.stylix.colors.withHashtag; {
-          Font = "JetBrainsMono";
-          FontSize = "12";
+        themeConfig = {
           Background = "${config.stylix.image}";
-          CropBackground = "false";
-          BackgroundHorizontalAlignment = "center";
-          BackgroundVerticalAlignment = "center";
-          DimBackground = "0.0";
-          HeaderTextColor = "${base07}";
-          DateTextColor = "${base07}";
-          TimeTextColor = "${base07}";
-
-          FormBackgroundColor = "${base00}";
-          BackgroundColor = "${base00}";
-          DimBackgroundColor = "${base00}";
-
-          LoginFieldBackgroundColor = "#${base00}";
-          PasswordFieldBackgroundColor = "${base00}";
-          LoginFieldTextColor = "${base0D}";
-          PasswordFieldTextColor = "${base0D}";
-          UserIconColor = "${base0D}";
-          PasswordIconColor = "${base0D}";
-
-          PlaceholderTextColor = "${base02}";
-          WarningColor = "${base0A}";
-
-          LoginButtonTextColor = "${base0D}";
-          LoginButtonBackgroundColor = "${base00}";
-          SystemButtonsIconsColor = "${base0D}";
-          SessionButtonTextColor = "${base0D}";
-          VirtualKeyboardButtonTextColor = "${base0D}";
-
-          DropdownTextColor = "${base0D}";
-          DropdownSelectedBackgroundColor = "${base00}";
-          DropdownBackgroundColor = "${base00}";
-
-          HighlightTextColor = "${base0D}";
-          HighlightBackgroundColor = "${base0D}";
-          HighlightBorderColor = "${base0D}";
-
-          HoverUserIconColor = "${base0A}";
-          HoverPasswordIconColor = "${base0A}";
-          HoverSystemButtonsIconsColor = "${base0A}";
-          HoverSessionButtonTextColor = "${base0A}";
-          HoverVirtualKeyboardButtonTextColor = "${base0A}";
-
+          CursorColor = colors.base05;
+          FullBlur = "true";
           PartialBlur = "true";
-          BlurMax = "35";
-          Blur = "2.0";
-
-          HourFormat = "h:mm AP";
-
+          HeaderTextColor = colors.base05;
           HaveFormBackground = "false";
           FormPosition = "left";
-
         };
       }
-    )
+    else
+      pkgs.sddm-astronaut)
   ];
 
   security.pam.services.sddm.enableGnomeKeyring = true;

--- a/modules/desktop/KDE/main/display-manager.nix
+++ b/modules/desktop/KDE/main/display-manager.nix
@@ -6,35 +6,11 @@
       wayland = {
         enable = true;
       };
-      # config, lib, wallpaper,   Need to be set this in the headers before enabling sddm-nix
-      # package = pkgs.kdePackages.sddm;
       extraPackages = with pkgs; [
         kdePackages.qtsvg
         kdePackages.qtmultimedia
         kdePackages.qtvirtualkeyboard
       ];
-      # theme = "black_hole";
-      # settings = {
-      #   Autologin = {
-      #     Session = "hyprland";
-      #     User = "rishabh";
-      #   };
-      # };
-      # sugarCandyNix = {
-      #   enable = true;
-      #   settings = {
-      #     # General settings
-      #     AccentColor = "#${config.stylix.base16Scheme.base0B}";
-      #     Background = "${lib.cleanSource wallpapers}/${wallpaper}";
-      #     Font = "JetBrainsMono Nerd Font Mono";
-      #     # Form settings
-      #     HeaderText = "Welcome!";
-      #     FormPosition = "left";
-      #     HaveFormBackground = true;
-      #     PartialBlur = true;
-      #     HourFormat = "h:m:s ap";
-      #   };
-      # };
       autoNumlock = true;
     };
   };

--- a/modules/desktop/Sway-DMS/main/sddm.nix
+++ b/modules/desktop/Sway-DMS/main/sddm.nix
@@ -1,6 +1,8 @@
-{ pkgs, config, username, ... }:
+{ pkgs, config, lib, ... }:
 
-
+let
+  stylixEnabled = config ? stylix && config.stylix.enable;
+in
 {
 
   services.displayManager.sddm = {
@@ -9,84 +11,38 @@
     theme = "sddm-astronaut-theme";
     package = pkgs.kdePackages.sddm;
     extraPackages = with pkgs; [
+      # kdePackages.qt6-declarative
+      kdePackages.qtsvg
       kdePackages.qtsvg
       kdePackages.qtmultimedia
       kdePackages.qtvirtualkeyboard
     ];
-    settings =
-      {
-        Autologin = {
-          Session = "sway";
-          User = "${username}";
-        };
-        Theme = {
-          CursorTheme = config.stylix.cursor.name;
-          CursorSize = config.stylix.cursor.size;
-        };
+    settings = {
+      Theme = lib.mkIf stylixEnabled {
+        CursorTheme = config.stylix.cursor.name;
+        CursorSize = config.stylix.cursor.size;
       };
+    };
   };
 
   environment.systemPackages = [
-    (
+    (if stylixEnabled then
+      let
+        colors = config.lib.stylix.colors.withHashtag;
+      in
       pkgs.sddm-astronaut.override {
-        themeConfig = with config.lib.stylix.colors.withHashtag; {
-          Font = "JetBrainsMono";
-          FontSize = "12";
+        themeConfig = {
           Background = "${config.stylix.image}";
-          CropBackground = "false";
-          BackgroundHorizontalAlignment = "center";
-          BackgroundVerticalAlignment = "center";
-          DimBackground = "0.0";
-          HeaderTextColor = "${base07}";
-          DateTextColor = "${base07}";
-          TimeTextColor = "${base07}";
-
-          FormBackgroundColor = "${base00}";
-          BackgroundColor = "${base00}";
-          DimBackgroundColor = "${base00}";
-
-          LoginFieldBackgroundColor = "#${base00}";
-          PasswordFieldBackgroundColor = "${base00}";
-          LoginFieldTextColo = "${base0D}";
-          PasswordFieldTestColor = "${base0D}";
-          UserIconColor = "${base0D}";
-          PasswordIconColor = "${base0D}";
-
-          PlaceholderTextColor = "${base02}";
-          WarningColor = "${base0A}";
-
-          LoginButtonTextColor = "${base0D}";
-          LoginButtonBackgroundColor = "${base00}";
-          SystemButtonsIconsColor = "${base0D}";
-          SessionButtonTextColor = "${base0D}";
-          VirtualKeyboardButtonTextColor = "${base0D}";
-
-          DropdownTextColor = "${base0D}";
-          DropdownSelectedBackgroundColor = "${base00}";
-          DropdownBackgroundColor = "${base00}";
-
-          HighlightTextColor = "${base0D}";
-          HighlightBackgroundColor = "${base0D}";
-          HighlightBorderColor = "${base0D}";
-
-          HoverUserIconColor = "${base0A}";
-          HoverPasswordIconColor = "${base0A}";
-          HoverSystemButtonsIconsColor = "${base0A}";
-          HoverSessionButtonTextColor = "${base0A}";
-          HoverVirtualKeyboardButtonTextColor = "${base0A}";
-
+          CursorColor = colors.base05;
+          FullBlur = "true";
           PartialBlur = "true";
-          BlurMax = "35";
-          Blur = "2.0";
-
-          HourFormat = "h:mm AP";
-
+          HeaderTextColor = colors.base05;
           HaveFormBackground = "false";
           FormPosition = "left";
-
         };
       }
-    )
+    else
+      pkgs.sddm-astronaut)
   ];
 
   security.pam.services.sddm.enableGnomeKeyring = true;

--- a/modules/desktop/Sway-Noctalia/main/sddm.nix
+++ b/modules/desktop/Sway-Noctalia/main/sddm.nix
@@ -1,6 +1,8 @@
-{ pkgs, config, username, ... }:
+{ pkgs, config, lib, ... }:
 
-
+let
+  stylixEnabled = config ? stylix && config.stylix.enable;
+in
 {
 
   services.displayManager.sddm = {
@@ -9,84 +11,38 @@
     theme = "sddm-astronaut-theme";
     package = pkgs.kdePackages.sddm;
     extraPackages = with pkgs; [
+      # kdePackages.qt6-declarative
+      kdePackages.qtsvg
       kdePackages.qtsvg
       kdePackages.qtmultimedia
       kdePackages.qtvirtualkeyboard
     ];
-    settings =
-      {
-        Autologin = {
-          Session = "sway";
-          User = "${username}";
-        };
-        Theme = {
-          CursorTheme = config.stylix.cursor.name;
-          CursorSize = config.stylix.cursor.size;
-        };
+    settings = {
+      Theme = lib.mkIf stylixEnabled {
+        CursorTheme = config.stylix.cursor.name;
+        CursorSize = config.stylix.cursor.size;
       };
+    };
   };
 
   environment.systemPackages = [
-    (
+    (if stylixEnabled then
+      let
+        colors = config.lib.stylix.colors.withHashtag;
+      in
       pkgs.sddm-astronaut.override {
-        themeConfig = with config.lib.stylix.colors.withHashtag; {
-          Font = "JetBrainsMono";
-          FontSize = "12";
+        themeConfig = {
           Background = "${config.stylix.image}";
-          CropBackground = "false";
-          BackgroundHorizontalAlignment = "center";
-          BackgroundVerticalAlignment = "center";
-          DimBackground = "0.0";
-          HeaderTextColor = "${base07}";
-          DateTextColor = "${base07}";
-          TimeTextColor = "${base07}";
-
-          FormBackgroundColor = "${base00}";
-          BackgroundColor = "${base00}";
-          DimBackgroundColor = "${base00}";
-
-          LoginFieldBackgroundColor = "#${base00}";
-          PasswordFieldBackgroundColor = "${base00}";
-          LoginFieldTextColo = "${base0D}";
-          PasswordFieldTestColor = "${base0D}";
-          UserIconColor = "${base0D}";
-          PasswordIconColor = "${base0D}";
-
-          PlaceholderTextColor = "${base02}";
-          WarningColor = "${base0A}";
-
-          LoginButtonTextColor = "${base0D}";
-          LoginButtonBackgroundColor = "${base00}";
-          SystemButtonsIconsColor = "${base0D}";
-          SessionButtonTextColor = "${base0D}";
-          VirtualKeyboardButtonTextColor = "${base0D}";
-
-          DropdownTextColor = "${base0D}";
-          DropdownSelectedBackgroundColor = "${base00}";
-          DropdownBackgroundColor = "${base00}";
-
-          HighlightTextColor = "${base0D}";
-          HighlightBackgroundColor = "${base0D}";
-          HighlightBorderColor = "${base0D}";
-
-          HoverUserIconColor = "${base0A}";
-          HoverPasswordIconColor = "${base0A}";
-          HoverSystemButtonsIconsColor = "${base0A}";
-          HoverSessionButtonTextColor = "${base0A}";
-          HoverVirtualKeyboardButtonTextColor = "${base0A}";
-
+          CursorColor = colors.base05;
+          FullBlur = "true";
           PartialBlur = "true";
-          BlurMax = "35";
-          Blur = "2.0";
-
-          HourFormat = "h:mm AP";
-
+          HeaderTextColor = colors.base05;
           HaveFormBackground = "false";
           FormPosition = "left";
-
         };
       }
-    )
+    else
+      pkgs.sddm-astronaut)
   ];
 
   security.pam.services.sddm.enableGnomeKeyring = true;

--- a/modules/desktop/i3/home/core/i3.nix
+++ b/modules/desktop/i3/home/core/i3.nix
@@ -1,9 +1,16 @@
-{ pkgs, wallpaper, wallpapers, ... }:
+{ pkgs, wallpaper, wallpapers, config, lib, ... }:
 
 let
   modifier = "Mod4"; # Use the Super key as the modifier
   browser = "firefox"; # Set default browser
   terminal = "kitty"; # Set default terminal
+  stylixEnabled = if config ? stylix then config.stylix.enable else false;
+  palette = if stylixEnabled then config.lib.stylix.colors else {
+    base00 = "000000"; base01 = "1e1e2e"; base02 = "313244"; base03 = "45475a";
+    base04 = "585b70"; base05 = "cdd6f4"; base06 = "f5e0dc"; base07 = "b4befe";
+    base08 = "f38ba8"; base09 = "fab387"; base0A = "f9e2af"; base0B = "a6e3a1";
+    base0C = "94e2d5"; base0D = "89b4fa"; base0E = "cba6f7"; base0F = "f2cdcd";
+  };
 in
 {
   xsession.enable = true;
@@ -31,23 +38,23 @@ in
           };
         }
       ];
-      # colors = {
-      #   background = "#${config.stylix.base16Scheme.base00}";
-      #   focused = {
-      #     border = "#${config.stylix.base16Scheme.base0D}";
-      #     background = "#${config.stylix.base16Scheme.base0D}";
-      #     text = "#${config.stylix.base16Scheme.base00}";
-      #     indicator = "#${config.stylix.base16Scheme.base0B}";
-      #     childBorder = "#${config.stylix.base16Scheme.base0D}";
-      #   };
-      #   unfocused = {
-      #     border = "#${config.stylix.base16Scheme.base00}";
-      #     background = "#${config.stylix.base16Scheme.base00}";
-      #     text = "#${config.stylix.base16Scheme.base05}";
-      #     indicator = "#${config.stylix.base16Scheme.base00}";
-      #     childBorder = "#${config.stylix.base16Scheme.base00}";
-      #   };
-      # };
+      colors = lib.mkIf stylixEnabled {
+        background = "#${palette.base00}";
+        focused = {
+          border = "#${palette.base0D}";
+          background = "#${palette.base0D}";
+          text = "#${palette.base00}";
+          indicator = "#${palette.base0B}";
+          childBorder = "#${palette.base0D}";
+        };
+        unfocused = {
+          border = "#${palette.base00}";
+          background = "#${palette.base00}";
+          text = "#${palette.base05}";
+          indicator = "#${palette.base00}";
+          childBorder = "#${palette.base00}";
+        };
+      };
 
       keybindings = {
         "${modifier}+Return" = "exec ${terminal}";

--- a/modules/desktop/i3/home/services/dunst.nix
+++ b/modules/desktop/i3/home/services/dunst.nix
@@ -1,5 +1,14 @@
 { config, lib, ... }:
 
+let
+  stylixEnabled = if config ? stylix then config.stylix.enable else false;
+  palette = if stylixEnabled then config.lib.stylix.colors else {
+    base00 = "000000"; base01 = "1e1e2e"; base02 = "313244"; base03 = "45475a";
+    base04 = "585b70"; base05 = "cdd6f4"; base06 = "f5e0dc"; base07 = "b4befe";
+    base08 = "f38ba8"; base09 = "fab387"; base0A = "f9e2af"; base0B = "a6e3a1";
+    base0C = "94e2d5"; base0D = "89b4fa"; base0E = "cba6f7"; base0F = "f2cdcd";
+  };
+in
 {
   services.dunst = {
     enable = true;
@@ -10,24 +19,36 @@
           <b>%s</b>
           %b
         '';
-        sort = "yes";
-        indicate_hidden = "yes";
-        alignment = "left";
-        bounce_freq = 0;
-        show_age_threshold = 60;
-        word_wrap = "yes";
-        ignore_newline = "no";
         stack_duplicates = true;
         hide_duplicate_count = true;
         show_indicators = "yes";
         icon_position = "left";
         max_icon_size = 32;
-        frame_color = "#${config.stylix.base16Scheme.base0D}";
-        separator_color = lib.mkForce "#${config.stylix.base16Scheme.base0D}";
+        frame_color = lib.mkIf stylixEnabled "#${palette.base0D}";
+        separator_color = lib.mkForce (if stylixEnabled then "#${palette.base0D}" else "#ffffff");
         padding = 8;
         horizontal_padding = 8;
         transparency = 10;
         corner_radius = 15;
+      };
+
+      urgency_low = {
+        background = lib.mkForce "#${palette.base00}";
+        foreground = lib.mkForce "#${palette.base05}";
+        timeout = 10;
+      };
+
+      urgency_normal = {
+        background = lib.mkForce "#${palette.base00}";
+        foreground = lib.mkForce "#${palette.base05}";
+        timeout = 10;
+      };
+
+      urgency_critical = {
+        background = lib.mkForce "#${palette.base00}";
+        foreground = lib.mkForce "#${palette.base08}";
+        frame_color = lib.mkForce "#${palette.base08}";
+        timeout = 0;
       };
     };
   };

--- a/modules/desktop/i3/home/ui/rofi/rofi.nix
+++ b/modules/desktop/i3/home/ui/rofi/rofi.nix
@@ -1,9 +1,20 @@
 { pkgs
 , config
+, lib
 , wallpaper
 , wallpapers
 , ...
-}: {
+}:
+let
+  stylixEnabled = if config ? stylix then config.stylix.enable else false;
+  palette = if stylixEnabled then config.lib.stylix.colors else {
+    base00 = "000000"; base01 = "1e1e2e"; base02 = "313244"; base03 = "45475a";
+    base04 = "585b70"; base05 = "cdd6f4"; base06 = "f5e0dc"; base07 = "b4befe";
+    base08 = "f38ba8"; base09 = "fab387"; base0A = "f9e2af"; base0B = "a6e3a1";
+    base0C = "94e2d5"; base0D = "89b4fa"; base0E = "cba6f7"; base0F = "f2cdcd";
+  };
+in
+{
   programs = {
     rofi = {
       enable = true;
@@ -22,17 +33,17 @@
         let
           inherit (config.lib.formats.rasi) mkLiteral;
         in
-        {
+        lib.mkIf stylixEnabled {
           "*" = {
-            bg = mkLiteral "#${config.stylix.base16Scheme.base00}";
-            bg-alt = mkLiteral "#${config.stylix.base16Scheme.base09}";
-            foreground = mkLiteral "#${config.stylix.base16Scheme.base01}";
-            selected = mkLiteral "#${config.stylix.base16Scheme.base08}";
-            active = mkLiteral "#${config.stylix.base16Scheme.base0B}";
-            text-selected = mkLiteral "#${config.stylix.base16Scheme.base00}";
-            text-color = mkLiteral "#${config.stylix.base16Scheme.base05}";
-            border-color = mkLiteral "#${config.stylix.base16Scheme.base0F}";
-            urgent = mkLiteral "#${config.stylix.base16Scheme.base0E}";
+            bg = mkLiteral "#${palette.base00}";
+            bg-alt = mkLiteral "#${palette.base09}";
+            foreground = mkLiteral "#${palette.base01}";
+            selected = mkLiteral "#${palette.base08}";
+            active = mkLiteral "#${palette.base0B}";
+            text-selected = mkLiteral "#${palette.base00}";
+            text-color = mkLiteral "#${palette.base05}";
+            border-color = mkLiteral "#${palette.base0F}";
+            urgent = mkLiteral "#${palette.base0E}";
           };
           "window" = {
             transparency = "real";

--- a/modules/desktop/i3/main/sddm.nix
+++ b/modules/desktop/i3/main/sddm.nix
@@ -1,85 +1,45 @@
-{ pkgs, config, ... }:
+{ pkgs, config, lib, ... }:
 
-
+let
+  stylixEnabled = config ? stylix && config.stylix.enable;
+in
 {
-
   services.displayManager.sddm = {
     enable = true;
     wayland.enable = true;
     theme = "sddm-astronaut-theme";
     package = pkgs.kdePackages.sddm;
     extraPackages = with pkgs; [
+      # kdePackages.qt6-declarative
+      kdePackages.qtsvg
       kdePackages.qtsvg
       kdePackages.qtmultimedia
       kdePackages.qtvirtualkeyboard
     ];
-    settings.Theme = {
+    settings.Theme = lib.mkIf stylixEnabled {
       CursorTheme = config.stylix.cursor.name;
       CursorSize = config.stylix.cursor.size;
     };
   };
 
   environment.systemPackages = [
-    (
+    (if stylixEnabled then
+      let
+        colors = config.lib.stylix.colors.withHashtag;
+      in
       pkgs.sddm-astronaut.override {
-        themeConfig = with config.lib.stylix.colors.withHashtag; {
-          Font = "JetBrainsMono";
-          FontSize = "12";
+        themeConfig = {
           Background = "${config.stylix.image}";
-          CropBackground = "false";
-          BackgroundHorizontalAlignment = "center";
-          BackgroundVerticalAlignment = "center";
-          DimBackground = "0.0";
-          HeaderTextColor = "${base07}";
-          DateTextColor = "${base07}";
-          TimeTextColor = "${base07}";
-
-          FormBackgroundColor = "${base00}";
-          BackgroundColor = "${base00}";
-          DimBackgroundColor = "${base00}";
-
-          LoginFieldBackgroundColor = "#${base00}";
-          PasswordFieldBackgroundColor = "${base00}";
-          LoginFieldTextColo = "${base0D}";
-          PasswordFieldTestColor = "${base0D}";
-          UserIconColor = "${base0D}";
-          PasswordIconColor = "${base0D}";
-
-          PlaceholderTextColor = "${base02}";
-          WarningColor = "${base0A}";
-
-          LoginButtonTextColor = "${base0D}";
-          LoginButtonBackgroundColor = "${base00}";
-          SystemButtonsIconsColor = "${base0D}";
-          SessionButtonTextColor = "${base0D}";
-          VirtualKeyboardButtonTextColor = "${base0D}";
-
-          DropdownTextColor = "${base0D}";
-          DropdownSelectedBackgroundColor = "${base00}";
-          DropdownBackgroundColor = "${base00}";
-
-          HighlightTextColor = "${base0D}";
-          HighlightBackgroundColor = "${base0D}";
-          HighlightBorderColor = "${base0D}";
-
-          HoverUserIconColor = "${base0A}";
-          HoverPasswordIconColor = "${base0A}";
-          HoverSystemButtonsIconsColor = "${base0A}";
-          HoverSessionButtonTextColor = "${base0A}";
-          HoverVirtualKeyboardButtonTextColor = "${base0A}";
-
+          CursorColor = colors.base05;
+          FullBlur = "true";
           PartialBlur = "true";
-          BlurMax = "35";
-          Blur = "2.0";
-
-          HourFormat = "h:mm AP";
-
+          HeaderTextColor = colors.base05;
           HaveFormBackground = "false";
           FormPosition = "left";
-
         };
       }
-    )
+    else
+      pkgs.sddm-astronaut)
   ];
 
   security.pam.services.sddm.enableGnomeKeyring = true;

--- a/modules/desktop/mangowm/home/core/mangowm.nix
+++ b/modules/desktop/mangowm/home/core/mangowm.nix
@@ -1,8 +1,15 @@
-{ config, inputs, ... }:
+{ config, inputs, lib, ... }:
 
 let
   inherit (import ../misc/variables.nix) browser terminal extraMonitorSettings;
   modifier = "SUPER";
+  stylixEnabled = if config ? stylix then config.stylix.enable else false;
+  palette = if stylixEnabled then config.stylix.base16Scheme else {
+    base00 = "000000"; base01 = "1e1e2e"; base02 = "313244"; base03 = "45475a";
+    base04 = "585b70"; base05 = "cdd6f4"; base06 = "f5e0dc"; base07 = "b4befe";
+    base08 = "f38ba8"; base09 = "fab387"; base0A = "f9e2af"; base0B = "a6e3a1";
+    base0C = "94e2d5"; base0D = "89b4fa"; base0E = "cba6f7"; base0F = "f2cdcd";
+  };
 in
 {
   imports = [
@@ -36,8 +43,8 @@ in
       gappov = 4
 
       # Colors
-      focuscolor = 0x${config.stylix.base16Scheme.base0D}ff
-      rootcolor = 0x${config.stylix.base16Scheme.base00}ff
+      focuscolor = 0x${palette.base0D}ff
+      rootcolor = 0x${palette.base00}ff
 
       # Keybindings - Applications
       bind = ${modifier}, Return, spawn, ${terminal}

--- a/modules/desktop/mangowm/main/lockscreen.nix
+++ b/modules/desktop/mangowm/main/lockscreen.nix
@@ -1,6 +1,8 @@
-{ pkgs, config, ... }:
+{ pkgs, config, lib, ... }:
 
-
+let
+  stylixEnabled = config ? stylix && config.stylix.enable;
+in
 {
 
   services.displayManager.sddm = {
@@ -9,77 +11,36 @@
     theme = "sddm-astronaut-theme";
     package = pkgs.kdePackages.sddm;
     extraPackages = with pkgs; [
+      # kdePackages.qt6-declarative
+      kdePackages.qtsvg
       kdePackages.qtsvg
       kdePackages.qtmultimedia
       kdePackages.qtvirtualkeyboard
     ];
-    settings.Theme = {
+    settings.Theme = lib.mkIf stylixEnabled {
       CursorTheme = config.stylix.cursor.name;
       CursorSize = config.stylix.cursor.size;
     };
   };
 
   environment.systemPackages = [
-    (
+    (if stylixEnabled then
+      let
+        colors = config.lib.stylix.colors.withHashtag;
+      in
       pkgs.sddm-astronaut.override {
-        themeConfig = with config.lib.stylix.colors.withHashtag; {
-          Font = "JetBrainsMono";
-          FontSize = "12";
+        themeConfig = {
           Background = "${config.stylix.image}";
-          CropBackground = "false";
-          BackgroundHorizontalAlignment = "center";
-          BackgroundVerticalAlignment = "center";
-          DimBackground = "0.0";
-          HeaderTextColor = "${base07}";
-          DateTextColor = "${base07}";
-          TimeTextColor = "${base07}";
-
-          FormBackgroundColor = "${base00}";
-          BackgroundColor = "${base00}";
-          DimBackgroundColor = "${base00}";
-
-          LoginFieldBackgroundColor = "#${base00}";
-          PasswordFieldBackgroundColor = "${base00}";
-          LoginFieldTextColo = "${base0D}";
-          PasswordFieldTestColor = "${base0D}";
-          UserIconColor = "${base0D}";
-          PasswordIconColor = "${base0D}";
-
-          PlaceholderTextColor = "${base02}";
-          WarningColor = "${base0A}";
-
-          LoginButtonTextColor = "${base0D}";
-          LoginButtonBackgroundColor = "${base00}";
-          SystemButtonsIconsColor = "${base0D}";
-          SessionButtonTextColor = "${base0D}";
-          VirtualKeyboardButtonTextColor = "${base0D}";
-
-          DropdownTextColor = "${base0D}";
-          DropdownSelectedBackgroundColor = "${base00}";
-          DropdownBackgroundColor = "${base00}";
-
-          HighlightTextColor = "${base0D}";
-          HighlightBackgroundColor = "${base0D}";
-          HighlightBorderColor = "${base0D}";
-
-          HoverUserIconColor = "${base0A}";
-          HoverPasswordIconColor = "${base0A}";
-          HoverSystemButtonsIconsColor = "${base0A}";
-          HoverSessionButtonTextColor = "${base0A}";
-          HoverVirtualKeyboardButtonTextColor = "${base0A}";
-
+          CursorColor = colors.base05;
+          FullBlur = "true";
           PartialBlur = "true";
-          BlurMax = "35";
-          Blur = "2.0";
-
-          HourFormat = "h:mm AP";
-
+          HeaderTextColor = colors.base05;
           HaveFormBackground = "false";
           FormPosition = "left";
-
         };
       }
-    )
+    else
+      pkgs.sddm-astronaut)
   ];
 
   security.pam.services.sddm.enableGnomeKeyring = true;

--- a/modules/desktop/niri-dms/home/core/hyprlock.nix
+++ b/modules/desktop/niri-dms/home/core/hyprlock.nix
@@ -6,9 +6,14 @@
 , ...
 }:
 let
-  color0 = "rgb(${config.stylix.base16Scheme.base00})";
-  color5 = "rgb(${config.stylix.base16Scheme.base05})";
-  color14 = "rgb(${config.stylix.base16Scheme.base0E})";
+  palette = if config.stylix.enable then config.stylix.base16Scheme else {
+    base00 = "000000";
+    base05 = "ffffff";
+    base0E = "ff00ff";
+  };
+  color0 = "rgb(${palette.base00})";
+  color5 = "rgb(${palette.base05})";
+  color14 = "rgb(${palette.base0E})";
 in
 {
   programs.hyprlock = {

--- a/modules/desktop/niri-dms/home/core/niri.nix
+++ b/modules/desktop/niri-dms/home/core/niri.nix
@@ -1,12 +1,14 @@
 { pkgs
 , config
 , inputs
+, lib
 , ...
 }:
 
 let
   inherit (import ../misc/variables.nix) browser terminal;
   modifier = "Mod";
+  stylixEnabled = if config ? stylix then config.stylix.enable else false;
 in
 {
   imports = [
@@ -14,56 +16,37 @@ in
   ];
 
   programs.niri = {
-    package = inputs.niri.packages.${pkgs.stdenv.hostPlatform.system}.niri-unstable;
+    package = inputs.niri.packages.${pkgs.system}.niri-unstable;
     settings = {
-      spawn-at-startup = [
-        { command = [ "dbus-update-activation-environment" "--all" "--systemd" "WAYLAND_DISPLAY" "XDG_CURRENT_DESKTOP" ]; }
-        { command = [ "systemctl" "--user" "import-environment" "QT_QPA_PLATFORMTHEME" "WAYLAND_DISPLAY" "XDG_CURRENT_DESKTOP" ]; }
-        { command = [ "swaync" ]; }
-        { command = [ "kdeconnect-indicator" ]; }
-        { command = [ "wl-paste" "--type" "text" "--watch" "cliphist" "store" ]; }
-        { command = [ "wl-paste" "--type" "image" "--watch" "cliphist" "store" ]; }
-        { command = [ "systemctl" "--user" "start" "hyprpolkitagent" ]; }
-      ];
-
       input = {
-        focus-follows-mouse = {
-          enable = true;
-        };
-        mod-key = "Super";
-        keyboard.xkb = {
-          layout = "us";
-          options = "grp:alt_shift_toggle,caps:super";
-        };
+        keyboard.xkb.layout = "us";
         touchpad = {
           tap = true;
           natural-scroll = true;
-          dwt = true;
         };
-        mouse.accel-profile = "flat";
+        mouse.natural-scroll = true;
       };
 
-      outputs."eDP-1" = {
-        mode = { width = 1920; height = 1080; refresh = 60.0; };
-        scale = 1.0;
-        transform = { rotation = 0; };
-        position = { x = 0; y = 0; };
+      outputs = {
+        "eDP-1" = {
+          mode = { width = 1920; height = 1080; refresh = 60.0; };
+          scale = 1.0;
+        };
       };
 
       layout = {
-        gaps = 4;
+        gaps = 8;
         center-focused-column = "never";
         preset-column-widths = [
-          { proportion = 0.33333; }
-          { proportion = 0.5; }
-          { proportion = 0.66667; }
-          { proportion = 1.0; }
+          { proportion = 1.0 / 3.0; }
+          { proportion = 1.0 / 2.0; }
+          { proportion = 2.0 / 3.0; }
         ];
         default-column-width.proportion = 1.0;
         border = {
           width = 2;
-          active = "#${config.stylix.base16Scheme.base0D}";
-          inactive = "#${config.stylix.base16Scheme.base00}";
+          active = if stylixEnabled then "#${config.stylix.base16Scheme.base0D}" else "#ffffff";
+          inactive = if stylixEnabled then "#${config.stylix.base16Scheme.base00}" else "#000000";
         };
         struts = {
           left = 0;
@@ -73,94 +56,31 @@ in
         };
       };
 
-      window-rules = [
-        {
-          matches = [{ }];
-          open-maximized = true;
-          geometry-corner-radius = {
-            top-left = 12.0;
-            top-right = 12.0;
-            bottom-left = 12.0;
-            bottom-right = 12.0;
-          };
-          clip-to-geometry = true;
-          focus-ring.enable = false;
-        }
-      ];
+      spawn-at-startup = [
+        { command = [ "${pkgs.waybar}/bin/waybar" ]; }
+        { command = [ "${pkgs.swaynotificationcenter}/bin/swaync" ]; }
+      ] ++ lib.optional stylixEnabled { command = [ "${pkgs.swaybg}/bin/swaybg" "-i" config.stylix.image ]; };
 
       binds = {
-        "${modifier}+Return".action.spawn = [ terminal ];
-        "Alt+Space".action.spawn = [ "dms" "ipc" "call" "spotlight" "toggle" ];
-        "${modifier}+V".action.spawn = [ "dms" "ipc" "call" "clipboard" "toggle" ];
-        "${modifier}+Alt+W".action.spawn = [ "wallSelector" ];
-        "${modifier}+W".action.spawn = [ browser ];
-        "Ctrl+L".action.spawn = [ "dms" "ipc" "call" "lock" "lock" ];
-        "${modifier}+E".action.spawn = [ "wofi-emoji" ];
-        "${modifier}+Shift+S".action.screenshot = [ ];
-        "${modifier}+D".action.spawn = [ "discord" ];
-        "${modifier}+C".action.spawn = [ "hyprpicker" "-a" ];
-        "${modifier}+T".action.spawn = [ "thunar" ];
-        "${modifier}+M".action.spawn = [ "spotify" ];
-        "${modifier}+N".action.spawn = [ "swaync-client" "-t" "-sw" ];
-
-        "${modifier}+Q".action.close-window = [ ];
-        "${modifier}+F".action.maximize-column = [ ];
-        "${modifier}+Shift+F".action.toggle-window-floating = [ ];
-        "${modifier}+Shift+C".action.quit = [ ];
-
-        "${modifier}+WheelScrollDown".action.focus-column-right = [ ];
-        "${modifier}+WheelScrollUp".action.focus-column-left = [ ];
-        "${modifier}+Shift+WheelScrollDown".action.focus-window-down = [ ];
-        "${modifier}+Shift+WheelScrollUp".action.focus-window-up = [ ];
-
-        "${modifier}+Left".action.focus-column-left = [ ];
-        "${modifier}+Right".action.focus-column-right = [ ];
-        "${modifier}+Up".action.focus-window-up = [ ];
-        "${modifier}+Down".action.focus-window-down = [ ];
-        "${modifier}+H".action.focus-column-left = [ ];
-        "${modifier}+L".action.focus-column-right = [ ];
-        "${modifier}+K".action.focus-window-up = [ ];
-        "${modifier}+J".action.focus-window-down = [ ];
-
-        "${modifier}+Shift+Left".action.move-column-left = [ ];
-        "${modifier}+Shift+Right".action.move-column-right = [ ];
-        "${modifier}+Shift+Up".action.move-window-up-or-to-workspace-up = [ ];
-        "${modifier}+Shift+Down".action.move-window-down-or-to-workspace-down = [ ];
-        "${modifier}+Shift+H".action.move-column-left = [ ];
-        "${modifier}+Shift+L".action.move-column-right = [ ];
-        "${modifier}+Shift+K".action.move-window-up-or-to-workspace-up = [ ];
-        "${modifier}+Shift+J".action.move-window-down-or-to-workspace-down = [ ];
-
-        "${modifier}+Ctrl+Left".action.set-column-width = "-10%";
-        "${modifier}+Ctrl+Right".action.set-column-width = "+10%";
-        "${modifier}+Ctrl+Up".action.set-window-height = "-10%";
-        "${modifier}+Ctrl+Down".action.set-window-height = "+10%";
-        "${modifier}+Ctrl+H".action.set-column-width = "-10%";
-        "${modifier}+Ctrl+L".action.set-column-width = "+10%";
-        "${modifier}+Ctrl+K".action.set-window-height = "-10%";
-        "${modifier}+Ctrl+J".action.set-window-height = "+10%";
-
-        "${modifier}+1".action.focus-workspace = 1;
-        "${modifier}+2".action.focus-workspace = 2;
-        "${modifier}+3".action.focus-workspace = 3;
-        "${modifier}+4".action.focus-workspace = 4;
-        "${modifier}+5".action.focus-workspace = 5;
-        "${modifier}+6".action.focus-workspace = 6;
-        "${modifier}+7".action.focus-workspace = 7;
-        "${modifier}+8".action.focus-workspace = 8;
-        "${modifier}+9".action.focus-workspace = 9;
-        "${modifier}+0".action.focus-workspace = 10;
-
-        "${modifier}+Shift+1".action.move-column-to-workspace = 1;
-        "${modifier}+Shift+2".action.move-column-to-workspace = 2;
-        "${modifier}+Shift+3".action.move-column-to-workspace = 3;
-        "${modifier}+Shift+4".action.move-column-to-workspace = 4;
-        "${modifier}+Shift+5".action.move-column-to-workspace = 5;
-        "${modifier}+Shift+6".action.move-column-to-workspace = 6;
-        "${modifier}+Shift+7".action.move-column-to-workspace = 7;
-        "${modifier}+Shift+8".action.move-column-to-workspace = 8;
-        "${modifier}+Shift+9".action.move-column-to-workspace = 9;
-        "${modifier}+Shift+0".action.move-column-to-workspace = 10;
+        "Mod+Return".action.spawn = [ terminal ];
+        "Mod+D".action.spawn = [ "rofi" "-show" "drun" ];
+        "Mod+Q".action.close-window = { };
+        "Mod+Left".action.focus-column-left = { };
+        "Mod+Right".action.focus-column-right = { };
+        "Mod+Up".action.focus-window-up = { };
+        "Mod+Down".action.focus-window-down = { };
+        "Mod+Shift+Left".action.move-column-left = { };
+        "Mod+Shift+Right".action.move-column-right = { };
+        "Mod+F".action.maximize-column = { };
+        "Mod+Shift+F".action.fullscreen-window = { };
+        "Mod+C".action.center-column = { };
+        "Mod+Minus".action.set-column-width = "-10%";
+        "Mod+Equal".action.set-column-width = "+10%";
+        "Mod+Shift+Minus".action.set-window-height = "-10%";
+        "Mod+Shift+Equal".action.set-window-height = "+10%";
+        "Mod+V".action.spawn = [ "cliphist" "list" "|" "rofi" "-dmenu" "|" "cliphist" "decode" "|" "wl-copy" ];
+        "Mod+Shift+E".action.quit = { };
+        "Mod+Shift+P".action.spawn = [ "swaylock" ];
 
         "XF86AudioRaiseVolume".action.spawn = [ "wpctl" "set-volume" "@DEFAULT_AUDIO_SINK@" "5%+" ];
         "XF86AudioLowerVolume".action.spawn = [ "wpctl" "set-volume" "@DEFAULT_AUDIO_SINK@" "5%-" ];

--- a/modules/desktop/sway/home/services/swaync.nix
+++ b/modules/desktop/sway/home/services/swaync.nix
@@ -1,4 +1,13 @@
-{ config, ... }: {
+{ config, ... }:
+let
+  palette = if (config ? stylix && config.stylix.enable) then config.lib.stylix.colors else {
+    base00 = "000000"; base01 = "1e1e2e"; base02 = "313244"; base03 = "45475a";
+    base04 = "585b70"; base05 = "cdd6f4"; base06 = "f5e0dc"; base07 = "b4befe";
+    base08 = "f38ba8"; base09 = "fab387"; base0A = "f9e2af"; base0B = "a6e3a1";
+    base0C = "94e2d5"; base0D = "89b4fa"; base0E = "cba6f7"; base0F = "f2cdcd";
+  };
+in
+{
   services.swaync = {
     enable = true;
     settings = {
@@ -66,7 +75,7 @@
       .control-center .notification-row:focus,
       .control-center .notification-row:hover {
         opacity: 0.9;
-        background: #${config.lib.stylix.colors.base00}
+        background: #${palette.base00}
       }
       .notification-row {
         outline: none;
@@ -79,10 +88,10 @@
         margin: 0px;
       }
       .notification-content {
-        background: #${config.lib.stylix.colors.base00};
+        background: #${palette.base00};
         padding: 10px;
         border-radius: 5px;
-        border: 2px solid #${config.lib.stylix.colors.base0D};
+        border: 2px solid #${palette.base0D};
         margin: 0;
       }
       .notification-default-action {
@@ -91,8 +100,8 @@
         border-radius: 5px;
       }
       .close-button {
-        background: #${config.lib.stylix.colors.base08};
-        color: #${config.lib.stylix.colors.base00};
+        background: #${palette.base08};
+        color: #${palette.base00};
         text-shadow: none;
         padding: 0;
         border-radius: 5px;
@@ -101,19 +110,19 @@
       }
       .close-button:hover {
         box-shadow: none;
-        background: #${config.lib.stylix.colors.base0D};
+        background: #${palette.base0D};
         transition: all .15s ease-in-out;
         border: none
       }
       .notification-action {
-        border: 2px solid #${config.lib.stylix.colors.base0D};
+        border: 2px solid #${palette.base0D};
         border-top: none;
         border-radius: 5px;
       }
       .notification-default-action:hover,
       .notification-action:hover {
-        color: #${config.lib.stylix.colors.base0B};
-        background: #${config.lib.stylix.colors.base0B}
+        color: #${palette.base0B};
+        background: #${palette.base0B}
       }
       .notification-default-action {
         border-radius: 5px;
@@ -125,40 +134,40 @@
       }
       .notification-action:first-child {
         border-bottom-left-radius: 10px;
-        background: #${config.lib.stylix.colors.base00}
+        background: #${palette.base00}
       }
       .notification-action:last-child {
         border-bottom-right-radius: 10px;
-        background: #${config.lib.stylix.colors.base00}
+        background: #${palette.base00}
       }
       .inline-reply {
         margin-top: 8px
       }
       .inline-reply-entry {
-        background: #${config.lib.stylix.colors.base00};
-        color: #${config.lib.stylix.colors.base05};
-        caret-color: #${config.lib.stylix.colors.base05};
-        border: 1px solid #${config.lib.stylix.colors.base09};
+        background: #${palette.base00};
+        color: #${palette.base05};
+        caret-color: #${palette.base05};
+        border: 1px solid #${palette.base09};
         border-radius: 5px
       }
       .inline-reply-button {
         margin-left: 4px;
-        background: #${config.lib.stylix.colors.base00};
-        border: 1px solid #${config.lib.stylix.colors.base09};
+        background: #${palette.base00};
+        border: 1px solid #${palette.base09};
         border-radius: 5px;
-        color: #${config.lib.stylix.colors.base05}
+        color: #${palette.base05}
       }
       .inline-reply-button:disabled {
         background: initial;
-        color: #${config.lib.stylix.colors.base03};
+        color: #${palette.base03};
         border: 1px solid transparent
       }
       .inline-reply-button:hover {
-        background: #${config.lib.stylix.colors.base00}
+        background: #${palette.base00}
       }
       .body-image {
         margin-top: 6px;
-        background-color: #${config.lib.stylix.colors.base05};
+        background-color: #${palette.base05};
         border-radius: 5px
       }
       .summary {
@@ -172,7 +181,7 @@
         font-size: 16px;
         font-weight: 700;
         background: transparent;
-        color: #${config.lib.stylix.colors.base05};
+        color: #${palette.base05};
         text-shadow: none;
         margin-right: 18px
       }
@@ -180,12 +189,12 @@
         font-size: 15px;
         font-weight: 400;
         background: transparent;
-        color: #${config.lib.stylix.colors.base05};
+        color: #${palette.base05};
         text-shadow: none
       }
       .control-center {
-        background: #${config.lib.stylix.colors.base00};
-        border: 2px solid #${config.lib.stylix.colors.base0C};
+        background: #${palette.base00};
+        border: 2px solid #${palette.base0C};
         border-radius: 5px;
       }
       .control-center-list {
@@ -201,8 +210,8 @@
         background: alpha(black, 0)
       }
       .widget-title {
-        color: #${config.lib.stylix.colors.base0B};
-        background: #${config.lib.stylix.colors.base00};
+        color: #${palette.base0B};
+        background: #${palette.base00};
         padding: 5px 10px;
         margin: 10px 10px 5px 10px;
         font-size: 1.5rem;
@@ -210,39 +219,39 @@
       }
       .widget-title>button {
         font-size: 1rem;
-        color: #${config.lib.stylix.colors.base05};
+        color: #${palette.base05};
         text-shadow: none;
-        background: #${config.lib.stylix.colors.base00};
+        background: #${palette.base00};
         box-shadow: none;
         border-radius: 5px;
       }
       .widget-title>button:hover {
-        background: #${config.lib.stylix.colors.base08};
-        color: #${config.lib.stylix.colors.base00};
+        background: #${palette.base08};
+        color: #${palette.base00};
       }
       .widget-dnd {
-        background: #${config.lib.stylix.colors.base00};
+        background: #${palette.base00};
         padding: 5px 10px;
         margin: 10px 10px 5px 10px;
         border-radius: 5px;
         font-size: large;
-        color: #${config.lib.stylix.colors.base0B};
+        color: #${palette.base0B};
       }
       .widget-dnd>switch {
         border-radius: 5px;
-        /* border: 1px solid #${config.lib.stylix.colors.base0B}; */
-        background: #${config.lib.stylix.colors.base0B};
+        /* border: 1px solid #${palette.base0B}; */
+        background: #${palette.base0B};
       }
       .widget-dnd>switch:checked {
-        background: #${config.lib.stylix.colors.base08};
-        border: 1px solid #${config.lib.stylix.colors.base08};
+        background: #${palette.base08};
+        border: 1px solid #${palette.base08};
       }
       .widget-dnd>switch slider {
-        background: #${config.lib.stylix.colors.base00};
+        background: #${palette.base00};
         border-radius: 5px
       }
       .widget-dnd>switch:checked slider {
-        background: #${config.lib.stylix.colors.base00};
+        background: #${palette.base00};
         border-radius: 5px
       }
       .widget-label {
@@ -250,10 +259,10 @@
       }
       .widget-label>label {
         font-size: 1rem;
-        color: #${config.lib.stylix.colors.base05};
+        color: #${palette.base05};
       }
       .widget-mpris {
-        color: #${config.lib.stylix.colors.base05};
+        color: #${palette.base05};
         padding: 5px 10px;
         margin: 10px 10px 5px 10px;
         border-radius: 5px;
@@ -281,30 +290,30 @@
         background: transparent
       }
       .widget-volume {
-        background: #${config.lib.stylix.colors.base01};
+        background: #${palette.base01};
         padding: 5px;
         margin: 10px 10px 5px 10px;
         border-radius: 5px;
         font-size: x-large;
-        color: #${config.lib.stylix.colors.base05};
+        color: #${palette.base05};
       }
       .widget-volume>box>button {
-        background: #${config.lib.stylix.colors.base0B};
+        background: #${palette.base0B};
         border: none
       }
       .per-app-volume {
-        background-color: #${config.lib.stylix.colors.base00};
+        background-color: #${palette.base00};
         padding: 4px 8px 8px;
         margin: 0 8px 8px;
         border-radius: 5px;
       }
       .widget-backlight {
-        background: #${config.lib.stylix.colors.base01};
+        background: #${palette.base01};
         padding: 5px;
         margin: 10px 10px 5px 10px;
         border-radius: 5px;
         font-size: x-large;
-        color: #${config.lib.stylix.colors.base05}
+        color: #${palette.base05}
       }
     '';
   };

--- a/modules/desktop/sway/home/ui/waybar/default.nix
+++ b/modules/desktop/sway/home/ui/waybar/default.nix
@@ -1,5 +1,11 @@
 { pkgs, lib, config, ... }:
 let
+  palette = if (config ? stylix && config.stylix.enable) then config.lib.stylix.colors else {
+    base00 = "000000"; base01 = "1e1e2e"; base02 = "313244"; base03 = "45475a";
+    base04 = "585b70"; base05 = "cdd6f4"; base06 = "f5e0dc"; base07 = "b4befe";
+    base08 = "f38ba8"; base09 = "fab387"; base0A = "f9e2af"; base0B = "a6e3a1";
+    base0C = "94e2d5"; base0D = "89b4fa"; base0E = "cba6f7"; base0F = "f2cdcd";
+  };
   betterTransition = "all 0.3s cubic-bezier(.55,-0.68,.48,1.682)";
   inherit (import ../../misc/variables.nix) clock24h;
 in
@@ -166,8 +172,8 @@ with lib;
           background: rgba(0,0,0,0);
         }
         #workspaces {
-          color: #${config.lib.stylix.colors.base00};
-          background: #${config.lib.stylix.colors.base01};
+          color: #${palette.base00};
+          background: #${palette.base01};
           margin: 4px 4px;
           padding: 5px 5px;
           border-radius: 16px;
@@ -177,8 +183,8 @@ with lib;
           padding: 0px 5px;
           margin: 0px 3px;
           border-radius: 16px;
-          color: #${config.lib.stylix.colors.base00};
-          background: linear-gradient(45deg, #${config.lib.stylix.colors.base08}, #${config.lib.stylix.colors.base0D});
+          color: #${palette.base00};
+          background: linear-gradient(45deg, #${palette.base08}, #${palette.base0D});
           opacity: 0.5;
           transition: ${betterTransition};
         }
@@ -187,8 +193,8 @@ with lib;
           padding: 0px 5px;
           margin: 0px 3px;
           border-radius: 16px;
-          color: #${config.lib.stylix.colors.base00};
-          background: linear-gradient(45deg, #${config.lib.stylix.colors.base08}, #${config.lib.stylix.colors.base0D});
+          color: #${palette.base00};
+          background: linear-gradient(45deg, #${palette.base08}, #${palette.base0D});
           transition: ${betterTransition};
           opacity: 1.0;
           min-width: 40px;
@@ -196,31 +202,31 @@ with lib;
         #workspaces button:hover {
           font-weight: bold;
           border-radius: 16px;
-          color: #${config.lib.stylix.colors.base00};
-          background: linear-gradient(45deg, #${config.lib.stylix.colors.base08}, #${config.lib.stylix.colors.base0D});
+          color: #${palette.base00};
+          background: linear-gradient(45deg, #${palette.base08}, #${palette.base0D});
           opacity: 0.8;
           transition: ${betterTransition};
         }
         tooltip {
-          background: #${config.lib.stylix.colors.base00};
-          border: 1px solid #${config.lib.stylix.colors.base08};
+          background: #${palette.base00};
+          border: 1px solid #${palette.base08};
           border-radius: 12px;
         }
         tooltip label {
-          color: #${config.lib.stylix.colors.base08};
+          color: #${palette.base08};
         }
         #window, #pulseaudio, #idle_inhibitor {
           font-weight: bold;
           margin: 4px 0px;
           margin-left: 7px;
           padding: 0px 18px;
-          background: #${config.lib.stylix.colors.base04};
-          color: #${config.lib.stylix.colors.base00};
+          background: #${palette.base04};
+          color: #${palette.base00};
           border-radius: 24px 10px 24px 10px;
         }
         #custom-startmenu {
-          color: #${config.lib.stylix.colors.base0B};
-          background: #${config.lib.stylix.colors.base02};
+          color: #${palette.base0B};
+          background: #${palette.base02};
           font-size: 28px;
           margin: 0px;
           padding: 0px 30px 0px 15px;
@@ -229,8 +235,8 @@ with lib;
         #custom-swaybindings, #network, #battery,
         #custom-notification, #tray, #custom-exit {
           font-weight: bold;
-          background: #${config.lib.stylix.colors.base0F};
-          color: #${config.lib.stylix.colors.base00};
+          background: #${palette.base0F};
+          color: #${palette.base00};
           margin: 4px 0px;
           margin-right: 7px;
           border-radius: 10px 24px 10px 24px;
@@ -239,7 +245,7 @@ with lib;
         #clock {
           font-weight: bold;
           color: #0D0E15;
-          background: linear-gradient(90deg, #${config.lib.stylix.colors.base0E}, #${config.lib.stylix.colors.base0C});
+          background: linear-gradient(90deg, #${palette.base0E}, #${palette.base0C});
           margin: 0px;
           padding: 0px 15px 0px 30px;
           border-radius: 0px 0px 0px 40px;

--- a/modules/desktop/sway/home/ui/waybar/simple-vertical.nix
+++ b/modules/desktop/sway/home/ui/waybar/simple-vertical.nix
@@ -2,7 +2,16 @@
 , lib
 , pkgs
 , ...
-}: with lib; {
+}:
+let
+  palette = if (config ? stylix && config.stylix.enable) then config.lib.stylix.colors else {
+    base00 = "000000"; base01 = "1e1e2e"; base02 = "313244"; base03 = "45475a";
+    base04 = "585b70"; base05 = "cdd6f4"; base06 = "f5e0dc"; base07 = "b4befe";
+    base08 = "f38ba8"; base09 = "fab387"; base0A = "f9e2af"; base0B = "a6e3a1";
+    base0C = "94e2d5"; base0D = "89b4fa"; base0E = "cba6f7"; base0F = "f2cdcd";
+  };
+in
+with lib; {
   programs.waybar = {
     enable = true;
     package = pkgs.waybar;
@@ -122,7 +131,7 @@
       };
     };
 
-    style = with config.lib.stylix.colors; ''
+    style = with palette; ''
       * {
         font-family: JetBrainsMono Nerd Font Mono;
         font-size: 16px;

--- a/modules/desktop/sway/home/ui/waybar/waybar-nekodyke.nix
+++ b/modules/desktop/sway/home/ui/waybar/waybar-nekodyke.nix
@@ -4,6 +4,12 @@
 , ...
 }:
 let
+  palette = if (config ? stylix && config.stylix.enable) then config.lib.stylix.colors else {
+    base00 = "000000"; base01 = "1e1e2e"; base02 = "313244"; base03 = "45475a";
+    base04 = "585b70"; base05 = "cdd6f4"; base06 = "f5e0dc"; base07 = "b4befe";
+    base08 = "f38ba8"; base09 = "fab387"; base0A = "f9e2af"; base0B = "a6e3a1";
+    base0C = "94e2d5"; base0D = "89b4fa"; base0E = "cba6f7"; base0F = "f2cdcd";
+  };
   betterTransition = "all 0.3s cubic-bezier(.55,-0.68,.48,1.682)";
   inherit (import ../../misc/variables.nix) clock24h;
 in
@@ -198,9 +204,9 @@ with lib; {
         /* --- The Main Bar --- */
         window#waybar {
           /* A solid background color from your stylix theme for a clean, bold look. */
-          background: #${config.lib.stylix.colors.base00};
-          border: 1px solid #${config.lib.stylix.colors.base03}; /* A subtle border for definition */
-          color: #${config.lib.stylix.colors.base05}; /* Default text color */
+          background: #${palette.base00};
+          border: 1px solid #${palette.base03}; /* A subtle border for definition */
+          color: #${palette.base05}; /* Default text color */
           transition: ${betterTransition};
         }
 
@@ -208,42 +214,42 @@ with lib; {
         /* Applies to all modules for consistency */
         #workspaces, #window, #clock, #battery, #pulseaudio, #network, #cpu, #memory, #idle_inhibitor, #tray, #custom-notification, #custom-exit, #custom-startmenu, #custom-hyprbindings {
           padding: 0px 12px; /* Horizontal padding for spacing inside the bar */
-          background-color: #${config.lib.stylix.colors.base01};
+          background-color: #${palette.base01};
           margin: 4px 0px;   /* Vertical margin to center modules in the bar */
           font-weight: bold;
         }
 
         /* --- Hover Effects for Interactivity --- */
         #clock:hover, #battery:hover, #pulseaudio:hover, #network:hover, #cpu:hover, #memory:hover, #idle_inhibitor:hover, #custom-notification:hover {
-          background-color: #${config.lib.stylix.colors.base01};
+          background-color: #${palette.base01};
         }
 
         /* --- Workspaces --- */
         #workspaces {
-          background-color: #${config.lib.stylix.colors.base01};
+          background-color: #${palette.base01};
           margin-left: 6px;
           padding: 0 5px;
         }
 
         #workspaces button {
-          color: #${config.lib.stylix.colors.base04}; /* Inactive workspace color */
+          color: #${palette.base04}; /* Inactive workspace color */
           padding: 0px 5px;
           transition: ${betterTransition};
         }
 
         #workspaces button:hover {
-          background-color: #${config.lib.stylix.colors.base02};
-          color: #${config.lib.stylix.colors.base06};
+          background-color: #${palette.base02};
+          color: #${palette.base06};
         }
 
         #workspaces button.focused {
-          background-color: #${config.lib.stylix.colors.base0D}; /* Use a bright accent for focus */
-          color: #${config.lib.stylix.colors.base00};
+          background-color: #${palette.base0D}; /* Use a bright accent for focus */
+          color: #${palette.base00};
         }
 
         #workspaces button.urgent {
-          background-color: #${config.lib.stylix.colors.base08}; /* Use red for urgent workspaces */
-          color: #${config.lib.stylix.colors.base00};
+          background-color: #${palette.base08}; /* Use red for urgent workspaces */
+          color: #${palette.base00};
         }
 
         /* --- Right Aligned Modules --- */
@@ -253,40 +259,40 @@ with lib; {
 
         /* --- State-Based Coloring for Glanceable Info --- */
         #memory.warning, #cpu.warning, #battery.warning {
-          color: #${config.lib.stylix.colors.base0A}; /* Yellow for warning */
+          color: #${palette.base0A}; /* Yellow for warning */
         }
 
         #memory.critical, #cpu.critical, #battery.critical {
-          color: #${config.lib.stylix.colors.base08}; /* Red for critical */
+          color: #${palette.base08}; /* Red for critical */
         }
 
         #battery.charging, #battery.plugged {
-          color: #${config.lib.stylix.colors.base0B}; /* Green/Blue for charging */
+          color: #${palette.base0B}; /* Green/Blue for charging */
         }
 
         #network.disconnected {
-          color: #${config.lib.stylix.colors.base08};
+          color: #${palette.base08};
         }
 
         /* --- Specific Module Tweaks --- */
         #clock {
-          color: #${config.lib.stylix.colors.base0E}; /* A distinct color for the clock */
+          color: #${palette.base0E}; /* A distinct color for the clock */
         }
 
         #window {
           /* The window title can be less prominent */
-          color: #${config.lib.stylix.colors.base04};
+          color: #${palette.base04};
           font-weight: normal;
         }
 
         /* --- Tooltips --- */
         tooltip {
-          background: #${config.lib.stylix.colors.base00};
-          border: 1px solid #${config.lib.stylix.colors.base0B};
+          background: #${palette.base00};
+          border: 1px solid #${palette.base0B};
         }
 
         tooltip label {
-          color: #${config.lib.stylix.colors.base05};
+          color: #${palette.base05};
         }
       ''
     ];

--- a/modules/desktop/sway/home/ui/waybar/waybar-vertical.nix
+++ b/modules/desktop/sway/home/ui/waybar/waybar-vertical.nix
@@ -1,5 +1,11 @@
 { pkgs, lib, config, ... }:
 let
+  palette = if (config ? stylix && config.stylix.enable) then config.lib.stylix.colors else {
+    base00 = "000000"; base01 = "1e1e2e"; base02 = "313244"; base03 = "45475a";
+    base04 = "585b70"; base05 = "cdd6f4"; base06 = "f5e0dc"; base07 = "b4befe";
+    base08 = "f38ba8"; base09 = "fab387"; base0A = "f9e2af"; base0B = "a6e3a1";
+    base0C = "94e2d5"; base0D = "89b4fa"; base0E = "cba6f7"; base0F = "f2cdcd";
+  };
   betterTransition = "all 0.3s cubic-bezier(.55,-0.68,.48,1.682)";
 in
 with lib;
@@ -349,40 +355,40 @@ with lib;
         /* Applies to all modules for consistency */
         #workspaces, #window, #clock, #battery, #pulseaudio, #network, #cpu, #memory, #idle_inhibitor, #tray, #custom-notification, #custom-exit, #custom-startmenu, #custom-hyprbindings {
           padding: 0px 12px; /* Horizontal padding for spacing inside the bar */
-          background-color: #${config.lib.stylix.colors.base01};
+          background-color: #${palette.base01};
           margin: 4px 0px;   /* Vertical margin to center modules in the bar */
           font-weight: bold;
         }
         /* --- Hover Effects for Interactivity --- */
         #clock:hover, #battery:hover, #pulseaudio:hover, #network:hover, #cpu:hover, #memory:hover, #idle_inhibitor:hover, #custom-notification:hover {
-          background-color: #${config.lib.stylix.colors.base01};
+          background-color: #${palette.base01};
         }
         /* --- Workspaces --- */
         #workspaces {
-          background-color: #${config.lib.stylix.colors.base01};
+          background-color: #${palette.base01};
           margin-left: 6px;
           padding: 0 5px;
         }
 
         #workspaces button {
-          color: #${config.lib.stylix.colors.base04}; /* Inactive workspace color */
+          color: #${palette.base04}; /* Inactive workspace color */
           padding: 0px 5px;
           transition: ${betterTransition};
         }
 
         #workspaces button:hover {
-          background-color: #${config.lib.stylix.colors.base02};
-          color: #${config.lib.stylix.colors.base06};
+          background-color: #${palette.base02};
+          color: #${palette.base06};
         }
 
         #workspaces button.focused {
-          background-color: #${config.lib.stylix.colors.base0D}; /* Use a bright accent for focus */
-          color: #${config.lib.stylix.colors.base00};
+          background-color: #${palette.base0D}; /* Use a bright accent for focus */
+          color: #${palette.base00};
         }
 
         #workspaces button.urgent {
-          background-color: #${config.lib.stylix.colors.base08}; /* Use red for urgent workspaces */
-          color: #${config.lib.stylix.colors.base00};
+          background-color: #${palette.base08}; /* Use red for urgent workspaces */
+          color: #${palette.base00};
         }
       ''
     ];

--- a/modules/desktop/sway/main/sddm.nix
+++ b/modules/desktop/sway/main/sddm.nix
@@ -1,85 +1,45 @@
-{ pkgs, config, ... }:
+{ pkgs, config, lib, ... }:
 
-
+let
+  stylixEnabled = config ? stylix && config.stylix.enable;
+in
 {
-
   services.displayManager.sddm = {
     enable = true;
     wayland.enable = true;
     theme = "sddm-astronaut-theme";
     package = pkgs.kdePackages.sddm;
     extraPackages = with pkgs; [
+      # kdePackages.qt6-declarative
+      kdePackages.qtsvg
       kdePackages.qtsvg
       kdePackages.qtmultimedia
       kdePackages.qtvirtualkeyboard
     ];
-    settings.Theme = {
+    settings.Theme = lib.mkIf stylixEnabled {
       CursorTheme = config.stylix.cursor.name;
       CursorSize = config.stylix.cursor.size;
     };
   };
 
   environment.systemPackages = [
-    (
+    (if stylixEnabled then
+      let
+        colors = config.lib.stylix.colors.withHashtag;
+      in
       pkgs.sddm-astronaut.override {
-        themeConfig = with config.lib.stylix.colors.withHashtag; {
-          Font = "JetBrainsMono";
-          FontSize = "12";
+        themeConfig = {
           Background = "${config.stylix.image}";
-          CropBackground = "false";
-          BackgroundHorizontalAlignment = "center";
-          BackgroundVerticalAlignment = "center";
-          DimBackground = "0.0";
-          HeaderTextColor = "${base07}";
-          DateTextColor = "${base07}";
-          TimeTextColor = "${base07}";
-
-          FormBackgroundColor = "${base00}";
-          BackgroundColor = "${base00}";
-          DimBackgroundColor = "${base00}";
-
-          LoginFieldBackgroundColor = "#${base00}";
-          PasswordFieldBackgroundColor = "${base00}";
-          LoginFieldTextColo = "${base0D}";
-          PasswordFieldTestColor = "${base0D}";
-          UserIconColor = "${base0D}";
-          PasswordIconColor = "${base0D}";
-
-          PlaceholderTextColor = "${base02}";
-          WarningColor = "${base0A}";
-
-          LoginButtonTextColor = "${base0D}";
-          LoginButtonBackgroundColor = "${base00}";
-          SystemButtonsIconsColor = "${base0D}";
-          SessionButtonTextColor = "${base0D}";
-          VirtualKeyboardButtonTextColor = "${base0D}";
-
-          DropdownTextColor = "${base0D}";
-          DropdownSelectedBackgroundColor = "${base00}";
-          DropdownBackgroundColor = "${base00}";
-
-          HighlightTextColor = "${base0D}";
-          HighlightBackgroundColor = "${base0D}";
-          HighlightBorderColor = "${base0D}";
-
-          HoverUserIconColor = "${base0A}";
-          HoverPasswordIconColor = "${base0A}";
-          HoverSystemButtonsIconsColor = "${base0A}";
-          HoverSessionButtonTextColor = "${base0A}";
-          HoverVirtualKeyboardButtonTextColor = "${base0A}";
-
+          CursorColor = colors.base05;
+          FullBlur = "true";
           PartialBlur = "true";
-          BlurMax = "35";
-          Blur = "2.0";
-
-          HourFormat = "h:mm AP";
-
+          HeaderTextColor = colors.base05;
           HaveFormBackground = "false";
           FormPosition = "left";
-
         };
       }
-    )
+    else
+      pkgs.sddm-astronaut)
   ];
 
   security.pam.services.sddm.enableGnomeKeyring = true;

--- a/modules/system/theme/stylix.nix
+++ b/modules/system/theme/stylix.nix
@@ -1,68 +1,77 @@
 { pkgs
 , wallpaper
 , wallpapers
+, lib
+, config
 , ...
 }:
 {
-  stylix = {
-    enable = true;
-    image = "${wallpapers}/${wallpaper}";
-    polarity = "dark";
+  config = lib.mkMerge [
+    {
+      stylix.enable = lib.mkOptionDefault false;
+    }
+    (lib.mkIf config.stylix.enable {
+      stylix = {
+        enableReleaseChecks = false;
+        image = "${wallpapers}/${wallpaper}";
+        polarity = "dark";
 
-    cursor = {
-      package = pkgs.afterglow-cursors-recolored;
-      name = "Afterglow-Recolored-Catppuccin-Flamingo";
-      size = 24;
-    };
+        cursor = {
+          package = pkgs.afterglow-cursors-recolored;
+          name = "Afterglow-Recolored-Catppuccin-Flamingo";
+          size = 24;
+        };
 
-    fonts = {
+        fonts = {
 
-      sansSerif = {
-        name = "Noto Sans";
-        package = pkgs.noto-fonts;
+          sansSerif = {
+            name = "Noto Sans";
+            package = pkgs.noto-fonts;
+          };
+
+          serif = {
+            name = "Noto Serif";
+            package = pkgs.noto-fonts;
+          };
+
+          monospace = {
+            package = pkgs.nerd-fonts.hack;
+            name = "Hack Nerd Font Mono";
+          };
+
+          emoji = {
+            package = pkgs.noto-fonts-color-emoji;
+            name = "Noto Color Emoji";
+          };
+
+          sizes = {
+            applications = 12;
+            terminal = 15;
+            desktop = 11;
+            popups = 12;
+          };
+        };
+
+        icons = {
+          enable = true;
+          package = pkgs.papirus-icon-theme;
+          dark = "Papirus-Dark";
+          light = "Papirus-Light";
+        };
+
+        opacity = {
+          applications = 1.0;
+          popups = 1.0;
+          terminal = 1.0;
+          desktop = 1.0;
+        };
+
+        targets = {
+          font-packages.enable = true;
+        };
       };
 
-      serif = {
-        name = "Noto Serif";
-        package = pkgs.noto-fonts;
-      };
-
-      monospace = {
-        package = pkgs.nerd-fonts.hack;
-        name = "Hack Nerd Font Mono";
-      };
-
-      emoji = {
-        package = pkgs.noto-fonts-color-emoji;
-        name = "Noto Color Emoji";
-      };
-
-      sizes = {
-        applications = 12;
-        terminal = 15;
-        desktop = 11;
-        popups = 12;
-      };
-    };
-
-    icons = {
-      enable = true;
-      package = pkgs.papirus-icon-theme;
-      dark = "Papirus-Dark";
-      light = "Papirus-Light";
-    };
-
-    opacity = {
-      applications = 1.0;
-      popups = 1.0;
-      terminal = 1.0;
-      desktop = 1.0;
-    };
-
-    targets = {
-      font-packages.enable = true;
-    };
-  };
-
-  gtk.iconCache.enable = true;
+      gtk.iconCache.enable = true;
+    })
+  ];
 }

--- a/modules/user/development/lazygit.nix
+++ b/modules/user/development/lazygit.nix
@@ -1,8 +1,26 @@
 # Lazygit is a simple terminal UI for git commands.
 { config, lib, ... }:
 let
-  accent = "#${config.lib.stylix.colors.base0D}";
-  muted = "#${config.lib.stylix.colors.base03}";
+  palette = if (config ? stylix && config.stylix.enable) then config.lib.stylix.colors else {
+    base00 = "000000";
+    base01 = "1e1e2e";
+    base02 = "313244";
+    base03 = "45475a";
+    base04 = "585b70";
+    base05 = "cdd6f4";
+    base06 = "f5e0dc";
+    base07 = "b4befe";
+    base08 = "f38ba8";
+    base09 = "fab387";
+    base0A = "f9e2af";
+    base0B = "a6e3a1";
+    base0C = "94e2d5";
+    base0D = "89b4fa";
+    base0E = "cba6f7";
+    base0F = "f2cdcd";
+  };
+  accent = "#${palette.base0D}";
+  muted = "#${palette.base03}";
 in
 {
   programs.lazygit = {

--- a/modules/user/development/nvf.nix
+++ b/modules/user/development/nvf.nix
@@ -205,7 +205,28 @@
       filetree.neo-tree.enable = true;
       notify = {
         nvim-notify.enable = true;
-        nvim-notify.setupOpts.background_colour = "#${config.lib.stylix.colors.base01}";
+        nvim-notify.setupOpts.background_colour =
+          let
+            palette = if (config ? stylix && config.stylix.enable) then config.lib.stylix.colors else {
+              base00 = "000000";
+              base01 = "1e1e2e";
+              base02 = "313244";
+              base03 = "45475a";
+              base04 = "585b70";
+              base05 = "cdd6f4";
+              base06 = "f5e0dc";
+              base07 = "b4befe";
+              base08 = "f38ba8";
+              base09 = "fab387";
+              base0A = "f9e2af";
+              base0B = "a6e3a1";
+              base0C = "94e2d5";
+              base0D = "89b4fa";
+              base0E = "cba6f7";
+              base0F = "f2cdcd";
+            };
+          in
+          "#${palette.base01}";
       };
       utility = {
         preview.markdownPreview.enable = true;

--- a/modules/user/shells/starship.nix
+++ b/modules/user/shells/starship.nix
@@ -4,8 +4,26 @@
 , ...
 }:
 let
-  accent = "#${config.lib.stylix.colors.base0D}";
-  background-alt = "#${config.lib.stylix.colors.base01}";
+  palette = if (config ? stylix && config.stylix.enable) then config.lib.stylix.colors else {
+    base00 = "000000";
+    base01 = "1e1e2e";
+    base02 = "313244";
+    base03 = "45475a";
+    base04 = "585b70";
+    base05 = "cdd6f4";
+    base06 = "f5e0dc";
+    base07 = "b4befe";
+    base08 = "f38ba8";
+    base09 = "fab387";
+    base0A = "f9e2af";
+    base0B = "a6e3a1";
+    base0C = "94e2d5";
+    base0D = "89b4fa";
+    base0E = "cba6f7";
+    base0F = "f2cdcd";
+  };
+  accent = "#${palette.base0D}";
+  background-alt = "#${palette.base01}";
 in
 {
   programs.starship = {

--- a/modules/user/shells/tmux.nix
+++ b/modules/user/shells/tmux.nix
@@ -23,23 +23,42 @@
       disableConfirmationPrompt = true;
       extraConfig =
         let
-          background = "${config.lib.stylix.colors.base01}";
-          foreground = "${config.lib.stylix.colors.base04}";
+          palette = if (config ? stylix && config.stylix.enable) then config.lib.stylix.colors else {
+            base00 = "000000";
+            base01 = "1e1e2e";
+            base02 = "313244";
+            base03 = "45475a";
+            base04 = "585b70";
+            base05 = "cdd6f4";
+            base06 = "f5e0dc";
+            base07 = "b4befe";
+            base08 = "f38ba8";
+            base09 = "fab387";
+            base0A = "f9e2af";
+            base0B = "a6e3a1";
+            base0C = "94e2d5";
+            base0D = "89b4fa";
+            base0E = "cba6f7";
+            base0F = "f2cdcd";
+          };
+
+          background = "${palette.base01}";
+          foreground = "${palette.base04}";
 
           r_arrow = { fg, bg }: ''#[fg=#${fg},bg=#${bg}]'';
           l_arrow = { fg, bg }: ''#[fg=#${fg},bg=#${bg}]'';
 
           color_1 = {
-            fg = "${config.lib.stylix.colors.base00}";
-            bg = "${config.lib.stylix.colors.base08}";
+            fg = "${palette.base00}";
+            bg = "${palette.base08}";
           };
           color_2 = {
-            fg = "${config.lib.stylix.colors.base00}";
-            bg = "${config.lib.stylix.colors.base0A}";
+            fg = "${palette.base00}";
+            bg = "${palette.base0A}";
           };
           color_3 = {
-            fg = "${config.lib.stylix.colors.base00}";
-            bg = "${config.lib.stylix.colors.base0B}";
+            fg = "${palette.base00}";
+            bg = "${palette.base0B}";
           };
           toString =
             { fg
@@ -137,7 +156,7 @@
           set -g status-left '${icon}'
 
 
-          set -g pane-active-border-style 'fg=#${config.lib.stylix.colors.base0D}'
+          set -g pane-active-border-style 'fg=#${palette.base0D}'
           # windows
           set -g window-status-style 'fg=#${color_2.bg} bg=#${background}'
           set -g window-status-format ' #I:#W '

--- a/modules/user/theme/stylix.nix
+++ b/modules/user/theme/stylix.nix
@@ -1,38 +1,38 @@
-_:
+{ lib, config, options, ... }:
+let
+  hasStylix = options ? stylix;
+in
 {
-  gtk = {
-    enable = true;
+  config = lib.mkMerge [
+    {
+      gtk = {
+        enable = true;
+        theme = {
+          name = "adw-gtk3";
+        };
+      };
 
-    # iconTheme = {
-    #   enable = true;
-    #   package = pkgs.papirus-icon-theme;
-    # };
+      qt = {
+        enable = true;
+      };
+    }
+    (lib.optionalAttrs hasStylix {
+      stylix.enable = lib.mkOptionDefault false;
 
-    theme = {
-      name = "adw-gtk3";
-    };
-  };
-
-  qt = {
-    enable = true;
-    # platformTheme.name = "qtct"; # Align with Stylix's supported platform
-    # style.name = "kvantum"; # Use Kvantum as the Qt style
-  };
-
-  stylix = {
-    targets = {
-      waybar.enable = false;
-      rofi.enable = false;
-      wofi.enable = false;
-      qt.enable = true;
-      qt.platform = "qtct";
-      hyprland.enable = false;
-      swaylock.enable = false;
-      hyprpanel.enable = false;
-      # zed.enable = true;
-      dank-material-shell.enable = false;
-      zen-browser.enable = false;
-      # spicetify.enable = false;
-    };
-  };
+      stylix.targets = lib.mkIf config.stylix.enable {
+        waybar.enable = false;
+        rofi.enable = false;
+        wofi.enable = false;
+        qt.enable = true;
+        qt.platform = "qtct";
+        hyprland.enable = false;
+        swaylock.enable = false;
+        hyprpanel.enable = false;
+        # zed.enable = true;
+        dank-material-shell.enable = false;
+        zen-browser.enable = false;
+        # spicetify.enable = false;
+      };
+    })
+  ];
 }

--- a/modules/user/utilities/libnotify.nix
+++ b/modules/user/utilities/libnotify.nix
@@ -6,13 +6,13 @@
 
 let
   inherit (lib) mkForce;
-
-  inherit (config.stylix.base16Scheme)
-    base02
-    base03
-    base08
-    base0A
-    ;
+  stylixEnabled = if config ? stylix then config.stylix.enable else false;
+  palette = if stylixEnabled then config.stylix.base16Scheme else {
+    base00 = "000000"; base01 = "1e1e2e"; base02 = "313244"; base03 = "45475a";
+    base04 = "585b70"; base05 = "cdd6f4"; base06 = "f5e0dc"; base07 = "b4befe";
+    base08 = "f38ba8"; base09 = "fab387"; base0A = "f9e2af"; base0B = "a6e3a1";
+    base0C = "94e2d5"; base0D = "89b4fa"; base0E = "cba6f7"; base0F = "f2cdcd";
+  };
 in
 {
   services.dunst = {
@@ -40,19 +40,19 @@ in
         markup = "full";
         min_icon_size = 32;
         max_icon_size = 128;
-        highlight = mkForce base03;
+        highlight = mkForce "#${palette.base03}";
       };
 
       urgency_low = {
-        foreground = mkForce base0A;
-        frame_color = mkForce base02;
+        foreground = mkForce "#${palette.base0A}";
+        frame_color = mkForce "#${palette.base02}";
       };
 
-      urgency_normal.frame_color = mkForce base02;
+      urgency_normal.frame_color = mkForce "#${palette.base02}";
 
       urgency_critical = {
-        foreground = mkForce base08;
-        frame_color = mkForce base02;
+        foreground = mkForce "#${palette.base08}";
+        frame_color = mkForce "#${palette.base02}";
       };
     };
   };

--- a/modules/user/utilities/wofi.nix
+++ b/modules/user/utilities/wofi.nix
@@ -1,10 +1,28 @@
 # Wofi is a launcher for Wayland, inspired by rofi.
 { config, pkgs, lib, ... }:
 let
-  accent = "#${config.stylix.base16Scheme.base0D}";
-  background = "#${config.stylix.base16Scheme.base00}";
-  background-alt = "#${config.stylix.base16Scheme.base01}";
-  foreground = "#${config.stylix.base16Scheme.base05}";
+  palette = if (config ? stylix && config.stylix.enable) then config.lib.stylix.colors else {
+    base00 = "000000";
+    base01 = "1e1e2e";
+    base02 = "313244";
+    base03 = "45475a";
+    base04 = "585b70";
+    base05 = "cdd6f4";
+    base06 = "f5e0dc";
+    base07 = "b4befe";
+    base08 = "f38ba8";
+    base09 = "fab387";
+    base0A = "f9e2af";
+    base0B = "a6e3a1";
+    base0C = "94e2d5";
+    base0D = "89b4fa";
+    base0E = "cba6f7";
+    base0F = "f2cdcd";
+  };
+  accent = "#${palette.base0D}";
+  background = "#${palette.base00}";
+  background-alt = "#${palette.base01}";
+  foreground = "#${palette.base05}";
   font = "JetBrainsMono NF ExtraBold 12";
   rounding = "5";
   font-size = "20";

--- a/system-manager/home/rishabh.nix
+++ b/system-manager/home/rishabh.nix
@@ -63,6 +63,8 @@ in
 
   targets.genericLinux.enable = true;
 
+  stylix.enable = lib.mkForce true;
+
   home.username = "rishabh";
   home.homeDirectory = "/home/rishabh";
 

--- a/system-manager/home/theme.nix
+++ b/system-manager/home/theme.nix
@@ -1,90 +1,62 @@
-{ wallpapers, wallpaper, pkgs, lib, ... }:
+{ wallpapers, wallpaper, pkgs, lib, options, config, ... }:
+let
+  hasStylix = options ? stylix;
+  stylixEnabled = if hasStylix then config.stylix.enable else false;
+in
 {
-  gtk = {
-    enable = lib.mkForce false;
+  config = lib.mkMerge [
+    {
+      gtk = {
+        enable = lib.mkForce false;
 
-    # iconTheme = {
-    #   enable = true;
-    #   package = pkgs.papirus-icon-theme;
-    # };
+        # iconTheme = {
+        #   enable = true;
+        #   package = pkgs.papirus-icon-theme;
+        # };
 
-    theme = {
-      name = "adw-gtk3";
-    };
-  };
-
-  stylix = {
-    enable = false;
-    image = "${wallpapers}/${wallpaper}";
-    polarity = "dark";
-
-    /*
-      cursor = {
-      package = pkgs.afterglow-cursors-recolored;
-      name = "Afterglow-Recolored-Catppuccin-Flamingo";
-      size = 24;
+        theme = {
+          name = "adw-gtk3";
+        };
       };
-    */
+    }
+    (lib.optionalAttrs hasStylix {
+      stylix = {
+        enable = lib.mkOptionDefault false;
 
-    # fonts = {
+        image = lib.mkIf stylixEnabled "${wallpapers}/${wallpaper}";
+        polarity = lib.mkIf stylixEnabled "dark";
 
-    #   sansSerif = {
-    #     name = "Noto Sans";
-    #     package = pkgs.noto-fonts;
-    #   };
+        icons = lib.mkIf stylixEnabled {
+          enable = true;
+          package = pkgs.papirus-icon-theme;
+          dark = "Papirus-Dark";
+          light = "Papirus-Light";
+        };
 
-    #   serif = {
-    #     name = "Noto Serif";
-    #     package = pkgs.noto-fonts;
-    #   };
+        opacity = lib.mkIf stylixEnabled {
+          applications = 1.0;
+          popups = 1.0;
+          terminal = 1.0;
+          desktop = 1.0;
+        };
 
-    #   monospace = {
-    #     package = pkgs.nerd-fonts.hack;
-    #     name = "Hack Nerd Font Mono";
-    #   };
-
-    #   emoji = {
-    #     package = pkgs.noto-fonts-color-emoji;
-    #     name = "Noto Color Emoji";
-    #   };
-
-    #   sizes = {
-    #     applications = 12;
-    #     terminal = 15;
-    #     desktop = 11;
-    #     popups = 12;
-    #   };
-    # };
-
-    icons = {
-      enable = true;
-      package = pkgs.papirus-icon-theme;
-      dark = "Papirus-Dark";
-      light = "Papirus-Light";
-    };
-
-    opacity = {
-      applications = 1.0;
-      popups = 1.0;
-      terminal = 1.0;
-      desktop = 1.0;
-    };
-
-    targets = {
-      font-packages.enable = false;
-      gtk.enable = false;
-      waybar.enable = false;
-      rofi.enable = false;
-      wofi.enable = false;
-      qt.enable = true;
-      qt.platform = "qtct";
-      hyprland.enable = false;
-      swaylock.enable = false;
-      dank-material-shell.enable = false;
-      hyprpanel.enable = false;
-      # zed.enable = true;
-      zen-browser.enable = false;
-      # spicetify.enable = false;
-    };
-  };
+        targets = lib.mkIf stylixEnabled {
+          font-packages.enable = false;
+          gtk.enable = false;
+          waybar.enable = false;
+          rofi.enable = false;
+          wofi.enable = false;
+          qt.enable = true;
+          qt.platform = "qtct";
+          hyprland.enable = false;
+          swaylock.enable = false;
+          dank-material-shell.enable = false;
+          hyprpanel.enable = false;
+          # zed.enable = true;
+          zen-browser.enable = false;
+          # spicetify.enable = false;
+        };
+      };
+    })
+  ];
 }


### PR DESCRIPTION
Stylix theming is now optional by default in modules, with explicit
enabling/disabling in host and user configurations.

Introduces conditional palette usage in Hyprland, Hyprlock, SDDM,
Niri, i3, Dunst, Rofi, Waybar, Wlogout, Lazygit, Nvf, Starship, and Tmux
to gracefully handle when Stylix is disabled.

Also simplifies Hyprlock, Niri, and SDDM configurations by removing
redundant settings and commented-out code.
